### PR TITLE
79 - Run-flow transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,50 @@ To generate eclipse project files run:
 `./gradlew eclipse`
 
 Then import the project into eclipse
+
+####Available Transforms
+Data Hub has provided several transforms that can be used when installed along with the created entities and flows in the MarkLogic server.
+####run-flow
+This transform can be used to run the flow when inserting document. It accepts the following `entity-name`, `flow-name` and `flow-type`. 
+
+#####Use Cases:
+
+1. Using [MarkLogic REST API PUT /v1/documents](http://docs.marklogic.com/REST/PUT/v1/documents)
+
+`curl --anyauth --user <user>:<password> -X PUT -T <documentDirectory> -H "Content-type:<contentType>" 'http://<mlHost>:<port>/<version>/documents?uri=<uri>&transform=run-flow&trans:entity-name=<entityName>&trans:flow-name=<flowName>&trans:flow-type=<flowType>'`
+
+Example:
+
+`cat ./documents/employee1.xml`
+
+`<employee xmlns="http://company.com/ns/employee">`
+`<id>1</id>`
+`</employee>`
+
+To insert/update this document with uri '/employee1.xml' into the database 'data-hub-in-a-box-STAGING' (with host 'localhost' and port '8010'), given a user 'admin' with password 'admin' and rest-writer role AND to be able to run the flow 'IngestFlow' of the 'Customer' entity, run the following:
+
+`curl --anyauth --user admin:admin -X PUT -T ./documents/employee1.xml -H "Content-type:application/xml" 'http://localhost:8010/LATEST/documents?uri=/employee1.xml&transform=run-flow&trans:entity-name=Customer&trans:flow-name=IngestFlow&trans:flow-type=input'`
+
+This will create a document with uri '/employee1.xml'. The content will depend on the data format of the entity. 
+
+If it is JSON ('application/json'), the content will be:
+
+`{`
+`"identifier": "/employee1.xml", `
+`"content": "<employee xmlns=\"http://company.com/ns/employee\">\n  <id>1</id>\n</employee>"`
+`}`
+
+Else if it is XML ('application/xml'), it will be:
+
+`<?xml  version="1.0" encoding="UTF-8"?>`
+`<envelope xmlns="http://marklogic.com/hub-in-a-box/envelope">`
+`<headers>`
+`</headers>`
+`<triples>`
+`</triples>`
+`<content>`
+`<employee xmlns="http://company.com/ns/employee">`
+`<id>1</id>`
+`</employee>`
+`</content>`
+`</envelope>`

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ Then import the project into eclipse
 ####Available Transforms
 Data Hub has provided several transforms that can be used when installed along with the created entities and flows in the MarkLogic server.
 ####run-flow
-This transform can be used to run the flow when inserting document. It accepts the following `entity-name`, `flow-name` and `flow-type`. 
+This transform can be used to run the flow when inserting document. It accepts the following `entity-name` and `flow-name`. 
 
 #####Use Cases:
 
 1. Using [MarkLogic REST API PUT /v1/documents](http://docs.marklogic.com/REST/PUT/v1/documents)
 
-`curl --anyauth --user <user>:<password> -X PUT -T <documentDirectory> -H "Content-type:<contentType>" 'http://<mlHost>:<port>/<version>/documents?uri=<uri>&transform=run-flow&trans:entity-name=<entityName>&trans:flow-name=<flowName>&trans:flow-type=<flowType>'`
+`curl --anyauth --user <user>:<password> -X PUT -T <documentDirectory> -H "Content-type:<contentType>" 'http://<mlHost>:<port>/<version>/documents?uri=<uri>&transform=run-flow&trans:entity-name=<entityName>&trans:flow-name=<flowName>'`
 
 Example:
 
@@ -61,7 +61,7 @@ Example:
 
 To insert/update this document with uri '/employee1.xml' into the database 'data-hub-in-a-box-STAGING' (with host 'localhost' and port '8010'), given a user 'admin' with password 'admin' and rest-writer role AND to be able to run the flow 'IngestFlow' of the 'Customer' entity, run the following:
 
-`curl --anyauth --user admin:admin -X PUT -T ./documents/employee1.xml -H "Content-type:application/xml" 'http://localhost:8010/LATEST/documents?uri=/employee1.xml&transform=run-flow&trans:entity-name=Customer&trans:flow-name=IngestFlow&trans:flow-type=input'`
+`curl --anyauth --user admin:admin -X PUT -T ./documents/employee1.xml -H "Content-type:application/xml" 'http://localhost:8010/LATEST/documents?uri=/employee1.xml&transform=run-flow&trans:entity-name=Customer&trans:flow-name=IngestFlow'`
 
 This will create a document with uri '/employee1.xml'. The content will depend on the data format of the entity. 
 

--- a/marklogic-data-hub/src/main/resources/ml-modules/transforms/run-flow.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/transforms/run-flow.xqy
@@ -13,9 +13,8 @@ declare function runFlow:transform(
 {
   let $entityName := map:get($params, 'entity-name')
   let $flowName := map:get($params, 'flow-name')
-  let $flowType := map:get($params, 'flow-type')
-
-  let $flow := flow:get-flow($entityName,$flowName,$flowType)
+  
+  let $flow := flow:get-flow($entityName,$flowName,())
   
   let $uri := map:get($context, 'uri')
 

--- a/marklogic-data-hub/src/main/resources/ml-modules/transforms/run-flow.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/transforms/run-flow.xqy
@@ -1,0 +1,26 @@
+xquery version "1.0-ml";
+
+module namespace runFlow = "http://marklogic.com/rest-api/transform/run-flow";
+
+import module namespace flow = "http://marklogic.com/hub-in-a-box/flow-lib"
+at "/com.marklogic.hub/lib/flow-lib.xqy";
+
+declare function runFlow:transform(
+  $context as map:map,
+  $params as map:map,
+  $content as document-node()
+  ) as document-node()
+{
+  let $entityName := map:get($params, 'entity-name')
+  let $flowName := map:get($params, 'flow-name')
+  let $flowType := map:get($params, 'flow-type')
+
+  let $flow := flow:get-flow($entityName,$flowName,$flowType)
+  
+  let $uri := map:get($context, 'uri')
+
+  let $transformedContent := flow:run-plugins($flow, $uri, $content, $params)
+
+  return document { $transformedContent }
+
+};


### PR DESCRIPTION
Implemented a run-flow transform that can be invoked from PUT /v1/documents, java code inside a Java container, and REST extension. To verify if the transform is already installed, run http://localhost:8010/LATEST/config/transforms where localhost is the mlHost and 8010 is the port (mlStagingRestPort or mlFinalRestPort). I also updated README.md to guide the users how to use it. 

Let me know if I also need to create a JAVA method that inserts multiple documents using the run-flow transform. 