### PR TITLE
Fixing Issue #578: Adding deletion dialog

### DIFF
--- a/quick-start/src/main/ui/app/entity-modeler/entity-modeler.component.ts
+++ b/quick-start/src/main/ui/app/entity-modeler/entity-modeler.component.ts
@@ -299,7 +299,10 @@ export class EntityModelerComponent implements AfterViewChecked {
   deleteEntity(entity: Entity) {
     let result = this.dialogService.confirm(`Really delete ${entity.name}?`, 'No', 'Yes');
     result.subscribe(() => {
-      this.entitiesService.deleteEntity(entity);
+      let confirmResult = this.dialogService.confirm(`Are you sure really want to delete the ${entity.name} entity as it will delete the entity and all associated flows and code?`, 'No', 'Yes');
+      confirmResult.subscribe(() => {
+        this.entitiesService.deleteEntity(entity);
+      }, () => {});
     }, () => {});
   }
 


### PR DESCRIPTION
Adding an additional dialog message to the 2.0 development branch
that will require the user to press yes twice before the entity
and all associated flows and code are deleted