### PR TITLE
Updating Issue #578: Update the deletion message

### DIFF
--- a/quick-start/src/main/ui/app/entity-modeler/entity-modeler.component.ts
+++ b/quick-start/src/main/ui/app/entity-modeler/entity-modeler.component.ts
@@ -297,12 +297,9 @@ export class EntityModelerComponent implements AfterViewChecked {
   }
 
   deleteEntity(entity: Entity) {
-    let result = this.dialogService.confirm(`Really delete ${entity.name}?`, 'No', 'Yes');
+    let result = this.dialogService.confirm(`Delete the ${entity.name} entity?\n\nAny flows associated with the entity will also be deleted.`, 'No', 'Yes');
     result.subscribe(() => {
-      let confirmResult = this.dialogService.confirm(`Are you sure really want to delete the ${entity.name} entity as it will delete the entity and all associated flows and code?`, 'No', 'Yes');
-      confirmResult.subscribe(() => {
-        this.entitiesService.deleteEntity(entity);
-      }, () => {});
+      this.entitiesService.deleteEntity(entity);
     }, () => {});
   }
 

--- a/quick-start/src/main/ui/styles.scss
+++ b/quick-start/src/main/ui/styles.scss
@@ -1,1 +1,6 @@
 /* You can add global styles to this file, and also import other style files */
+
+.mdl-dialog__content {
+  white-space: pre;
+}
+


### PR DESCRIPTION
Removing the double confirmation dialog and updating the
deletion message that is displayed to the user to make it
clearer to what they are deleting.

@aebadirad, this incorporates the latest feedback by @wooldridge and @ayuwono