### PR TITLE
Updating Issue #578: Update the deletion message

### DIFF
--- a/quick-start/src/main/ui/app/entity-modeler/entity-modeler.component.ts
+++ b/quick-start/src/main/ui/app/entity-modeler/entity-modeler.component.ts
@@ -297,12 +297,9 @@ export class EntityModelerComponent implements AfterViewChecked {
   }
 
   deleteEntity(entity: Entity) {
-    let result = this.dialogService.confirm(`Really delete ${entity.name}?`, 'No', 'Yes');
+    let result = this.dialogService.confirm(`Delete the ${entity.name} entity?\n\nAny flows associated with the entity will also be deleted.`, 'No', 'Yes');
     result.subscribe(() => {
-      let confirmResult = this.dialogService.confirm(`Are you sure really want to delete the ${entity.name} entity as it will delete the entity and all associated flows and code?`, 'No', 'Yes');
-      confirmResult.subscribe(() => {
-        this.entitiesService.deleteEntity(entity);
-      }, () => {});
+      this.entitiesService.deleteEntity(entity);
     }, () => {});
   }
 


### PR DESCRIPTION
Removing the double confirmation dialog and updating the
deletion message that is displayed to the user to make it
clearer to what they are deleting.

@aebadirad, Synchronizing the changes that were in [PR#919](https://github.com/marklogic/marklogic-data-hub/pull/919), 7f02225 on the develop branch with 2.x