### PR TITLE
Updating Issue #578: Update the deletion message

### DIFF
--- a/quick-start/src/main/ui/app/entity-modeler/entity-modeler.component.ts
+++ b/quick-start/src/main/ui/app/entity-modeler/entity-modeler.component.ts
@@ -292,10 +292,7 @@ export class EntityModelerComponent implements AfterViewChecked {
   deleteEntity(entity: Entity) {
     let result = this.dialogService.confirm(`Delete the ${entity.name} entity?\n\nAny flows associated with the entity will also be deleted.`, 'No', 'Yes');
     result.subscribe(() => {
-      let confirmResult = this.dialogService.confirm(`Are you sure really want to delete the ${entity.name} entity as it will delete the entity and all associated flows and code?`, 'No', 'Yes');
-      confirmResult.subscribe(() => {
-        this.entitiesService.deleteEntity(entity);
-      }, () => {});
+      this.entitiesService.deleteEntity(entity);
     }, () => {});
   }
 


### PR DESCRIPTION
Removing the double confirmation dialog and updating the
deletion message that is displayed to the user to make it
clearer to what they are deleting.

@aebadirad and @ayuwono, synchronizing the changes that were made with the develop 7f02225 and 2.x-develop 28658b9 branches with 3.x-develop.