### PR TITLE
DHFPROD-502 fix tutorial, primary key does not add element range index

### DIFF
--- a/_pages/tutorial/3x/modeling-order-entity.md
+++ b/_pages/tutorial/3x/modeling-order-entity.md
@@ -64,7 +64,7 @@ After clicking **Save** you will be prompted whether you want to update indexes 
 
 ![Update Indexes]({{site.baseurl}}/images/3x/modeling-order-entity/update-indexes2.png)
 
-One of the benefits of having the Data Hub Framework model your data with Entity Services is that it can use the model to create database configuration options automatically. This means it can update the necessary index settings bases on how you model your data. For the Product entity, you made sku the primary key. The Data Hub Framework will create a range index on the sku element.
+One of the benefits of having the Data Hub Framework model your data with Entity Services is that it can use the model to create database configuration options automatically. This means it can update the necessary index settings based on how you model your data.
 
 ## Up Next
 

--- a/_pages/tutorial/3x/modeling-product-entity.md
+++ b/_pages/tutorial/3x/modeling-product-entity.md
@@ -36,9 +36,9 @@ After clicking **Save** you will be prompted whether you want to Update Indexes 
 
 <i class="fa fa-hand-pointer-o"></i> Click **Yes**.
 
-One of the benefits of modeling your data with Entity Services is that you can use the model to create database configuration options automatically. This means you can update the necessary index settings bases on how you model your data. For the Product entity, you made sku the primary key. The Data Hub Framework will create a range index on the sku element.
-
 ![Update Indexes]({{site.baseurl}}/images/3x/modeling-product-entity/update-indexes1.png)
+
+One of the benefits of modeling your data with Entity Services is that you can use the model to create database configuration options automatically. This means you can update the necessary index settings based on how you model your data.
 
 ## Up Next
 


### PR DESCRIPTION
Remove the information in the tutorial about setting a primary key to a property automatically adding an element range index for that property.

According to @grechaw, you now have to explicitly set an element range index if you want such a thing on a property with a primary key. This is based on how Entity Services now works.