### PR TITLE
QuickStart UI fixes for 2.x-develop

### DIFF
--- a/quick-start/src/main/ui/app/entities/entity.model.ts
+++ b/quick-start/src/main/ui/app/entities/entity.model.ts
@@ -138,8 +138,8 @@ export class Entity {
       },
       'filename': null,
       'hubUi': {
-        x: 100,
-        y: 100,
+        x: 10,
+        y: 115,
         width: 350,
         height: 100
       },

--- a/quick-start/src/main/ui/app/entities/property.model.ts
+++ b/quick-start/src/main/ui/app/entities/property.model.ts
@@ -13,6 +13,11 @@ export class PropertyType {
 
   // ui only
   showCollation: boolean = false;
+  isPrimaryKey: boolean = false;
+  hasElementRangeIndex: boolean = false;
+  hasRangeIndex: boolean = false;
+  hasWordLexicon: boolean = false;
+  required: boolean = false;
 
   UNICODE_COLLATION: string = 'http://marklogic.com/collation/codepoint';
 

--- a/quick-start/src/main/ui/app/entity-modeler/entity-editor.component.html
+++ b/quick-start/src/main/ui/app/entity-modeler/entity-editor.component.html
@@ -44,11 +44,11 @@
       <tbody>
         <tr *ngFor="let property of entity.definition.properties; let i = index">
           <td><input type="checkbox" [(ngModel)]="property.selected"></td>
-          <td class="col-toggler" (click)="togglePrimaryKey(property)"><i [ngClass]="{'active': isPrimaryKey(property.name)}" class="fa fa-key"></i></td>
-          <td class="col-toggler" (click)="toggleRangeIndex(property)"><i [ngClass]="{'active': isRangeIndex(property.name)}" class="fa fa-bolt"></i></td>
-          <td class="col-toggler" (click)="togglePathRangeIndex(property)"><i [ngClass]="{'active': isPathRangeIndex(property.name)}" class="fa fa-code"></i></td>
-          <td class="col-toggler" (click)="toggleWordLexicon(property)"><i [ngClass]="{'active': isWordLexicon(property.name)}" class="fa fa-won"></i></td>
-          <td class="col-toggler" (click)="toggleRequired(property)"><i [ngClass]="{'active': isRequired(property.name)}" class="fa fa-exclamation"></i></td>
+          <td class="col-toggler" (click)="togglePrimaryKey(property)"><i [ngClass]="{'active': property.isPrimaryKey}" class="fa fa-key"></i></td>
+          <td class="col-toggler" (click)="property.hasElementRangeIndex = !property.hasElementRangeIndex"><i [ngClass]="{'active': property.hasElementRangeIndex}" class="fa fa-bolt"></i></td>
+          <td class="col-toggler" (click)="property.hasRangeIndex = !property.hasRangeIndex"><i [ngClass]="{'active': property.hasRangeIndex}" class="fa fa-code"></i></td>
+          <td class="col-toggler" (click)="property.hasWordLexicon = !property.hasWordLexicon"><i [ngClass]="{'active': property.hasWordLexicon}" class="fa fa-won"></i></td>
+          <td class="col-toggler" (click)="property.required = !property.required"><i [ngClass]="{'active': property.required}" class="fa fa-exclamation"></i></td>
 
           <td><input type="text" [(ngModel)]="property.name"></td>
           <td>

--- a/quick-start/src/main/ui/app/entity-modeler/entity-modeler.component.ts
+++ b/quick-start/src/main/ui/app/entity-modeler/entity-modeler.component.ts
@@ -282,14 +282,7 @@ export class EntityModelerComponent implements AfterViewChecked {
   startEditing(entity: Entity) {
     this.entitiesService.editEntity(entity).subscribe(() => {
       this.entitiesService.saveEntity(entity).subscribe(() => {
-        let result = this.dialogService.confirm(`Saved. Update Indexes in MarkLogic?`, 'No', 'Yes');
-        result.subscribe(() => {
-          this.installService.updateIndexes().subscribe(() => {
-            this.snackbar.showSnackbar({
-              message: 'Indexes updated.',
-            });
-          });
-        }, () => {});
+        this.confirmUpdateIndexes()
       });
     },
     // cancel... do nothing
@@ -375,12 +368,32 @@ export class EntityModelerComponent implements AfterViewChecked {
     this.entitiesService.editEntity(entity).subscribe(() => {
       this.adjustCoords(entity);
       this.adjustSize(entity);
-      this.entitiesService.saveEntity(entity);
+      this.entitiesService.saveEntity(entity).subscribe(() => {
+        this.confirmUpdateIndexes();
+      });
     },
     // cancel... do nothing
     () => {
       console.log('cancel');
     });
+  }
+
+  /**
+   * Display confirm dialog and update entity indexes upon confirmation
+   */
+  confirmUpdateIndexes() {
+    let result = this.dialogService.confirm(
+      `Saved. Update Indexes in MarkLogic?`,
+      'No',
+      'Yes'
+    );
+    result.subscribe(() => {
+      this.installService.updateIndexes().subscribe(() => {
+        this.snackbar.showSnackbar({
+          message: 'Indexes updated.',
+        });
+      });
+    }, () => {});
   }
 
 }

--- a/quick-start/src/main/ui/app/entity-modeler/entity-modeler.component.ts
+++ b/quick-start/src/main/ui/app/entity-modeler/entity-modeler.component.ts
@@ -353,9 +353,28 @@ export class EntityModelerComponent implements AfterViewChecked {
     this.saveUiState();
   }
 
+  /**
+   * Adjust entity container coordinates based on number of entities already in UI
+   * @param {Entity} entity
+   */
+  adjustCoords(entity: Entity) {
+    entity.hubUi.x += 20*this.entities.length;
+    entity.hubUi.y += 30*this.entities.length;
+  }
+
+  /**
+   * Adjust entity container size based on its number of properties
+   * @param {Entity} entity
+   */
+  adjustSize(entity: Entity) {
+    entity.hubUi.height += 22*entity.definition.properties.length;
+  }
+
   addEntity() {
     let entity = new Entity().defaultValues();
     this.entitiesService.editEntity(entity).subscribe(() => {
+      this.adjustCoords(entity);
+      this.adjustSize(entity);
       this.entitiesService.saveEntity(entity);
     },
     // cancel... do nothing


### PR DESCRIPTION
Three recent fixes in QuickStart made to the develop branch, pushing to 2.x-develop:

DHFPROD-664: Stagger placement of entity containers in Entities view in QuickStart to avoid hidden containers
DHFPROD-675: Make sure new entity indexes can be added upon entity creation (via dialog) in QuickStart
DHFPROD-497: Fix selection of indexes in entity editor in QuickStart