### PR TITLE
Run modules db load in modules db

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -545,6 +545,8 @@ public class DataHubImpl implements DataHub {
                 updatedFlows.addAll(flows);
             }
 
+            runInDatabase("cts:uris(\"\", (), cts:and-not-query(cts:collection-query(\"hub-core-module\"), cts:document-query((\"/com.marklogic.hub/config.sjs\", \"/com.marklogic.hub/config.xqy\")))) ! xdmp:document-delete(.)", hubConfig.getDbName(DatabaseKind.MODULES));
+
             if (isHubInstalled) {
                 // install hub modules into MarkLogic
                 this.install();

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -347,7 +347,7 @@ public class DataHubImpl implements DataHub {
     }
 
     private void runInDatabase(String query, String databaseName) {
-        ServerEvaluationCall eval = hubConfig.newStagingClient().newServerEval();
+        ServerEvaluationCall eval = hubConfig.newModulesDbClient().newServerEval();
         String xqy =
             "xdmp:invoke-function(function() {" +
                 query +

--- a/quick-start/src/main/java/com/marklogic/quickstart/web/CurrentProjectController.java
+++ b/quick-start/src/main/java/com/marklogic/quickstart/web/CurrentProjectController.java
@@ -204,10 +204,14 @@ public class CurrentProjectController extends EnvironmentAware implements FileSy
 
     @RequestMapping(value = "/update-hub", method = RequestMethod.POST)
     public ResponseEntity<?> updateHub() throws IOException, CantUpgradeException {
-        if (dataHubService.updateHub(envConfig().getMlSettings())) {
-            installUserModules(envConfig().getMlSettings(), true);
-            startProjectWatcher();
-            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        try {
+            if (dataHubService.updateHub(envConfig().getMlSettings())) {
+                installUserModules(envConfig().getMlSettings(), true);
+                startProjectWatcher();
+                return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+            }
+        } catch (CantUpgradeException e) {
+            return new ResponseEntity<>(e, HttpStatus.BAD_REQUEST);
         }
         return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }


### PR DESCRIPTION
I noticed that runInDatabase is a private function and the only callers use the Modules database.  This change simplifies the eval stack to not use two database contexts.  This seems to help things.