### PR TITLE
DHFPROD-646 remove link in setup, no content

### DIFF
--- a/quick-start/src/main/ui/app/login/login.component.html
+++ b/quick-start/src/main/ui/app/login/login.component.html
@@ -166,7 +166,9 @@
             <p class="help-text">Each Hub Project can be deployed to multiple environments. Environments are
             determined by the presence of a gradle-env.properties file in your hub project
             directory. By default QuickStart only creates a local environment file.
+            <!-- DHFPROD-663 TODO no content here
             Read more <a target="_blank" href="https://github.com/marklogic/marklogic-data-hub/wiki/Data-Hub-QuickStart-Project-Environments">on the Data Hub Framework Wiki</a>.
+            -->
             </p>
             <app-select-list
               [items]="currentProject.environments"


### PR DESCRIPTION
Link on Choose Your Project Environment leads to wiki page with no content (“todo”).