### PR TITLE
Update Java Client API dependency to 4.0.4

### DIFF
--- a/examples/data-integration-tests/build.gradle
+++ b/examples/data-integration-tests/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     // on the Data Hub Framework library
     compile 'com.marklogic:marklogic-data-hub:2.0.3'
     compile 'com.marklogic:marklogic-xcc:9.0.4'
-    compile 'com.marklogic:marklogic-client-api:4.0.3.1'
+    compile 'com.marklogic:marklogic-client-api:4.0.4'
     // prototyping with kotlin tests
     compile 'io.github.microutils:kotlin-logging:1.4.6'
     compile "org.jetbrains.kotlin:kotlin-stdlib"

--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -25,7 +25,7 @@ ext.junitPlatformVersion = '1.0.0-RC3'
 ext.junitJupiterVersion  = '5.0.0-RC3'
 
 dependencies {
-    compile 'com.marklogic:marklogic-client-api:4.0.3.1'
+    compile 'com.marklogic:marklogic-client-api:4.0.4'
     compile 'com.marklogic:mlcp-util:0.9.0'
     compile 'com.marklogic:ml-app-deployer:3.6.1'
     compile 'com.marklogic:marklogic-data-movement-components:1.0'


### PR DESCRIPTION
Here is a PR that will fail to build until the Java Client API is available publicly.