### PR TITLE
Bug #959 fix Traces output JSON formatting

### DIFF
--- a/quick-start/src/main/ui/app/traces/trace-viewer.component.ts
+++ b/quick-start/src/main/ui/app/traces/trace-viewer.component.ts
@@ -59,7 +59,7 @@ export class TraceViewerComponent implements OnInit, OnDestroy {
     if (_.isObject(data) || _.isArray(data)) {
       return JSON.stringify(data, null, '  ');
     }
-    return data;
+    return JSON.stringify(JSON.parse(data), null, '  ');
   }
 
   getButtonClasses(plugin) {


### PR DESCRIPTION
This is a bit of a hack, we’re parsing and then re-stringifying the output if it is a string to fix the formatting.

This is also applied to rawContent (since both rawContent and output use the underlying formatting method).