### PR TITLE
Bug #960 fix Traces duration in plugin icon

### DIFF
--- a/quick-start/src/main/ui/app/traces/trace-viewer.component.html
+++ b/quick-start/src/main/ui/app/traces/trace-viewer.component.html
@@ -17,7 +17,7 @@
           class="plugin"
           [ngClass]="getButtonClasses(plugin)">
           <div class="plugin-name">{{plugin.label}}</div>
-          <div class="plugin-duration">{{plugin.duration}}<span class="unit">s</span></div>
+          <div class="plugin-duration">{{plugin.duration}}<span *ngIf="plugin.duration" class="unit">s</span></div>
         </mdl-button>
         <i class="mdi mdi-arrow-right"></i>
       </ng-template>


### PR DESCRIPTION
Do not display “s” suffix in plugin icon if no duration exists for that plugin.
This is an issue for the Write icon currently.

This will apply to all the plugin icons if, for whatever reason, they are missing a duration.