### PR TITLE
CodeMirror Rendering fixes #396

### DIFF
--- a/quick-start/src/main/ui/app/codemirror/codemirror.component.scss
+++ b/quick-start/src/main/ui/app/codemirror/codemirror.component.scss
@@ -10,3 +10,6 @@ div.CodeMirror {
   height: 100%;
 }
 
+span.cm-tab {
+  letter-spacing: 8px;
+}


### PR DESCRIPTION
Rendering fix to CodeMirror to make tab indent rendering eq to 8 spaces

Fixes #396

See new correct rendering:
http://www.clipular.com/c/5055280828907520.png?k=MIH1aCCHRUfvwzy4TfJot_w7tz8