### PR TITLE
Improvement to test infrastructure to capture screenshots with proper filenames

### DIFF
--- a/quick-start/protractor.conf.js
+++ b/quick-start/protractor.conf.js
@@ -39,6 +39,7 @@ exports.config = {
     jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
       takeScreenshots: true,
       takeScreenshotsOnlyOnFailures: true,
+      fixedScreenshotName: true,
       consolidateAll: true,
       savePath: './e2e/reports/',
       filePrefix: 'html-report'


### PR DESCRIPTION
Added a flag so screenshots on failures will have test name instead of a random number.
Will help debugging failed tests faster and better by knowing which screenshot to look at for a particular test.