### PR TITLE
Fix for DHFPROD-853, 908

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -157,13 +157,13 @@ public class DataHubImpl implements DataHub {
                     alteredString = StringUtils.rightPad(alteredString, 4, "0");
                 }
                 int ver = Integer.parseInt(alteredString.substring(0, 4));
-                if (!isNightly && ver < 9011) {
+                if (!isNightly && ver < 9050) {
                     return false;
                 }
             }
             if (isNightly) {
                 String dateString = versionString.replaceAll("[^-]+-(\\d{4})(\\d{2})(\\d{2})", "$1-$2-$3");
-                Date minDate = new GregorianCalendar(2017, 6, 1).getTime();
+                Date minDate = new GregorianCalendar(2018, 4, 5).getTime();
                 Date date = new SimpleDateFormat("y-M-d").parse(dateString);
                 if (date.before(minDate)) {
                     return false;

--- a/marklogic-data-hub/src/server-side/dhf.sjs
+++ b/marklogic-data-hub/src/server-side/dhf.sjs
@@ -188,7 +188,7 @@ function logTrace(context) {
   for (let key in inputs) {
     tracelib.setPluginInput(key, inputs[key]);
   }
-  tracelib.pluginTrace(null, "PT0S");
+  tracelib.pluginTrace(null, null, "PT0S");
 };
 
 module.exports = {


### PR DESCRIPTION
1. Fix for DHFPROD-853- Versions > 9.0-5 can install DHF
 Versions > 9.0-5 and nightly version >= 9.0-20180505 can only install DHF 

2. Fix for DHFPROD-908- Trace file is generated in correct format
