### PR TITLE
Fix date type parsing for mapping data

### DIFF
--- a/quick-start/src/main/ui/app/map/map.component.ts
+++ b/quick-start/src/main/ui/app/map/map.component.ts
@@ -176,7 +176,10 @@ export class MapComponent implements OnInit {
    */
   getType(value) {
     let result = '';
-    if (moment(value, moment.ISO_8601,true).isValid()) {
+    let RFC_2822 = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
+    if (/^\d+$/.test(value)) {
+      result = 'number';
+    } else if (moment(value, [moment.ISO_8601, RFC_2822], true).isValid()) {
       result = 'date';
     } else if (Number.isInteger(Number.parseInt(value))) {
       result = 'number';


### PR DESCRIPTION
- Do not recognize strings with all digits as dates (e.g., ordinal dates such as "1000192"). Recognize them as numbers.
- Recognize RFC 2822-formatted strings as dates.

Fixes marklogic/datahub-central#932 