### PR TITLE
 Fix for DHFPROD-872,DHFPROD-767

### DIFF
--- a/marklogic-data-hub/src/server-side/impl/flow-lib.sjs
+++ b/marklogic-data-hub/src/server-side/impl/flow-lib.sjs
@@ -109,7 +109,9 @@ function cleanData(resp, destination, dataFormat)
 {
   if (resp instanceof Document) {
     if (fn.count(resp.xpath('node()')) > 1) {
-      fn.error(null, "DATAHUB-TOO-MANY-NODES", Sequence.from([400, "Too Many Nodes!. Return just 1 node"]));
+	  if(fn.count(resp.xpath('element()')) > 1) {
+        fn.error(null, "DATAHUB-TOO-MANY-NODES", Sequence.from([400, "Too Many Nodes!. Return just 1 node"]));
+	  }	
     } else {
       resp = resp.xpath('node()');
     }

--- a/marklogic-data-hub/src/server-side/impl/flow-lib.xqy
+++ b/marklogic-data-hub/src/server-side/impl/flow-lib.xqy
@@ -299,7 +299,10 @@ declare function flow:run-flow(
     => rfc:with-id($identifier)
     => rfc:with-content(
         if ($content instance of document-node()) then
-          $content/node()
+		  if(fn:count($content/node()) > 1) then
+		    $content
+		  else
+            $content/node()
         else $content
       )
     => rfc:with-options($options)
@@ -316,7 +319,10 @@ declare function flow:clean-data($resp, $destination, $data-format)
     typeswitch($resp)
       case document-node() return
         if (fn:count($resp/node()) > 1) then
-          fn:error((), "DATAHUB-TOO-MANY-NODES", "Too Many Nodes!. Return just 1 node")
+		  if(fn:count($resp/element()) > 1) then
+            fn:error((), "DATAHUB-TOO-MANY-NODES", "Too Many Nodes!. Return just 1 node")
+		  else
+		    $resp
         else
           $resp/node()
       default return

--- a/marklogic-data-hub/src/test/resources/e2e-test/extra-nodes-js.xml
+++ b/marklogic-data-hub/src/test/resources/e2e-test/extra-nodes-js.xml
@@ -1,0 +1,26 @@
+<?xml  version="1.0" encoding="UTF-8"?>
+<envelope xmlns="http://marklogic.com/entity-services">
+<headers>
+<a xmlns="">1</a>
+<b xmlns="">2</b>
+</headers>
+<triples>
+<sem:triple xmlns:sem="http://marklogic.com/semantics">
+<sem:subject datatype="http://www.w3.org/2001/XMLSchema#string">a</sem:subject>
+<sem:predicate datatype="http://www.w3.org/2001/XMLSchema#string">b</sem:predicate>
+<sem:object datatype="http://www.w3.org/2001/XMLSchema#string">c</sem:object>
+</sem:triple>
+<sem:triple xmlns:sem="http://marklogic.com/semantics">
+<sem:subject datatype="http://www.w3.org/2001/XMLSchema#string">x</sem:subject>
+<sem:predicate datatype="http://www.w3.org/2001/XMLSchema#string">y</sem:predicate>
+<sem:object datatype="http://www.w3.org/2001/XMLSchema#string">z</sem:object>
+</sem:triple>
+</triples>
+<instance>
+<FootballFeed TimeStamp="20180316T200931+0000" xmlns="">
+Football Feed
+</FootballFeed>
+</instance>
+<attachments>
+</attachments>
+</envelope>

--- a/marklogic-data-hub/src/test/resources/e2e-test/extra-nodes.xml
+++ b/marklogic-data-hub/src/test/resources/e2e-test/extra-nodes.xml
@@ -1,0 +1,39 @@
+<?xml  version="1.0" encoding="UTF-8"?>
+<envelope xmlns="http://marklogic.com/entity-services">
+<headers>
+<a xmlns="">1</a>
+<b xmlns="">2</b>
+</headers>
+<triples>
+<sem:triple xmlns:sem="http://marklogic.com/semantics">
+<sem:subject datatype="http://www.w3.org/2001/XMLSchema#string">a</sem:subject>
+<sem:predicate datatype="http://www.w3.org/2001/XMLSchema#string">b</sem:predicate>
+<sem:object datatype="http://www.w3.org/2001/XMLSchema#string">c</sem:object>
+</sem:triple>
+<sem:triple xmlns:sem="http://marklogic.com/semantics">
+<sem:subject datatype="http://www.w3.org/2001/XMLSchema#string">x</sem:subject>
+<sem:predicate datatype="http://www.w3.org/2001/XMLSchema#string">y</sem:predicate>
+<sem:object datatype="http://www.w3.org/2001/XMLSchema#string">z</sem:object>
+</sem:triple>
+</triples>
+<instance>
+<!--
+ Copyright 2012-2018 MarkLogic Corporation 
+-->
+<!--
+ PRODUCTION HEADER
+     produced on:        abc.def.ghij.net
+     production time:    20180316T200933,494Z
+     production module:  ML::Feed::XML::Football::F10
+-->
+<?xml-stylesheet  href = "mlstyle.css" type = "text/css"?>
+<FootballFeed TimeStamp="20180316T200931+0000" xmlns="">
+Football Feed
+</FootballFeed>
+<!--
+ Copyright 2012-2018 MarkLogic Corporation 
+-->
+</instance>
+<attachments>
+</attachments>
+</envelope>

--- a/marklogic-data-hub/src/test/resources/e2e-test/input/input-extra-nodes.xml
+++ b/marklogic-data-hub/src/test/resources/e2e-test/input/input-extra-nodes.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2012-2018 MarkLogic Corporation -->
+<!-- PRODUCTION HEADER
+     produced on:        abc.def.ghij.net
+     production time:    20180316T200933,494Z
+     production module:  ML::Feed::XML::Football::F10
+-->
+<?xml-stylesheet href = "mlstyle.css" type = "text/css"?>
+<FootballFeed TimeStamp="20180316T200931+0000">
+Football Feed
+</FootballFeed>
+<!-- Copyright 2012-2018 MarkLogic Corporation -->


### PR DESCRIPTION
The fix preserves all nodes (processing instruction, comments) when running XML input flow with xqy and retains only root element when running with sjs