### PR TITLE
Fix for #1039

### DIFF
--- a/quick-start/src/main/ui/app/facets/facets.component.html
+++ b/quick-start/src/main/ui/app/facets/facets.component.html
@@ -18,7 +18,7 @@
           <i class="fa fa-plus-circle facet-add-pos"></i>
           <span *ngIf="!!value.name" title="{{ value.name }}" [ngClass]='{"facet-small-name": value.name.length > 17}'>{{ value.name | truncate : 30 }}</span>
           <em *ngIf="!value.name">blank</em>
-          <span class="badge" [mdl-badge]="value.count"></span>
+          <span class="badge" [mdl-badge]="value.count">{{ value.count }}</span>
           <i class="fa fa-ban facet-add-neg" *ngIf="shouldNegate" (click)="negate({facet: facet.__key, value: value.name})" title="{{ value.name }}"></i>
         </div>
         <div *ngIf="shouldShowMore &amp;&amp; !facet.displayingAll">


### PR DESCRIPTION
MDL component styles require that the span tag have contents, otherwise, style applied sets "display: none;"   Fix adds count value within the badge span tag.