### PR TITLE
Dhfprod 500 attachments

### DIFF
--- a/marklogic-data-hub/src/server-side/impl/flow-lib.sjs
+++ b/marklogic-data-hub/src/server-side/impl/flow-lib.sjs
@@ -266,7 +266,12 @@ function makeEnvelope(content, headers, triples, dataFormat) {
 
         nb.startElement("attachments", "http://marklogic.com/entity-services");
         if (content instanceof Object && content.hasOwnProperty("$attachments")) {
-          nb.addNode(content["$attachments"]);
+            let attachments = content["$attachments"];
+            if (tracelib.isXmlNode(content)) {
+              nb.addNode(attachments);
+            } else {
+              nb.addText(xdmp.quote(attachments))
+            }
         }
         nb.endElement();
       nb.endElement();

--- a/marklogic-data-hub/src/server-side/impl/flow-lib.sjs
+++ b/marklogic-data-hub/src/server-side/impl/flow-lib.sjs
@@ -348,7 +348,8 @@ function instanceToCanonicalJson(entityInstance) {
   else {
     o = {};
     for (let key in entityInstance) {
-      if (key !== '$type') {
+      if (key === '$attachments' || key === '$type' || key === '$version') {
+      } else {
         let instanceProperty = entityInstance[key];
         if (instanceProperty instanceof Sequence) {
           for (let prop in instanceProperty) {

--- a/marklogic-data-hub/src/server-side/impl/flow-lib.sjs
+++ b/marklogic-data-hub/src/server-side/impl/flow-lib.sjs
@@ -267,7 +267,7 @@ function makeEnvelope(content, headers, triples, dataFormat) {
         nb.startElement("attachments", "http://marklogic.com/entity-services");
         if (content instanceof Object && content.hasOwnProperty("$attachments")) {
             let attachments = content["$attachments"];
-            if (tracelib.isXmlNode(content)) {
+            if (attachments instanceof XMLDocument || tracelib.isXmlNode(attachments)) {
               nb.addNode(attachments);
             } else {
               nb.addText(xdmp.quote(attachments))

--- a/marklogic-data-hub/src/server-side/impl/flow-lib.xqy
+++ b/marklogic-data-hub/src/server-side/impl/flow-lib.xqy
@@ -479,7 +479,7 @@ declare function flow:instance-to-canonical-json(
       let $_ := (
         for $key in map:keys($entity-instance)
         let $instance-property := map:get($entity-instance, $key)
-        where ($key castable as xs:NCName and $key ne "$type")
+        where ($key castable as xs:NCName and not($key = ("$type", "$attachments","$version")))
         return
           typeswitch ($instance-property)
           (: This branch handles embedded objects.  You can choose to prune

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/EndToEndFlowTests.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/EndToEndFlowTests.java
@@ -42,6 +42,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.skyscreamer.jsonassert.JSONCompareResult;
 import org.w3c.dom.Document;
 
+import javax.xml.transform.TransformerException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -988,7 +989,7 @@ public class EndToEndFlowTests extends HubTestBase {
         }
     }
 
-    private void testInputFlowViaMlcp(String prefix, String fileSuffix, DatabaseClient databaseClient, CodeFormat codeFormat, DataFormat dataFormat, boolean useEs, Map<String, Object> options, FinalCounts finalCounts) throws InterruptedException {
+    private void testInputFlowViaMlcp(String prefix, String fileSuffix, DatabaseClient databaseClient, CodeFormat codeFormat, DataFormat dataFormat, boolean useEs, Map<String, Object> options, FinalCounts finalCounts) throws InterruptedException, TransformerException {
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME, HubConfig.DEFAULT_JOB_NAME);
 
         String flowName = getFlowName(prefix, codeFormat, dataFormat, FlowType.INPUT, useEs);
@@ -1080,6 +1081,8 @@ public class EndToEndFlowTests extends HubTestBase {
             } else {
                 Document expected = getXmlFromResource("e2e-test/" + filename + "." + dataFormat.toString());
                 Document actual = stagingDocMgr.read("/input" + fileSuffix + "." + dataFormat.toString()).next().getContent(new DOMHandle()).get();
+                //debugOutput(expected);
+                //debugOutput(actual);
                 assertXMLEqual(expected, actual);
             }
         }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -15,12 +15,7 @@
  */
 package com.marklogic.hub;
 
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -43,6 +38,12 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 
 import com.marklogic.hub.error.DataHubConfigurationException;
 import com.marklogic.hub.util.ComboListener;
@@ -1007,6 +1008,17 @@ public class HubTestBase {
         }
     }
 
+    protected void debugOutput(Document xmldoc) throws TransformerException {
+        debugOutput(xmldoc, System.out);
+    }
+
+    protected void debugOutput(Document xmldoc, OutputStream os) throws TransformerException {
+        TransformerFactory tf = TransformerFactory.newInstance();
+        Transformer transformer = tf.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+        transformer.transform(new DOMSource(xmldoc), new StreamResult(os));
+    }
 }
 
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunnerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunnerTest.java
@@ -15,13 +15,18 @@
  */
 package com.marklogic.hub.flow;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.eval.EvalResultIterator;
+import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.hub.DataHub;
 import com.marklogic.hub.FlowManager;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.HubTestBase;
 import com.marklogic.hub.scaffold.Scaffolding;
+import org.custommonkey.xmlunit.XMLAssert;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,42 +38,43 @@ import java.nio.file.*;
 import java.util.HashMap;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class FlowRunnerTest extends HubTestBase {
     private static final String ENTITY = "e2eentity";
     private static Path projectDir = Paths.get(".", "ye-olde-project");
+    private Scaffolding scaffolding;
+
 
     @Before
     public void setup() throws IOException {
         XMLUnit.setIgnoreWhitespace(true);
-
         deleteProjectDir();
-
         createProjectDir();
-
         enableDebugging();
         enableTracing();
 
-        Scaffolding scaffolding = Scaffolding.create(projectDir.toString(), stagingClient);
+        scaffolding = Scaffolding.create(projectDir.toString(), stagingClient);
         scaffolding.createEntity(ENTITY);
-        scaffolding.createFlow(ENTITY, "testharmonize", FlowType.HARMONIZE,
-            CodeFormat.XQUERY, DataFormat.XML);
-
         DataHub dh = DataHub.create(getHubConfig());
         dh.clearUserModules();
 
+    }
+
+    @Test
+    public void testPassOptions() throws IOException, ParserConfigurationException, SAXException {
+        scaffolding.createFlow(ENTITY, "testharmonize", FlowType.HARMONIZE,
+            CodeFormat.XQUERY, DataFormat.XML);
         Files.copy(getResourceStream("flow-runner-test/collector.xqy"),
             projectDir.resolve("plugins/entities/" + ENTITY + "/harmonize/testharmonize/collector.xqy"),
             StandardCopyOption.REPLACE_EXISTING);
         Files.copy(getResourceStream("flow-runner-test/content-for-options.xqy"),
             projectDir.resolve("plugins/entities/" + ENTITY + "/harmonize/testharmonize/content.xqy"),
             StandardCopyOption.REPLACE_EXISTING);
+
         installUserModules(getHubConfig(), false);
 
-    }
-
-    @Test
-    public void testPassOptions() throws IOException, ParserConfigurationException, SAXException {
 
         FlowManager fm = FlowManager.create(getHubConfig());
         Flow harmonizeFlow = fm.getFlow(ENTITY, "testharmonize",
@@ -86,11 +92,16 @@ public class FlowRunnerTest extends HubTestBase {
 
         EvalResultIterator resultItr = runInDatabase("xdmp:database('" + HubConfig.DEFAULT_FINAL_NAME + "')", HubConfig.DEFAULT_FINAL_NAME);
         String targetDB = resultItr.next().getString();
-        String expected = "<envelope xmlns=\"http://marklogic.com/entity-services\">\n" +
+        String expected =
+            "<envelope xmlns=\"http://marklogic.com/entity-services\">\n" +
             "  <headers></headers>\n" +
             "  <triples></triples>\n" +
             "  <instance>\n" +
-            "    <result xmlns=\"\">\n" +
+            "   <info>\n" +
+            "     <title>Person</title>\n" +
+            "     <version>0.0.2</version>\n" +
+            "   </info>\n" +
+            "    <Person xmlns=\"\">\n" +
             "      <name>Bob Smith</name>\n" +
             "      <age>55</age>\n" +
             "      <entity>e2eentity</entity>\n" +
@@ -98,11 +109,141 @@ public class FlowRunnerTest extends HubTestBase {
             "      <flowType>harmonize</flowType>\n" +
             "      <dataFormat>xml</dataFormat>\n" +
             "      <target-database>" + targetDB + "</target-database>\n" +
-            "    </result>\n" +
+            "    </Person>\n" +
             "  </instance>\n" +
-            "  <attachments></attachments>\n" +
+            "  <attachments><original xmlns=\"\">data</original></attachments>\n" +
             "</envelope>";
 
-        assertXMLEqual(expected, finalDocMgr.read("1.xml").next().getContent(new StringHandle()).get());
+        String actual = finalDocMgr.read("1.xml").next().getContent(new StringHandle()).get();
+
+        assertXMLEqual(expected, actual);
     }
+
+    // bug DHFPROD-500, attachments showing up in two places
+    @Test
+    public void testEnvelopeSJS() throws IOException {
+        scaffolding.createFlow(ENTITY, "testharmonize-sjs-json", FlowType.HARMONIZE,
+            CodeFormat.JAVASCRIPT, DataFormat.JSON);
+        //testing sjs JSON canonical instance
+        Files.copy(getResourceStream("flow-runner-test/collector.sjs"),
+            projectDir.resolve("plugins/entities/" + ENTITY + "/harmonize/testharmonize-sjs-json/collector.sjs"),
+            StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(getResourceStream("flow-runner-test/contentTestingEnvelope.sjs"),
+            projectDir.resolve("plugins/entities/" + ENTITY + "/harmonize/testharmonize-sjs-json/content.sjs"),
+            StandardCopyOption.REPLACE_EXISTING);
+
+        installUserModules(getHubConfig(), false);
+
+
+        FlowManager fm = FlowManager.create(getHubConfig());
+        Flow harmonizeFlow = fm.getFlow(ENTITY, "testharmonize-sjs-json",
+            FlowType.HARMONIZE);
+        FlowRunner flowRunner = fm.newFlowRunner()
+            .withFlow(harmonizeFlow)
+            .withBatchSize(10)
+            .withThreadCount(1);
+        flowRunner.run();
+        flowRunner.awaitCompletion();
+
+        JsonNode jsonEnvelope = finalDocMgr.read("1.json").next().getContent(new JacksonHandle()).get();
+
+        try {
+            logger.debug(new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(jsonEnvelope));
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        assertNull(jsonEnvelope.get("envelope").get("instance").get("Person").get("$attachments"));
+        assertNotNull(jsonEnvelope.get("envelope").get("attachments"));
+    }
+
+    @Test
+    public void testEnvelopeXQY() throws IOException {
+
+        //testing xqy JSON canonical instance
+        scaffolding.createFlow(ENTITY, "testharmonize-xqy-json", FlowType.HARMONIZE,
+            CodeFormat.XQUERY, DataFormat.JSON);
+        Files.copy(getResourceStream("flow-runner-test/collector2.xqy"),
+            projectDir.resolve("plugins/entities/" + ENTITY + "/harmonize/testharmonize-xqy-json/collector.xqy"),
+            StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(getResourceStream("flow-runner-test/content-testing-envelope.xqy"),
+            projectDir.resolve("plugins/entities/" + ENTITY + "/harmonize/testharmonize-xqy-json/content.xqy"),
+            StandardCopyOption.REPLACE_EXISTING);
+
+        installUserModules(getHubConfig(), false);
+
+
+
+
+        FlowManager fm = FlowManager.create(getHubConfig());
+        Flow harmonizeFlow = fm.getFlow(ENTITY, "testharmonize-xqy-json",
+            FlowType.HARMONIZE);
+        FlowRunner flowRunner = fm.newFlowRunner()
+            .withFlow(harmonizeFlow)
+            .withBatchSize(10)
+            .withThreadCount(1);
+        flowRunner.run();
+        flowRunner.awaitCompletion();
+
+        JsonNode jsonEnvelope = finalDocMgr.read("2.json").next().getContent(new JacksonHandle()).get();
+
+        try {
+            logger.debug(new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(jsonEnvelope));
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        assertNull(jsonEnvelope.get("envelope").get("instance").get("Person").get("$attachments"));
+        assertNotNull(jsonEnvelope.get("envelope").get("attachments"));
+    }
+
+    // bug DHFPROD-500, attachments showing up in two places
+    @Test
+    public void testEnvelopeSJSXML() throws IOException, SAXException {
+        scaffolding.createFlow(ENTITY, "testharmonize-sjs-xml", FlowType.HARMONIZE,
+            CodeFormat.JAVASCRIPT, DataFormat.XML);
+
+        Files.copy(getResourceStream("flow-runner-test/collector2.sjs"),
+            projectDir.resolve("plugins/entities/" + ENTITY + "/harmonize/testharmonize-sjs-xml/collector.sjs"),
+            StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(getResourceStream("flow-runner-test/contentTestingEnvelope.sjs"),
+            projectDir.resolve("plugins/entities/" + ENTITY + "/harmonize/testharmonize-sjs-xml/content.sjs"),
+            StandardCopyOption.REPLACE_EXISTING);
+
+        installUserModules(getHubConfig(), false);
+
+
+        FlowManager fm = FlowManager.create(getHubConfig());
+        Flow harmonizeFlow = fm.getFlow(ENTITY, "testharmonize-sjs-xml",
+            FlowType.HARMONIZE);
+        FlowRunner flowRunner = fm.newFlowRunner()
+            .withFlow(harmonizeFlow)
+            .withBatchSize(10)
+            .withThreadCount(1);
+        flowRunner.run();
+        flowRunner.awaitCompletion();
+
+        String expected =
+            "<envelope xmlns=\"http://marklogic.com/entity-services\">\n" +
+                "  <headers></headers>\n" +
+                "  <triples></triples>\n" +
+                "  <instance>\n" +
+                "   <info>\n" +
+                "     <title>Person</title>\n" +
+                "     <version>0.0.1</version>\n" +
+                "   </info>\n" +
+                "    <Person xmlns=\"\">\n" +
+                "       <an>instance</an>\n" +
+                "       <document>that</document>\n" +
+                "       <is>not</is>\n" +
+                "       <harmononized>yeah</harmononized>\n" +
+                "    </Person>\n" +
+                "  </instance>\n" +
+                "  <attachments>{\"and\":\"originaldochere\"}</attachments>\n" +
+                "</envelope>";
+
+        String actual = finalDocMgr.read("2.xml").next().getContentAs(String.class);
+        logger.debug(actual);
+        XMLAssert.assertXMLEqual(expected, actual);
+
+    }
+
 }

--- a/marklogic-data-hub/src/test/resources/flow-runner-test/collector2.sjs
+++ b/marklogic-data-hub/src/test/resources/flow-runner-test/collector2.sjs
@@ -1,0 +1,14 @@
+/*
+ * Collect IDs plugin
+ *
+ * @param options - a map containing options. Options are sent from Java
+ *
+ * @return - an array of ids or uris
+ */
+function collect(options) {
+  return "2.xml";
+}
+
+module.exports = {
+  collect: collect
+};

--- a/marklogic-data-hub/src/test/resources/flow-runner-test/collector2.xqy
+++ b/marklogic-data-hub/src/test/resources/flow-runner-test/collector2.xqy
@@ -1,0 +1,19 @@
+xquery version "1.0-ml";
+
+module namespace plugin = "http://marklogic.com/data-hub/plugins";
+
+declare option xdmp:mapping "false";
+
+(:~
+ : Collect IDs plugin
+ :
+ : @param $options - a map containing options. Options are sent from Java
+ :
+ : @return - a sequence of ids or uris
+ :)
+declare function plugin:collect(
+  $options as map:map) as xs:string*
+{
+  "2.json"
+};
+

--- a/marklogic-data-hub/src/test/resources/flow-runner-test/content-testing-envelope.xqy
+++ b/marklogic-data-hub/src/test/resources/flow-runner-test/content-testing-envelope.xqy
@@ -17,15 +17,14 @@ declare option xdmp:mapping "false";
  :)
 declare function plugin:create-content(
   $id as xs:string,
-  $options as map:map) as map:map
+  $options as map:map)
 {
-  let $m := json:object()
-  let $_ :=
-    for $x in map:keys($options)
-    return
-      map:put($m, $x, map:get($options, $x))
-  let $_ := map:put($m, "$type", "Person")
-  let $_ := map:put($m, "$version", "0.0.2")
-  let $_ := map:put($m, "$attachments", element original { "data" } )
-  return $m
+  object-node {
+    "$type":"Person",
+    "$version":"0.0.2",
+    "$attachments": object-node { "you":"there!" },
+    "and":"of",
+    "course":"other",
+    "keys":"yeah"
+  }=>xdmp:from-json()
 };

--- a/marklogic-data-hub/src/test/resources/flow-runner-test/contentTestingEnvelope.sjs
+++ b/marklogic-data-hub/src/test/resources/flow-runner-test/contentTestingEnvelope.sjs
@@ -1,0 +1,24 @@
+/*
+ * Create Content Plugin
+ *
+ * @param id         - the identifier returned by the collector
+ * @param options    - an object containing options. Options are sent from Java
+ *
+ * @return - your content
+ */
+function createContent(id, options) {
+  return {
+    "an":"instance",
+    "document":"that",
+    "is":"not",
+    "harmononized":"yeah",
+    "$attachments": { "and" : "originaldochere" },
+    "$type":"Person",
+    "$version":"0.0.1"
+  }
+}
+
+module.exports = {
+  createContent: createContent
+};
+


### PR DESCRIPTION
This change fixes issues we've seen with $attachments being attached to JSON instances at multiple locations.

I extended FlowRunnerTest.java to cover the four combinations of language and format.  The DHF flow libs were not removing the keys from the json objects.

Some of our flows are not generating map:map from content plugins, which is the trigger on which ES instances are made... 

I'm looking over E2E flows, there are some assertion failures now.  I'll see what has changed and modify this PR accordingly before asking for review.