### PR TITLE
DHFPROD-983 job db reports no counts

### DIFF
--- a/quick-start/src/main/ui/app/dashboard/dashboard.component.html
+++ b/quick-start/src/main/ui/app/dashboard/dashboard.component.html
@@ -11,7 +11,7 @@
     </div>
     <div layout="row" layout-align="center center" *ngFor="let row of rows">
       <div class="info-card" mdl-shadow="2" *ngFor="let db of databases.slice(row * 2, (row * 2) + 2)">
-        <div class="info-title"><i class="mdi mdi-database"></i> {{db | titlecase }}</div>
+        <div class="info-title"><i class="mdi mdi-database"></i> {{labelify(db) | titlecase }}</div>
         <div class="info-body" layout="column" *ngIf="!stats">
           <div class="info-column" layout="column" layout-align="center center">
             <mdl-spinner single-color active></mdl-spinner>

--- a/quick-start/src/main/ui/app/dashboard/dashboard.component.ts
+++ b/quick-start/src/main/ui/app/dashboard/dashboard.component.ts
@@ -18,7 +18,7 @@ export class DashboardComponent implements OnInit {
   databases: any = [
     'staging',
     'final',
-    'jobs'
+    'job'
   ];
 
   stats: any;
@@ -40,6 +40,14 @@ export class DashboardComponent implements OnInit {
     this.getStatus();
   }
 
+  labelify(db) {
+    if (db === "job") {
+      return "jobs";
+    } else {
+      return db;
+    }
+
+  }
   getDbCount(db) {
     return this.stats[db + 'Count'];
   }


### PR DESCRIPTION
This fix to the angular app keeps the old configuration key from before the regression (job), but displays the database name as label (jobs).

Fixing this any other way would have introduced compatibility issues -- all of the configuration keys start with 'job' but the database name is -JOBS