### PR TITLE
DHFPROD-907 Close Iterator after use

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/impl/FlowRunnerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/impl/FlowRunnerImpl.java
@@ -375,16 +375,22 @@ public class FlowRunnerImpl implements FlowRunner {
                     params.put("options", objectMapper.writeValueAsString(options));
                 }
                 ResourceServices.ServiceResultIterator resultItr = this.getServices().post(params, new StringHandle("{}").withFormat(Format.JSON));
-                if (resultItr == null || ! resultItr.hasNext()) {
-                    resp = new RunFlowResponse();
+                try {
+                    if (resultItr == null || !resultItr.hasNext()) {
+                        resp = new RunFlowResponse();
+                    }
+                    else {
+                        ResourceServices.ServiceResult res = resultItr.next();
+                        StringHandle handle = new StringHandle();
+                        ObjectMapper objectMapper = new ObjectMapper();
+                        resp = objectMapper.readValue(res.getContent(handle).get(), RunFlowResponse.class);
+                    }
                 }
-                else {
-                    ResourceServices.ServiceResult res = resultItr.next();
-                    StringHandle handle = new StringHandle();
-                    ObjectMapper objectMapper = new ObjectMapper();
-                    resp = objectMapper.readValue(res.getContent(handle).get(), RunFlowResponse.class);
+                finally {
+                    if (resultItr != null) {
+                        resultItr.close();
+                    }
                 }
-
             }
             catch(Exception e) {
                 e.printStackTrace();


### PR DESCRIPTION
This along with an update to MarkLogic Java Client API which has the fixes for https://github.com/marklogic/java-client-api/issues/881 and https://github.com/marklogic/java-client-api/issues/920 will fix the issue DHFPROD-907 (Excessive sockets in time_wait in harmonization tasks)