### PR TITLE
Minor cleanup in FlowRunnerImpl and FlowManagerImpl

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/FlowManagerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/FlowManagerImpl.java
@@ -16,7 +16,6 @@
 package com.marklogic.hub.impl;
 
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.datamovement.DataMovementManager;
 import com.marklogic.client.extensions.ResourceManager;
 import com.marklogic.client.extensions.ResourceServices.ServiceResult;
 import com.marklogic.client.extensions.ResourceServices.ServiceResultIterator;
@@ -27,7 +26,6 @@ import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.collector.impl.CollectorImpl;
 import com.marklogic.hub.flow.*;
 import com.marklogic.hub.flow.impl.FlowRunnerImpl;
-import com.marklogic.hub.job.JobManager;
 import com.marklogic.hub.main.impl.MainPluginImpl;
 import com.marklogic.hub.scaffold.Scaffolding;
 import org.apache.commons.io.FileUtils;
@@ -46,25 +44,16 @@ import java.util.Properties;
 import java.util.regex.Pattern;
 
 public class FlowManagerImpl extends ResourceManager implements FlowManager {
-    private static final String HUB_NS = "http://marklogic.com/data-hub";
+
     private static final String NAME = "ml:flow";
 
     private DatabaseClient stagingClient;
-    private DatabaseClient finalClient;
-    private DatabaseClient jobClient;
     private HubConfig hubConfig;
-    private JobManager jobManager;
-
-    private DataMovementManager dataMovementManager;
 
     public FlowManagerImpl(HubConfig hubConfig) {
         super();
         this.hubConfig = hubConfig;
         this.stagingClient = hubConfig.newStagingManageClient();
-        this.finalClient = hubConfig.newFinalManageClient();
-        this.jobClient = hubConfig.newJobDbClient();
-        this.jobManager = JobManager.create(this.jobClient);
-        this.dataMovementManager = this.stagingClient.newDataMovementManager();
         this.stagingClient.init(NAME, this);
     }
 


### PR DESCRIPTION
I made some minor cleanup changes while reading the Java code for the first time:

- Renamed sourceClient to stagingClient for consistency
- Only instantiating FlowResource once now (it's threadsafe and thus we don't need to create one per batch)
- Removed unused variables in FlowManagerImpl