### PR TITLE
Do not allow duplicate mapping names

### DIFF
--- a/quick-start/src/main/ui/app/mappings/mappings.component.html
+++ b/quick-start/src/main/ui/app/mappings/mappings.component.html
@@ -12,7 +12,7 @@
           <div [attr.data-entity]="entity.name" class="mdl-list__item-primary-content">
             <i class="fa fa-industry"></i> {{ entity.name }}
             <div class="mdl-layout-spacer"></div>
-            <mdl-button *ngIf="entity.hasDocs" mdl-button-type="icon" id="new-map" (click)="showNewMapping(entity)">
+            <mdl-button *ngIf="entity.hasDocs" mdl-button-type="icon" id="new-map" (click)="showNewMapping(entity, mappings)">
               <i class="fa fa-plus"></i>
             </mdl-button>
             <mdl-button *ngIf="!entity.hasDocs" mdl-button-type="icon" id="new-map-disabled" disabled>

--- a/quick-start/src/main/ui/app/mappings/mappings.component.ts
+++ b/quick-start/src/main/ui/app/mappings/mappings.component.ts
@@ -97,7 +97,7 @@ export class MappingsComponent implements OnInit, OnDestroy, AfterViewInit {
       this.activeMapping && this.activeMapping.name === mapping.name;
   }
 
-  showNewMapping(entity: Entity) {
+  showNewMapping(entity: Entity, mappings: Array<Mapping>) {
     let actions = {
       save: (newMapName: string, newMapDesc: string) => {
 
@@ -126,7 +126,8 @@ export class MappingsComponent implements OnInit, OnDestroy, AfterViewInit {
       component: NewMapComponent,
       providers: [
         { provide: 'actions', useValue: actions },
-        { provide: 'entity', useValue: entity}
+        { provide: 'entity', useValue: entity },
+        { provide: 'mappings', useValue: mappings }
       ],
       isModal: true
     });

--- a/quick-start/src/main/ui/app/mappings/new-map.component.html
+++ b/quick-start/src/main/ui/app/mappings/new-map.component.html
@@ -10,23 +10,34 @@
     <form (submit)="create()">
       <div class="modal-body">
         <div class="md-dialog-content" flex layout="column">
-          <mdl-textfield name="mapNameInput" type="text"
-            required autofocus floating-label
+          <mdl-textfield
+            name="mapNameInput"
+            type="text"
+            [class.is-invalid]="nameDuplicate()"
+            floating-label
             id="mapNameInput"
             label="Mapping Name (required)"
+            disableNativeValidityChecking
             #mapNameInput="ngModel"
-            [(ngModel)]="mapName"></mdl-textfield>
+            [(ngModel)]="mapName"
+            error-msg="A mapping with this name already exists"
+          >
+          </mdl-textfield>
         </div>
-        <mdl-textfield name="mapDescInput" type="text"
-             required floating-label
-             id="mapDescInput"
-             label="Mapping Description"
-             #mapDescInput="ngModel"
-             [(ngModel)]="mapDesc">
+        <mdl-textfield
+            name="mapDescInput"
+            type="text"
+            floating-label
+            id="mapDescInput"
+            label="Mapping Description"
+            disableNativeValidityChecking
+            #mapDescInput="ngModel"
+            [(ngModel)]="mapDesc"
+        >
         </mdl-textfield>
       </div>
       <div class="mdl-dialog__actions">
-        <button type="submit" [disabled]="mapNameInput && mapNameInput.errors && mapNameInput.errors.required" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect">Create</button>
+        <button type="submit" [disabled]="nameEmpty() || nameDuplicate()" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect">Create</button>
         <button type="button" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect" (click)="cancel()">Cancel</button>
       </div>
     </form>

--- a/quick-start/src/main/ui/app/mappings/new-map.component.scss
+++ b/quick-start/src/main/ui/app/mappings/new-map.component.scss
@@ -20,3 +20,8 @@
 /deep/ .mdl-textfield__label:after {
   bottom: 12px;
 }
+
+/deep/ .is-invalid .mdl-textfield__input,
+/deep/ .mdl-textfield__error {
+  color: #a94442;
+}

--- a/quick-start/src/main/ui/app/mappings/new-map.component.ts
+++ b/quick-start/src/main/ui/app/mappings/new-map.component.ts
@@ -17,18 +17,21 @@ import {Entity} from "../entities";
 export class NewMapComponent {
   actions: any;
   entity: Entity;
-  mapName: string;
+  mapName: string = '';
   mapDesc: string = '';
+  mappings: Array<Mapping>;
 
   constructor(
     private dialog: MdlDialogReference,
     private envService: EnvironmentService,
     private mapService: MapService,
     @Inject('actions') actions: any,
-    @Inject('entity') entity: Entity
+    @Inject('entity') entity: Entity,
+    @Inject('mappings') mappings: Array<Mapping>
   ) {
     this.actions = actions;
     this.entity = entity;
+    this.mappings = mappings;
   }
 
   ngOnInit() {
@@ -45,8 +48,25 @@ export class NewMapComponent {
     this.cancel();
   }
 
+  nameEmpty() {
+    let result = true;
+    if (this.mapName) {
+      result = this.mapName.length === 0;
+    }
+    return result;
+  }
+
+  nameDuplicate() {
+    let result;
+    if (this.mappings && this.mapName) {
+      let name = this.mapName;
+      result =  _.findIndex(this.mappings, function(m) { return m.name === name; });
+    }
+    return result > -1;
+  }
+
   create() {
-    if (this.mapName && this.mapName.length > 0) {
+    if (!this.nameEmpty() && !this.nameDuplicate()) {
       this.hide();
       if (this.actions && this.actions.save) {
         this.actions.save(this.mapName, this.mapDesc);


### PR DESCRIPTION
When duplicate name is entered, the following error text is displayed:

A mapping with this name already exists

And the Create button is disabled.