### PR TITLE
E2e/harmonize mappings

### DIFF
--- a/quick-start/e2e/page-objects/viewer/viewer.ts
+++ b/quick-start/e2e/page-objects/viewer/viewer.ts
@@ -26,7 +26,7 @@ export class ViewerPage extends AppPage {
   }
 
   verifyHarmonizedProperty(propertyName: string, harmonizedValue: string) {
-    return element(by.xpath(`//span[@class="cm-variable" and contains(text(), ${propertyName})]/../span[@class="cm-string" and contains(text(), ${harmonizedValue})]`));
+    return element(by.xpath(`//span[@class="cm-variable" and contains(text(), "${propertyName}")]/../span[@class="cm-string" and contains(text(), "${harmonizedValue}")]`));
   }
 }
 

--- a/quick-start/e2e/page-objects/viewer/viewer.ts
+++ b/quick-start/e2e/page-objects/viewer/viewer.ts
@@ -16,6 +16,18 @@ export class ViewerPage extends AppPage {
   searchResultUri() {
     return element(by.css('.title > h4'));
   }
+
+  verifyVariableName(variableName: string) {
+    return element(by.cssContainingText('.cm-variable', variableName));
+  }
+
+  verifyStringName(stringName: string) {
+    return element(by.cssContainingText('.cm-string', stringName));
+  }
+
+  verifyHarmonizedProperty(propertyName: string, harmonizedValue: string) {
+    return element(by.xpath(`//span[@class="cm-variable" and contains(text(), ${propertyName})]/../span[@class="cm-string" and contains(text(), ${harmonizedValue})]`));
+  }
 }
 
 var viewerPage = new ViewerPage();

--- a/quick-start/e2e/specs/create/create.ts
+++ b/quick-start/e2e/specs/create/create.ts
@@ -599,7 +599,7 @@ export default function() {
     });
 
     it ('should open the Entity disclosure', function() {
-      flowPage.entityDisclosure('TestEntity').click();
+      flowPage.clickEntityDisclosure('TestEntity');
     });
     
     ['sjs', 'xqy'].forEach((codeFormat) => {
@@ -625,7 +625,7 @@ export default function() {
     });
     
     it ('should open Product entity disclosure', function() {
-      flowPage.entityDisclosure('Product').click();
+      flowPage.clickEntityDisclosure('Product');
     });
 
     it ('should create input and harmonize flows on Product entity', function() {
@@ -666,13 +666,13 @@ export default function() {
       expect(flowPage.getValueFlowOptionsByPosition(3).getAttribute('value')).toEqual('2017-03-07');
       //move to other harmonize flow and go back to the flow
       console.log('going to the other flow and back');
-      flowPage.entityDisclosure('TestEntity').click();
+      flowPage.clickEntityDisclosure('TestEntity');
       browser.wait(EC.visibilityOf(flowPage.getFlow('TestEntity', 'sjs json HARMONIZE', 'HARMONIZE')));
       expect(flowPage.getFlow('TestEntity', 'sjs json HARMONIZE', 'HARMONIZE').isPresent()).toBe(true);
       flowPage.getFlow('TestEntity', 'sjs json HARMONIZE', 'HARMONIZE').click();
       browser.wait(EC.visibilityOf(flowPage.runHarmonizeButton()));
       expect(flowPage.runHarmonizeButton().isPresent()).toBe(true);
-      flowPage.entityDisclosure('Product').click();
+      flowPage.clickEntityDisclosure('Product');
       browser.wait(EC.visibilityOf(flowPage.getFlow('Product', 'Harmonize Products', 'HARMONIZE')));
       expect(flowPage.getFlow('Product', 'Harmonize Products', 'HARMONIZE').isPresent()).toBe(true);
       flowPage.getFlow('Product', 'Harmonize Products', 'HARMONIZE').click();
@@ -698,7 +698,7 @@ export default function() {
       console.log('verify the removed option');
       flowPage.entitiesTab.click();
       entityPage.flowsTab.click();
-      flowPage.entityDisclosure('Product').click();
+      flowPage.clickEntityDisclosure('Product');
       browser.wait(EC.visibilityOf(flowPage.getFlow('Product', 'Harmonize Products', 'HARMONIZE')));
       expect(flowPage.getFlow('Product', 'Harmonize Products', 'HARMONIZE').isPresent()).toBe(true);
       flowPage.getFlow('Product', 'Harmonize Products', 'HARMONIZE').click();

--- a/quick-start/e2e/specs/create/create.ts
+++ b/quick-start/e2e/specs/create/create.ts
@@ -601,20 +601,29 @@ export default function() {
     it ('should open the Entity disclosure', function() {
       flowPage.entityDisclosure('TestEntity').click();
     });
-
-    ['INPUT', 'HARMONIZE'].forEach((flowType) => {
-      ['sjs', 'xqy'].forEach((codeFormat) => {
-        ['xml', 'json'].forEach((dataFormat) => {
-          let flowName = `${codeFormat} ${dataFormat} ${flowType}`;
-          it (`should create a ${flowName} flow`, function() {
-            flowPage.createFlow('TestEntity', flowName, flowType, dataFormat, codeFormat, false);
-            browser.wait(EC.visibilityOf(flowPage.getFlow('TestEntity', flowName, flowType)));
-            expect(flowPage.getFlow('TestEntity', flowName, flowType).isDisplayed()).toBe(true, flowName + ' is not present');
-          });
+    
+    ['sjs', 'xqy'].forEach((codeFormat) => {
+      ['xml', 'json'].forEach((dataFormat) => {
+        let flowName = `${codeFormat} ${dataFormat} INPUT`;
+        it (`should create a ${flowName} input flow`, function() {
+          flowPage.createInputFlow('TestEntity', flowName, dataFormat, codeFormat, false);
+          browser.wait(EC.visibilityOf(flowPage.getFlow('TestEntity', flowName, 'INPUT')));
+          expect(flowPage.getFlow('TestEntity', flowName, 'INPUT').isDisplayed()).toBe(true, flowName + ' is not present');
         });
       });
     });
 
+    ['sjs', 'xqy'].forEach((codeFormat) => {
+      ['xml', 'json'].forEach((dataFormat) => {
+        let flowName = `${codeFormat} ${dataFormat} HARMONIZE`;
+        it (`should create a ${flowName} harmonize flow`, function() {
+          flowPage.createHarmonizeFlow('TestEntity', flowName, dataFormat, codeFormat, true);
+          browser.wait(EC.visibilityOf(flowPage.getFlow('TestEntity', flowName, 'HARMONIZE')));
+          expect(flowPage.getFlow('TestEntity', flowName, 'HARMONIZE').isDisplayed()).toBe(true, flowName + ' is not present');
+        });
+      });
+    });
+    
     it ('should open Product entity disclosure', function() {
       flowPage.entityDisclosure('Product').click();
     });

--- a/quick-start/e2e/specs/mappings/typeAhead.ts
+++ b/quick-start/e2e/specs/mappings/typeAhead.ts
@@ -30,6 +30,11 @@ export default function() {
           toBe(true, 'Load TypeAhead' + ' is not present');
       });
 
+      it ('should redeploy modules', function() {
+        flowPage.redeployButton.click();
+        browser.sleep(5000);
+      });
+
       it ('should run Load TypeAhead flow', function() {
         flowPage.clickEntityDisclosure('TypeAhead');
         browser.wait(EC.elementToBeClickable(flowPage.getFlow('TypeAhead', 'Load TypeAhead', 'INPUT')));
@@ -195,7 +200,7 @@ export default function() {
         browsePage.resultsUri().click();
         viewerPage.isLoaded();
         expect(viewerPage.searchResultUri().getText()).toContain('long_props_typeahead');
-        expect(viewerPage.verifyHarmonizedProperty('title', 'passage married child')).toBeTruthy();
+        expect(viewerPage.verifyHarmonizedProperty('title', 'passage married child').isPresent()).toBeTruthy();
       });
 
       it ('should go to flows page', function() {

--- a/quick-start/e2e/specs/mappings/typeAhead.ts
+++ b/quick-start/e2e/specs/mappings/typeAhead.ts
@@ -7,6 +7,7 @@ import appPage from '../../page-objects/appPage';
 import entityPage from '../../page-objects/entities/entities';
 import browsePage from '../../page-objects/browse/browse';
 import mappingsPage from '../../page-objects/mappings/mappings';
+import viewerPage from '../../page-objects/viewer/viewer';
 
 export default function() {
     describe('Run TypeAhead', () => {
@@ -22,18 +23,17 @@ export default function() {
 
       it ('should create input flow on TypeAhead entity', function() {  
         //create TypeAhead input flow
-        flowPage.entityDisclosure('TypeAhead').click();
+        flowPage.clickEntityDisclosure('TypeAhead');
         flowPage.createInputFlow('TypeAhead', 'Load TypeAhead', 'json', 'sjs', false);
         browser.wait(EC.visibilityOf(flowPage.getFlow('TypeAhead', 'Load TypeAhead', 'INPUT')));
         expect(flowPage.getFlow('TypeAhead', 'Load TypeAhead', 'INPUT').isDisplayed()).
           toBe(true, 'Load TypeAhead' + ' is not present');
-        flowPage.entityDisclosure('TypeAhead').click();
       });
 
       it ('should run Load TypeAhead flow', function() {
-        flowPage.entityDisclosure('TypeAhead').click();
+        flowPage.clickEntityDisclosure('TypeAhead');
         browser.wait(EC.elementToBeClickable(flowPage.getFlow('TypeAhead', 'Load TypeAhead', 'INPUT')));
-        flowPage.runInputFlowWithFolder('TypeAhead', 'Load TypeAhead', 'json', 'long-props', 'documents', 
+        flowPage.runInputFlow('TypeAhead', 'Load TypeAhead', 'json', 'long-props', 'documents', 
           '?doc=yes&type=foo');
       });
 
@@ -99,7 +99,7 @@ export default function() {
         mappingsPage.mapCreateButton().click();
         browser.wait(EC.elementToBeClickable(mappingsPage.entityMapping('MapTypeAhead')));
         //flicker bug, sleep will be removed once it's fixed
-        browser.sleep(5000);
+        browser.sleep(8000);
         browser.wait(EC.elementToBeClickable(mappingsPage.entityMapping('MapTypeAhead')));
         mappingsPage.entityMapping('MapTypeAhead').click();
         browser.wait(EC.elementToBeClickable(mappingsPage.editMapDescription()));
@@ -140,7 +140,7 @@ export default function() {
         mappingsPage.saveMapButton().click();
         browser.wait(EC.elementToBeClickable(mappingsPage.entityMapping('MapTypeAhead')));
         //flicker bug, sleep will be removed once it's fixed
-        browser.sleep(5000);
+        browser.sleep(8000);
         browser.wait(EC.elementToBeClickable(mappingsPage.entityMapping('MapTypeAhead')));
         expect(mappingsPage.verifySourcePropertyName('anywhere').isPresent()).toBeTruthy();
         expect(mappingsPage.verifySourcePropertyName('been').isPresent()).toBeTruthy();
@@ -148,6 +148,54 @@ export default function() {
         // verify that unselected sources are not saved
         expect(mappingsPage.verifySourcePropertyName('further').isPresent()).toBeFalsy();
         expect(mappingsPage.verifySourcePropertyName('active').isPresent()).toBeFalsy();
+      });
+
+      it('should go to flows tab', function() {
+        appPage.flowsTab.click();
+        flowPage.isLoaded();
+      });
+
+      it('should create Harmonize TypeAhead flow', function() {
+        flowPage.clickEntityDisclosure('TypeAhead');
+        flowPage.createHarmonizeFlow('TypeAhead', 'Harmonize TypeAhead', 'json', 'sjs', true, 'MapTypeAhead');
+        browser.wait(EC.visibilityOf(flowPage.getFlow('TypeAhead', 'Harmonize TypeAhead', 'HARMONIZE')));
+        expect(flowPage.getFlow('TypeAhead', 'Harmonize TypeAhead', 'HARMONIZE').isDisplayed()).
+          toBe(true, 'Harmonize TypeAhead' + ' is not present');
+      });
+
+      it ('should redeploy modules', function() {
+        flowPage.redeployButton.click();
+        browser.sleep(5000);
+      });
+      
+      it('should run Harmonize TypeAhead flow with mapping', function() {
+        flowPage.clickEntityDisclosure('TypeAhead');
+        browser.wait(EC.visibilityOf(flowPage.getFlow('TypeAhead', 'Harmonize TypeAhead', 'HARMONIZE')));
+        expect(flowPage.getFlow('TypeAhead', 'Harmonize TypeAhead', 'HARMONIZE').isPresent()).toBe(true);
+        flowPage.getFlow('TypeAhead', 'Harmonize TypeAhead', 'HARMONIZE').click();
+        browser.wait(EC.visibilityOf(flowPage.runHarmonizeButton()));
+        expect(flowPage.runHarmonizeButton().isPresent()).toBe(true);
+        flowPage.runHarmonizeButton().click();
+        browser.sleep(10000);
+      });
+
+      it('should verify the harmonized data with mappings', function() {
+        appPage.browseDataTab.click()
+        browsePage.isLoaded();
+        browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
+        browsePage.databaseDropDown().click();
+        browsePage.selectDatabase('FINAL').click();
+        browser.wait(EC.elementToBeClickable(browsePage.resultsUri()));
+        browsePage.searchBox().clear();
+        browsePage.searchBox().sendKeys('passage married child');
+        browsePage.searchButton().click();
+        browser.wait(EC.elementToBeClickable(browsePage.resultsUri()));
+        expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 1 of 1');
+        expect(browsePage.resultsUri().getText()).toContain('long_props_typeahead');
+        browsePage.resultsUri().click();
+        viewerPage.isLoaded();
+        expect(viewerPage.searchResultUri().getText()).toContain('long_props_typeahead');
+        expect(viewerPage.verifyHarmonizedProperty('title', 'passage married child')).toBeTruthy();
       });
 
       it ('should go to flows page', function() {

--- a/quick-start/e2e/specs/run/run.ts
+++ b/quick-start/e2e/specs/run/run.ts
@@ -23,7 +23,7 @@ export default function(tmpDir) {
     it ('should run Load Products flow', function() {
       flowPage.entityDisclosure('Product').click();
       browser.wait(EC.elementToBeClickable(flowPage.getFlow('Product', 'Load Products', 'INPUT')));
-      flowPage.runInputFlowWithFolder('Product', 'Load Products', 'json', 'products', 
+      flowPage.runInputFlow('Product', 'Load Products', 'json', 'products', 
         'delimited_text', '?doc=yes&type=foo');
     });
 
@@ -197,14 +197,12 @@ export default function(tmpDir) {
       browser.wait(EC.elementToBeClickable(flowPage.getFlow('TestEntity', 'sjs json INPUT', 'INPUT')));
     });
 
-    let flowCount = 1;
     ['sjs', 'xqy'].forEach((codeFormat) => {
       ['xml', 'json'].forEach((dataFormat) => {
         let flowType = 'INPUT';
         let flowName = `${codeFormat} ${dataFormat} ${flowType}`;
         it (`should run a ${flowName} flow`, function() {
-          flowPage.runInputFlow('TestEntity', flowName, dataFormat, flowCount);
-          flowCount++;
+          flowPage.runInputFlow('TestEntity', flowName, dataFormat, 'products', 'delimited_text', '');
         });
       });
     });

--- a/quick-start/e2e/specs/run/run.ts
+++ b/quick-start/e2e/specs/run/run.ts
@@ -21,7 +21,7 @@ export default function(tmpDir) {
     });
 
     it ('should run Load Products flow', function() {
-      flowPage.entityDisclosure('Product').click();
+      flowPage.clickEntityDisclosure('Product');
       browser.wait(EC.elementToBeClickable(flowPage.getFlow('Product', 'Load Products', 'INPUT')));
       flowPage.runInputFlow('Product', 'Load Products', 'json', 'products', 
         'delimited_text', '?doc=yes&type=foo');
@@ -109,7 +109,7 @@ export default function(tmpDir) {
     it('should run Harmonize Products flow', function() {
       flowPage.isLoaded();
       console.log('clicking Product entity');
-      flowPage.entityDisclosure('Product').click();
+      flowPage.clickEntityDisclosure('Product');
       console.log('clicking Harmonize Products flow');
       browser.wait(EC.visibilityOf(flowPage.getFlow('Product', 'Harmonize Products', 'HARMONIZE')));
       expect(flowPage.getFlow('Product', 'Harmonize Products', 'HARMONIZE').isPresent()).toBe(true);
@@ -193,7 +193,7 @@ export default function(tmpDir) {
     });
 
     it ('should open the TestEntity disclosure', function() {
-      flowPage.entityDisclosure('TestEntity').click();
+      flowPage.clickEntityDisclosure('TestEntity');
       browser.wait(EC.elementToBeClickable(flowPage.getFlow('TestEntity', 'sjs json INPUT', 'INPUT')));
     });
 


### PR DESCRIPTION
- Extended mapping typeahead test to run harmonize flow with mapping, along with final data verification
- Removed old create flow functions. Separating this function into createInputFlow() and createHarmonizeFlow(). The new createHarmonizeFlow() can use the mapping
- Removed old run flow function. The new runInputFlow() has some parameters to use different input data folder, input file type, and suffix uri
- Added some page objects for viewer page to verify the mapped harmonized data
- Added a function on flow to recognize if entity disclosure is collapsed or not, so clicking on it will be more consistent  