### PR TITLE
E2e/output uri prefix

### DIFF
--- a/quick-start/e2e/page-objects/flows/flows.ts
+++ b/quick-start/e2e/page-objects/flows/flows.ts
@@ -232,10 +232,11 @@ export class FlowPage extends AppPage {
   * @dataFolderName: folder name under input directory
   * @inputFileType: aggregates | archive | delimited_text | delimited_json | documents
   *   | forest | rdf | sequencefile
+  * @uriPrefix: document uri prefix to append
   * @uriSuffix: document uri suffix to append
   */
   runInputFlow(entityName: string, flowName: string, dataFormat: string, 
-      dataFolderName: string, inputFileType: string, uriSuffix: string) {
+      dataFolderName: string, inputFileType: string, uriPrefix: string, uriSuffix: string) {
     console.log(`running flow: ${entityName}: ${flowName}: ${dataFormat}`)
     this.getFlow(entityName, flowName, 'INPUT').click();
 
@@ -268,6 +269,10 @@ export class FlowPage extends AppPage {
     browser.actions().mouseMove(this.menuItem(dataFormat)).perform();
     this.menuItem(dataFormat).click();
 
+    // set output uri prefix
+    this.mlcpInput('output_uri_prefix').clear();
+    this.mlcpInput('output_uri_prefix').sendKeys(uriPrefix);
+    
     // set output uri suffix
     this.mlcpInput('output_uri_suffix').clear();
     this.mlcpInput('output_uri_suffix').sendKeys(uriSuffix);

--- a/quick-start/e2e/specs/create/create.ts
+++ b/quick-start/e2e/specs/create/create.ts
@@ -652,8 +652,10 @@ export default function() {
     it ('should retain flow options when moving around', function() {
       //move to other tab and go back to flows tab
       console.log('going to the other tab and back');
-      flowPage.entitiesTab.click();
-      entityPage.flowsTab.click();
+      appPage.entitiesTab.click();
+      entityPage.isLoaded();
+      appPage.flowsTab.click();
+      flowPage.isLoaded();
       flowPage.clickEntityDisclosure('Product');
       browser.wait(EC.visibilityOf(flowPage.getFlow('Product', 'Harmonize Products', 'HARMONIZE')));
       //verify the options are retained
@@ -698,8 +700,10 @@ export default function() {
       flowPage.removeFlowOptionsByPositionButton(4).click();
       //verify the removed option
       console.log('verify the removed option');
-      flowPage.entitiesTab.click();
-      entityPage.flowsTab.click();
+      appPage.entitiesTab.click();
+      entityPage.isLoaded();
+      appPage.flowsTab.click();
+      flowPage.isLoaded();
       flowPage.clickEntityDisclosure('Product');
       browser.wait(EC.visibilityOf(flowPage.getFlow('Product', 'Harmonize Products', 'HARMONIZE')));
       expect(flowPage.getFlow('Product', 'Harmonize Products', 'HARMONIZE').isPresent()).toBe(true);

--- a/quick-start/e2e/specs/mappings/mappings.ts
+++ b/quick-start/e2e/specs/mappings/mappings.ts
@@ -22,6 +22,17 @@ export default function() {
       });
 
       it('should create a mapping for Product entity with sku source', function() {
+        // get the document uri with sku - board_games_accessories.csv-0-1
+        appPage.browseDataTab.click()
+        browsePage.isLoaded();
+        browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
+        browsePage.searchBox().clear();
+        browsePage.searchBox().sendKeys('442403950907');
+        browsePage.searchButton().click();
+        browser.wait(EC.elementToBeClickable(browsePage.resultsUri()));
+        let sourceDocUriWithSmallSku = 
+          browsePage.resultsSpecificUri('/board_games_accessories.csv-0-1?doc=yes&type=foo').getText(); 
+        // create the map with specific sku doc uri
         appPage.mappingsTab.click();
         mappingsPage.isLoaded();
         browser.wait(EC.elementToBeClickable(mappingsPage.newMapButton('Product')));
@@ -41,7 +52,7 @@ export default function() {
         mappingsPage.editSourceURI().click()
         browser.wait(EC.elementToBeClickable(mappingsPage.inputSourceURI()));
         mappingsPage.inputSourceURI().clear();
-        mappingsPage.inputSourceURI().sendKeys('/private/board_games_accessories.csv-0-1?doc=yes&type=foo');
+        mappingsPage.inputSourceURI().sendKeys(sourceDocUriWithSmallSku);
         mappingsPage.editSourceURITick().click();
         browser.wait(EC.elementToBeClickable(mappingsPage.srcPropertyContainer('sku')));
         // select source for sku
@@ -70,6 +81,17 @@ export default function() {
       });
 
       it('should update MapProduct with SKU source', function() {
+        // get the document uri with SKU - board_games.csv-0-10
+        appPage.browseDataTab.click()
+        browsePage.isLoaded();
+        browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
+        browsePage.searchBox().clear();
+        browsePage.searchBox().sendKeys('159929577929');
+        browsePage.searchButton().click();
+        browser.wait(EC.elementToBeClickable(browsePage.resultsUri()));
+        let sourceDocUriWithBigSku = 
+          browsePage.resultsSpecificUri('/board_games.csv-0-10?doc=yes&type=foo').getText();
+        // update the map with specific SKU doc uri
         appPage.mappingsTab.click();
         mappingsPage.isLoaded();
         browser.wait(EC.elementToBeClickable(mappingsPage.entityMapping('MapProduct')));
@@ -79,7 +101,7 @@ export default function() {
         mappingsPage.editSourceURI().click()
         browser.wait(EC.elementToBeClickable(mappingsPage.inputSourceURI()));
         mappingsPage.inputSourceURI().clear();
-        mappingsPage.inputSourceURI().sendKeys('/private/board_games.csv-0-10?doc=yes&type=foo');
+        mappingsPage.inputSourceURI().sendKeys(sourceDocUriWithBigSku);
         mappingsPage.editSourceURITick().click();
         browser.wait(EC.elementToBeClickable(mappingsPage.editSourceURIConfirmationOK()));
         mappingsPage.editSourceURIConfirmationOK().click();
@@ -164,6 +186,8 @@ export default function() {
         browser.wait(EC.elementToBeClickable(mappingsPage.entityMapping('MapProduct')));
         mappingsPage.entityMapping('MapProduct').click();
         browser.wait(EC.elementToBeClickable(mappingsPage.editMapDescription()));
+        // get the original doc URI
+        let originalDocUri = mappingsPage.getSourceURITitle();
         // change the source URI
         mappingsPage.editSourceURI().click()
         browser.wait(EC.elementToBeClickable(mappingsPage.inputSourceURI()));
@@ -172,12 +196,13 @@ export default function() {
         mappingsPage.editSourceURITick().click();
         browser.wait(EC.elementToBeClickable(mappingsPage.editSourceURIConfirmationOK()));
         mappingsPage.editSourceURIConfirmationOK().click();
+        browser.sleep(3000);
         browser.wait(EC.elementToBeClickable(mappingsPage.docNotFoundConfirmationOK()));
         expect(mappingsPage.docNotFoundMessage().getText()).toContain('Document URI not found: invalidURI');
         mappingsPage.docNotFoundConfirmationOK().click();
         browser.wait(EC.elementToBeClickable(mappingsPage.srcPropertyContainer('sku')));
         // verify that the old valid URI persists
-        expect(mappingsPage.getSourceURITitle()).toEqual('/private/board_games.csv-0-10?doc=yes&type=foo');
+        expect(mappingsPage.getSourceURITitle()).toEqual(originalDocUri);
         // verify that the selected properties persist
         expect(mappingsPage.verifySourcePropertyName('SKU').isPresent()).toBeTruthy();
         expect(mappingsPage.verifySourcePropertyName('price').isPresent()).toBeTruthy();
@@ -190,6 +215,8 @@ export default function() {
         browser.wait(EC.elementToBeClickable(mappingsPage.entityMapping('MapProduct')));
         mappingsPage.entityMapping('MapProduct').click();
         browser.wait(EC.elementToBeClickable(mappingsPage.editMapDescription()));
+        // get the original doc URI
+        let originalDocUri = mappingsPage.getSourceURITitle();
         // change the sku source
         mappingsPage.sourcePropertyDropDown('sku').click();
         mappingsPage.sourceTypeAheadInput('sku').sendKeys('game_id');
@@ -201,7 +228,7 @@ export default function() {
         mappingsPage.resetConfirmationCancel().click();
         browser.wait(EC.elementToBeClickable(mappingsPage.srcPropertyContainer('sku')));
         // verify that the source URI and the properties persist (still game_id, but not saved)
-        expect(mappingsPage.getSourceURITitle()).toEqual('/private/board_games.csv-0-10?doc=yes&type=foo');
+        expect(mappingsPage.getSourceURITitle()).toEqual(originalDocUri);
         expect(mappingsPage.verifySourcePropertyName('game_id').isPresent()).toBeTruthy();
         expect(mappingsPage.verifySourcePropertyName('price').isPresent()).toBeTruthy();
       });
@@ -212,6 +239,8 @@ export default function() {
         browser.wait(EC.elementToBeClickable(mappingsPage.entityMapping('MapProduct')));
         mappingsPage.entityMapping('MapProduct').click();
         browser.wait(EC.elementToBeClickable(mappingsPage.editMapDescription()));
+        // get the original doc URI
+        let originalDocUri = mappingsPage.getSourceURITitle();
         // change the sku source
         mappingsPage.sourcePropertyDropDown('sku').click();
         mappingsPage.sourceTypeAheadInput('sku').sendKeys('game_id');
@@ -223,7 +252,7 @@ export default function() {
         mappingsPage.resetConfirmationOK().click()
         browser.wait(EC.elementToBeClickable(mappingsPage.srcPropertyContainer('sku')));
         // verify that the properties reset to old SKU (rollback to previous version)
-        expect(mappingsPage.getSourceURITitle()).toEqual('/private/board_games.csv-0-10?doc=yes&type=foo');
+        expect(mappingsPage.getSourceURITitle()).toEqual(originalDocUri);
         expect(mappingsPage.verifySourcePropertyName('SKU').isPresent()).toBeTruthy();
         expect(mappingsPage.verifySourcePropertyName('price').isPresent()).toBeTruthy();
       });

--- a/quick-start/e2e/specs/mappings/typeAhead.ts
+++ b/quick-start/e2e/specs/mappings/typeAhead.ts
@@ -39,7 +39,7 @@ export default function() {
         flowPage.clickEntityDisclosure('TypeAhead');
         browser.wait(EC.elementToBeClickable(flowPage.getFlow('TypeAhead', 'Load TypeAhead', 'INPUT')));
         flowPage.runInputFlow('TypeAhead', 'Load TypeAhead', 'json', 'long-props', 'documents', 
-          '?doc=yes&type=foo');
+          '/typeahead', '?doc=yes&type=foo');
       });
 
       it('should verify the loaded data', function() {

--- a/quick-start/e2e/specs/run/run.ts
+++ b/quick-start/e2e/specs/run/run.ts
@@ -24,7 +24,7 @@ export default function(tmpDir) {
       flowPage.clickEntityDisclosure('Product');
       browser.wait(EC.elementToBeClickable(flowPage.getFlow('Product', 'Load Products', 'INPUT')));
       flowPage.runInputFlow('Product', 'Load Products', 'json', 'products', 
-        'delimited_text', '?doc=yes&type=foo');
+        'delimited_text', '/product', '?doc=yes&type=foo');
     });
 
     it('should verify the loaded data', function() {
@@ -202,7 +202,7 @@ export default function(tmpDir) {
         let flowType = 'INPUT';
         let flowName = `${codeFormat} ${dataFormat} ${flowType}`;
         it (`should run a ${flowName} flow`, function() {
-          flowPage.runInputFlow('TestEntity', flowName, dataFormat, 'products', 'delimited_text', '');
+          flowPage.runInputFlow('TestEntity', flowName, dataFormat, 'products', 'delimited_text', '/testEntity', '');
         });
       });
     });


### PR DESCRIPTION
- Fix verification on mapping on source doc URI. Apparently when using the filesystem tmp object, the input file always have a private folder appended. Fixed this by getting the doc uri directly from browse data page
- Some page stabilization on flow options test