### PR TITLE
e2e/save input flow options

### DIFF
--- a/quick-start/e2e/page-objects/flows/flows.ts
+++ b/quick-start/e2e/page-objects/flows/flows.ts
@@ -204,6 +204,10 @@ export class FlowPage extends AppPage {
     return element(by.cssContainingText('mdl-button', 'Run Import'));
   }
 
+  get mlcpSaveOptionsButton() {
+    return element(by.cssContainingText('mdl-button', 'Save Options'));
+  }
+
   runHarmonizeButton() {
     return element(by.cssContainingText('mdl-button', 'Run Harmonize'));
   }
@@ -287,7 +291,8 @@ export class FlowPage extends AppPage {
       browser.wait(EC.elementToBeClickable(this.mlcpSwitch('generate_uri')));
       this.mlcpSwitch('generate_uri').click();
     }
-
+    
+    this.mlcpSaveOptionsButton.click();
     this.mlcpRunButton.click();
     browser.sleep(10000);
     this.jobsTab.click();

--- a/quick-start/e2e/specs/create/create.ts
+++ b/quick-start/e2e/specs/create/create.ts
@@ -188,11 +188,6 @@ export default function() {
       entityPage.getPropertyCardinality(lastProperty).element(by.css(selectCardinalityOneToManyOption)).click();
       entityPage.getPropertyDescription(lastProperty).sendKeys('products description');
       entityPage.getPropertyWordLexicon(lastProperty).click();
-      // add a duplicate price property, negative test
-      entityPage.addProperty.click();
-      lastProperty = entityPage.lastProperty;
-      entityPage.getPropertyName(lastProperty).sendKeys('price');
-      entityPage.getPropertyType(lastProperty).element(by.cssContainingText('option', 'decimal')).click();
       entityPage.saveEntity.click();
       browser.wait(EC.elementToBeClickable(entityPage.confirmDialogYesButton));
       expect(entityPage.confirmDialogYesButton.isPresent()).toBe(true);
@@ -536,6 +531,24 @@ export default function() {
       // verify the error message on white space in property name
       let errorMessage = entityPage.errorWhiteSpaceMessage;
       expect(errorMessage.getText()).toBe('Property names are required and whitespaces are not allowed');
+      // verify if the Save button is disabled on white space
+      expect(entityPage.saveEntity.isEnabled()).toBe(false);
+      entityPage.cancelEntity.click();
+      browser.wait(EC.invisibilityOf(entityPage.entityEditor));
+    });
+
+    it ('should not be able to create duplicate properties', function() {
+      entityPage.clickEditEntity('PIIEntity');
+      browser.wait(EC.visibilityOf(entityPage.entityEditor));
+      expect(entityPage.entityEditor.isPresent()).toBe(true);
+      // add test property to verify duplicate property
+      console.log('add duplicate property');
+      entityPage.addProperty.click();
+      let lastProperty = entityPage.lastProperty;
+      entityPage.getPropertyName(lastProperty).sendKeys('pii_test');
+      // verify the error message on white space in property name
+      let errorMessage = entityPage.errorWhiteSpaceMessage;
+      expect(errorMessage.getText()).toBe('Property names are required, must be unique and whitespaces are not allowed');
       // verify if the Save button is disabled on white space
       expect(entityPage.saveEntity.isEnabled()).toBe(false);
       entityPage.cancelEntity.click();


### PR DESCRIPTION
Minor stabilization
- Adding page object for Save Options button on input flow
- Add Save Options click step before running input flow
- Change the entity test, due to the fix for DHFPROD-1074, PR#1238. The behavior for duplicate property is different