### PR TITLE
DHFPROD-1124 do a full mapping save with desc save

### DIFF
--- a/quick-start/src/main/ui/app/mappings/map.component.ts
+++ b/quick-start/src/main/ui/app/mappings/map.component.ts
@@ -191,9 +191,7 @@ export class MapComponent implements OnInit {
 
   updateDesc() {
     this.mapping.description = this.editDescVal;
-    this.mapService.saveMap(this.mapping.name, JSON.stringify(this.mapping)).subscribe((res: any) => {
-      console.log('map saved with edited description');
-    });
+    this.saveMap();
     this.editingDesc = false;
   }
 


### PR DESCRIPTION
When the user edits and saves a mapping description, we need to save the entire mapping. This makes the interaction consistent with editing the source URI. 

Fixes #1180