### PR TITLE
Update to mlcp transform paths

### DIFF
--- a/_pages/ingest/mlcp.md
+++ b/_pages/ingest/mlcp.md
@@ -33,7 +33,6 @@ For SJS transforms use
 -transform_module "/com.marklogic.hub/mlcp-flow-transform.sjs"
 </pre>
 
-
 The `-transform_param` parameter will contain a comma-delimited list of key=value pairs to be passed to the `mlcp-flow-transform.xqy` module. Here are the keys and a description of their values:
 
  - **entity-name** - the URL-encoded name of the entity to which the flow belongs.
@@ -56,11 +55,10 @@ This is how you would run a flow named "My Awesome Flow" for the entity named "Y
 
 ... \
 
--transform_module "/MarklOgic/data-hub-framework/transforms/mlcp-flow-transform.xqy" \
+-transform_module "/MarkLogic/data-hub-framework/transforms/mlcp-flow-transform.xqy" \
 -transform_namespace "http://marklogic.com/data-hub/mlcp-flow-transform" \
 -transform_param "entity-name=YourEntityName,flow-name=My%20Awesome%20Flow,job-id=someString,options={'your':'options'}"
 </pre>
-
 
 If your flow is implemented with JavaScript, use this module:
 
@@ -70,5 +68,5 @@ If your flow is implemented with JavaScript, use this module:
 
 ... \
 
--transform_module "/MarklOgic/data-hub-framework/transforms/mlcp-flow-transform.sjs" \
+-transform_module "/MarkLogic/data-hub-framework/transforms/mlcp-flow-transform.sjs" \
 -transform_param "entity-name=YourEntityName,flow-name=My%20Awesome%20Flow,job-id=someString,options={'your':'options'}"

--- a/_pages/ingest/mlcp.md
+++ b/_pages/ingest/mlcp.md
@@ -27,6 +27,13 @@ The `-transform_module` and `-transform_namespace` parameters must be set to the
 -transform_namespace "http://marklogic.com/data-hub/mlcp-flow-transform"
 </pre>
 
+For SJS transforms use
+
+<pre class="cmdline">
+-transform_module "/com.marklogic.hub/mlcp-flow-transform.sjs"
+</pre>
+
+
 The `-transform_param` parameter will contain a comma-delimited list of key=value pairs to be passed to the `mlcp-flow-transform.xqy` module. Here are the keys and a description of their values:
 
  - **entity-name** - the URL-encoded name of the entity to which the flow belongs.
@@ -49,7 +56,19 @@ This is how you would run a flow named "My Awesome Flow" for the entity named "Y
 
 ... \
 
--transform_module "/com.marklogic.hub/mlcp-flow-transform.xqy" \
+-transform_module "/MarklOgic/data-hub-framework/transforms/mlcp-flow-transform.xqy" \
 -transform_namespace "http://marklogic.com/data-hub/mlcp-flow-transform" \
 -transform_param "entity-name=YourEntityName,flow-name=My%20Awesome%20Flow,job-id=someString,options={'your':'options'}"
 </pre>
+
+
+If your flow is implemented with JavaScript, use this module:
+
+
+<pre class="cmdline">
+/path/to/mlcp import \
+
+... \
+
+-transform_module "/MarklOgic/data-hub-framework/transforms/mlcp-flow-transform.sjs" \
+-transform_param "entity-name=YourEntityName,flow-name=My%20Awesome%20Flow,job-id=someString,options={'your':'options'}"


### PR DESCRIPTION
Here's the change to mlcp paths along with a bit for SJS.  I do not know whether or not, indeed, one should not use the namespace param with SJS.  I figure if I try I might have to fix something :)