### PR TITLE
DHFPROD-1164 add valMaxLen

### DIFF
--- a/quick-start/src/main/ui/app/mappings/map.component.ts
+++ b/quick-start/src/main/ui/app/mappings/map.component.ts
@@ -30,6 +30,7 @@ export class MapComponent implements OnInit {
   public sampleDocURI: string = null;
   private sampleDocSrc: any = null;
   private sampleDocSrcProps: Array<any> = [];
+  public valMaxLen: number = 17;
 
   // Connections
   public conns: Object = {};


### PR DESCRIPTION
Limit the displayed length of source value in mapping UI so it doesn't overflow source container.

Fixes DHFPROD-1164