### PR TITLE
DHFPROD-1178 change “Model” to “Entity” in Mapping view

### DIFF
--- a/quick-start/src/main/ui/app/mappings/map.component.html
+++ b/quick-start/src/main/ui/app/mappings/map.component.html
@@ -95,7 +95,7 @@
 
     <div id="harmonized">
       <div id="harm-heading">
-        <div class="item-type">Model</div>
+        <div class="item-type">Entity</div>
         <p class="item-identifying-info">
           <span ng-class="title-entity-model">{{ chosenEntity?.info.title }}</span>
         </p>


### PR DESCRIPTION
Fixes DHFPROD-1178. Updates right-hand-side header label in Mapping UI. No change in code logic. 