### PR TITLE
fix logo on browser tab

### DIFF
--- a/quick-start/src/main/ui/app/header/header.component.html
+++ b/quick-start/src/main/ui/app/header/header.component.html
@@ -1,6 +1,6 @@
 <header class="mdl-layout__header">
   <div class="mdl-layout__header-row">
-    <a class="isActive('/')" [routerLink]="['']"><img src="main/ui/assets/img/odh.svg"></a>
+    <a class="isActive('/')" [routerLink]="['']"><img src="/main/ui/assets/img/odh.svg"></a>
     <span class="mdl-layout-title">Data Hub QuickStart</span>
     <!-- Add spacer, to align navigation to the right -->
     <div class="mdl-layout-spacer"></div>


### PR DESCRIPTION
This will fix the icon on the browser tab, so it will look like this:
<img width="268" alt="screen shot 2018-08-13 at 5 19 58 pm" src="https://user-images.githubusercontent.com/7096668/44065249-76a926ee-9f1e-11e8-8580-20f5afc21b6f.png">

It was missing before
