### PR TITLE
Upgrading protractor to 5.4.0 to get latest webdriver-js-extender dependency

### DIFF
--- a/quick-start/package.json
+++ b/quick-start/package.json
@@ -72,7 +72,7 @@
     "karma-firefox-launcher": "^1.0.1",
     "karma-jasmine": "^1.1.2",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "protractor": "^5.3.2",
+    "protractor": "^5.4.0",
     "protractor-html-reporter": "^1.3.2",
     "protractor-jasmine2-html-reporter": "0.0.7",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
QS tests were failing to run on windows platform with following error:
```
15:03:12] I/update - chromedriver: unzipping chromedriver_2.40.zip 
path.js:28 
    throw new TypeError('Path must be a string. Received ' + inspect(path)); 
    ^ 

TypeError: Path must be a string. Received undefined 
```
This is because of the issue: https://github.com/angular/webdriver-js-extender/issues/17
The fix to the issue is available in webdriver-js-extender version 2.0.0 and the same is downloaded as a dependency with protractor 5.4.0. 

Hence the PR!

Here is the link to release notes that includes the fix we require:
https://github.com/angular/protractor/blob/master/CHANGELOG.md