### PR TITLE
E2e/cleanups

### DIFF
--- a/quick-start/e2e/qa-data/users/flow-admin-user.json
+++ b/quick-start/e2e/qa-data/users/flow-admin-user.json
@@ -1,0 +1,6 @@
+{
+  "user-name": "flow-admin-user",
+  "description": "A user that is used for reading and writing from MarkLogic Data Hub databases and for maintaining DHF modules",
+  "password": "flow-admin-user",
+  "role": ["%%mlHubAdminRole%%","%%mlHubUserRole%%"]
+}

--- a/quick-start/e2e/qa-data/users/run-flow-user.json
+++ b/quick-start/e2e/qa-data/users/run-flow-user.json
@@ -1,0 +1,6 @@
+{
+  "user-name": "run-flow-user",
+  "description": "A user that is used for reading and writing from MarkLogic Data Hub databases",
+  "password": "run-flow-user",
+  "role": ["%%mlHubUserRole%%"]
+}

--- a/quick-start/e2e/specs/auth/authenticated.ts
+++ b/quick-start/e2e/specs/auth/authenticated.ts
@@ -1,8 +1,8 @@
-import { protractor , browser, element, by, By, $, $$, ExpectedConditions as EC} from 'protractor';
-import { pages } from '../../page-objects/page';
+import {  browser, ExpectedConditions as EC} from 'protractor';
 import loginPage from '../../page-objects/auth/login';
 import dashboardPage from '../../page-objects/dashboard/dashboard';
 import appPage from '../../page-objects/appPage';
+const fs = require('fs-extra');
 
 export default function(tmpDir) {
   describe('login', () => {
@@ -76,6 +76,20 @@ export default function(tmpDir) {
       browser.wait(EC.elementToBeClickable(loginPage.postInitTab));
     });
 
+    it ('should copy run-flow-user.json file', function() {
+      //copy run-flow-user.json
+      console.log('copy run-flow-user.json');
+      let runFlowUserFilePath = 'e2e/qa-data/users/run-flow-user.json';
+      fs.copy(runFlowUserFilePath, tmpDir + '/hub-internal-config/security/users/run-flow-user.json');
+    });
+
+    it ('should copy flow-admin-user.json file', function() {
+      //copy flow-admin-user.json
+      console.log('copy flow-admin-user.json');
+      let flowAdminUserFilePath = 'e2e/qa-data/users/flow-admin-user.json';
+      fs.copy(flowAdminUserFilePath, tmpDir + '/hub-internal-config/security/users/flow-admin-user.json');
+    });
+
     it ('Should be on the post init page', function() {
       expect(loginPage.projectDirTab.isDisplayed()).toBe(false);
       expect(loginPage.initIfNeededTab.isDisplayed()).toBe(false);
@@ -114,15 +128,14 @@ export default function(tmpDir) {
       expect(loginPage.requiresUpdateUpdateTab.isDisplayed()).toBe(false);
       expect(loginPage.preInstallCheckTab.isDisplayed()).toBe(false);
       expect(loginPage.installerTab.isPresent()).toBe(false);
-      // Bug: DHFPROD-925
       //negative test on login
-      /*console.log('login negative test');
+      console.log('login negative test');
       loginPage.loginAs('foo', 'foo');
       expect(loginPage.loginInvalidCredentialsError.isDisplayed()).toBe(true);
       loginPage.loginAs('foo', '');
       expect(loginPage.loginInvalidCredentialsError.isDisplayed()).toBe(true);
       loginPage.loginAs('', 'foo');
-      expect(loginPage.loginInvalidCredentialsError.isDisplayed()).toBe(true);*/
+      expect(loginPage.loginInvalidCredentialsError.isDisplayed()).toBe(true);
       loginPage.login();
     });
 

--- a/quick-start/e2e/specs/create/create.ts
+++ b/quick-start/e2e/specs/create/create.ts
@@ -1,10 +1,8 @@
-import { protractor , browser, element, by, By, $, $$, ExpectedConditions as EC} from 'protractor';
-import { pages } from '../../page-objects/page';
+import {  browser, by, ExpectedConditions as EC} from 'protractor';
 import loginPage from '../../page-objects/auth/login';
 import dashboardPage from '../../page-objects/dashboard/dashboard';
 import entityPage from '../../page-objects/entities/entities';
 import flowPage from '../../page-objects/flows/flows';
-import {assertNotNull} from "@angular/compiler/src/output/output_ast";
 import appPage from '../../page-objects/appPage';
 
 const selectCardinalityOneToOneOption = 'select option:nth-child(1)';
@@ -79,7 +77,7 @@ export default function() {
     });
 
     it ('should go to the entities page', function() {
-      dashboardPage.entitiesTab.click();
+      appPage.entitiesTab.click();
       entityPage.isLoaded();
     });
 
@@ -604,7 +602,7 @@ export default function() {
     });
 
     it ('should go to the flow page', function() {
-      entityPage.flowsTab.click();
+      appPage.flowsTab.click();
       flowPage.isLoaded();
     });
 
@@ -621,9 +619,11 @@ export default function() {
       ['xml', 'json'].forEach((dataFormat) => {
         let flowName = `${codeFormat} ${dataFormat} INPUT`;
         it (`should create a ${flowName} input flow`, function() {
+          browser.wait(EC.elementToBeClickable(flowPage.inputFlowButton('TestEntity')));
           flowPage.createInputFlow('TestEntity', flowName, dataFormat, codeFormat, false);
           browser.wait(EC.visibilityOf(flowPage.getFlow('TestEntity', flowName, 'INPUT')));
           expect(flowPage.getFlow('TestEntity', flowName, 'INPUT').isDisplayed()).toBe(true, flowName + ' is not present');
+          browser.sleep(3000);
         });
       });
     });
@@ -632,9 +632,11 @@ export default function() {
       ['xml', 'json'].forEach((dataFormat) => {
         let flowName = `${codeFormat} ${dataFormat} HARMONIZE`;
         it (`should create a ${flowName} harmonize flow`, function() {
+          browser.wait(EC.elementToBeClickable(flowPage.harmonizeFlowButton('TestEntity')));
           flowPage.createHarmonizeFlow('TestEntity', flowName, dataFormat, codeFormat, true);
           browser.wait(EC.visibilityOf(flowPage.getFlow('TestEntity', flowName, 'HARMONIZE')));
           expect(flowPage.getFlow('TestEntity', flowName, 'HARMONIZE').isDisplayed()).toBe(true, flowName + ' is not present');
+          browser.sleep(3000);
         });
       });
     });

--- a/quick-start/e2e/specs/jobs/jobs.ts
+++ b/quick-start/e2e/specs/jobs/jobs.ts
@@ -1,22 +1,24 @@
-import { browser, ExpectedConditions as EC, element, by} from 'protractor';
+import { browser, ExpectedConditions as EC } from 'protractor';
 import dashboardPage from '../../page-objects/dashboard/dashboard';
 import flowPage from '../../page-objects/flows/flows';
 import jobsPage from '../../page-objects/jobs/jobs';
+import appPage from '../../page-objects/appPage';
 
 export default function() {
     describe('Run Jobs', () => {
-      beforeAll(() => {
+      it ('should go to jobs page', function() {
+        appPage.jobsTab.click();
         jobsPage.isLoaded();
       });
 
       it ('should count the jobs', function() {
         expect(jobsPage.jobResults().getText()).toContain('Showing Results 1 to 6 of 6');
         //verfiy on dashboard page
-        jobsPage.dashboardTab.click();
+        appPage.dashboardTab.click();
         dashboardPage.isLoaded();
         //count jobs and traces
         expect(dashboardPage.jobCount().getText()).toEqual('2,707');
-        dashboardPage.jobsTab.click();
+        appPage.jobsTab.click();
         jobsPage.isLoaded();
       });
 
@@ -31,7 +33,6 @@ export default function() {
         browser.wait(EC.visibilityOf(jobsPage.jobResults()));
         jobsPage.facetButton('input').click();
         browser.wait(EC.visibilityOf(jobsPage.jobResults()));
-
         expect(jobsPage.jobResults().getText()).toContain('Showing Results 1 to 5 of 5');
       });
 
@@ -68,9 +69,9 @@ export default function() {
 
       it ('check and delete some jobs', function() {
         //reset the checkboxes by going to another tab
-        jobsPage.flowsTab.click();
+        appPage.flowsTab.click();
         flowPage.isLoaded();
-        flowPage.jobsTab.click();
+        appPage.jobsTab.click();
         jobsPage.isLoaded();
         //verify to delete some jobs
         jobsPage.jobCheckboxByPosition(1).click();
@@ -83,17 +84,12 @@ export default function() {
         browser.wait(EC.visibilityOf(jobsPage.jobResults()));
         expect(jobsPage.jobResults().getText()).toContain('Showing Results 1 to 4 of 4');
         //verify on dashboard page
-        jobsPage.dashboardTab.click();
+        appPage.dashboardTab.click();
         dashboardPage.isLoaded();
         //count jobs and traces
         expect(dashboardPage.jobCount().getText()).toEqual('1,805');
-        dashboardPage.jobsTab.click();
+        appPage.jobsTab.click();
         jobsPage.isLoaded();
-      });
-
-      it ('should go to flows page', function() {
-        jobsPage.flowsTab.click();
-        flowPage.isLoaded();
       });
     });
   }

--- a/quick-start/e2e/specs/mappings/mappings.ts
+++ b/quick-start/e2e/specs/mappings/mappings.ts
@@ -1,10 +1,6 @@
-import { browser, element, by, ExpectedConditions as EC} from 'protractor';
-import loginPage from '../../page-objects/auth/login';
+import { browser, ExpectedConditions as EC} from 'protractor';
 import flowPage from '../../page-objects/flows/flows';
-import tracesPage from '../../page-objects/traces/traces';
-import traceViewerPage from '../../page-objects/traceViewer/traceViewer';
 import appPage from '../../page-objects/appPage';
-import entityPage from '../../page-objects/entities/entities';
 import browsePage from '../../page-objects/browse/browse';
 import mappingsPage from '../../page-objects/mappings/mappings';
 import viewerPage from '../../page-objects/viewer/viewer';
@@ -255,11 +251,6 @@ export default function() {
         expect(mappingsPage.getSourceURITitle()).toEqual(originalDocUri);
         expect(mappingsPage.verifySourcePropertyName('SKU').isPresent()).toBeTruthy();
         expect(mappingsPage.verifySourcePropertyName('price').isPresent()).toBeTruthy();
-      });
-
-      it ('should go to flows page', function() {
-        appPage.flowsTab.click();
-        flowPage.isLoaded();
       });
     });
   }

--- a/quick-start/e2e/specs/mappings/typeAhead.ts
+++ b/quick-start/e2e/specs/mappings/typeAhead.ts
@@ -1,8 +1,5 @@
-import { browser, element, by, ExpectedConditions as EC} from 'protractor';
-import loginPage from '../../page-objects/auth/login';
+import { browser, by, ExpectedConditions as EC} from 'protractor';
 import flowPage from '../../page-objects/flows/flows';
-import tracesPage from '../../page-objects/traces/traces';
-import traceViewerPage from '../../page-objects/traceViewer/traceViewer';
 import appPage from '../../page-objects/appPage';
 import entityPage from '../../page-objects/entities/entities';
 import browsePage from '../../page-objects/browse/browse';
@@ -236,11 +233,6 @@ export default function() {
         expect(viewerPage.verifyHarmonizedProperty('approvalDate', '2013-06-28T00:00:00Z').isPresent()).toBeTruthy();
         expect(viewerPage.verifyHarmonizedPropertyAtomicValue('cost', 60000000).isPresent()).toBeTruthy();
         expect(viewerPage.verifyHarmonizedProperty('title', 'Adaptable Program Loan').isPresent()).toBeTruthy();
-      });
-
-      it ('should go to flows page', function() {
-        appPage.flowsTab.click();
-        flowPage.isLoaded();
       });
     });
   }

--- a/quick-start/e2e/specs/run/run.ts
+++ b/quick-start/e2e/specs/run/run.ts
@@ -1,8 +1,6 @@
-import { protractor , browser, element, by, By, $, $$, ExpectedConditions as EC} from 'protractor';
-import { pages } from '../../page-objects/page';
+import {  browser, ExpectedConditions as EC} from 'protractor';
 import loginPage from '../../page-objects/auth/login';
 import dashboardPage from '../../page-objects/dashboard/dashboard';
-import entityPage from '../../page-objects/entities/entities';
 import flowPage from '../../page-objects/flows/flows';
 import jobsPage from '../../page-objects/jobs/jobs';
 import browsePage from '../../page-objects/browse/browse';
@@ -12,11 +10,8 @@ const fs = require('fs-extra');
 
 export default function(tmpDir) {
   describe('Run Flows', () => {
-    beforeAll(() => {
-      flowPage.isLoaded();
-    });
-
-    beforeEach(() => {
+    it ('should go to the flow page', function() {
+      appPage.flowsTab.click();
       flowPage.isLoaded();
     });
 
@@ -29,7 +24,7 @@ export default function(tmpDir) {
 
     it('should verify the loaded data', function() {
       //verify on jobs page
-      flowPage.jobsTab.click();
+      appPage.jobsTab.click();
       jobsPage.isLoaded();
       expect(jobsPage.lastFinishedJob.isPresent()).toBe(true);
       //verify the output
@@ -40,7 +35,7 @@ export default function(tmpDir) {
       expect(jobsPage.jobOutputContent('OUTPUT_RECORDS_FAILED: 0').isPresent()).toBe(true);
       jobsPage.jobOutputCloseButton().click();
       //verify on browse data page
-      jobsPage.browseDataTab.click();
+      appPage.browseDataTab.click();
       browsePage.isLoaded();
       browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
       expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 450');
@@ -63,10 +58,10 @@ export default function(tmpDir) {
       expect(viewerPage.verifyVariableName('opt1').isPresent()).toBeFalsy();
       expect(viewerPage.verifyStringName('world').isPresent()).toBeFalsy();
       //verfiy on dashboard page
-      viewerPage.dashboardTab.click();
+      appPage.dashboardTab.click();
       dashboardPage.isLoaded();
       expect(dashboardPage.stagingCount().getText()).toEqual('450');
-      dashboardPage.flowsTab.click();
+      appPage.flowsTab.click();
       flowPage.isLoaded();
     });
 
@@ -92,13 +87,18 @@ export default function(tmpDir) {
     });
 
     it ('should logout and login', function() {
-      flowPage.logout();
+      appPage.logout();
       loginPage.isLoaded();
       loginPage.clickNext('ProjectDirTab');
       browser.wait(EC.elementToBeClickable(loginPage.environmentTab));
       loginPage.clickNext('EnvironmentTab');
       browser.wait(EC.elementToBeClickable(loginPage.loginTab));
       loginPage.login();
+    });
+
+    it ('should go to the flow page', function() {
+      appPage.flowsTab.click();
+      flowPage.isLoaded();
     });
 
     it ('should redeploy modules', function() {
@@ -120,15 +120,15 @@ export default function(tmpDir) {
       flowPage.runHarmonizeButton().click();
       console.log('clicked the button');
       browser.sleep(10000);
-      flowPage.jobsTab.click();
+      appPage.jobsTab.click();
       jobsPage.isLoaded();
       expect(jobsPage.finishedHarmonizedFlows.isPresent()).toBe(true);
-      jobsPage.flowsTab.click();
+      appPage.flowsTab.click();
       flowPage.isLoaded();
     });
 
     it('should verify the harmonized data with sku as original property', function() {
-      flowPage.browseDataTab.click();
+      appPage.browseDataTab.click();
       browsePage.isLoaded();
       browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
       expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 450');
@@ -148,12 +148,12 @@ export default function(tmpDir) {
       expect(viewerPage.verifyHarmonizedProperty('opt1', 'world').isPresent()).toBeTruthy();
       expect(viewerPage.verifyHarmonizedProperty('user', 'admin').isPresent()).toBeTruthy();
       expect(viewerPage.verifyHarmonizedProperty('object', 'http://www.marklogic.com/foo/456').isPresent()).toBeTruthy();
-      viewerPage.flowsTab.click();
+      appPage.flowsTab.click();
       flowPage.isLoaded();
     });
 
     it('should verify the harmonized data with SKU as original property', function() {
-      flowPage.browseDataTab.click();
+      appPage.browseDataTab.click();
       browsePage.isLoaded();
       browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
       expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 450');
@@ -175,7 +175,7 @@ export default function(tmpDir) {
       expect(viewerPage.verifyHarmonizedProperty('opt1', 'world').isPresent()).toBeTruthy();
       expect(viewerPage.verifyHarmonizedProperty('user', 'admin').isPresent()).toBeTruthy();
       expect(viewerPage.verifyHarmonizedProperty('object', 'http://www.marklogic.com/foo/456').isPresent()).toBeTruthy();
-      viewerPage.flowsTab.click();
+      appPage.flowsTab.click();
       flowPage.isLoaded();
     });
 
@@ -197,11 +197,6 @@ export default function(tmpDir) {
           flowPage.runInputFlow('TestEntity', flowName, dataFormat, 'products', 'delimited_text', '/testEntity', '');
         });
       });
-    });
-
-    it ('should go to jobs page', function() {
-      flowPage.jobsTab.click();
-      jobsPage.isLoaded();
     });
   });
 }

--- a/quick-start/e2e/specs/traces/traces.ts
+++ b/quick-start/e2e/specs/traces/traces.ts
@@ -1,13 +1,11 @@
 import { browser, element, by, ExpectedConditions as EC} from 'protractor';
-import loginPage from '../../page-objects/auth/login';
-import flowPage from '../../page-objects/flows/flows';
 import tracesPage from '../../page-objects/traces/traces';
 import traceViewerPage from '../../page-objects/traceViewer/traceViewer';
 import appPage from '../../page-objects/appPage';
 
 export default function() {
     describe('Run Traces', () => {
-      beforeAll(() => {
+      it ('should go to traces page', function() {
         appPage.tracesTab.click();
         tracesPage.isLoaded();
       });
@@ -58,12 +56,6 @@ export default function() {
         expect(traceViewerPage.pluginSubheader('triples').isPresent()).toBe(true);
         expect(element(by.cssContainingText('.cm-string', 'http://www.marklogic.com/foo/123')).isPresent()).toBe(true);
         traceViewerPage.tracesTab.click();
-      });
-
-      it ('should go to flows page', function() {
-        tracesPage.isLoaded();
-        tracesPage.flowsTab.click();
-        flowPage.isLoaded();
       });
     });
   }

--- a/quick-start/e2e/specs/uninstall/uninstall.ts
+++ b/quick-start/e2e/specs/uninstall/uninstall.ts
@@ -1,22 +1,13 @@
-import { protractor , browser, element, by, By, $, $$, ExpectedConditions as EC} from 'protractor';
-import { pages } from '../../page-objects/page';
+import {  browser, ExpectedConditions as EC} from 'protractor';
 import loginPage from '../../page-objects/auth/login';
-import dashboardPage from '../../page-objects/dashboard/dashboard';
-import entityPage from '../../page-objects/entities/entities';
-import flowPage from '../../page-objects/flows/flows';
 import settingsPage from '../../page-objects/settings/settings';
 import appPage from '../../page-objects/appPage';
 const fs = require('fs-extra');
 
 export default function(tmpDir) {
   describe('Uninstall', () => {
-    beforeAll(() => {
-      appPage.flowsTab.click();
-      flowPage.isLoaded();
-    });
-
     it ('should go to the settings page', function() {
-      flowPage.settingsTab.click();
+      appPage.settingsTab.click();
       settingsPage.isLoaded();
     });
 


### PR DESCRIPTION
- Cleanup on unused codes
- Added browser.sleep() to avoid occasional stale element (make it more stable)
- Added non-admin users for future use on e2e tests (right now, using non-admin users on QuickStart is buggy)
- Enable negative tests on invalid user auth as the bug was fixed
- Better navigation on clicking tabs