### PR TITLE
Upgrade protractor to version 5.4.0

### DIFF
--- a/quick-start/package.json
+++ b/quick-start/package.json
@@ -72,7 +72,7 @@
     "karma-firefox-launcher": "^1.0.1",
     "karma-jasmine": "^1.1.2",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "protractor": "^5.3.2",
+    "protractor": "^5.4.0",
     "protractor-html-reporter": "^1.3.2",
     "protractor-jasmine2-html-reporter": "0.0.7",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
This is to fix the windows issue on 3.x-develop

[10:59:59] I/update - chromedriver: unzipping chromedriver_2.41.zip
path.js:28
    throw new TypeError('Path must be a string. Received ' + inspect(path));
    ^

TypeError: Path must be a string. Received undefined