### PR TITLE
bug:50063 mlcp no longer allows query mode

### DIFF
--- a/marklogic-data-hub/src/server-side/impl/flow-lib.xqy
+++ b/marklogic-data-hub/src/server-side/impl/flow-lib.xqy
@@ -288,7 +288,8 @@ declare function flow:run-flow(
   $mainFunc)
 {
   (: assert that we are in query mode :)
-  let $_must_run_in_query_mode as xs:unsignedLong := xdmp:request-timestamp()
+  (: mlcp flows cannot run in query mode in 9.0-7 :)
+  (: let $_must_run_in_query_mode as xs:unsignedLong := xdmp:request-timestamp() :)
 
   (: configure the global context :)
   let $_ := (


### PR DESCRIPTION
This fixes DHF 3.0.0 deployments when running against 9.0-7.  It changes how mlcp flows run, because of a bugfix in the server now causes dhf-lib.xqy to throw an error.