### PR TITLE
DHFPROD-1299 server-version dependent amps install

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/DeployHubAmpsCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/DeployHubAmpsCommand.java
@@ -17,14 +17,12 @@ package com.marklogic.hub.deploy.commands;
 
 import com.marklogic.appdeployer.command.CommandContext;
 import com.marklogic.appdeployer.command.security.DeployAmpsCommand;
-import com.marklogic.appdeployer.command.security.DeployRolesCommand;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.eval.ServerEvaluationCall;
-import com.marklogic.client.io.InputStreamHandle;
-import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.error.DataHubConfigurationException;
+import com.marklogic.hub.util.Versions;
 import com.marklogic.mgmt.ManageClient;
 import com.marklogic.mgmt.ManageConfig;
 import org.apache.commons.io.IOUtils;
@@ -49,20 +47,91 @@ public class DeployHubAmpsCommand extends DeployAmpsCommand {
      */
     @Override
     public void execute(CommandContext context) {
-        String stagingModulesDatabaseName = hubConfig.getStagingAppConfig().getModulesDatabaseName();
-        ManageClient manageClient = context.getManageClient();
 
-        try (InputStream is = new ClassPathResource("hub-internal-config/configurations/amps.json").getInputStream()) {
-            String payload = IOUtils.toString(is, "utf-8");
-            manageClient.postJsonAsSecurityUser("/manage/v3", payload);
-        } catch (IOException e) {
-            throw new DataHubConfigurationException(e);
+        // this is a place to optimize -- is there a way to get
+        // server versions without an http call?
+        Versions versions = new Versions(hubConfig);
+        String serverVersion = versions.getMarkLogicVersion();
+
+
+        logger.info("Choosing amp installation based on server version " + serverVersion);
+
+        if (serverVersion.matches("^[789]\\.0-[1234]\\.\\d+")) {
+            throw new DataHubConfigurationException("DHF " + hubConfig.getDHFVersion() +" cannot deploy security to server version " + serverVersion);
+        }
+        if (serverVersion.startsWith("9.0-5")) {
+            logger.info("Using non-SSL-compatable method for 9.0-5 servers, for demos only");
+            String stagingModulesDatabaseName = hubConfig.getStagingAppConfig().getModulesDatabaseName();
+            ManageConfig manageConfig = context.getManageClient().getManageConfig();
+            String securityUsername = manageConfig.getSecurityUsername();
+            String securityPassword = manageConfig.getSecurityPassword();
+            DatabaseClient installerClient = DatabaseClientFactory.newClient(
+                hubConfig.getHost(),
+                8000,
+                "Security",
+                new DatabaseClientFactory.DigestAuthContext(securityUsername, securityPassword)
+            );
+            //new AmpsInstaller(securityStagingClient).installAmps(stagingModulesDatabaseName);
+            ServerEvaluationCall call = installerClient.newServerEval();
+            try (InputStream is = new ClassPathResource("installer-util/install-amps.xqy").getInputStream()) {
+                String ampCall = IOUtils.toString(is, "utf-8");
+                is.close();
+                ampCall = ampCall.replace("data-hub-MODULES", stagingModulesDatabaseName);
+                call.xquery(ampCall);
+                call.eval();
+            } catch (IOException e) {
+                throw new DataHubConfigurationException(e);
+            }
+        } else {
+            logger.info("Using CMA for servers starting with 9.0-6");
+            String stagingModulesDatabaseName = hubConfig.getStagingAppConfig().getModulesDatabaseName();
+            ManageClient manageClient = context.getManageClient();
+
+            try (InputStream is = new ClassPathResource("hub-internal-config/configurations/amps.json").getInputStream()) {
+                String payload = IOUtils.toString(is, "utf-8");
+                manageClient.postJsonAsSecurityUser("/manage/v3", payload);
+            } catch (IOException e) {
+                throw new DataHubConfigurationException(e);
+            }
         }
     }
 
     @Override
     public void undo(CommandContext context) {
-        logger.warn("Amps from uninstalled data hub framework to remain, but are disabled.");
+        // this is a place to optimize -- is there a way to get
+        // server versions without an http call?
+        Versions versions = new Versions(hubConfig);
+        String serverVersion = versions.getMarkLogicVersion();
+        logger.info("Choosing amp uninstall based on server version " + serverVersion);
+
+        if (serverVersion.startsWith("9.0-5")) {
+            logger.info("Using non-SSL-compatable method for 9.0-5 servers");
+            String stagingModulesDatabaseName = hubConfig.getStagingAppConfig().getModulesDatabaseName();
+            ManageConfig manageConfig = context.getManageClient().getManageConfig();
+            String securityUsername = manageConfig.getSecurityUsername();
+            String securityPassword = manageConfig.getSecurityPassword();
+            DatabaseClient installerClient = DatabaseClientFactory.newClient(
+                hubConfig.getHost(),
+                8000,
+                "Security",
+                new DatabaseClientFactory.DigestAuthContext(securityUsername, securityPassword)
+            );
+            //new AmpsInstaller(securityStagingClient).unInstallAmps(stagingModulesDatabaseName);
+            ServerEvaluationCall call = installerClient.newServerEval();
+            try (InputStream is = new ClassPathResource("installer-util/uninstall-amps.xqy").getInputStream()) {
+                String ampCall = IOUtils.toString(is, "utf-8");
+                is.close();
+                ampCall = ampCall.replace("data-hub-MODULES", stagingModulesDatabaseName);
+                call.xquery(ampCall);
+                call.eval();
+            } catch (IOException e) {
+                throw new DataHubConfigurationException(e);
+            }
+        }
+        else {
+            // only on 9.0-5 are amps uninstalled at all.
+            logger.warn("Amps from uninstalled data hub framework to remain, but are disabled.");
+        }
     }
 
     @Override

--- a/marklogic-data-hub/src/main/resources/installer-util/install-amps.xqy
+++ b/marklogic-data-hub/src/main/resources/installer-util/install-amps.xqy
@@ -1,0 +1,80 @@
+xquery version "1.0-ml";
+
+import module namespace sec="http://marklogic.com/xdmp/security"
+at "/MarkLogic/security.xqy";
+
+declare variable $modules-db-name := xdmp:database("data-hub-MODULES");
+
+declare function local:check-then-create-amp($namespace, $local-name, $document-uri, $database-name, $role-names) {
+  if(sec:amp-exists($namespace, $local-name, $document-uri, $database-name)) then ()
+  else (
+    sec:create-amp($namespace, $local-name, $document-uri, $database-name, $role-names)
+  )
+};
+
+local:check-then-create-amp("", "addResponseHeader", "/data-hub/4/rest-api/lib/endpoint-util.sjs", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/db-util", "access-config", "/data-hub/4/rest-api/lib/db-util.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/db-util", "update-config", "/data-hub/4/rest-api/lib/db-util.xqy", $modules-db-name, ("rest-admin-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/db-util", "rest-modules-database", "/data-hub/4/rest-api/lib/db-util.xqy", $modules-db-name, ("rest-admin-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/db-util", "do-set-transaction-time-limit", "/data-hub/4/rest-api/lib/db-util.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/endpoint-util", "add-cookie", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/endpoint-util", "add-response-header", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/endpoint-util", "default-page-with-transform", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/endpoint-util", "delete-cookie", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/endpoint-util", "get-mimetypes", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/endpoint-util", "get-server-field", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/endpoint-util", "invoke-module", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/endpoint-util", "set-server-field", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/endpoint-util", "xslt-invoke", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/endpoint-util", "lookup-role-ids", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-common", "read-collections", "/data-hub/4/rest-api/models/document-model-common.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-common", "read-permissions", "/data-hub/4/rest-api/models/document-model-common.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-common", "read-properties", "/data-hub/4/rest-api/models/document-model-common.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-common", "read-quality", "/data-hub/4/rest-api/models/document-model-common.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-common", "lookup-role-names", "/data-hub/4/rest-api/models/document-model-common.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-query", "get", "/data-hub/4/rest-api/models/document-model-query.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-query-get", "get", "/data-hub/4/rest-api/models/document-model-query-get.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-query-head", "head", "/data-hub/4/rest-api/models/document-model-query-head.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-query", "read-content", "/data-hub/4/rest-api/models/document-model-query.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-query", "check-document-exists", "/data-hub/4/rest-api/models/document-model-query.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "put", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update-put", "put", "/data-hub/4/rest-api/models/document-model-update-put.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update-delete", "delete", "/data-hub/4/rest-api/models/document-model-update-delete.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "patch", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "delete", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "apply-content-patch", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "apply-metadata-patch", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "delete-document", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "write-content", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "load-content", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "write-collections", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "write-permissions", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "write-properties", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "write-quality", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "replace-role-permissions", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "replace-named-properties", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "remove-collections", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "reset-permissions", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "remove-properties", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "reset-quality", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/document-model-update", "cpf-config", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name, ("manage-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/config-query", "put", "/MarkLogic/rest-api/models/config-query-model.xqy", $modules-db-name, ("rest-admin-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/config-query", "post", "/MarkLogic/rest-api/models/config-query-model.xqy", $modules-db-name, ("rest-admin-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/config-query", "put-child", "/MarkLogic/rest-api/models/config-query-model.xqy", $modules-db-name, ("rest-admin-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/config-query", "post-child", "/MarkLogic/rest-api/models/config-query-model.xqy", $modules-db-name, ("rest-admin-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/config-query", "get", "/MarkLogic/rest-api/models/config-query-model.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/config-query", "get-child", "/MarkLogic/rest-api/models/config-query-model.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/config-query", "get-options", "/MarkLogic/rest-api/models/config-query-model.xqy", $modules-db-name, ("rest-reader")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/search-util", "search-to-json", "/MarkLogic/rest-api/lib/search-util.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/search-util", "search-from-json", "/MarkLogic/rest-api/lib/search-util.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/forestinfo", "get-forest-info", "/data-hub/4/rest-api/models/forest-info-model.xqy", $modules-db-name, ("rest-reader-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/search-model-update", "delete", "/data-hub/4/rest-api/models/search-model-update.xqy", $modules-db-name, ("rest-writer-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/models/search-model-update", "clear", "/data-hub/4/rest-api/models/search-model-update.xqy", $modules-db-name, ("rest-admin-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/extensions-util", "do-directory-delete", "/data-hub/4/rest-api/lib/extensions-util.xqy", $modules-db-name, ("rest-admin-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/extensions-util", "do-document-delete", "/data-hub/4/rest-api/lib/extensions-util.xqy", $modules-db-name, ("rest-admin-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/extensions-util", "do-document-insert", "/data-hub/4/rest-api/lib/extensions-util.xqy", $modules-db-name, ("rest-admin-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/extensions-util", "do-eval", "/data-hub/4/rest-api/lib/extensions-util.xqy", $modules-db-name, ("rest-admin-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/extensions-util", "do-js-eval", "/data-hub/4/rest-api/lib/extensions-util.xqy", $modules-db-name, ("rest-admin-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/extensions-util", "do-list-extension-metadata", "/data-hub/4/rest-api/lib/extensions-util.xqy", $modules-db-name, ("rest-admin-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/extensions-util", "execute-transform", "/data-hub/4/rest-api/lib/extensions-util.xqy", $modules-db-name, ("rest-admin-internal")),
+local:check-then-create-amp("http://marklogic.com/rest-api/lib/extensions-util", "invoke-service", "/data-hub/4/rest-api/lib/extensions-util.xqy", $modules-db-name, ("rest-reader-internal"))

--- a/marklogic-data-hub/src/main/resources/installer-util/uninstall-amps.xqy
+++ b/marklogic-data-hub/src/main/resources/installer-util/uninstall-amps.xqy
@@ -1,0 +1,81 @@
+xquery version "1.0-ml";
+
+import module namespace sec="http://marklogic.com/xdmp/security"
+at "/MarkLogic/security.xqy";
+
+declare variable $modules-db-name := xdmp:database("data-hub-MODULES");
+
+declare function local:check-then-remove-amp($namespace, $local-name, $document-uri, $database-name) {
+  if(sec:amp-exists($namespace, $local-name, $document-uri, $database-name)) then (
+    sec:remove-amp($namespace, $local-name, $document-uri, $database-name)
+  ) else ()
+};
+
+local:check-then-remove-amp("", "addResponseHeader", "/data-hub/4/rest-api/lib/endpoint-util.sjs", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/db-util", "access-config", "/data-hub/4/rest-api/lib/db-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/db-util", "update-config", "/data-hub/4/rest-api/lib/db-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/db-util", "rest-modules-database", "/data-hub/4/rest-api/lib/db-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/db-util", "do-set-transaction-time-limit", "/data-hub/4/rest-api/lib/db-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/endpoint-util", "add-cookie", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/endpoint-util", "add-response-header", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/endpoint-util", "default-page-with-transform", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/endpoint-util", "delete-cookie", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/endpoint-util", "get-mimetypes", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/endpoint-util", "get-server-field", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/endpoint-util", "invoke-module", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/endpoint-util", "set-server-field", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/endpoint-util", "xslt-invoke", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/endpoint-util", "lookup-role-ids", "/data-hub/4/rest-api/lib/endpoint-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-common", "read-collections", "/data-hub/4/rest-api/models/document-model-common.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-common", "read-permissions", "/data-hub/4/rest-api/models/document-model-common.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-common", "read-properties", "/data-hub/4/rest-api/models/document-model-common.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-common", "read-quality", "/data-hub/4/rest-api/models/document-model-common.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-common", "lookup-role-names", "/data-hub/4/rest-api/models/document-model-common.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-query", "get", "/data-hub/4/rest-api/models/document-model-query.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-query-get", "get", "/data-hub/4/rest-api/models/document-model-query-get.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-query-head", "head", "/data-hub/4/rest-api/models/document-model-query-head.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-query", "read-content", "/data-hub/4/rest-api/models/document-model-query.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-query", "check-document-exists", "/data-hub/4/rest-api/models/document-model-query.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "put", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update-put", "put", "/data-hub/4/rest-api/models/document-model-update-put.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update-delete", "delete", "/data-hub/4/rest-api/models/document-model-update-delete.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "patch", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "delete", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "apply-content-patch", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "apply-metadata-patch", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "delete-document", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "write-content", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "load-content", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "write-collections", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "write-permissions", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "write-properties", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "write-quality", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "replace-role-permissions", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "replace-named-properties", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "remove-collections", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "reset-permissions", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "remove-properties", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "reset-quality", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/document-model-update", "cpf-config", "/data-hub/4/rest-api/models/document-model-update.xqy", $modules-db-name),
+
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/config-query", "put", "/MarkLogic/rest-api/models/config-query-model.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/config-query", "post", "/MarkLogic/rest-api/models/config-query-model.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/config-query", "put-child", "/MarkLogic/rest-api/models/config-query-model.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/config-query", "post-child", "/MarkLogic/rest-api/models/config-query-model.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/config-query", "get", "/MarkLogic/rest-api/models/config-query-model.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/config-query", "get-child", "/MarkLogic/rest-api/models/config-query-model.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/config-query", "get-options", "/MarkLogic/rest-api/models/config-query-model.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/search-util", "search-to-json", "/MarkLogic/rest-api/lib/search-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/search-util", "search-from-json", "/MarkLogic/rest-api/lib/search-util.xqy", $modules-db-name),
+
+local:check-then-remove-amp("http://marklogic.com/rest-api/forestinfo", "get-forest-info", "/data-hub/4/rest-api/models/forest-info-model.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/search-model-update", "delete", "/data-hub/4/rest-api/models/search-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/models/search-model-update", "clear", "/data-hub/4/rest-api/models/search-model-update.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/extensions-util", "do-directory-delete", "/data-hub/4/rest-api/lib/extensions-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/extensions-util", "do-document-delete", "/data-hub/4/rest-api/lib/extensions-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/extensions-util", "do-document-insert", "/data-hub/4/rest-api/lib/extensions-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/extensions-util", "do-eval", "/data-hub/4/rest-api/lib/extensions-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/extensions-util", "do-js-eval", "/data-hub/4/rest-api/lib/extensions-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/extensions-util", "do-list-extension-metadata", "/data-hub/4/rest-api/lib/extensions-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/extensions-util", "execute-transform", "/data-hub/4/rest-api/lib/extensions-util.xqy", $modules-db-name),
+local:check-then-remove-amp("http://marklogic.com/rest-api/lib/extensions-util", "invoke-service", "/data-hub/4/rest-api/lib/extensions-util.xqy", $modules-db-name)


### PR DESCRIPTION
This PR partially reverts the update to use CMA.  Since the CMA method for amps only works with 9.0-6 and later, we check the server version in this patch to switch on server version.
If the server version is earlier than 9.0-5, a configuration error is now thrown.