### PR TITLE
E2e/pii final data verification

### DIFF
--- a/quick-start/e2e/page-objects/settings/settings.ts
+++ b/quick-start/e2e/page-objects/settings/settings.ts
@@ -24,6 +24,14 @@ export class SettingsPage extends AppPage {
   get redeployButton() {
     return element(by.buttonText('Redeploy Hub'));
   }
+
+  get redeployConfirmation() {
+    return element(by.buttonText('Redeploy'));
+  }
+
+  get redeployStatus() {
+    return element(by.cssContainingText('h3', 'Redeploy Status'));
+  }
 }
 
 var settingsPage = new SettingsPage();

--- a/quick-start/e2e/qa-data/plugins/contentWithOptions.sjs
+++ b/quick-start/e2e/qa-data/plugins/contentWithOptions.sjs
@@ -49,7 +49,7 @@ function extractInstanceProduct(source, opts) {
   }
   let sku = !fn.empty(source.sku || source.SKU) ? xs.string(fn.head(source.sku || source.SKU)) : null;
   let price = !fn.empty(source.price) ? xs.decimal(fn.head(source.xpath('//price'))) : null;
-  let title = !fn.empty(source.title) ? xs.string(fn.head(source.title)) : null;
+  let titlePii = !fn.empty(source.title) ? xs.string(fn.head(source.title)) : null;
   let value1 = !fn.empty(opts.hello) ? xs.string(fn.head(opts.hello)) : null;
   let value2 = !fn.empty(opts.myNumber) ? xs.string(fn.head(opts.myNumber)) : null;
 
@@ -60,7 +60,7 @@ function extractInstanceProduct(source, opts) {
     '$version': '0.0.1',
     'sku': sku,
     'price': price,
-    'title': title,
+    'titlePii': titlePii,
     'opt1': value1,
     'opt2': value2
   }

--- a/quick-start/e2e/qa-data/plugins/writerPiiPermissions.sjs
+++ b/quick-start/e2e/qa-data/plugins/writerPiiPermissions.sjs
@@ -1,0 +1,16 @@
+/*~
+ * Writer Plugin
+ *
+ * @param id       - the identifier returned by the collector
+ * @param envelope - the final envelope
+ * @param options  - an object options. Options are sent from Java
+ *
+ * @return - nothing
+ */
+function write(id, envelope, options) {
+  let perms = [xdmp.permission("hub-admin-role", "read"), xdmp.permission("data-hub-role", "read")];
+  xdmp.documentInsert(id, envelope, perms, options.entity);
+}
+
+module.exports = write;
+

--- a/quick-start/e2e/qa-data/protected-paths/attachment-pii.json
+++ b/quick-start/e2e/qa-data/protected-paths/attachment-pii.json
@@ -1,0 +1,8 @@
+{
+  "path-expression" : "/envelope/attachments//instance/title",
+  "path-namespace" : [ ],
+  "permission" : {
+    "role-name" : "pii-reader",
+    "capability" : "read"
+  }
+}

--- a/quick-start/e2e/qa-data/users/no-pii-user.json
+++ b/quick-start/e2e/qa-data/users/no-pii-user.json
@@ -1,0 +1,6 @@
+{
+  "user-name": "no-pii-user",
+  "description": "A user that cannot read pii property",
+  "password": "x",
+  "role": ["hub-admin-role", "data-hub-role"]
+}

--- a/quick-start/e2e/qa-data/users/pii-user.json
+++ b/quick-start/e2e/qa-data/users/pii-user.json
@@ -1,0 +1,6 @@
+{
+  "user-name": "pii-user",
+  "description": "A user that can read pii property",
+  "password": "x",
+  "role": ["hub-admin-role", "data-hub-role", "pii-reader"]
+}

--- a/quick-start/e2e/specs/auth/authenticated.ts
+++ b/quick-start/e2e/specs/auth/authenticated.ts
@@ -116,6 +116,20 @@ export default function(tmpDir) {
       fs.copy(flowAdminUserFilePath, tmpDir + '/src/main/ml-config/security/users/flow-admin-user.json');
     });
 
+    it ('should copy pii-user.json file', function() {
+      //copy pii-user.json
+      console.log('copy pii-user.json');
+      let piiUserFilePath = 'e2e/qa-data/users/pii-user.json';
+      fs.copy(piiUserFilePath, tmpDir + '/src/main/ml-config/security/users/pii-user.json');
+    });
+
+    it ('should copy no-pii-user.json file', function() {
+      //copy no-pii-user.json
+      console.log('copy no-pii-user.json');
+      let noPiiUserFilePath = 'e2e/qa-data/users/no-pii-user.json';
+      fs.copy(noPiiUserFilePath, tmpDir + '/src/main/ml-config/security/users/no-pii-user.json');
+    });
+
     it ('Should be on the post init page', function() {
       expect(loginPage.projectDirTab.isDisplayed()).toBe(false);
       expect(loginPage.initIfNeededTab.isDisplayed()).toBe(false);

--- a/quick-start/e2e/specs/create/create.ts
+++ b/quick-start/e2e/specs/create/create.ts
@@ -4,11 +4,13 @@ import dashboardPage from '../../page-objects/dashboard/dashboard';
 import entityPage from '../../page-objects/entities/entities';
 import flowPage from '../../page-objects/flows/flows';
 import appPage from '../../page-objects/appPage';
+import settingsPage from '../../page-objects/settings/settings';
+const fs = require('fs-extra');
 
 const selectCardinalityOneToOneOption = 'select option:nth-child(1)';
 const selectCardinalityOneToManyOption = 'select option:nth-child(2)';
 
-export default function() {
+export default function(tmpDir) {
   describe('create entities', () => {
     beforeAll(() => {
       loginPage.isLoaded();
@@ -146,6 +148,14 @@ export default function() {
       entityPage.getPropertyType(lastProperty).element(by.cssContainingText('option', 'decimal')).click();
       entityPage.getPropertyDescription(lastProperty).sendKeys('price description');
       entityPage.getPropertyRangeIndex(lastProperty).click();
+      // add titlePii property
+      console.log('add titlePii property');
+      entityPage.addProperty.click();
+      lastProperty = entityPage.lastProperty;
+      entityPage.getPropertyName(lastProperty).sendKeys('titlePii');
+      entityPage.getPropertyType(lastProperty).element(by.cssContainingText('option', 'string')).click();
+      entityPage.getPropertyDescription(lastProperty).sendKeys('titlePii description');
+      entityPage.getPropertyPii(lastProperty).click();
       entityPage.saveEntity.click();
       browser.wait(EC.elementToBeClickable(entityPage.confirmDialogYesButton));
       expect(entityPage.confirmDialogYesButton.isPresent()).toBe(true);
@@ -209,6 +219,11 @@ export default function() {
       expect(entityPage.getPropertyType(priceProperty).getAttribute('value')).toContain('decimal');
       expect(entityPage.getPropertyDescription(priceProperty).getAttribute('value')).toEqual('price description');
       expect(entityPage.hasClass(entityPage.getPropertyRangeIndex(priceProperty), 'active')).toBe(true);
+      let titlePiiProperty = entityPage.getPropertyByPosition(3);
+      expect(entityPage.getPropertyName(titlePiiProperty).getAttribute('value')).toEqual('titlePii');
+      expect(entityPage.getPropertyType(titlePiiProperty).getAttribute('value')).toContain('string');
+      expect(entityPage.getPropertyDescription(titlePiiProperty).getAttribute('value')).toEqual('titlePii description');
+      expect(entityPage.hasClass(entityPage.getPropertyPii(titlePiiProperty), 'active')).toBe(true);
       entityPage.cancelEntity.click();
       browser.wait(EC.invisibilityOf(entityPage.entityEditor));
     });
@@ -604,6 +619,25 @@ export default function() {
       // move entity WorldBank
       entityPage.selectEntity('WorldBank');
       browser.actions().dragAndDrop(entityPage.entityBox('WorldBank'), {x: 750, y: 750}).perform();
+    });
+
+    it ('should copy attachment-pii.json file to protect title on attachment', function() {
+      //copy attachment-pii.json
+      console.log('copy attachment-pii.json');
+      let attachmentPiiFilePath = 'e2e/qa-data/protected-paths/attachment-pii.json';
+      fs.copy(attachmentPiiFilePath, tmpDir + '/src/main/ml-config/security/protected-paths/attachment-pii.json');
+    });
+
+    it ('should redeploy hub to make the pii takes effect', function() {
+      appPage.settingsTab.click();
+      settingsPage.isLoaded();
+      settingsPage.redeployButton.click();
+      browser.wait(EC.elementToBeClickable(settingsPage.redeployConfirmation));
+      settingsPage.redeployConfirmation.click();
+      browser.wait(EC.visibilityOf(settingsPage.redeployStatus));
+      expect(settingsPage.redeployStatus.isDisplayed()).toBe(true);
+      browser.sleep(120000);
+      browser.wait(EC.invisibilityOf(settingsPage.redeployStatus));
     });
 
     it ('should go to the flow page', function() {

--- a/quick-start/e2e/specs/create/index.ts
+++ b/quick-start/e2e/specs/create/index.ts
@@ -1,7 +1,7 @@
 import runCreate from './create'
 
-export default function () {
+export default function (tmpDir) {
   describe('create', function () {
-    runCreate()
+    runCreate(tmpDir)
   })
 }

--- a/quick-start/e2e/specs/index.ts
+++ b/quick-start/e2e/specs/index.ts
@@ -57,7 +57,7 @@ describe('QuickStart', function () {
   });
 
   auth(tmpobj.name);
-  create();
+  create(tmpobj.name);
   runFlows(tmpobj.name);
   jobs();
   runTraces();

--- a/quick-start/e2e/specs/run/run.ts
+++ b/quick-start/e2e/specs/run/run.ts
@@ -86,6 +86,13 @@ export default function(tmpDir) {
       fs.copy(customTriplesFilePath, tmpDir + '/plugins/entities/Product/harmonize/Harmonize\ Products/triples.sjs');
     });
 
+    it ('should setup customized writer on Harmonize Products flow', function() {
+      //copy customized writer.sjs
+      console.log('copy customized writer.sjs');
+      let customWriterFilePath = 'e2e/qa-data/plugins/writerPiiPermissions.sjs';
+      fs.copy(customWriterFilePath, tmpDir + '/plugins/entities/Product/harmonize/Harmonize\ Products/writer.sjs');
+    });
+
     it ('should redeploy modules', function() {
       flowPage.redeployButton.click();
       browser.sleep(5000);
@@ -322,6 +329,96 @@ export default function(tmpDir) {
       expect(viewerPage.verifyTagName('bookstore').isPresent()).toBeTruthy();
       expect(viewerPage.verifyAttributeName('category').isPresent()).toBeTruthy();
       expect(viewerPage.verifyStringName('cooking').isPresent()).toBeTruthy();
+      appPage.flowsTab.click();
+      flowPage.isLoaded();
+    });
+
+    it ('should logout and login as no-pii-user to verify pii', function() {
+      appPage.logout();
+      loginPage.isLoaded();
+      loginPage.clickNext('ProjectDirTab');
+      browser.wait(EC.elementToBeClickable(loginPage.environmentTab));
+      loginPage.clickNext('EnvironmentTab');
+      browser.wait(EC.elementToBeClickable(loginPage.loginTab));
+      loginPage.loginAs('no-pii-user', 'x');
+      browser.wait(EC.elementToBeClickable(appPage.odhLogo));
+    });
+
+    it('should verify that no-pii-user cannot see titlePii and attachment title on harmonized data', function() {
+      appPage.browseDataTab.click();
+      browsePage.isLoaded();
+      browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
+      browsePage.databaseDropDown().click();
+      browsePage.selectDatabase('FINAL').click();
+      browser.wait(EC.elementToBeClickable(browsePage.resultsUri()));
+      browsePage.facetName('Product').click();
+      browser.wait(EC.elementToBeClickable(browsePage.resultsUri()));
+      browsePage.searchBox().clear();
+      browsePage.searchBox().sendKeys('442403950907');
+      browsePage.searchButton().click();
+      browser.wait(EC.elementToBeClickable(browsePage.resultsUri()));
+      expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 1 of 1');
+      expect(browsePage.resultsUri().getText()).toContain('/board_games_accessories.csv-0-1');
+      browsePage.resultsUri().click();
+      viewerPage.isLoaded();
+      expect(viewerPage.searchResultUri().getText()).toContain('/board_games_accessories.csv-0-1');
+      expect(viewerPage.verifyVariableName('titlePii').isPresent()).toBeFalsy();
+      expect(viewerPage.verifyHarmonizedProperty('title', 'Cards').isPresent()).toBeFalsy();
+      expect(viewerPage.verifyHarmonizedProperty('sku', '442403950907').isPresent()).toBeTruthy();
+      appPage.flowsTab.click();
+      flowPage.isLoaded();
+    });
+
+    it ('should logout and login as pii-user to verify pii', function() {
+      appPage.logout();
+      loginPage.isLoaded();
+      loginPage.clickNext('ProjectDirTab');
+      browser.wait(EC.elementToBeClickable(loginPage.environmentTab));
+      loginPage.clickNext('EnvironmentTab');
+      browser.wait(EC.elementToBeClickable(loginPage.loginTab));
+      loginPage.loginAs('pii-user', 'x');
+      browser.wait(EC.elementToBeClickable(appPage.odhLogo));
+    });
+
+    it('should verify that pii-user can see titlePii and attachment title on harmonized data', function() {
+      appPage.browseDataTab.click();
+      browsePage.isLoaded();
+      browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
+      browsePage.databaseDropDown().click();
+      browsePage.selectDatabase('FINAL').click();
+      browser.wait(EC.elementToBeClickable(browsePage.resultsUri()));
+      browsePage.facetName('Product').click();
+      browser.wait(EC.elementToBeClickable(browsePage.resultsUri()));
+      browsePage.searchBox().clear();
+      browsePage.searchBox().sendKeys('442403950907');
+      browsePage.searchButton().click();
+      browser.wait(EC.elementToBeClickable(browsePage.resultsUri()));
+      expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 1 of 1');
+      expect(browsePage.resultsUri().getText()).toContain('/board_games_accessories.csv-0-1');
+      browsePage.resultsUri().click();
+      viewerPage.isLoaded();
+      expect(viewerPage.searchResultUri().getText()).toContain('/board_games_accessories.csv-0-1');
+      expect(viewerPage.verifyVariableName('titlePii').isPresent()).toBeTruthy();
+      expect(viewerPage.verifyVariableName('title').isPresent()).toBeTruthy();
+      expect(viewerPage.verifyHarmonizedProperty('titlePii', 'Cards').isPresent()).toBeTruthy();
+      expect(viewerPage.verifyHarmonizedProperty('title', 'Cards').isPresent()).toBeTruthy();
+      expect(viewerPage.verifyHarmonizedProperty('sku', '442403950907').isPresent()).toBeTruthy();
+      expect(viewerPage.verifyHarmonizedProperty('opt1', 'world').isPresent()).toBeTruthy();
+      expect(viewerPage.verifyHarmonizedProperty('user', 'admin').isPresent()).toBeTruthy();
+      expect(viewerPage.verifyHarmonizedProperty('object', 'http://www.marklogic.com/foo/456').isPresent()).toBeTruthy();
+      appPage.flowsTab.click();
+      flowPage.isLoaded();
+    });
+
+    it ('should logout and login as admin', function() {
+      appPage.logout();
+      loginPage.isLoaded();
+      loginPage.clickNext('ProjectDirTab');
+      browser.wait(EC.elementToBeClickable(loginPage.environmentTab));
+      loginPage.clickNext('EnvironmentTab');
+      browser.wait(EC.elementToBeClickable(loginPage.loginTab));
+      loginPage.login();
+      browser.wait(EC.elementToBeClickable(appPage.odhLogo));
       appPage.flowsTab.click();
       flowPage.isLoaded();
     });


### PR DESCRIPTION
This PR will expand QuickStart PII end to end test:
- Creating users that can read pii prop and can't read pii
- Create protected path for property on attachment section
- Run harmonize flow on Product with pii prop on instance and attachment section
- Verify to login with users with specific pii-reader role that they can/can't read the pii property on final harmonized data