### PR TITLE
Issue #1364 Remove "3.x" from the tutorial page titles

### DIFF
--- a/_pages/tutorial/3x/3x.md
+++ b/_pages/tutorial/3x/3x.md
@@ -1,6 +1,6 @@
 ---
 layout: inner
-title: Getting Started Tutorial 3.x
+title: Getting Started Tutorial
 lead_text: ''
 permalink: /tutorial/
 ---
@@ -95,5 +95,8 @@ Easy. Just click Settings in the QuickStart top navigation and then Uninstall Hu
 1. [Wrapping Up](./wrapping-up/)
 
 ## Previous Tutorial Versions
+
+This is the tutorial for the latest version of DHF. See the following for older versions:
+
 - [Getting Started Tutorial 2.x](./2x/)
 - [Getting Started Tutorial 1.x](./1x/)

--- a/_pages/tutorial/3x/browse-understand-product-data.md
+++ b/_pages/tutorial/3x/browse-understand-product-data.md
@@ -1,6 +1,6 @@
 ---
 layout: inner
-title: Getting Started Tutorial 3.x<br>Browse and Understand the Product Data
+title: Getting Started Tutorial<br>Browse and Understand the Product Data
 lead_text: ''
 permalink: /tutorial/browse-understand-product-data/
 ---

--- a/_pages/tutorial/3x/create-order-entity.md
+++ b/_pages/tutorial/3x/create-order-entity.md
@@ -1,11 +1,11 @@
 ---
 layout: inner
-title: Getting Started Tutorial 3.x<br>Create the Order Entity
+title: Getting Started Tutorial<br>Create the Order Entity
 lead_text: ''
 permalink: /tutorial/create-order-entity/
 ---
 
-Next, we will create an Order entity, following the same procedure we used to create the Product entity. 
+Next, we will create an Order entity, following the same procedure we used to create the Product entity.
 
 Click **Entities** on the top navigation bar.
 

--- a/_pages/tutorial/3x/create-order-input-flow.md
+++ b/_pages/tutorial/3x/create-order-input-flow.md
@@ -1,6 +1,6 @@
 ---
 layout: inner
-title: Getting Started Tutorial 3.x<br>Create the Order Input Flow
+title: Getting Started Tutorial<br>Create the Order Input Flow
 lead_text: ''
 permalink: /tutorial/create-order-input-flow/
 ---

--- a/_pages/tutorial/3x/create-product-entity.md
+++ b/_pages/tutorial/3x/create-product-entity.md
@@ -1,6 +1,6 @@
 ---
 layout: inner
-title: Getting Started Tutorial 3.x<br>Create the Product Entity
+title: Getting Started Tutorial<br>Create the Product Entity
 lead_text: ''
 permalink: /tutorial/create-product-entity/
 ---

--- a/_pages/tutorial/3x/create-product-input-flow.md
+++ b/_pages/tutorial/3x/create-product-input-flow.md
@@ -1,6 +1,6 @@
 ---
 layout: inner
-title: Getting Started Tutorial 3.x<br>Create the Product Input Flow
+title: Getting Started Tutorial<br>Create the Product Input Flow
 lead_text: ''
 permalink: /tutorial/create-product-input-flow/
 ---

--- a/_pages/tutorial/3x/harmonizing-order-data.md
+++ b/_pages/tutorial/3x/harmonizing-order-data.md
@@ -1,6 +1,6 @@
 ---
 layout: inner
-title: Getting Started Tutorial 3.x<br>Harmonize the Order Data
+title: Getting Started Tutorial<br>Harmonize the Order Data
 lead_text: ''
 permalink: /tutorial/harmonizing-order-data/
 ---

--- a/_pages/tutorial/3x/harmonizing-product-data.md
+++ b/_pages/tutorial/3x/harmonizing-product-data.md
@@ -1,6 +1,6 @@
 ---
 layout: inner
-title: Getting Started Tutorial 3.x<br>Harmonize the Product Data
+title: Getting Started Tutorial<br>Harmonize the Product Data
 lead_text: ''
 permalink: /tutorial/harmonizing-product-data/
 ---

--- a/_pages/tutorial/3x/install.md
+++ b/_pages/tutorial/3x/install.md
@@ -1,6 +1,6 @@
 ---
 layout: inner
-title: Getting Started Tutorial 3.x<br>Install the Data Hub Framework
+title: Getting Started Tutorial<br>Install the Data Hub Framework
 lead_text: ''
 permalink: /tutorial/install/
 ---

--- a/_pages/tutorial/3x/load-orders-as-is.md
+++ b/_pages/tutorial/3x/load-orders-as-is.md
@@ -1,6 +1,6 @@
 ---
 layout: inner
-title: Getting Started Tutorial 3.x<br>Load the Orders As-Is
+title: Getting Started Tutorial<br>Load the Orders As-Is
 lead_text: ''
 permalink: /tutorial/load-orders-as-is/
 ---
@@ -21,13 +21,13 @@ Follow these steps to configure the input flow:
 1. Under **Input Files**, use the file browser to select the **input/orders** directory.
 
     ![Input Files]({{site.baseurl}}/images/3x/load-orders-as-is/input-files.png){:.screenshot-border}
-    
+
 1. Under **General Options**, change **Input File Type** to **Delimited Text**.
 
     ![General Options]({{site.baseurl}}/images/3x/load-orders-as-is/general-options.png)
-    
+
 1. Under **Delimited Text Options**, slide the **Generate URI?** slider to the right, enabling automatic unique URI generation.
-    
+
     ![Delimited Text Options]({{site.baseurl}}/images/3x/load-orders-as-is/delimited-text-options.png)
 
 1. Scroll to the bottom of the wizard and click **SAVE OPTIONS**.

--- a/_pages/tutorial/3x/load-products-as-is.md
+++ b/_pages/tutorial/3x/load-products-as-is.md
@@ -1,6 +1,6 @@
 ---
 layout: inner
-title: Getting Started Tutorial 3.x<br>Load the Product Data As-Is
+title: Getting Started Tutorial<br>Load the Product Data As-Is
 lead_text: ''
 permalink: /tutorial/load-products-as-is/
 ---

--- a/_pages/tutorial/3x/mapping-product-entity.md
+++ b/_pages/tutorial/3x/mapping-product-entity.md
@@ -1,6 +1,6 @@
 ---
 layout: inner
-title: Getting Started Tutorial 3.x<br>Create a Model-to-Model Mapping for Product
+title: Getting Started Tutorial<br>Create a Model-to-Model Mapping for Product
 lead_text: ''
 permalink: /tutorial/mapping-product-entity/
 ---

--- a/_pages/tutorial/3x/modeling-order-entity.md
+++ b/_pages/tutorial/3x/modeling-order-entity.md
@@ -1,6 +1,6 @@
 ---
 layout: inner
-title: Getting Started Tutorial 3.x<br>Model the Order Entity
+title: Getting Started Tutorial<br>Model the Order Entity
 lead_text: ''
 permalink: /tutorial/modeling-order-entity/
 ---

--- a/_pages/tutorial/3x/modeling-product-entity.md
+++ b/_pages/tutorial/3x/modeling-product-entity.md
@@ -1,6 +1,6 @@
 ---
 layout: inner
-title: Getting Started Tutorial 3.x<br>Model the Product Entity
+title: Getting Started Tutorial<br>Model the Product Entity
 lead_text: ''
 permalink: /tutorial/modeling-product-entity/
 ---

--- a/_pages/tutorial/3x/serve-data.md
+++ b/_pages/tutorial/3x/serve-data.md
@@ -1,6 +1,6 @@
 ---
 layout: inner
-title: Getting Started Tutorial 3.x<br>Serve the Data Out of MarkLogic
+title: Getting Started Tutorial<br>Serve the Data Out of MarkLogic
 lead_text: ''
 permalink: /tutorial/serve-data/
 ---

--- a/_pages/tutorial/3x/wrapping-up.md
+++ b/_pages/tutorial/3x/wrapping-up.md
@@ -1,6 +1,6 @@
 ---
 layout: inner
-title: Getting Started Tutorial 3.x<br>Wrapping Up
+title: Getting Started Tutorial<br>Wrapping Up
 lead_text: ''
 permalink: /tutorial/wrapping-up/
 ---


### PR DESCRIPTION
This doesn't fix the underlying fundamental problem, but it will ensure the published content doesn't falsely advertise itself as the 3.x tutorial.