### PR TITLE
#1388 Add bottom space and scrolling for mapping menus

### DIFF
--- a/quick-start/src/main/ui/app/mappings/mappings.component.html
+++ b/quick-start/src/main/ui/app/mappings/mappings.component.html
@@ -46,10 +46,10 @@
 
     </div>
     <gm-divider></gm-divider>
-    <div gm-col class="flex-100">
-
-      <router-outlet></router-outlet>
-
+    <div gm-col class="flex-100 maps-content">
+      <div class="page-content">
+        <router-outlet></router-outlet>
+      </div>
     </div>
   </div>
 </div>

--- a/quick-start/src/main/ui/app/mappings/mappings.component.scss
+++ b/quick-start/src/main/ui/app/mappings/mappings.component.scss
@@ -34,6 +34,16 @@ $header-height: 48px;
   }
 }
 
+.page-content {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  overflow: auto;
+  padding: 8px 8px 300px 8px;
+}
+
 .mdl-layout-title {
   width: 100%;
   display: flex;


### PR DESCRIPTION
Include bottom padding in the content container to account for open menus.
Make the content container scrollable if needed when a menu opens.
Applies the .page-content class similar to that in the flows view.

Fixes #1388 