### PR TITLE
DHFPROD-1418 property names reversed for docs on 4.0.1

### DIFF
--- a/_pages/project/dhsdeploy.md
+++ b/_pages/project/dhsdeploy.md
@@ -18,17 +18,17 @@ mlHost=YOUR_DHS_HOSTNAME
 
 mlIsHostLoadBalancer=true
 
-mlUsername=YOUR_FLOW_DEVELOPER_USER
-mlPassword=YOUR_FLOW_DEVELOPER_PASSWORD
-mlManageUsername=YOUR_FLOW_OPERATOR_USER
-mlManagePassword=YOUR_FLOW_OPERATOR_PASSWORD
+mlUsername=YOUR_FLOW_OPERATOR_USER
+mlPassword=YOUR_FLOW_OPERATOR_PASSWORD
+mlManageUsername=YOUR_FLOW_DEVELOPER_USER
+mlManagePassword=YOUR_FLOW_DEVELOPER_PASSWORD
 
 mlStagingAppserverName=data-hub-STAGING
 mlStagingPort=8006
 mlStagingDbName=data-hub-STAGING
 mlStagingForestsPerHost=1
 
-mlFinalAppserverName=data-hub-FINAL
+mlFinalAppserverName=data-hub-ADMIN
 mlFinalPort=8004
 mlFinalDbName=data-hub-FINAL
 mlFinalForestsPerHost=1


### PR DESCRIPTION
This is a small change -- a bug in the docs went out to docs prematurely, so it will be good to rectify.