### PR TITLE
Hub modules are now loaded before all other modules

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadHubModulesCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadHubModulesCommand.java
@@ -43,7 +43,12 @@ public class LoadHubModulesCommand extends AbstractCommand {
     private Throwable caughtException;
 
     public LoadHubModulesCommand(HubConfig hubConfig) {
-        setExecuteSortOrder(SortOrderConstants.LOAD_MODULES);
+        /**
+         * Hub modules should be loaded before any other modules - including those depended on via
+         * ml-gradle's mlRestApi dependency - to ensure that the DHF REST rewriter is available before any REST
+         * extensions are loaded via a /v1/config/* endpoint.
+         */
+        setExecuteSortOrder(SortOrderConstants.LOAD_MODULES - 1);
         this.hubConfig = hubConfig;
     }
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadHubModulesCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadHubModulesCommandTest.java
@@ -16,7 +16,7 @@
 package com.marklogic.hub.deploy.commands;
 
 import com.marklogic.appdeployer.command.CommandContext;
-import com.marklogic.appdeployer.command.security.DeployAmpsCommand;
+import com.marklogic.appdeployer.command.modules.LoadModulesCommand;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.HubTestBase;
 import com.marklogic.hub.util.Versions;
@@ -62,4 +62,13 @@ public class LoadHubModulesCommandTest extends HubTestBase {
 
     }
 
+    @Test
+    public void hubModulesShouldBeLoadedBeforeAllOtherModules() {
+        LoadModulesCommand loadModulesCommand = new LoadModulesCommand();
+        assertTrue(
+            loadHubModulesCommand.getExecuteSortOrder() < loadModulesCommand.getExecuteSortOrder(),
+            "Hub modules need to be loaded before all other modules so that the DHF-specific REST " +
+                "rewriter is guaranteed to be loaded before any calls are made to /v1/config/* for " +
+                "loading REST extensions");
+    }
 }


### PR DESCRIPTION
This fixes an issue where, when a DHF4 project depends on a library like smart-mastering-core or marklogic-unit-test via ml-gradle's "mlRestApi" Gradle configuration, the library fails to be loaded. That's due to the library having REST extensions in it which must be loaded via /v1/config/*. But because the hub modules haven't been loaded yet, those calls fail because the staging server can't find its rewriter. 

So this fix simply ensures that the command for deploying hub modules is executed before the command for deploying all other modules. 