### PR TITLE
RFC: HubWatchTask now extends ml-gradle's WatchTask

### DIFF
--- a/ml-data-hub-plugin/build.gradle
+++ b/ml-data-hub-plugin/build.gradle
@@ -42,6 +42,7 @@ repositories {
     jcenter()
     mavenCentral()
     maven { url 'http://developer.marklogic.com/maven2' }
+    mavenLocal()
 }
 
 dependencies {
@@ -49,7 +50,7 @@ dependencies {
     compile (project(':marklogic-data-hub')) {
         exclude group: 'ch.qos.logback'
     }
-    compile ('com.marklogic:ml-gradle:3.9.0') {
+    compile ('com.marklogic:ml-gradle:3.9.1.dev') {
         exclude group: 'ch.qos.logback'
     }
     testCompile localGroovy()


### PR DESCRIPTION
Don't merge this yet. This is my first attempt for making HubWatchTask do everything that ml-gradle's WatchTask does - to fix #1429 - plus load hub modules from the plugins directory. 

I made a tiny change to WatchTask in ml-gradle - https://github.com/marklogic-community/ml-gradle/commit/29165edd7570fd1a21a7f64557f034f050b1224a - so that there's a method for HubWatchTask to override where it can load hub modules. 

This is of course more fragile since it's using extension over composition. Another approach would be for the guts of WatchTask in ml-gradle to be refactored into a Java class in ml-gradle that e.g. provides a callback interface. HubWatchTask could then provide a callback for loading hub modules.

Longer term, I wonder if the "plugins" directory could go away and ./entities could just be under src/main/ml-modules/root (would get rid of the REST directories under each entity as well). That would remove a lot of custom code from DHF and allow for things like mlWatch to just work.  