### PR TITLE
Adding mlSecurityUsername/mlSecurityPassword to gradle.properties

### DIFF
--- a/marklogic-data-hub/src/main/resources/scaffolding/gradle_properties
+++ b/marklogic-data-hub/src/main/resources/scaffolding/gradle_properties
@@ -30,17 +30,12 @@ mlPassword=
 # To use SSL on the Manage appserver (port 8002 by default)
 # mlManageScheme=https
 # mlManageSimpleSsl=true
-
-# If specified, the admin username/password combo is used with the ML Management REST API for creating users and roles. This
-# user must have the manage-admin or admin role. A good practice is to use your admin account here to create app-specific
-# users and roles, which can then be used as mlManageUsername/mlManagePassword and mlUsername/mlPassword.
 #
-# These properties are also used for connecting to the admin application on port 8001 - e.g. for initializing ML and for
-# waiting for ML to restart.
+# If specified, mlSecurityUsername/mlSecurityPassword is used for talking to Security end points on port 8002; this 
+# user must have the "manage-admin" and "security" roles.
 #
-# If these properties are not set, then mlUsername/mlPassword will be used.
-# mlAdminUsername=
-# mlAdminPassword=
+# mlSecurityUsername=
+# mlSecurityPassword=
 #
 # To change the Admin Port
 # mlAdminPort=8001

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -529,7 +529,7 @@ public class HubTestBase {
             try {
                 FileUtils.forceDelete(new File(PROJECT_PATH));
             } catch (IOException e) {
-                throw new RuntimeException(e);
+            	logger.warn("Unable to delete the project directory", e);
             }
         }
     }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/core/HubProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/core/HubProjectTest.java
@@ -76,8 +76,8 @@ public class HubProjectTest extends HubTestBase {
         fileContents = fileContents.replace("mlPassword=", "mlPassword=twitpassword");
         fileContents = fileContents.replace("# mlManageUsername=", "mlManageUsername=manage-user");
         fileContents = fileContents.replace("# mlManagePassword=", "mlManagePassword=manage-password");
-        fileContents = fileContents.replace("# mlAdminUsername=", "mlAdminUsername=admin-user");
-        fileContents = fileContents.replace("# mlAdminPassword=", "mlAdminPassword=admin-password");
+        fileContents = fileContents.replace("# mlSecurityUsername=", "mlSecurityUsername=security-user");
+        fileContents = fileContents.replace("# mlSecurityPassword=", "mlSecurityPassword=security-password");
         fileContents = fileContents.replace("# mlAppServicesPort=8000", "mlAppServicesPort=9000");
         fileContents = fileContents.replace("# mlAdminPort=8001", "mlAdminPort=9001");
         fileContents = fileContents.replace("# mlManagePort=8002", "mlManagePort=9002");
@@ -94,8 +94,8 @@ public class HubProjectTest extends HubTestBase {
         assertEquals("manage-user", props.getProperty("mlManageUsername"));
         assertEquals("manage-password", props.getProperty("mlManagePassword"));
 
-        assertEquals("admin-user", props.getProperty("mlAdminUsername"));
-        assertEquals("admin-password", props.getProperty("mlAdminPassword"));
+        assertEquals("security-user", props.getProperty("mlSecurityUsername"));
+        assertEquals("security-password", props.getProperty("mlSecurityPassword"));
 
         assertEquals("9000", props.getProperty("mlAppServicesPort"));
         assertEquals("9001", props.getProperty("mlAdminPort"));

--- a/quick-start/src/test/java/com/marklogic/quickstart/web/EntitiesControllerTest.java
+++ b/quick-start/src/test/java/com/marklogic/quickstart/web/EntitiesControllerTest.java
@@ -95,7 +95,7 @@ public class EntitiesControllerTest extends BaseTestController {
         Path harmonizeDir = projectDir.resolve("plugins/entities/" + ENTITY + "/harmonize");
         FileUtil.copy(getResourceStream("flow-manager/sjs-harmonize-flow/headers.sjs"), harmonizeDir.resolve("sjs-json-harmonization-flow/headers.sjs").toFile());
 
-        installUserModules(getHubFlowRunnerConfig(), true);
+        installUserModules(getHubAdminConfig(), true);
 
         DocumentMetadataHandle meta = new DocumentMetadataHandle();
         meta.getCollections().add(ENTITY);
@@ -138,7 +138,7 @@ public class EntitiesControllerTest extends BaseTestController {
         Path harmonizeDir = projectDir.resolve("plugins/entities/" + ENTITY + "/harmonize");
         FileUtil.copy(getResourceStream("flow-manager/sjs-harmonize-flow/headers.sjs"), harmonizeDir.resolve("sjs-json-harmonization-flow/headers.sjs").toFile());
 
-        installUserModules(getHubFlowRunnerConfig(), true);
+        installUserModules(getHubAdminConfig(), true);
 
         DocumentMetadataHandle meta = new DocumentMetadataHandle();
         meta.getCollections().add(ENTITY);


### PR DESCRIPTION
1. Fix for DHFPROD-1306 since mlAdminUsername/mlAdminPassword are deprecated since ml-gradle 3.4
2. Fixing 'EntitiesControllerTest'