### PR TITLE
Fixing the mlcp classpath

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/util/MlcpRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/util/MlcpRunner.java
@@ -196,12 +196,16 @@ public class MlcpRunner extends ProcessRunner {
                                 u -> (
                                     u.contains("jdk") ||
                                     u.contains("jre") ||
-                                    u.contains("log") ||
+                                    u.contains(System.getProperty("user.dir")) ||
+                                    u.contains("marklogic") ||
+                                    u.contains("logback") ||
+                                    u.contains("slf4j-api") ||
+                                    u.contains("log4j-over-slf4j") ||
+                                    u.contains("winutils") ||
                                     u.contains("xml") ||
                                     u.contains("json") ||
                                     u.contains("jackson") ||
                                     u.contains("xerces") ||
-                                    u.contains("slf") ||
                                     u.contains("mlcp") ||
                                     u.contains("xcc") ||
                                     u.contains("xpp") ||


### PR DESCRIPTION
Fixing the mlcp classpath for getting the mlcp tests in https://github.com/marklogic/dhf-project-tests/tree/end-to-end-flow-tests/end-to-end-flows-project passing.