### PR TITLE
DHFPROD-1246 flow operator/data-hub-user can deploy flows

### DIFF
--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/privileges/dhf-internal-data-hub.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/privileges/dhf-internal-data-hub.json
@@ -1,0 +1,5 @@
+{
+  "privilege-name": "dhf-internal-data-hub",
+  "action": "/data-hub",
+  "kind": "uri"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/privileges/dhf-internal-entities.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/privileges/dhf-internal-entities.json
@@ -1,0 +1,5 @@
+{
+  "privilege-name": "dhf-internal-entities",
+  "action": "/entities",
+  "kind": "uri"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/privileges/dhf-internal-trace-ui.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/privileges/dhf-internal-trace-ui.json
@@ -1,0 +1,5 @@
+{
+  "privilege-name": "dhf-internal-trace-ui",
+  "action": "/trace-ui",
+  "kind": "uri"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-role.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-role.json
@@ -81,6 +81,11 @@
       "privilege-name": "unprotected-collections",
       "action": "http://marklogic.com/xdmp/privileges/unprotected-collections",
       "kind": "execute"
+    },
+    {
+      "privilege-name": "unprotected-uri",
+      "action": "http://marklogic.com/xdmp/privileges/unprotected-uri",
+      "kind": "execute"
     }
   ]
 }

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-role.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-role.json
@@ -81,11 +81,6 @@
       "privilege-name": "unprotected-collections",
       "action": "http://marklogic.com/xdmp/privileges/unprotected-collections",
       "kind": "execute"
-    },
-    {
-      "privilege-name": "any-uri",
-      "action": "http://marklogic.com/xdmp/privileges/any-uri",
-      "kind": "execute"
     }
   ]
 }


### PR DESCRIPTION
This PR added three URI privileges to security configuration for DHF, and removes the any-uri execute privilege for data-hub-role.

A corresponding change needs to be made in DHS provisioning (note to self)