### PR TITLE
DHFPROD-1302 Issues in trace ui binary asset loading

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/tracing/trace-ui.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/tracing/trace-ui.xqy
@@ -23,7 +23,21 @@ import module namespace debug = "http://marklogic.com/data-hub/debug"
 
 declare option xdmp:mapping "false";
 
-debug:dump-env(),
+debug:dump-env()
+,
+switch (xdmp:get-request-field("extension"))
+case "css" return   xdmp:set-response-content-type("text/css")
+case "js" return    xdmp:set-response-content-type("application/javascript")
+case "ico" return   xdmp:set-response-content-type("image/vnd.microsoft.icon")
+case "ttf" return   xdmp:set-response-content-type("application/font-sfont")
+case "eot" return   xdmp:set-response-content-type("application/vnd.ms-fontobject")
+case "woff" return  xdmp:set-response-content-type("application/font-woff")
+case "woff2" return xdmp:set-response-content-type("application/font-woff2")
+case "svg" return   xdmp:set-response-content-type("image/svg+xml")
+default return      ()
+,
+xdmp:log(("FIELD", xdmp:get-request-field("uri")))
+,
 hul:run-in-modules(function() {
   fn:doc("/trace-ui" || xdmp:get-request-field("uri"))
 })

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/tracing/tracing-rewriter.xml
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/tracing/tracing-rewriter.xml
@@ -29,8 +29,9 @@
         <dispatch>/trace-ui/index.html</dispatch>
     </match-path>
 
-    <match-path matches="^/.*\.(js|css|ttf|eot|woff|woff2|svg)$">
+    <match-path matches="^/.*\.(ico|js|css|ttf|eot|woff|woff2|svg)$">
         <add-query-param name="uri">$0</add-query-param>
+        <add-query-param name="extension">$1</add-query-param>
         <dispatch>/data-hub/4/tracing/trace-ui.xqy</dispatch>
     </match-path>
 


### PR DESCRIPTION
This is a straightforward fix for trace-ui, which has several issues in 3.0-4.  Basically binary assets were getting processed by the cache buster and loaded as text, which garbled images, fonts, and the favicon.