### PR TITLE
Running DHF core tests with servers set to SSL/ cert auth in spring context

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,6 @@ subprojects {
 
 }
 
-task wrapper(type: Wrapper) {
+wrapper {
     gradleVersion = '4.10'
 }

--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -72,11 +72,6 @@ configurations.all {
 }
 
 
-
-
-import com.marklogic.mgmt.ManageClient
-import com.marklogic.mgmt.resource.hosts.HostManager
-
 node {
   // Version of node to use.
   version = '8.9.4'
@@ -261,8 +256,7 @@ def props = new Properties()
 propFile.withInputStream { props.load(it) }
 
 task bootstrap(type: JavaExec) {
-	dependsOn 'setupSSL'
-    classpath = sourceSets.test.runtimeClasspath
+	classpath = sourceSets.test.runtimeClasspath
     main = 'com.marklogic.bootstrap.Installer'
 }
 
@@ -299,24 +293,21 @@ task testBootstrap(type: Test) {
     }
 }
 
-task cleanupTask{
-	dependsOn 'teardown'
-	doLast{
-    	if(sslRun || certAuth){
-    		propFile.write(fileContents)
-		}
-    }
-}
-
 task setupSSL{
 	doFirst{
+		com.marklogic.mgmt.ManageClient manageClient = new ManageClient(new com.marklogic.mgmt.ManageConfig(mlHost, 8002, mlSecurityUsername, mlSecurityPassword))
+		com.marklogic.mgmt.resource.hosts.HostManager hostManager = new HostManager(manageClient)
+		def	bootStrapHost = hostManager.getHostNames().get(0)
+		if(! bootStrapHost.toLowerCase().contains("marklogic.com")){
+			 throw new GradleException("The test with current options will run only in marklogic.com domain")
+		}
 		if(sslRun || certAuth){
-			com.marklogic.mgmt.ManageClient manageClient = new ManageClient(new com.marklogic.mgmt.ManageConfig(mlHost, 8002, mlSecurityUsername, mlSecurityPassword))
-			com.marklogic.mgmt.resource.hosts.HostManager hostManager = new HostManager(manageClient)
-			def	bootStrapHost = hostManager.getHostNames().get(0)
-			if(! bootStrapHost.toLowerCase().contains("marklogic.com")){
-				 throw new GradleException("The test with current options will run only in marklogic.com domain")
-			}
+			javaexec {
+				classpath = sourceSets.test.runtimeClasspath
+				main = 'com.marklogic.bootstrap.SSLsetup'
+				args = [mlHost, mlSecurityUsername, mlSecurityPassword, certAuth]
+				}
+		  	}
 			if(sslRun) {
 				//checking if one of the property is already set
 				if(props.getProperty('mlJobSimpleSsl')==null){
@@ -335,16 +326,19 @@ task setupSSL{
 							"mlFinalAuth=certificate\n" +
 							"mlHost="+bootStrapHost+"\n"+
 							"mlAdminScheme=https\n" +
-							"mlManageScheme=https\n" +
+							"mlFinalScheme=https\n" +
+							"mlStagingScheme=https\n" +
+							"mlJobScheme=https\n" +
 							"mlJobAuth=certificate")
-				}
 			}
 		}
 	}
 }
+
 setupSSL.dependsOn(testClasses)
+bootstrap.dependsOn(setupSSL)
 test.dependsOn(bootstrap)
 testIntegration.dependsOn(bootstrap)
 testAcceptance.dependsOn(bootstrap)
 //Uncomment this line if hub has to be uninstalled after test
-//test.finalizedBy(cleanupTask)
+//test.finalizedBy(teardown)

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/DeployHubPrivilegesCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/DeployHubPrivilegesCommand.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -31,6 +32,7 @@ import com.marklogic.hub.error.DataHubConfigurationException;
 import com.marklogic.mgmt.ManageClient;
 import com.marklogic.mgmt.resource.ResourceManager;
 
+@Component
 public class DeployHubPrivilegesCommand extends DeployPrivilegesCommand {
 	private List<String> payLoads;
 	

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -100,10 +100,10 @@ public class DataHubImpl implements DataHub {
     private String stagingFile = "staging-database.json";
     private String jobsFile = "job-database.json";
 
-	@PostConstruct
+    @PostConstruct
     public void wireClient() {
-	    this._manageClient = hubConfig.getManageClient();
-	    this._adminManager = hubConfig.getAdminManager();
+        this._manageClient = hubConfig.getManageClient();
+        this._adminManager = hubConfig.getAdminManager();
         this._databaseManager = new DatabaseManager(_manageClient);
         this._serverManager = new ServerManager(_manageClient);
     }
@@ -123,7 +123,7 @@ public class DataHubImpl implements DataHub {
     }
 
     private ManageClient getManageClient() {
-	    return _manageClient;
+        return _manageClient;
     }
 
     private DatabaseManager getDatabaseManager() {
@@ -865,14 +865,12 @@ public class DataHubImpl implements DataHub {
     }
 
     // only used in test
-    public void setHubConfig(HubConfigImpl hubConfig)
-    {
+    public void setHubConfig(HubConfigImpl hubConfig) {
         this.hubConfig = hubConfig;
     }
 
     // only used in test
-    public void setVersions(Versions versions)
-    {
+    public void setVersions(Versions versions) {
         this.versions = versions;
     }
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -86,6 +86,9 @@ public class DataHubImpl implements DataHub {
 
     @Autowired
     private DeployHubAmpsCommand deployHubAmpsCommand;
+    
+    @Autowired
+    private DeployHubPrivilegesCommand deployHubPrivilegesCommand;
 
     @Autowired
     private Versions versions;
@@ -623,7 +626,7 @@ public class DataHubImpl implements DataHub {
         // staging deploys amps.
         List<Command> securityCommand = new ArrayList<>();
         securityCommand.add(deployHubAmpsCommand);
-        securityCommand.add(new DeployHubPrivilegesCommand());
+        securityCommand.add(deployHubPrivilegesCommand);
         commandMap.put("mlSecurityCommand", securityCommand);
 
         // don't deploy rest api servers

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -843,12 +843,12 @@ public class HubConfigImpl implements HubConfig
     }
     
     public void setMlUsername(String mlUsername) {
-		this.mlUsername = mlUsername;
-	}
+        this.mlUsername = mlUsername;
+    }
 
-	public void setMlPassword(String mlPassword) {
-		this.mlPassword = mlPassword;
-	}
+    public void setMlPassword(String mlPassword) {
+        this.mlPassword = mlPassword;
+    }
     @Override  public void setHubUserName(String hubUserName) {
         this.hubUserName = hubUserName;
     }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -841,6 +841,14 @@ public class HubConfigImpl implements HubConfig
     public String getMlPassword() {
         return mlPassword;
     }
+    
+    public void setMlUsername(String mlUsername) {
+		this.mlUsername = mlUsername;
+	}
+
+	public void setMlPassword(String mlPassword) {
+		this.mlPassword = mlPassword;
+	}
     @Override  public void setHubUserName(String hubUserName) {
         this.hubUserName = hubUserName;
     }

--- a/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/SSLsetup.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/SSLsetup.java
@@ -1,0 +1,144 @@
+package com.marklogic.bootstrap;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.hub.error.DataHubConfigurationException;
+import com.marklogic.hub.util.CertificateTemplateManagerPlus;
+import com.marklogic.mgmt.ManageClient;
+import com.marklogic.mgmt.ManageConfig;
+import com.marklogic.mgmt.resource.hosts.HostManager;
+import com.marklogic.mgmt.resource.security.CertificateAuthorityManager;
+import com.marklogic.mgmt.util.ObjectMapperFactory;
+import com.marklogic.rest.util.JsonNodeUtil;
+
+public class SSLsetup {
+
+	public static void main(String[] args) {
+		SSLsetup s = new SSLsetup();
+		s.convertToSSL(args);
+	}	
+
+	private void convertToSSL(String[] args) {
+		String mlHost = args[0];
+		String mlSecurityUsername = args[1];
+		String mlSecurityPassword = args[2];
+		boolean certAuth = Boolean.parseBoolean(args[3]); 
+		if(!certAuth)
+			return;
+		
+		/*String mlHost = "localhost";
+		String mlSecurityUsername = "admin";
+		String mlSecurityPassword = "admin";
+		boolean certAuth = true;*/
+		
+		ManageClient manageClient = new ManageClient(new ManageConfig(mlHost, 8002, mlSecurityUsername, mlSecurityPassword));
+		HostManager hostManager = new HostManager(manageClient);
+		String	bootStrapHost = hostManager.getHostNames().get(0);
+		if(! bootStrapHost.toLowerCase().contains("marklogic.com")){
+			 throw new DataHubConfigurationException("The test with current options will run only in marklogic.com domain");
+		}
+		
+		CertificateTemplateManagerPlus certManager = new CertificateTemplateManagerPlus(manageClient);
+		certManager.save(dhfCert());
+		
+	    String cacert = null;
+			try {
+				cacert = FileUtils.readFileToString(getResourceFile("ssl/ca-cert.crt"));
+			} catch (IOException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+
+		CertificateAuthorityManager cam = new CertificateAuthorityManager(manageClient);
+		cam.create(cacert);
+		try {
+			certManager.setCertificatesForTemplate("dhf-cert");
+		}
+		catch(IOException e) {
+			System.err.println("Unable to associate cert to template");
+			e.printStackTrace();
+		}
+
+	    ObjectNode node = ObjectMapperFactory.getObjectMapper().createObjectNode();
+	    ArrayNode certnode = node.arrayNode();
+	    certnode.add(cacert);
+	    node.put("ssl-certificate-template", "dhf-cert");
+	    node.put("ssl-allow-sslv3", "true");
+	    node.put("ssl-allow-tls", "true");
+	    node.put("ssl-disable-sslv3", "false");
+	    node.put("ssl-disable-tlsv1", "false");
+	    node.put("ssl-disable-tlsv1-1", "false");
+	    node.put("ssl-disable-tlsv1-2", "false");
+	    if(certAuth) {
+	    	node.put("authentication", "certificate");
+	       	node.put("ssl-client-certificate-pem", certnode );
+	    }
+	    try {
+			FileUtils.writeStringToFile(new File(System.getProperty("java.io.tmpdir")+"/ssl-server.json"), node.toString());
+		} catch (IOException e1) {
+			// TODO Auto-generated catch block
+			e1.printStackTrace();
+		}
+
+		File finalServerFile = getResourceFile("ml-config/servers");
+		File hubServerFile = getResourceFile("hub-internal-config/servers");
+
+		//set servers to ssl/ cert-auth
+		mergeFiles(finalServerFile);
+		mergeFiles(hubServerFile);
+
+	    manageClient.putJson("/manage/v2/servers/Admin/properties?group-id=Default", node.toString());
+	    manageClient.putJson("/manage/v2/servers/App-Services/properties?group-id=Default", node.toString());
+	    manageClient.putJson("/manage/v2/servers/Manage/properties?group-id=Default", node.toString());
+
+	    try {
+			Files.deleteIfExists(Paths.get(System.getProperty("java.io.tmpdir")+"/ssl-server.json"));
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+
+	
+	}
+	
+	protected static File getResourceFile(String resourceName) {
+        return new File(SSLsetup.class.getClassLoader().getResource(resourceName).getFile());
+    }
+
+	private String dhfCert() {
+		return new String(
+				"<certificate-template-properties xmlns=\"http://marklogic.com/manage\"> <template-name>dhf-cert</template-name><template-description>System Cert</template-description> <key-type>rsa</key-type><key-options/><req><version>0</version><subject><countryName>US</countryName><stateOrProvinceName>CA</stateOrProvinceName><commonName>*.marklogic.com</commonName><emailAddress>fbermude@marklogic.com</emailAddress><localityName>San Carlos</localityName><organizationName>MarkLogic</organizationName><organizationalUnitName>Engineering</organizationalUnitName></subject></req> </certificate-template-properties>");
+	}
+	
+	private void mergeFiles(File file) {
+		List<File> files = new ArrayList<>();
+		files.add(new File(System.getProperty("java.io.tmpdir")+"/ssl-server.json"));
+		Path serverPath = file.toPath();
+		try {
+			Files.list(serverPath).forEach(filePath ->
+				{	File server = filePath.toFile();
+					files.add(server);
+					
+					try {
+						FileUtils.writeStringToFile(new File(System.getProperty("java.io.tmpdir")+"/"+ server.getName())
+								, FileUtils.readFileToString(server));
+						ObjectNode serverFiles = (ObjectNode) JsonNodeUtil.mergeJsonFiles(files);
+						FileUtils.writeStringToFile(server, serverFiles.toString());
+					} catch (IOException e) {
+						throw new RuntimeException(e);
+					}
+				});
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/SSLsetup.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/SSLsetup.java
@@ -23,122 +23,123 @@ import com.marklogic.rest.util.JsonNodeUtil;
 
 public class SSLsetup {
 
-	public static void main(String[] args) {
-		SSLsetup s = new SSLsetup();
-		s.convertToSSL(args);
-	}	
+    public static void main(String[] args) {
+        SSLsetup s = new SSLsetup();
+        s.convertToSSL(args);
+    }
 
-	private void convertToSSL(String[] args) {
-		String mlHost = args[0];
-		String mlSecurityUsername = args[1];
-		String mlSecurityPassword = args[2];
-		boolean certAuth = Boolean.parseBoolean(args[3]); 
-		if(!certAuth)
-			return;
-		
-		/*String mlHost = "localhost";
-		String mlSecurityUsername = "admin";
-		String mlSecurityPassword = "admin";
-		boolean certAuth = true;*/
-		
-		ManageClient manageClient = new ManageClient(new ManageConfig(mlHost, 8002, mlSecurityUsername, mlSecurityPassword));
-		HostManager hostManager = new HostManager(manageClient);
-		String	bootStrapHost = hostManager.getHostNames().get(0);
-		if(! bootStrapHost.toLowerCase().contains("marklogic.com")){
-			 throw new DataHubConfigurationException("The test with current options will run only in marklogic.com domain");
-		}
-		
-		CertificateTemplateManagerPlus certManager = new CertificateTemplateManagerPlus(manageClient);
-		certManager.save(dhfCert());
-		
-	    String cacert = null;
-			try {
-				cacert = FileUtils.readFileToString(getResourceFile("ssl/ca-cert.crt"));
-			} catch (IOException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
+    private void convertToSSL(String[] args) {
+        String mlHost = args[0];
+        String mlSecurityUsername = args[1];
+        String mlSecurityPassword = args[2];
+        boolean certAuth = Boolean.parseBoolean(args[3]);
+        if (!certAuth)
+            return;
 
-		CertificateAuthorityManager cam = new CertificateAuthorityManager(manageClient);
-		cam.create(cacert);
-		try {
-			certManager.setCertificatesForTemplate("dhf-cert");
-		}
-		catch(IOException e) {
-			System.err.println("Unable to associate cert to template");
-			e.printStackTrace();
-		}
+        /*
+         * String mlHost = "localhost"; String mlSecurityUsername = "admin"; String
+         * mlSecurityPassword = "admin"; boolean certAuth = true;
+         */
 
-	    ObjectNode node = ObjectMapperFactory.getObjectMapper().createObjectNode();
-	    ArrayNode certnode = node.arrayNode();
-	    certnode.add(cacert);
-	    node.put("ssl-certificate-template", "dhf-cert");
-	    node.put("ssl-allow-sslv3", "true");
-	    node.put("ssl-allow-tls", "true");
-	    node.put("ssl-disable-sslv3", "false");
-	    node.put("ssl-disable-tlsv1", "false");
-	    node.put("ssl-disable-tlsv1-1", "false");
-	    node.put("ssl-disable-tlsv1-2", "false");
-	    if(certAuth) {
-	    	node.put("authentication", "certificate");
-	       	node.put("ssl-client-certificate-pem", certnode );
-	    }
-	    try {
-			FileUtils.writeStringToFile(new File(System.getProperty("java.io.tmpdir")+"/ssl-server.json"), node.toString());
-		} catch (IOException e1) {
-			// TODO Auto-generated catch block
-			e1.printStackTrace();
-		}
+        ManageClient manageClient = new ManageClient(
+                new ManageConfig(mlHost, 8002, mlSecurityUsername, mlSecurityPassword));
+        HostManager hostManager = new HostManager(manageClient);
+        String bootStrapHost = hostManager.getHostNames().get(0);
+        if (!bootStrapHost.toLowerCase().contains("marklogic.com")) {
+            throw new DataHubConfigurationException(
+                    "The test with current options will run only in marklogic.com domain");
+        }
 
-		File finalServerFile = getResourceFile("ml-config/servers");
-		File hubServerFile = getResourceFile("hub-internal-config/servers");
+        CertificateTemplateManagerPlus certManager = new CertificateTemplateManagerPlus(manageClient);
+        certManager.save(dhfCert());
 
-		//set servers to ssl/ cert-auth
-		mergeFiles(finalServerFile);
-		mergeFiles(hubServerFile);
+        String cacert = null;
+        try {
+            cacert = FileUtils.readFileToString(getResourceFile("ssl/ca-cert.crt"));
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
 
-	    manageClient.putJson("/manage/v2/servers/Admin/properties?group-id=Default", node.toString());
-	    manageClient.putJson("/manage/v2/servers/App-Services/properties?group-id=Default", node.toString());
-	    manageClient.putJson("/manage/v2/servers/Manage/properties?group-id=Default", node.toString());
+        CertificateAuthorityManager cam = new CertificateAuthorityManager(manageClient);
+        cam.create(cacert);
+        try {
+            certManager.setCertificatesForTemplate("dhf-cert");
+        } catch (IOException e) {
+            System.err.println("Unable to associate cert to template");
+            e.printStackTrace();
+        }
 
-	    try {
-			Files.deleteIfExists(Paths.get(System.getProperty("java.io.tmpdir")+"/ssl-server.json"));
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
+        ObjectNode node = ObjectMapperFactory.getObjectMapper().createObjectNode();
+        ArrayNode certnode = node.arrayNode();
+        certnode.add(cacert);
+        node.put("ssl-certificate-template", "dhf-cert");
+        node.put("ssl-allow-sslv3", "true");
+        node.put("ssl-allow-tls", "true");
+        node.put("ssl-disable-sslv3", "false");
+        node.put("ssl-disable-tlsv1", "false");
+        node.put("ssl-disable-tlsv1-1", "false");
+        node.put("ssl-disable-tlsv1-2", "false");
+        if (certAuth) {
+            node.put("authentication", "certificate");
+            node.put("ssl-client-certificate-pem", certnode);
+        }
+        try {
+            FileUtils.writeStringToFile(new File(System.getProperty("java.io.tmpdir") + "/ssl-server.json"),
+                    node.toString());
+        } catch (IOException e1) {
+            // TODO Auto-generated catch block
+            e1.printStackTrace();
+        }
 
-	
-	}
-	
-	protected static File getResourceFile(String resourceName) {
+        File finalServerFile = getResourceFile("ml-config/servers");
+        File hubServerFile = getResourceFile("hub-internal-config/servers");
+
+        // set servers to ssl/ cert-auth
+        mergeFiles(finalServerFile);
+        mergeFiles(hubServerFile);
+
+        manageClient.putJson("/manage/v2/servers/Admin/properties?group-id=Default", node.toString());
+        manageClient.putJson("/manage/v2/servers/App-Services/properties?group-id=Default", node.toString());
+        manageClient.putJson("/manage/v2/servers/Manage/properties?group-id=Default", node.toString());
+
+        try {
+            Files.deleteIfExists(Paths.get(System.getProperty("java.io.tmpdir") + "/ssl-server.json"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    protected static File getResourceFile(String resourceName) {
         return new File(SSLsetup.class.getClassLoader().getResource(resourceName).getFile());
     }
 
-	private String dhfCert() {
-		return new String(
-				"<certificate-template-properties xmlns=\"http://marklogic.com/manage\"> <template-name>dhf-cert</template-name><template-description>System Cert</template-description> <key-type>rsa</key-type><key-options/><req><version>0</version><subject><countryName>US</countryName><stateOrProvinceName>CA</stateOrProvinceName><commonName>*.marklogic.com</commonName><emailAddress>fbermude@marklogic.com</emailAddress><localityName>San Carlos</localityName><organizationName>MarkLogic</organizationName><organizationalUnitName>Engineering</organizationalUnitName></subject></req> </certificate-template-properties>");
-	}
-	
-	private void mergeFiles(File file) {
-		List<File> files = new ArrayList<>();
-		files.add(new File(System.getProperty("java.io.tmpdir")+"/ssl-server.json"));
-		Path serverPath = file.toPath();
-		try {
-			Files.list(serverPath).forEach(filePath ->
-				{	File server = filePath.toFile();
-					files.add(server);
-					
-					try {
-						FileUtils.writeStringToFile(new File(System.getProperty("java.io.tmpdir")+"/"+ server.getName())
-								, FileUtils.readFileToString(server));
-						ObjectNode serverFiles = (ObjectNode) JsonNodeUtil.mergeJsonFiles(files);
-						FileUtils.writeStringToFile(server, serverFiles.toString());
-					} catch (IOException e) {
-						throw new RuntimeException(e);
-					}
-				});
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-	}
+    private String dhfCert() {
+        return new String(
+                "<certificate-template-properties xmlns=\"http://marklogic.com/manage\"> <template-name>dhf-cert</template-name><template-description>System Cert</template-description> <key-type>rsa</key-type><key-options/><req><version>0</version><subject><countryName>US</countryName><stateOrProvinceName>CA</stateOrProvinceName><commonName>*.marklogic.com</commonName><emailAddress>fbermude@marklogic.com</emailAddress><localityName>San Carlos</localityName><organizationName>MarkLogic</organizationName><organizationalUnitName>Engineering</organizationalUnitName></subject></req> </certificate-template-properties>");
+    }
+
+    private void mergeFiles(File file) {
+        List<File> files = new ArrayList<>();
+        files.add(new File(System.getProperty("java.io.tmpdir") + "/ssl-server.json"));
+        Path serverPath = file.toPath();
+        try {
+            Files.list(serverPath).forEach(filePath -> {
+                File server = filePath.toFile();
+                files.add(server);
+
+                try {
+                    FileUtils.writeStringToFile(new File(System.getProperty("java.io.tmpdir") + "/" + server.getName()),
+                            FileUtils.readFileToString(server));
+                    ObjectNode serverFiles = (ObjectNode) JsonNodeUtil.mergeJsonFiles(files);
+                    FileUtils.writeStringToFile(server, serverFiles.toString());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/UnInstaller.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/UnInstaller.java
@@ -1,13 +1,24 @@
 package com.marklogic.bootstrap;
 
 import com.marklogic.hub.HubTestBase;
+import com.marklogic.hub.impl.HubConfigImpl;
+import com.marklogic.hub.util.CertificateTemplateManagerPlus;
+import com.marklogic.mgmt.ManageClient;
+import com.marklogic.mgmt.ManageConfig;
+import com.marklogic.mgmt.util.ObjectMapperFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.hub.ApplicationConfig;
+
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
+
+import java.io.File;
+import java.io.IOException;
 
 import javax.annotation.PostConstruct;
 
@@ -28,7 +39,51 @@ public class UnInstaller extends HubTestBase {
         dataHub.initProject();
         dataHub.uninstall();
         if (isCertAuth() || isSslRun()) {
-            sslCleanup();
+        	ManageClient manageClient = ((HubConfigImpl)getHubAdminConfig()).getManageClient();
+        	File finalServerFile = getResourceFile("ml-config/servers");
+    		File hubServerFile = getResourceFile("hub-internal-config/servers");
+    		try {
+    			FileUtils.writeStringToFile(new File(finalServerFile, "final-server.json")
+    					, FileUtils.readFileToString(new File(System.getProperty("java.io.tmpdir")+"/final-server.json")));
+    			FileUtils.writeStringToFile(new File(hubServerFile, "job-server.json")
+    					, FileUtils.readFileToString(new File(System.getProperty("java.io.tmpdir")+"/job-server.json")));
+    			FileUtils.writeStringToFile(new File(hubServerFile, "staging-server.json")
+    					, FileUtils.readFileToString(new File(System.getProperty("java.io.tmpdir")+"/staging-server.json")));
+			} catch (IOException e1) {
+				throw new RuntimeException(e1);
+				
+			}
+    		ManageConfig manageConfig = manageClient.getManageConfig();
+    		
+    		manageConfig.setUsername(secUser);
+    		manageConfig.setHost(host);
+    		manageConfig.setSslContext(certContext);
+    		manageClient.setManageConfig(manageConfig);
+    		ObjectNode node = ObjectMapperFactory.getObjectMapper().createObjectNode();
+
+    	    node.put("ssl-certificate-template", (String)null);
+    	    node.put("ssl-client-certificate-authorities", (String)null );
+    	    node.put("authentication", "digest");
+
+    		try {
+    			manageClient.putJson("/manage/v2/servers/Admin/properties?group-id=Default", node.toString());
+    	        manageClient.putJson("/manage/v2/servers/App-Services/properties?group-id=Default", node.toString());
+    	        manageClient.putJson("/manage/v2/servers/Manage/properties?group-id=Default", node.toString());
+    		}
+    		catch(Exception e) {
+    			throw new RuntimeException(e);
+    		}
+    		manageConfig.setScheme("http");
+    		manageConfig.setSslContext(null);
+    		manageConfig.setPassword(secPassword);
+    		manageClient.setManageConfig(manageConfig);
+    		CertificateTemplateManagerPlus certManager = new CertificateTemplateManagerPlus(manageClient);
+    		try {
+    			certManager.delete(dhfCert());
+    		}
+    		catch(Exception e) {
+    			e.printStackTrace();
+    		}    	    	
         }
         try {
             deleteProjectDir();
@@ -36,6 +91,7 @@ public class UnInstaller extends HubTestBase {
         catch(Exception e) {
             logger.warn("Unable to delete the project directory", e);
         }
+  
     }
 
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -163,7 +163,7 @@ public class HubTestBase {
     private  AdminConfig adminConfig = null;
     private  ManageConfig manageConfig = null;
     private  ManageClient manageClient = null;
-	private  static boolean sslRun = false;
+    private  static boolean sslRun = false;
     private  static boolean certAuth = false;
     public static SSLContext certContext;
     static SSLContext datahubadmincertContext;
@@ -175,11 +175,11 @@ public class HubTestBase {
     public  JSONDocumentManager jobDocMgr;
     public  GenericDocumentManager modMgr;
     public  String bootStrapHost = null;
-	static TrustManagerFactory tmf;
-	
+    static TrustManagerFactory tmf;
+    
     static {
         try {
-            installCARootCertIntoStore();
+            installCARootCertIntoStore(getResourceFile("ssl/ca-cert.crt"));
             certContext = createSSLContext(getResourceFile("ssl/client-cert.p12"));
             datahubadmincertContext = createSSLContext(getResourceFile("ssl/client-hub-admin-user.p12"));
             flowRunnercertContext = createSSLContext(getResourceFile("ssl/client-data-hub-user.p12"));
@@ -224,8 +224,8 @@ public class HubTestBase {
         boolean sslJob = Boolean.parseBoolean(properties.getProperty("mlJobSimpleSsl"));
         boolean sslFinal = Boolean.parseBoolean(properties.getProperty("mlFinalSimpleSsl"));
         if(sslStaging && sslJob && sslFinal){
-	    	setSslRun(true);
-	    }
+            setSslRun(true);
+        }
 
         host = properties.getProperty("mlHost");
         stagingPort = Integer.parseInt(properties.getProperty("mlStagingPort"));
@@ -270,14 +270,14 @@ public class HubTestBase {
         }
         if(jobAuthMethod.equals(Authentication.CERTIFICATE)
         && stagingAuthMethod.equals(Authentication.CERTIFICATE)) {
-        	setCertAuth(true);
+            setCertAuth(true);
         }
         adminHubConfig.refreshProject();
         if(isSslRun() || isCertAuth()) {
-        	certInit();
+            certInit();
         }
         try {
-        	stagingClient = getClient(host, stagingPort, HubConfig.DEFAULT_STAGING_NAME, user, password, stagingAuthMethod);
+            stagingClient = getClient(host, stagingPort, HubConfig.DEFAULT_STAGING_NAME, user, password, stagingAuthMethod);
             flowRunnerClient = getClient(host, stagingPort, HubConfig.DEFAULT_STAGING_NAME, flowRunnerUser, flowRunnerPassword, stagingAuthMethod);
             finalFlowRunnerClient = getClient(host, stagingPort, HubConfig.DEFAULT_FINAL_NAME, flowRunnerUser, flowRunnerPassword, stagingAuthMethod);
             stagingModulesClient  = getClient(host, stagingPort, HubConfig.DEFAULT_MODULES_DB_NAME, manageUser, managePassword, stagingAuthMethod);
@@ -287,8 +287,8 @@ public class HubTestBase {
             jobModulesClient  = getClient(host, stagingPort, HubConfig.DEFAULT_MODULES_DB_NAME, manageUser, managePassword, jobAuthMethod);
         }
         catch(Exception e) {
-        	System.err.println("client objects not created.");
-        	e.printStackTrace();
+            System.err.println("client objects not created.");
+            e.printStackTrace();
         }
         stagingDocMgr = stagingClient.newDocumentManager();
         flowRunnerDocMgr = flowRunnerClient.newDocumentManager();
@@ -341,21 +341,21 @@ public class HubTestBase {
         return null;  // unreachable
     }
 
-	public static boolean isCertAuth() {
-		return certAuth;
-	}
+    public static boolean isCertAuth() {
+        return certAuth;
+    }
 
-	public void setCertAuth(boolean certAuth) {
-		this.certAuth = certAuth;
-	}
+    public void setCertAuth(boolean certAuth) {
+        this.certAuth = certAuth;
+    }
 
-	public static boolean isSslRun() {
-		return sslRun;
-	}
+    public static boolean isSslRun() {
+        return sslRun;
+    }
 
-	public void setSslRun(boolean sslRun) {
-		this.sslRun = sslRun;
-	}
+    public void setSslRun(boolean sslRun) {
+        this.sslRun = sslRun;
+    }
 
     protected void enableDebugging() {
         Debugging.create(stagingClient).enable();
@@ -374,18 +374,18 @@ public class HubTestBase {
     }
 
     protected HubConfig getHubAdminConfig(String projectDir) {
-    	if (isSslRun() || isCertAuth()) {
-    		certInit();
-    	}
-    	wireClients();
+        if (isSslRun() || isCertAuth()) {
+            certInit();
+        }
+        wireClients();
         return adminHubConfig;
     }
 
     protected HubConfig getHubAdminConfig() {
-    	if (isSslRun() || isCertAuth()) {
-    		certInit();
-    	}
-    	wireClients();
+        if (isSslRun() || isCertAuth()) {
+            certInit();
+        }
+        wireClients();
         return adminHubConfig;
     }
 
@@ -395,13 +395,13 @@ public class HubTestBase {
         adminHubConfig.setMlUsername(flowRunnerUser);
         adminHubConfig.setMlPassword(flowRunnerPassword);
         if(isCertAuth()) {
-     		stagingAppConfig.setAppServicesCertFile("src/test/resources/ssl/client-data-hub-user.p12");
-    		finalAppConfig.setAppServicesCertFile("src/test/resources/ssl/client-data-hub-user.p12");
-    		adminHubConfig.setCertFile(DatabaseKind.STAGING, "src/test/resources/ssl/client-data-hub-user.p12");
-    		adminHubConfig.setCertFile(DatabaseKind.FINAL, "src/test/resources/ssl/client-data-hub-user.p12");
-    		adminHubConfig.setSslContext(DatabaseKind.JOB,flowRunnercertContext);
-           	manageConfig.setSslContext(flowRunnercertContext);
-           	adminConfig.setSslContext(flowRunnercertContext);           	           
+            stagingAppConfig.setAppServicesCertFile("src/test/resources/ssl/client-data-hub-user.p12");
+            finalAppConfig.setAppServicesCertFile("src/test/resources/ssl/client-data-hub-user.p12");
+            adminHubConfig.setCertFile(DatabaseKind.STAGING, "src/test/resources/ssl/client-data-hub-user.p12");
+            adminHubConfig.setCertFile(DatabaseKind.FINAL, "src/test/resources/ssl/client-data-hub-user.p12");
+            adminHubConfig.setSslContext(DatabaseKind.JOB,flowRunnercertContext);
+            manageConfig.setSslContext(flowRunnercertContext);
+            adminConfig.setSslContext(flowRunnercertContext);                          
         }
        // dataHub.setHubConfig(adminHubConfig);
         wireClients();
@@ -445,104 +445,104 @@ public class HubTestBase {
         // props reading should be in this directory...
     }
     private void certInit() {
-    	adminHubConfig.setMlUsername(user);
-    	adminHubConfig.setMlPassword(password);
-    	    	
-    	AppConfig stagingAppConfig = adminHubConfig.getStagingAppConfig();
-    	AppConfig finalAppConfig = adminHubConfig.getFinalAppConfig();
-    	manageConfig = ((HubConfigImpl)adminHubConfig).getManageConfig();
-    	manageClient = ((HubConfigImpl)adminHubConfig).getManageClient();
-    	adminConfig = ((HubConfigImpl)adminHubConfig).getAdminConfig();
+        adminHubConfig.setMlUsername(user);
+        adminHubConfig.setMlPassword(password);
+                
+        AppConfig stagingAppConfig = adminHubConfig.getStagingAppConfig();
+        AppConfig finalAppConfig = adminHubConfig.getFinalAppConfig();
+        manageConfig = ((HubConfigImpl)adminHubConfig).getManageConfig();
+        manageClient = ((HubConfigImpl)adminHubConfig).getManageClient();
+        adminConfig = ((HubConfigImpl)adminHubConfig).getAdminConfig();
 
-	    adminHubConfig.setScheme(DatabaseKind.STAGING,"https");
-		adminHubConfig.setScheme(DatabaseKind.FINAL,"https");
-		adminHubConfig.setScheme(DatabaseKind.JOB,"https");
+        adminHubConfig.setScheme(DatabaseKind.STAGING,"https");
+        adminHubConfig.setScheme(DatabaseKind.FINAL,"https");
+        adminHubConfig.setScheme(DatabaseKind.JOB,"https");
 
-		adminHubConfig.setSslHostnameVerifier(DatabaseKind.STAGING,SSLHostnameVerifier.ANY);
-		adminHubConfig.setSslHostnameVerifier(DatabaseKind.FINAL,SSLHostnameVerifier.ANY);
-		adminHubConfig.setSslHostnameVerifier(DatabaseKind.JOB,SSLHostnameVerifier.ANY);
-		manageConfig.setScheme("https");
+        adminHubConfig.setSslHostnameVerifier(DatabaseKind.STAGING,SSLHostnameVerifier.ANY);
+        adminHubConfig.setSslHostnameVerifier(DatabaseKind.FINAL,SSLHostnameVerifier.ANY);
+        adminHubConfig.setSslHostnameVerifier(DatabaseKind.JOB,SSLHostnameVerifier.ANY);
+        manageConfig.setScheme("https");
         adminConfig.setScheme("https");
         manageConfig.setHost(host);
         manageConfig.setUsername(user);
         manageConfig.setSecurityUsername(secUser);
-    	
-    	if(isSslRun()) {
-    		stagingAppConfig.setAppServicesSslContext(SimpleX509TrustManager.newSSLContext());
-    		stagingAppConfig.setAppServicesSslHostnameVerifier(SSLHostnameVerifier.ANY);
+        
+        if(isSslRun()) {
+            stagingAppConfig.setAppServicesSslContext(SimpleX509TrustManager.newSSLContext());
+            stagingAppConfig.setAppServicesSslHostnameVerifier(SSLHostnameVerifier.ANY);
 
-    		finalAppConfig.setAppServicesSslContext(SimpleX509TrustManager.newSSLContext());
-    		finalAppConfig.setAppServicesSslHostnameVerifier(SSLHostnameVerifier.ANY);
-    		
-    		adminHubConfig.setSimpleSsl(DatabaseKind.STAGING,true);
-    		adminHubConfig.setSimpleSsl(DatabaseKind.JOB,true);
-    		adminHubConfig.setSimpleSsl(DatabaseKind.FINAL,true);
-    		
-    		adminHubConfig.setSslContext(DatabaseKind.STAGING,SimpleX509TrustManager.newSSLContext());
-    		adminHubConfig.setSslContext(DatabaseKind.FINAL,SimpleX509TrustManager.newSSLContext());
-        	adminHubConfig.setSslContext(DatabaseKind.JOB,SimpleX509TrustManager.newSSLContext());
-  		
-    		manageConfig.setConfigureSimpleSsl(true);
-    		manageConfig.setSslContext(SimpleX509TrustManager.newSSLContext());
+            finalAppConfig.setAppServicesSslContext(SimpleX509TrustManager.newSSLContext());
+            finalAppConfig.setAppServicesSslHostnameVerifier(SSLHostnameVerifier.ANY);
+            
+            adminHubConfig.setSimpleSsl(DatabaseKind.STAGING,true);
+            adminHubConfig.setSimpleSsl(DatabaseKind.JOB,true);
+            adminHubConfig.setSimpleSsl(DatabaseKind.FINAL,true);
+            
+            adminHubConfig.setSslContext(DatabaseKind.STAGING,SimpleX509TrustManager.newSSLContext());
+            adminHubConfig.setSslContext(DatabaseKind.FINAL,SimpleX509TrustManager.newSSLContext());
+            adminHubConfig.setSslContext(DatabaseKind.JOB,SimpleX509TrustManager.newSSLContext());
+        
+            manageConfig.setConfigureSimpleSsl(true);
+            manageConfig.setSslContext(SimpleX509TrustManager.newSSLContext());
 
-    		adminConfig.setConfigureSimpleSsl(true);
-    		adminConfig.setSslContext(SimpleX509TrustManager.newSSLContext());
-    	}
-    	if(isCertAuth()) {
-			stagingAppConfig.setAppServicesCertFile("src/test/resources/ssl/client-hub-admin-user.p12");
-			finalAppConfig.setAppServicesCertFile("src/test/resources/ssl/client-hub-admin-user.p12");
-			adminHubConfig.setCertFile(DatabaseKind.STAGING, "src/test/resources/ssl/client-hub-admin-user.p12");
-			adminHubConfig.setCertFile(DatabaseKind.FINAL, "src/test/resources/ssl/client-hub-admin-user.p12");
-			adminHubConfig.setSslContext(DatabaseKind.JOB,datahubadmincertContext);
-			manageConfig.setSslContext(datahubadmincertContext);
-			adminConfig.setSslContext(datahubadmincertContext);
-			
-    		stagingAppConfig.setAppServicesCertPassword("abcd");
-    		stagingAppConfig.setAppServicesTrustManager((X509TrustManager) tmf.getTrustManagers()[0]);
-    		stagingAppConfig.setAppServicesSslHostnameVerifier(SSLHostnameVerifier.ANY);
-    		stagingAppConfig.setAppServicesSecurityContextType(SecurityContextType.CERTIFICATE);
-    		stagingAppConfig.setAppServicesPassword(null);
+            adminConfig.setConfigureSimpleSsl(true);
+            adminConfig.setSslContext(SimpleX509TrustManager.newSSLContext());
+        }
+        if(isCertAuth()) {
+            stagingAppConfig.setAppServicesCertFile("src/test/resources/ssl/client-hub-admin-user.p12");
+            finalAppConfig.setAppServicesCertFile("src/test/resources/ssl/client-hub-admin-user.p12");
+            adminHubConfig.setCertFile(DatabaseKind.STAGING, "src/test/resources/ssl/client-hub-admin-user.p12");
+            adminHubConfig.setCertFile(DatabaseKind.FINAL, "src/test/resources/ssl/client-hub-admin-user.p12");
+            adminHubConfig.setSslContext(DatabaseKind.JOB,datahubadmincertContext);
+            manageConfig.setSslContext(datahubadmincertContext);
+            adminConfig.setSslContext(datahubadmincertContext);
+            
+            stagingAppConfig.setAppServicesCertPassword("abcd");
+            stagingAppConfig.setAppServicesTrustManager((X509TrustManager) tmf.getTrustManagers()[0]);
+            stagingAppConfig.setAppServicesSslHostnameVerifier(SSLHostnameVerifier.ANY);
+            stagingAppConfig.setAppServicesSecurityContextType(SecurityContextType.CERTIFICATE);
+            stagingAppConfig.setAppServicesPassword(null);
 
-    		finalAppConfig.setAppServicesCertPassword("abcd");
-    		finalAppConfig.setAppServicesTrustManager((X509TrustManager) tmf.getTrustManagers()[0]);
-    		finalAppConfig.setAppServicesSslHostnameVerifier(SSLHostnameVerifier.ANY);
-    		finalAppConfig.setAppServicesSecurityContextType(SecurityContextType.CERTIFICATE);
-    		finalAppConfig.setAppServicesPassword(null);
+            finalAppConfig.setAppServicesCertPassword("abcd");
+            finalAppConfig.setAppServicesTrustManager((X509TrustManager) tmf.getTrustManagers()[0]);
+            finalAppConfig.setAppServicesSslHostnameVerifier(SSLHostnameVerifier.ANY);
+            finalAppConfig.setAppServicesSecurityContextType(SecurityContextType.CERTIFICATE);
+            finalAppConfig.setAppServicesPassword(null);
 
-    		adminHubConfig.setAuthMethod(DatabaseKind.STAGING,"certificate");
-    		adminHubConfig.setAuthMethod(DatabaseKind.JOB,"certificate");
-    		adminHubConfig.setAuthMethod(DatabaseKind.FINAL,"certificate");
+            adminHubConfig.setAuthMethod(DatabaseKind.STAGING,"certificate");
+            adminHubConfig.setAuthMethod(DatabaseKind.JOB,"certificate");
+            adminHubConfig.setAuthMethod(DatabaseKind.FINAL,"certificate");
 
-    		adminHubConfig.setTrustManager(DatabaseKind.STAGING, (X509TrustManager) tmf.getTrustManagers()[0]);
-    		adminHubConfig.setCertPass(DatabaseKind.STAGING, "abcd");
+            adminHubConfig.setTrustManager(DatabaseKind.STAGING, (X509TrustManager) tmf.getTrustManagers()[0]);
+            adminHubConfig.setCertPass(DatabaseKind.STAGING, "abcd");
 
-    		adminHubConfig.setTrustManager(DatabaseKind.FINAL, (X509TrustManager) tmf.getTrustManagers()[0]);
-    		adminHubConfig.setCertPass(DatabaseKind.FINAL, "abcd");
+            adminHubConfig.setTrustManager(DatabaseKind.FINAL, (X509TrustManager) tmf.getTrustManagers()[0]);
+            adminHubConfig.setCertPass(DatabaseKind.FINAL, "abcd");
 
-    		manageConfig.setConfigureSimpleSsl(false);
-    		manageConfig.setSecuritySslContext(certContext);
-    		manageConfig.setPassword(null);
-    		manageConfig.setSecurityPassword(null);
+            manageConfig.setConfigureSimpleSsl(false);
+            manageConfig.setSecuritySslContext(certContext);
+            manageConfig.setPassword(null);
+            manageConfig.setSecurityPassword(null);
 
-    		adminConfig.setConfigureSimpleSsl(false);
-    		adminConfig.setPassword(null);
+            adminConfig.setConfigureSimpleSsl(false);
+            adminConfig.setPassword(null);
 
-    	}
-    	adminHubConfig.setStagingAppConfig(stagingAppConfig);
-    	adminHubConfig.setFinalAppConfig(finalAppConfig);
-    	((HubConfigImpl)adminHubConfig).setManageConfig(manageConfig);
-    	manageClient.setManageConfig(manageConfig);
-    	((HubConfigImpl)adminHubConfig).setManageClient(manageClient);
+        }
+        adminHubConfig.setStagingAppConfig(stagingAppConfig);
+        adminHubConfig.setFinalAppConfig(finalAppConfig);
+        ((HubConfigImpl)adminHubConfig).setManageConfig(manageConfig);
+        manageClient.setManageConfig(manageConfig);
+        ((HubConfigImpl)adminHubConfig).setManageClient(manageClient);
 
-    	((HubConfigImpl)adminHubConfig).setAdminConfig(adminConfig);
-    	wireClients();
+        ((HubConfigImpl)adminHubConfig).setAdminConfig(adminConfig);
+        wireClients();
     }
     public void deleteProjectDir() {
         if (new File(PROJECT_PATH).exists()) {
             try {
                 FileUtils.forceDelete(new File(PROJECT_PATH));
             } catch (IOException e) {
-            	logger.warn("Unable to delete the project directory", e);
+                logger.warn("Unable to delete the project directory", e);
             }
         }
     }
@@ -888,50 +888,50 @@ public class HubTestBase {
     }
 
     public void clearUserModules() {
-    	getDataHub().clearUserModules();
+        getDataHub().clearUserModules();
     }
 
-	protected String dhfCert() {
-		return new String(
-				"<certificate-template-properties xmlns=\"http://marklogic.com/manage\"> <template-name>dhf-cert</template-name><template-description>System Cert</template-description> <key-type>rsa</key-type><key-options/><req><version>0</version><subject><countryName>US</countryName><stateOrProvinceName>CA</stateOrProvinceName><commonName>*.marklogic.com</commonName><emailAddress>fbermude@marklogic.com</emailAddress><localityName>San Carlos</localityName><organizationName>MarkLogic</organizationName><organizationalUnitName>Engineering</organizationalUnitName></subject></req> </certificate-template-properties>");
-	}
+    protected String dhfCert() {
+        return new String(
+                "<certificate-template-properties xmlns=\"http://marklogic.com/manage\"> <template-name>dhf-cert</template-name><template-description>System Cert</template-description> <key-type>rsa</key-type><key-options/><req><version>0</version><subject><countryName>US</countryName><stateOrProvinceName>CA</stateOrProvinceName><commonName>*.marklogic.com</commonName><emailAddress>fbermude@marklogic.com</emailAddress><localityName>San Carlos</localityName><organizationName>MarkLogic</organizationName><organizationalUnitName>Engineering</organizationalUnitName></subject></req> </certificate-template-properties>");
+    }
 
-	private static SSLContext createSSLContext(File certFile) {
-		String certPassword = "abcd";
-	    SSLContext sslContext = null;
-	    KeyStore keyStore = null;
-	    KeyManagerFactory keyManagerFactory = null;
-	    KeyManager[] keyMgr = null;
-	    try {
-	    	keyManagerFactory = KeyManagerFactory.getInstance("SunX509");
-	    }
-	    catch (NoSuchAlgorithmException e) {
-	    	throw new IllegalStateException("CertificateAuthContext requires KeyManagerFactory.getInstance(\"SunX509\")");
-	    }
-	    try {
-	    	keyStore = KeyStore.getInstance("PKCS12");
-	    }
-	    catch (KeyStoreException e) {
-		    throw new IllegalStateException("CertificateAuthContext requires KeyStore.getInstance(\"PKCS12\")");
-	    }
-	    try {
-	    	FileInputStream certFileStream = new FileInputStream(certFile);
-		    try {
-		    	keyStore.load(certFileStream, certPassword.toCharArray());
-		    }
-		    finally {
-		      if (certFileStream != null)
-		        certFileStream.close();
-		    }
-		    keyManagerFactory.init(keyStore, certPassword.toCharArray());
-		    keyMgr = keyManagerFactory.getKeyManagers();
-		    sslContext = SSLContext.getInstance("TLSv1.2");
-		  }
-	    catch (NoSuchAlgorithmException | KeyStoreException e) {
-		    throw new IllegalStateException("The certificate algorithm used or the Key store "
-		    + "Service provider Implementaion (SPI) is invalid. CertificateAuthContext "
-		    + "requires SunX509 algorithm and PKCS12 Key store SPI", e);
-		} catch (CertificateException e) {
+    private static SSLContext createSSLContext(File certFile) {
+        String certPassword = "abcd";
+        SSLContext sslContext = null;
+        KeyStore keyStore = null;
+        KeyManagerFactory keyManagerFactory = null;
+        KeyManager[] keyMgr = null;
+        try {
+            keyManagerFactory = KeyManagerFactory.getInstance("SunX509");
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("CertificateAuthContext requires KeyManagerFactory.getInstance(\"SunX509\")");
+        }
+        try {
+            keyStore = KeyStore.getInstance("PKCS12");
+        }
+        catch (KeyStoreException e) {
+            throw new IllegalStateException("CertificateAuthContext requires KeyStore.getInstance(\"PKCS12\")");
+        }
+        try {
+            FileInputStream certFileStream = new FileInputStream(certFile);
+            try {
+                keyStore.load(certFileStream, certPassword.toCharArray());
+            }
+            finally {
+              if (certFileStream != null)
+                certFileStream.close();
+            }
+            keyManagerFactory.init(keyStore, certPassword.toCharArray());
+            keyMgr = keyManagerFactory.getKeyManagers();
+            sslContext = SSLContext.getInstance("TLSv1.2");
+          }
+        catch (NoSuchAlgorithmException | KeyStoreException e) {
+            throw new IllegalStateException("The certificate algorithm used or the Key store "
+            + "Service provider Implementaion (SPI) is invalid. CertificateAuthContext "
+            + "requires SunX509 algorithm and PKCS12 Key store SPI", e);
+        } catch (CertificateException e) {
             throw new IllegalStateException(e);
         } catch (UnrecoverableKeyException e) {
             throw new IllegalStateException(e);
@@ -947,21 +947,18 @@ public class HubTestBase {
         }
         return sslContext;
                 
-	}
-		
-	private static TrustManagerFactory installCARootCertIntoStore() {
-		File caRootCert = getResourceFile("ssl/ca-cert.crt");
-		//TrustManagerFactory tmf = null;
-		try (InputStream keyInputStream =  new ByteArrayInputStream(FileUtils.readFileToByteArray(caRootCert)))
-		{
-			X509Certificate caCert = (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(new BufferedInputStream(keyInputStream));
-			tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-			KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-			ks.load(null);
-			ks.setCertificateEntry("caCert", caCert);
-			tmf.init(ks);
+    }
 
-		} catch (CertificateException e) {
+    private static void installCARootCertIntoStore(File caRootCert) {
+        try (InputStream keyInputStream =  new ByteArrayInputStream(FileUtils.readFileToByteArray(caRootCert)))
+        {
+            X509Certificate caCert = (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(new BufferedInputStream(keyInputStream));
+            tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+            ks.load(null);
+            ks.setCertificateEntry("caCert", caCert);
+            tmf.init(ks);
+        } catch (CertificateException e) {
             throw new DataHubConfigurationException(e);
         } catch (NoSuchAlgorithmException e) {
             throw new DataHubConfigurationException(e);
@@ -970,7 +967,6 @@ public class HubTestBase {
         } catch (IOException e) {
             throw new DataHubConfigurationException(e);
         }
-		return tmf;
     }
 
     protected void debugOutput(Document xmldoc) {
@@ -978,7 +974,7 @@ public class HubTestBase {
     }
 
     protected void debugOutput(Document xmldoc, OutputStream os) {
-    	try {
+        try {
             TransformerFactory tf = TransformerFactory.newInstance();
             Transformer transformer = tf.newTransformer();
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -394,6 +394,11 @@ public class HubTestBase {
     protected HubConfig getHubFlowRunnerConfig() {
         adminHubConfig.setMlUsername(flowRunnerUser);
         adminHubConfig.setMlPassword(flowRunnerPassword);
+        stagingAppConfig = adminHubConfig.getStagingAppConfig();
+        finalAppConfig = adminHubConfig.getFinalAppConfig();
+        manageConfig = ((HubConfigImpl)adminHubConfig).getManageConfig();
+        manageClient = ((HubConfigImpl)adminHubConfig).getManageClient();
+        adminConfig = ((HubConfigImpl)adminHubConfig).getAdminConfig();
         if(isCertAuth()) {
             stagingAppConfig.setAppServicesCertFile("src/test/resources/ssl/client-data-hub-user.p12");
             finalAppConfig.setAppServicesCertFile("src/test/resources/ssl/client-data-hub-user.p12");
@@ -403,7 +408,12 @@ public class HubTestBase {
             manageConfig.setSslContext(flowRunnercertContext);
             adminConfig.setSslContext(flowRunnercertContext);                          
         }
-       // dataHub.setHubConfig(adminHubConfig);
+        adminHubConfig.setStagingAppConfig(stagingAppConfig);
+        adminHubConfig.setFinalAppConfig(finalAppConfig);
+        ((HubConfigImpl)adminHubConfig).setManageConfig(manageConfig);
+        manageClient.setManageConfig(manageConfig);
+        ((HubConfigImpl)adminHubConfig).setManageClient(manageClient);
+        ((HubConfigImpl)adminHubConfig).setAdminConfig(adminConfig);
         wireClients();
         return adminHubConfig;
     }
@@ -448,8 +458,8 @@ public class HubTestBase {
         adminHubConfig.setMlUsername(user);
         adminHubConfig.setMlPassword(password);
                 
-        AppConfig stagingAppConfig = adminHubConfig.getStagingAppConfig();
-        AppConfig finalAppConfig = adminHubConfig.getFinalAppConfig();
+        stagingAppConfig = adminHubConfig.getStagingAppConfig();
+        finalAppConfig = adminHubConfig.getFinalAppConfig();
         manageConfig = ((HubConfigImpl)adminHubConfig).getManageConfig();
         manageClient = ((HubConfigImpl)adminHubConfig).getManageClient();
         adminConfig = ((HubConfigImpl)adminHubConfig).getAdminConfig();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/PiiE2E.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/PiiE2E.java
@@ -26,8 +26,8 @@ import com.marklogic.hub.util.FileUtil;
 import com.marklogic.bootstrap.Installer;
 import org.apache.commons.io.FileUtils;
 import org.custommonkey.xmlunit.XMLUnit;
-import org.junit.Assert;
-import org.junit.Assume;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.FixMethodOrder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -82,7 +82,6 @@ public class PiiE2E extends HubTestBase {
 
     @BeforeAll
     public static void setupAll() throws Exception {
-        Assume.assumeTrue(!(isCertAuth()|| isSslRun()));
         XMLUnit.setIgnoreWhitespace(true);
         Path src = Paths.get(PiiE2E.class.getClassLoader().getResource("pii-test").toURI());
         Path dest = Paths.get(PROJECT_PATH).getFileName().toAbsolutePath();
@@ -100,6 +99,7 @@ public class PiiE2E extends HubTestBase {
 
     @BeforeEach
     public void setup() {
+        Assumptions.assumeTrue(!(isCertAuth()|| isSslRun()));
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME,  HubConfig.DEFAULT_FINAL_NAME);
         installHubModules();
         installUserModules(getHubAdminConfig(), true);
@@ -155,7 +155,7 @@ public class PiiE2E extends HubTestBase {
             updateHarmonizedDocument(officerClient);
             fail("Officer client should be able to update");
         } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Permission denied"));
+            Assertions.assertTrue(e.getMessage().contains("Permission denied"));
         }
         //verify that doc is not changed
         assertEquals("{\"fullName\":\"Morgan King\",\"worksFor\":\"Linger Company\",\"email\":\"morgan.king@lingercompany.com\",\"ssn\":\"136-70-5036\"}", getCustomerHistory(officerClient, "King"));
@@ -292,7 +292,7 @@ public class PiiE2E extends HubTestBase {
     private void installEntities() {
         Path employeeDir = project.getEntityDir("EmployeePii");
         employeeDir.toFile().mkdirs();
-        Assert.assertTrue(employeeDir.toFile().exists());
+        Assertions.assertTrue(employeeDir.toFile().exists());
         FileUtil.copy(getResourceStream("pii-test/test-entities/EmployeePii.entity.json"), employeeDir.resolve("EmployeePii.entity.json").toFile());
    }
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/PiiE2E.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/PiiE2E.java
@@ -27,6 +27,7 @@ import com.marklogic.bootstrap.Installer;
 import org.apache.commons.io.FileUtils;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.FixMethodOrder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -81,6 +82,7 @@ public class PiiE2E extends HubTestBase {
 
     @BeforeAll
     public static void setupAll() throws Exception {
+        Assume.assumeTrue(!(isCertAuth()|| isSslRun()));
         XMLUnit.setIgnoreWhitespace(true);
         Path src = Paths.get(PiiE2E.class.getClassLoader().getResource("pii-test").toURI());
         Path dest = Paths.get(PROJECT_PATH).getFileName().toAbsolutePath();


### PR DESCRIPTION
This PR enables running DHF core tests to run with all servers (DHF server, Manage, App Services and Admin) set to ssl/ cert auth in Spring Context.