### PR TITLE
DHFPROD-1513 Issue #1402 Traces don't have SJS stacks

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/impl/flow-lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/impl/flow-lib.sjs
@@ -626,7 +626,7 @@ function safeRun(func) {
   }
   catch(ex) {
     tracelib.errorTrace(rfc.getItemContext(), ex, xdmp.elapsedTime().subtract(before));
-    fn.error(null, "DATAHUB-PLUGIN-ERROR", Sequence.from(["error in a plugin", JSON.stringify(ex)]));
+    fn.error(null, "DATAHUB-PLUGIN-ERROR", ex);
   }
 };
 

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/impl/flow-lib.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/impl/flow-lib.xqy
@@ -988,7 +988,7 @@ declare function flow:safe-run($func)
     catch($ex) {
       debug:log(xdmp:describe($ex, (), ())),
       trace:error-trace($rfc:item-context, $ex, xdmp:elapsed-time() - $before),
-      fn:error((), "DATAHUB-PLUGIN-ERROR", ("error in a plugin", $ex))
+      fn:error((), "DATAHUB-PLUGIN-ERROR", $ex)
     }
 };
 

--- a/marklogic-data-hub/src/trace-ui/src/app/ml-error/ml-error.component.html
+++ b/marklogic-data-hub/src/trace-ui/src/app/ml-error/ml-error.component.html
@@ -1,9 +1,23 @@
 <div *ngIf="error" class="error">
   <div class="header">Error Info</div>
-  <p class="format-string">{{error.formatString}}</p>
+  <p class="format-string">{{error.formatString}}{{error.stack}}</p>
   <div class="stack">
     <div class="header">Stack</div>
     <ul class="stack-list">
+      <li *ngFor="let stack of error.stackFrames"
+        (click)=setActiveStack(stack)
+        [ngClass]="{'active': isActiveStack(stack)}">
+        <i class="fa fa-caret-right" [ngClass]="{ 'collapsed' : !isActiveStack(stack) }"></i>
+        <span>{{stack.uri}}:{{stack.line}}:{{stack.column}}</span>
+        <div class="variables" *ngIf="isActiveStack(stack)">
+          <div class="header">Variables:</div>
+          <ul>
+            <li *ngFor="let variable of variables">
+              <span class="key">{{variable}}</span>: <span class="value">{{stack.variables[variable]}}</span>
+            </li>
+          </ul>
+        </div>
+      </li>
       <li *ngFor="let stack of error.stacks"
         (click)=setActiveStack(stack)
         [ngClass]="{'active': isActiveStack(stack)}">

--- a/marklogic-data-hub/src/trace-ui/src/app/ml-error/ml-error.ts
+++ b/marklogic-data-hub/src/trace-ui/src/app/ml-error/ml-error.ts
@@ -13,9 +13,11 @@ export class MlError {
   xqueryVersion: string;
   message: string;
   formatString: string;
+  stack: string;
   retryable: boolean;
   expr: string;
   data: Array<string>;
+  stackFrames: Array<MlErrorStack>;
   stacks: Array<MlErrorStack>;
 
   constructor() {}

--- a/quick-start/src/main/ui/app/shared/components/ml-error/ml-error.component.html
+++ b/quick-start/src/main/ui/app/shared/components/ml-error/ml-error.component.html
@@ -1,9 +1,23 @@
 <div *ngIf="error" class="error">
   <div class="header">Error Info</div>
-  <p class="format-string">{{error.formatString}}</p>
+  <p class="format-string">{{error.formatString}}{{error.stack}}</p>
   <div class="stack">
     <div class="header">Stack</div>
     <ul class="stack-list">
+      <li *ngFor="let stack of error.stackFrames"
+        (click)=setActiveStack(stack)
+        [ngClass]="{'active': isActiveStack(stack)}">
+        <i class="fa fa-caret-right" [ngClass]="{ 'collapsed' : !isActiveStack(stack) }"></i>
+        <span>{{stack.uri}}:{{stack.line}}:{{stack.column}}</span>
+        <div class="variables" *ngIf="isActiveStack(stack)">
+          <div class="header">Variables:</div>
+          <ul>
+            <li *ngFor="let variable of variables">
+              <span class="key">{{variable}}</span>: <span class="value">{{stack.variables[variable]}}</span>
+            </li>
+          </ul>
+        </div>
+      </li>
       <li *ngFor="let stack of error.stacks"
         (click)=setActiveStack(stack)
         [ngClass]="{'active': isActiveStack(stack)}">

--- a/quick-start/src/main/ui/app/shared/components/ml-error/ml-error.ts
+++ b/quick-start/src/main/ui/app/shared/components/ml-error/ml-error.ts
@@ -13,10 +13,12 @@ export class MlError {
   xqueryVersion: string;
   message: string;
   formatString: string;
+  stack: string;
   retryable: boolean;
   expr: string;
   data: Array<string>;
   stacks: Array<MlErrorStack>;
+  stackFrames: Array<MlErrorStack>;
 
   constructor() {}
 }

--- a/quick-start/src/main/ui/app/shared/stories/components/ml-error/ml-error.component.stories.ts
+++ b/quick-start/src/main/ui/app/shared/stories/components/ml-error/ml-error.component.stories.ts
@@ -35,7 +35,15 @@ storiesOf('Components|ML Error', module)
     props: {
       error: object('Error Object', {
         formatString: "Error Name",
+        stack: "SJS Error Name",
         stacks: [
+          {
+            "uri": "http://Aasd",
+            "line": "asd",
+            "column": 10
+          }
+        ],
+        stackFrames: [
           {
             "uri": "http://Aasd",
             "line": "asd",


### PR DESCRIPTION
This PR addresses a long-standing issue with traces from SJS plugins.  Errors are not reported in the tracing database in 4.0.2.  This fix makes an initial attempt at displaying these traces.  There is a server-side component to the fix, so users might have to upgrade to 9.0-8 to see it.   While Jenkins works on this PR I'll see what quick start looks like against 9.0-7.