### PR TITLE
Change version and update mlcprunner classpath

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=4.0.1
+version=4.0.3

--- a/marklogic-data-hub/gradle.properties
+++ b/marklogic-data-hub/gradle.properties
@@ -12,7 +12,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-mlDHFVersion=4.0.1
+mlDHFVersion=4.0.3
 mlHost=localhost
 mlAppName=data-hub
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/util/MlcpRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/util/MlcpRunner.java
@@ -194,6 +194,7 @@ public class MlcpRunner extends ProcessRunner {
                             .stream()
                             .filter(
                                 u -> (
+                                    u.contains(System.getProperty("user.dir")) ||
                                     u.contains("jdk") ||
                                     u.contains("jre") ||
                                     u.contains("log") ||

--- a/ml-data-hub-plugin/gradle.properties
+++ b/ml-data-hub-plugin/gradle.properties
@@ -12,7 +12,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-mlDHFVersion=4.0.1
+mlDHFVersion=4.0.3
 mlHost=localhost
 mlAppName=data-hub
 

--- a/quick-start/gradle.properties
+++ b/quick-start/gradle.properties
@@ -13,7 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # What version of DHF am I intending on targetting? Make sure you use the full SemVer x.x.x
-mlDHFVersion=4.0.1
+mlDHFVersion=4.0.3
 
 mlHost=localhost
 mlAppName=data-hub


### PR DESCRIPTION
1. This PR changes the versions in gradle.properties to align with 4.0.3 release and the already made changes in HubConfigImpl and other files
2. Updates MlcpRunner's classpath to run the dhf-project-tests