### PR TITLE
e2e navigate to url on each spec

### DIFF
--- a/quick-start/e2e/specs/create/create.ts
+++ b/quick-start/e2e/specs/create/create.ts
@@ -84,6 +84,7 @@ export default function(tmpDir) {
     });
 
     it ('should create a new Order entity', async function() {
+      browser.get('http://localhost:8080/#/entities');
       //create Order entity
       console.log('create Order entity');
       await entityPage.toolsButton.click();
@@ -105,6 +106,7 @@ export default function(tmpDir) {
     });
 
     it ('should create a new Product entity', async function() {
+      browser.get('http://localhost:8080/#/entities');
       //create Product entity
       console.log('create Product entity');
       await entityPage.toolsButton.click();
@@ -126,6 +128,7 @@ export default function(tmpDir) {
     });
 
     it ('should add properties to Product entity', async function() {
+      browser.get('http://localhost:8080/#/entities');
       //add properties
       console.log('add properties to Product entity');
       console.log('edit Product entity');
@@ -165,6 +168,7 @@ export default function(tmpDir) {
     });
 
     it ('should add properties to Order entity', async function() {
+      browser.get('http://localhost:8080/#/entities');
       //add properties
       console.log('add properties to Order entity');
       console.log('edit Order entity');
@@ -205,6 +209,7 @@ export default function(tmpDir) {
     });
 
     it ('should verify properties to Product entity', async function() {
+      browser.get('http://localhost:8080/#/entities');
       console.log('verify properties to Product entity');
       await entityPage.clickEditEntity('Product');
       browser.wait(EC.visibilityOf(entityPage.entityEditor));
@@ -229,6 +234,7 @@ export default function(tmpDir) {
     });
 
     it ('should verify properties to Order entity', async function() {
+      browser.get('http://localhost:8080/#/entities');
       console.log('verify properties to Order entity');
       await entityPage.clickEditEntity('Order');
       browser.wait(EC.visibilityOf(entityPage.entityEditor));
@@ -311,6 +317,7 @@ export default function(tmpDir) {
     });*/
 
     it ('should remove a created entity', async function() {
+      browser.get('http://localhost:8080/#/entities');
       //create removeEntity entity
       console.log('create removeEntity entity');
       await entityPage.toolsButton.click();
@@ -340,6 +347,7 @@ export default function(tmpDir) {
     });
 
     it ('should create a new entity', async function() {
+      browser.get('http://localhost:8080/#/entities');
       await entityPage.toolsButton.click();
       await entityPage.newEntityButton.click();
       expect(entityPage.entityEditor.isDisplayed()).toBe(true);
@@ -362,6 +370,7 @@ export default function(tmpDir) {
     // after the general create script and before the general tear down scripts
 
     it('should create a new property', async function(){
+      browser.get('http://localhost:8080/#/entities');
       await entityPage.clickEditEntity('TestEntity');
       browser.wait(EC.visibilityOf(entityPage.entityEditor));
       expect(entityPage.entityEditor.isDisplayed()).toBe(true);
@@ -401,6 +410,7 @@ export default function(tmpDir) {
     });
 
     it('should remove a property', async function(){
+      browser.get('http://localhost:8080/#/entities');
       //now time to delete, let's reopen the editor
       await entityPage.clickEditEntity('TestEntity');
       browser.wait(EC.visibilityOf(entityPage.entityEditor));
@@ -425,6 +435,7 @@ export default function(tmpDir) {
     });
 
     it('should retain settings on remaining property', async function() {
+      browser.get('http://localhost:8080/#/entities');
       //now let's confirm we didn't lose any settings, reopen editor
       await entityPage.clickEditEntity('TestEntity');
       browser.wait(EC.visibilityOf(entityPage.entityEditor));
@@ -449,6 +460,7 @@ export default function(tmpDir) {
     });
 
     it ('should create a new entity for PII', async function() {
+      browser.get('http://localhost:8080/#/entities');
       await entityPage.toolsButton.click();
       await entityPage.newEntityButton.click();
       expect(entityPage.entityEditor.isDisplayed()).toBe(true);
@@ -466,6 +478,7 @@ export default function(tmpDir) {
     });
 
     it('should create a pii property', async function(){
+      browser.get('http://localhost:8080/#/entities');
       await entityPage.clickEditEntity('PIIEntity');
       browser.wait(EC.visibilityOf(entityPage.entityEditor));
       expect(entityPage.entityEditor.isDisplayed()).toBe(true);
@@ -504,6 +517,7 @@ export default function(tmpDir) {
     });
 
     it ('should verify pii property to PII entity', async function() {
+      browser.get('http://localhost:8080/#/entities');
       console.log('verify pii property to PII entity');
       await entityPage.clickEditEntity('PIIEntity');
       browser.wait(EC.visibilityOf(entityPage.entityEditor));
@@ -535,6 +549,7 @@ export default function(tmpDir) {
     });
 
     it ('should verify naming conventions on properties', async function() {
+      browser.get('http://localhost:8080/#/entities');
       await entityPage.clickEditEntity('PIIEntity');
       browser.wait(EC.visibilityOf(entityPage.entityEditor));
       expect(entityPage.entityEditor.isDisplayed()).toBe(true);
@@ -553,6 +568,7 @@ export default function(tmpDir) {
     });
 
     it ('should not be able to create duplicate properties', async function() {
+      browser.get('http://localhost:8080/#/entities');
       await entityPage.clickEditEntity('PIIEntity');
       browser.wait(EC.visibilityOf(entityPage.entityEditor));
       expect(entityPage.entityEditor.isDisplayed()).toBe(true);
@@ -587,6 +603,7 @@ export default function(tmpDir) {
     });
 
     it ('should verify pii property is retained after logout', async function() {
+      browser.get('http://localhost:8080/#/entities');
       console.log('verify pii property is retained after logout');
       await entityPage.clickEditEntity('PIIEntity');
       browser.wait(EC.visibilityOf(entityPage.entityEditor));
@@ -605,6 +622,7 @@ export default function(tmpDir) {
     });
 
     it ('should create a new entity for WorldBank', async function() {
+      browser.get('http://localhost:8080/#/entities');
       await entityPage.toolsButton.click();
       await entityPage.newEntityButton.click();
       expect(entityPage.entityEditor.isDisplayed()).toBe(true);
@@ -646,12 +664,14 @@ export default function(tmpDir) {
     });
 
     it ('should open the Entity disclosure', async function() {
+      browser.get('http://localhost:8080/#/flows');
       await flowPage.clickEntityDisclosure('TestEntity');
       browser.wait(EC.elementToBeClickable(flowPage.inputFlowButton('TestEntity')));
       browser.sleep(5000);
     });
 
     it('should create sjs xml input flow with ES', async function() {
+      browser.get('http://localhost:8080/#/flows');
       let codeFormat = 'sjs';
       let dataFormat = 'xml';
       let flowName = `${codeFormat} ${dataFormat} INPUT`;
@@ -662,6 +682,7 @@ export default function(tmpDir) {
     });
 
     it('should create sjs json input flow', async function() {
+      browser.get('http://localhost:8080/#/flows');
       let codeFormat = 'sjs';
       let dataFormat = 'json';
       let flowName = `${codeFormat} ${dataFormat} INPUT`;
@@ -672,6 +693,7 @@ export default function(tmpDir) {
     });
 
     it('should create xqy xml input flow', async function() {
+      browser.get('http://localhost:8080/#/flows');
       let codeFormat = 'xqy';
       let dataFormat = 'xml';
       let flowName = `${codeFormat} ${dataFormat} INPUT`;
@@ -682,6 +704,7 @@ export default function(tmpDir) {
     });
 
     it('should create xqy json input flow with ES', async function() {
+      browser.get('http://localhost:8080/#/flows');
       let codeFormat = 'xqy';
       let dataFormat = 'json';
       let flowName = `${codeFormat} ${dataFormat} INPUT`;
@@ -692,6 +715,7 @@ export default function(tmpDir) {
     });
 
     it('should create sjs xml harmonize flow', async function() {
+      browser.get('http://localhost:8080/#/flows');
       let codeFormat = 'sjs';
       let dataFormat = 'xml';
       let flowName = `${codeFormat} ${dataFormat} HARMONIZE`;
@@ -702,6 +726,7 @@ export default function(tmpDir) {
     });
 
     it('should create sjs json harmonize flow', async function() {
+      browser.get('http://localhost:8080/#/flows');
       let codeFormat = 'sjs';
       let dataFormat = 'json';
       let flowName = `${codeFormat} ${dataFormat} HARMONIZE`;
@@ -712,6 +737,7 @@ export default function(tmpDir) {
     });
 
     it('should create xqy xml harmonize flow', async function() {
+      browser.get('http://localhost:8080/#/flows');
       let codeFormat = 'xqy';
       let dataFormat = 'xml';
       let flowName = `${codeFormat} ${dataFormat} HARMONIZE`;
@@ -722,6 +748,7 @@ export default function(tmpDir) {
     });
 
     it('should create xqy json harmonize flow', async function() {
+      browser.get('http://localhost:8080/#/flows');
       let codeFormat = 'xqy';
       let dataFormat = 'json';
       let flowName = `${codeFormat} ${dataFormat} HARMONIZE`;
@@ -732,11 +759,13 @@ export default function(tmpDir) {
     });
 
     it ('should open Product entity disclosure', async function() {
+      browser.get('http://localhost:8080/#/flows');
       await flowPage.clickEntityDisclosure('Product');
       browser.wait(EC.elementToBeClickable(flowPage.inputFlowButton('Product')));
     });
 
     it ('should create input flow on Product entity', async function() {
+      browser.get('http://localhost:8080/#/flows');
       //create Product input flow
       await flowPage.createInputFlow('Product', 'Load Products', 'json', 'sjs', false);
       browser.wait(EC.elementToBeClickable(flowPage.getFlow('Product', 'Load Products', 'INPUT')));
@@ -745,6 +774,7 @@ export default function(tmpDir) {
     });
 
     it ('should create harmonize flow on Product entity', async function() {
+      browser.get('http://localhost:8080/#/flows');
       //create Product harmonize flow
       await flowPage.createHarmonizeFlow('Product', 'Harmonize Products', 'json', 'sjs', true);
       browser.wait(EC.elementToBeClickable(flowPage.getFlow('Product', 'Harmonize Products', 'HARMONIZE')));
@@ -763,6 +793,7 @@ export default function(tmpDir) {
     });
 
     it ('should redeploy modules', async function() {
+      browser.get('http://localhost:8080/#/flows');
       flowPage.redeployButton.click();
       browser.sleep(5000);
       await appPage.dashboardTab.click();

--- a/quick-start/e2e/specs/mappings/mappings.ts
+++ b/quick-start/e2e/specs/mappings/mappings.ts
@@ -14,11 +14,13 @@ export default function() {
       });
 
       it ('should redeploy modules', async function() {
+        browser.get('http://localhost:8080/#/flows');
         await flowPage.redeployButton.click();
         browser.sleep(5000);
       });
 
       it('should create a mapping for Product entity with sku source', async function() {
+        browser.get('http://localhost:8080/#/browse');
         // get the document uri with sku - board_games_accessories.csv-0-1
         await appPage.browseDataTab.click()
         browsePage.isLoaded();
@@ -29,6 +31,7 @@ export default function() {
         browser.wait(EC.elementToBeClickable(browsePage.resultsUri()));
         let sourceDocUriWithSmallSku =
           browsePage.resultsSpecificUri('/board_games_accessories.csv-0-1?doc=yes&type=foo').getText();
+        browser.get('http://localhost:8080/#/mappings');
         // create the map with specific sku doc uri
         await appPage.mappingsTab.click();
         mappingsPage.isLoaded();
@@ -82,6 +85,7 @@ export default function() {
       });
 
       it('should update MapProduct with SKU source', async function() {
+        browser.get('http://localhost:8080/#/browse');
         // get the document uri with SKU - board_games.csv-0-10
         await appPage.browseDataTab.click()
         browsePage.isLoaded();
@@ -92,6 +96,7 @@ export default function() {
         browser.wait(EC.elementToBeClickable(browsePage.resultsUri()));
         let sourceDocUriWithBigSku =
           browsePage.resultsSpecificUri('/board_games.csv-0-10?doc=yes&type=foo').getText();
+        browser.get('http://localhost:8080/#/mappings');  
         // update the map with specific SKU doc uri
         await appPage.mappingsTab.click();
         mappingsPage.isLoaded();
@@ -104,6 +109,7 @@ export default function() {
         await mappingsPage.inputSourceURI().clear();
         await mappingsPage.inputSourceURI().sendKeys(sourceDocUriWithBigSku);
         await mappingsPage.editSourceURITick().click();
+        browser.sleep(5000);
         browser.wait(EC.elementToBeClickable(mappingsPage.editSourceURIConfirmationOK()));
         await mappingsPage.editSourceURIConfirmationOK().click();
         // putting sleep right until the flickering bug is fixed
@@ -133,11 +139,13 @@ export default function() {
       });
 
       it('should go to flows tab', async function() {
+        browser.get('http://localhost:8080/#/flows');
         await appPage.flowsTab.click();
         flowPage.isLoaded();
       });
 
       it('should create Harmonize SKU flow on Product', async function() {
+        browser.get('http://localhost:8080/#/flows');
         await flowPage.clickEntityDisclosure('Product');
         //browser.sleep(5000);
         await flowPage.createHarmonizeFlow('Product', 'Harmonize SKU', 'json', 'sjs', true, 'MapProduct');
@@ -147,11 +155,13 @@ export default function() {
       });
 
       it ('should redeploy modules', async function() {
+        browser.get('http://localhost:8080/#/flows');
         await flowPage.redeployButton.click();
         browser.sleep(5000);
       });
 
       it('should run Harmonize SKU flow with mapping', async function() {
+        browser.get('http://localhost:8080/#/flows');
         await flowPage.clickEntityDisclosure('Product');
         //browser.sleep(5000);
         browser.wait(EC.elementToBeClickable(flowPage.getFlow('Product', 'Harmonize SKU', 'HARMONIZE')));
@@ -164,6 +174,7 @@ export default function() {
       });
 
       it('should verify the harmonized SKU data with mappings', async function() {
+        browser.get('http://localhost:8080/#/browse');
         await appPage.browseDataTab.click()
         browsePage.isLoaded();
         browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
@@ -188,6 +199,7 @@ export default function() {
       });
 
       it('should rollback to current URI when providing invalid URI', async function() {
+        browser.get('http://localhost:8080/#/mappings');
         await appPage.mappingsTab.click();
         mappingsPage.isLoaded();
         browser.wait(EC.elementToBeClickable(mappingsPage.entityMapping('MapProduct')));
@@ -201,6 +213,7 @@ export default function() {
         await mappingsPage.inputSourceURI().clear();
         await mappingsPage.inputSourceURI().sendKeys('invalidURI');
         await mappingsPage.editSourceURITick().click();
+        browser.sleep(5000);
         browser.wait(EC.elementToBeClickable(mappingsPage.editSourceURIConfirmationOK()));
         await mappingsPage.editSourceURIConfirmationOK().click();
         //browser.sleep(3000);
@@ -219,6 +232,7 @@ export default function() {
       });
 
       it('should verify the behavior on reset cancel', async function() {
+        browser.get('http://localhost:8080/#/mappings');
         await appPage.mappingsTab.click();
         mappingsPage.isLoaded();
         browser.wait(EC.elementToBeClickable(mappingsPage.entityMapping('MapProduct')));
@@ -245,6 +259,7 @@ export default function() {
       });
 
       it('should verify the behavior on reset ok', async function() {
+        browser.get('http://localhost:8080/#/mappings');
         await appPage.mappingsTab.click();
         mappingsPage.isLoaded();
         browser.wait(EC.elementToBeClickable(mappingsPage.entityMapping('MapProduct')));

--- a/quick-start/e2e/specs/mappings/typeAhead.ts
+++ b/quick-start/e2e/specs/mappings/typeAhead.ts
@@ -14,11 +14,13 @@ export default function() {
       });
 
       it ('should redeploy modules', async function() {
+        browser.get('http://localhost:8080/#/flows');
         await flowPage.redeployButton.click();
         browser.sleep(5000);
       });
 
       it ('should create input flow on WorldBank entity', async function() {
+        browser.get('http://localhost:8080/#/flows');
         //create WorldBank input flow
         await flowPage.clickEntityDisclosure('WorldBank');
         await flowPage.createInputFlow('WorldBank', 'Load WorldBank', 'json', 'sjs', false);
@@ -28,11 +30,13 @@ export default function() {
       });
 
       it ('should redeploy modules', async function() {
+        browser.get('http://localhost:8080/#/flows');
         await flowPage.redeployButton.click();
         browser.sleep(5000);
       });
 
       it ('should run Load WorldBank flow', async function() {
+        browser.get('http://localhost:8080/#/flows');
         await flowPage.clickEntityDisclosure('WorldBank');
         browser.wait(EC.elementToBeClickable(flowPage.getFlow('WorldBank', 'Load WorldBank', 'INPUT')));
         await flowPage.runInputFlow('WorldBank', 'Load WorldBank', 'json', 'worldbank', 'delimited_json',
@@ -40,6 +44,7 @@ export default function() {
       });
 
       it('should verify the loaded data', async function() {
+        browser.get('http://localhost:8080/#/browse');
         //verify on browse data page
         await appPage.browseDataTab.click();
         browsePage.isLoaded();
@@ -55,6 +60,7 @@ export default function() {
       });
 
       it ('should add properties to WorldBank entity', async function() {
+        browser.get('http://localhost:8080/#/entities');
         await appPage.entitiesTab.click();
         entityPage.isLoaded();
         //add properties
@@ -101,6 +107,7 @@ export default function() {
       });
 
       it('should create a mapping for WorldBank entity', async function() {
+        browser.get('http://localhost:8080/#/browse');
         // get the document uri - /worldbank/world_bank.zip-0-100
         await appPage.browseDataTab.click()
         browsePage.isLoaded();
@@ -111,6 +118,7 @@ export default function() {
         browser.wait(EC.elementToBeClickable(browsePage.resultsUri()));
         let sourceDocUri =
           browsePage.resultsSpecificUri('/world_bank.zip-0-100?doc=yes&type=foo').getText();
+          browser.get('http://localhost:8080/#/mappings');
         // create the map with specific worldbank doc uri
         await appPage.mappingsTab.click();
         mappingsPage.isLoaded();
@@ -193,11 +201,13 @@ export default function() {
       });
 
       it('should go to flows tab', async function() {
+        browser.get('http://localhost:8080/#/flows');
         await appPage.flowsTab.click();
         flowPage.isLoaded();
       });
 
       it('should create Harmonize WorldBank flow', async function() {
+        browser.get('http://localhost:8080/#/flows');
         await flowPage.clickEntityDisclosure('WorldBank');
         await flowPage.createHarmonizeFlow('WorldBank', 'Harmonize WorldBank', 'json', 'sjs', true, 'MapWorldBank');
         browser.wait(EC.elementToBeClickable(flowPage.getFlow('WorldBank', 'Harmonize WorldBank', 'HARMONIZE')));
@@ -206,11 +216,13 @@ export default function() {
       });
 
       it ('should redeploy modules', async function() {
+        browser.get('http://localhost:8080/#/flows');
         await flowPage.redeployButton.click();
         browser.sleep(5000);
       });
 
       it('should run Harmonize WorldBank flow with mapping', async function() {
+        browser.get('http://localhost:8080/#/flows');
         await flowPage.clickEntityDisclosure('WorldBank');
         browser.wait(EC.elementToBeClickable(flowPage.getFlow('WorldBank', 'Harmonize WorldBank', 'HARMONIZE')));
         expect(flowPage.getFlow('WorldBank', 'Harmonize WorldBank', 'HARMONIZE').isPresent()).toBe(true);
@@ -222,6 +234,7 @@ export default function() {
       });
 
       it('should verify the harmonized data with mappings', async function() {
+        browser.get('http://localhost:8080/#/browse');
         await appPage.browseDataTab.click()
         browsePage.isLoaded();
         browser.wait(EC.visibilityOf(browsePage.resultsPagination()));

--- a/quick-start/e2e/specs/run/run.ts
+++ b/quick-start/e2e/specs/run/run.ts
@@ -16,6 +16,7 @@ export default function(tmpDir) {
     });
 
     it ('should run Load Products flow', async function() {
+      browser.get('http://localhost:8080/#/flows');
       await flowPage.clickEntityDisclosure('Product');
       browser.wait(EC.elementToBeClickable(flowPage.getFlow('Product', 'Load Products', 'INPUT')));
       await flowPage.runInputFlow('Product', 'Load Products', 'json', 'products',
@@ -92,6 +93,7 @@ export default function(tmpDir) {
     });
 
     it ('should redeploy modules', async function() {
+      browser.get('http://localhost:8080/#/flows');
       await appPage.flowsTab.click();
       flowPage.isLoaded();
       await flowPage.redeployButton.click();
@@ -115,11 +117,13 @@ export default function(tmpDir) {
     });
 
     it ('should redeploy modules', async function() {
+      browser.get('http://localhost:8080/#/flows');
       await flowPage.redeployButton.click();
       browser.sleep(5000);
     });
 
     it('should run Harmonize Products flow', async function() {
+      browser.get('http://localhost:8080/#/flows');
       flowPage.isLoaded();
       console.log('clicking Product entity');
       await flowPage.clickEntityDisclosure('Product');
@@ -141,6 +145,7 @@ export default function(tmpDir) {
     });
 
     it('should verify the harmonized data with sku as original property', async function() {
+      browser.get('http://localhost:8080/#/browse');
       await appPage.browseDataTab.click();
       browsePage.isLoaded();
       browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
@@ -166,6 +171,7 @@ export default function(tmpDir) {
     });
 
     it('should verify the harmonized data with SKU as original property', async function() {
+      browser.get('http://localhost:8080/#/browse');
       await appPage.browseDataTab.click();
       browsePage.isLoaded();
       browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
@@ -207,6 +213,7 @@ export default function(tmpDir) {
     });
 
     it ('should redeploy modules', async function() {
+      browser.get('http://localhost:8080/#/flows');
       await appPage.flowsTab.click();
       flowPage.isLoaded();
       await flowPage.redeployButton.click();
@@ -214,11 +221,13 @@ export default function(tmpDir) {
     });
 
     it ('should open the TestEntity disclosure', async function() {
+      browser.get('http://localhost:8080/#/flows');
       await flowPage.clickEntityDisclosure('TestEntity');
       browser.wait(EC.elementToBeClickable(flowPage.getFlow('TestEntity', 'sjs json INPUT', 'INPUT')));
     });
 
     it('should run sjs xml input flow with ES', async function() {
+      browser.get('http://localhost:8080/#/flows');
       let codeFormat = 'sjs';
       let dataFormat = 'xml';
       let flowName = `${codeFormat} ${dataFormat} INPUT`;
@@ -226,6 +235,7 @@ export default function(tmpDir) {
     });
 
     it('should run sjs json input flow', async function() {
+      browser.get('http://localhost:8080/#/flows');
       let codeFormat = 'sjs';
       let dataFormat = 'json';
       let flowName = `${codeFormat} ${dataFormat} INPUT`;
@@ -233,6 +243,7 @@ export default function(tmpDir) {
     });
 
     it('should run xqy xml input flow', async function() {
+      browser.get('http://localhost:8080/#/flows');
       let codeFormat = 'xqy';
       let dataFormat = 'xml';
       let flowName = `${codeFormat} ${dataFormat} INPUT`;
@@ -240,6 +251,7 @@ export default function(tmpDir) {
     });
 
     it('should run xqy json input flow with ES', async function() {
+      browser.get('http://localhost:8080/#/flows');
       let codeFormat = 'xqy';
       let dataFormat = 'json';
       let flowName = `${codeFormat} ${dataFormat} INPUT`;
@@ -247,6 +259,7 @@ export default function(tmpDir) {
     });
 
     it('should verify the ES json data with small sku', async function() {
+      browser.get('http://localhost:8080/#/browse');
       //verify on browse data page
       await appPage.browseDataTab.click();
       browsePage.isLoaded();
@@ -275,6 +288,7 @@ export default function(tmpDir) {
     });
 
     it('should verify the ES json data with big SKU', async function() {
+      browser.get('http://localhost:8080/#/browse');
       //verify on browse data page
       await appPage.browseDataTab.click();
       browsePage.isLoaded();
@@ -303,6 +317,7 @@ export default function(tmpDir) {
     });
 
     it('should verify the ES xml data', async function() {
+      browser.get('http://localhost:8080/#/browse');
       //verify on browse data page
       await appPage.browseDataTab.click();
       browsePage.isLoaded();
@@ -347,6 +362,7 @@ export default function(tmpDir) {
     });
 
     it('should verify that no-pii-user cannot see titlePii and attachment title on harmonized data', async function() {
+      browser.get('http://localhost:8080/#/browse');
       await appPage.browseDataTab.click();
       browsePage.isLoaded();
       browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
@@ -383,6 +399,7 @@ export default function(tmpDir) {
     });
 
     it('should verify that pii-user can see titlePii and attachment title on harmonized data', async function() {
+      browser.get('http://localhost:8080/#/browse');
       await appPage.browseDataTab.click();
       browsePage.isLoaded();
       browser.wait(EC.visibilityOf(browsePage.resultsPagination()));

--- a/quick-start/e2e/specs/traces/traces.ts
+++ b/quick-start/e2e/specs/traces/traces.ts
@@ -11,12 +11,14 @@ export default function() {
       });
 
       it ('should verify the traces page', function() {
+        browser.get('http://localhost:8080/#/traces');
         tracesPage.isLoaded();
         browser.wait(EC.visibilityOf(tracesPage.tracesResults()));
         expect(tracesPage.tracesResults().isDisplayed()).toBe(true);
       });
 
       it ('should verify the traces viewer page', async function() {
+        browser.get('http://localhost:8080/#/traces');
         await tracesPage.searchBox().clear();
         await tracesPage.searchBox().sendKeys('442403950907');
         console.log('searching the specific harmonize trace');

--- a/quick-start/e2e/specs/uninstall/uninstall.ts
+++ b/quick-start/e2e/specs/uninstall/uninstall.ts
@@ -12,6 +12,7 @@ export default function(tmpDir) {
     });
 
     it ('should click the uninstall button', async function() {
+      browser.get('http://localhost:8080/#/settings');
       await settingsPage.uninstallButton.click();
       browser.wait(EC.elementToBeClickable(settingsPage.uninstallConfirmation));
       await settingsPage.uninstallConfirmation.click();


### PR DESCRIPTION
This PR implements navigate to respective page url on each spec. In case of element/dialog box timeout, it will bring a refreshed page for the next spec to minimize the cascading failures (often caused by protractor trying to click on background overlay elements)