### PR TITLE
Fixes issue where mlUsername/mlPassword were not set in gradle.proper…

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -987,8 +987,10 @@ public class HubConfigImpl implements HubConfig
         File file = hubProject.getProjectDir().resolve("gradle.properties").toFile();
         loadPropertiesFromFile(file, projectProperties);
         if (usePropertiesFromEnvironment && envString != null) {
-            File envPropertiesFile = hubProject.getProjectDir().resolve("gradle-" + environment + ".properties").toFile();
-            loadPropertiesFromFile(envPropertiesFile, projectProperties);
+            File envPropertiesFile = hubProject.getProjectDir().resolve("gradle-" + envString + ".properties").toFile();
+            if (envPropertiesFile != null && envPropertiesFile.exists()) {
+                loadPropertiesFromFile(envPropertiesFile, projectProperties);
+            }
         }
 
         if (properties != null){

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -160,7 +160,17 @@ class DataHubPlugin implements Plugin<Project> {
         if(! hubProject.isInitialized()) {
             hubConfig.initHubProject()
         }
-        hubConfig.refreshProject()
+
+        def environmentNameProperty = "environmentName"
+        if (project.hasProperty("propertiesPluginEnvironmentNameProperty")) {
+            environmentNameProperty = project.property("propertiesPluginEnvironmentNameProperty")
+        }
+        def environmentName = "local"
+        if (project.hasProperty(environmentNameProperty)) {
+            environmentName = project.property(environmentNameProperty)
+        }
+
+        hubConfig.withPropertiesFromEnvironment(environmentName).refreshProject()
 
         hubConfig.setStagingAppConfig(extensions.getByName("mlAppConfig"))
         hubConfig.setAdminConfig(extensions.getByName("mlAdminConfig"))


### PR DESCRIPTION
…ties

If they're set in gradle-local.properties but not gradle.properties, then the properties were not being set because hubConfig.withPropertiesFromEnvironment was not being called. 

Not familiar with writing DHF tests yet, but we definitely need a test where mlUsername/mlPassword are not in gradle.properties