### PR TITLE
Better fix for passing Gradle properties into HubConfigImpl

### DIFF
--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -161,16 +161,8 @@ class DataHubPlugin implements Plugin<Project> {
             hubConfig.initHubProject()
         }
 
-        def environmentNameProperty = "environmentName"
-        if (project.hasProperty("propertiesPluginEnvironmentNameProperty")) {
-            environmentNameProperty = project.property("propertiesPluginEnvironmentNameProperty")
-        }
-        def environmentName = "local"
-        if (project.hasProperty(environmentNameProperty)) {
-            environmentName = project.property(environmentNameProperty)
-        }
-
-        hubConfig.withPropertiesFromEnvironment(environmentName).refreshProject()
+        // The Gradle set of properties is passed in as they've already been loaded and processed by the Gradle properties plugin.
+        hubConfig.refreshProject(new ProjectPropertySource(project).getProperties(), false)
 
         hubConfig.setStagingAppConfig(extensions.getByName("mlAppConfig"))
         hubConfig.setAdminConfig(extensions.getByName("mlAdminConfig"))

--- a/quick-start/src/main/java/com/marklogic/quickstart/auth/ConnectionAuthenticationFilter.java
+++ b/quick-start/src/main/java/com/marklogic/quickstart/auth/ConnectionAuthenticationFilter.java
@@ -115,7 +115,7 @@ public class ConnectionAuthenticationFilter extends
         Properties overrides = new Properties();
         overrides.put("mlUsername", username);
         overrides.put("mlPassword", password);
-        hubConfig.refreshProject(overrides);
+        hubConfig.refreshProject(overrides, true);
         hubConfig.getStagingAppConfig().setAppServicesUsername(username);
         hubConfig.getStagingAppConfig().setAppServicesPassword(password);
 


### PR DESCRIPTION
DataHubPlugin now passes in the already-processed set of Gradle properties. No other code was calling withPropertiesFromEnvironment, so there's no longer a need to load any properties from a file.