### PR TITLE
1561 Removing line that disables database ordering

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -1083,7 +1083,6 @@ public class HubConfigImpl implements HubConfig
 
     private void hydrateAppConfigs(com.marklogic.mgmt.util.PropertySource propertySource) {
         setAppConfig(new DefaultAppConfigFactory(propertySource).newAppConfig());
-        getAppConfig().setSortOtherDatabaseByDependencies(false);
 
         setAdminConfig(new DefaultAdminConfigFactory(propertySource).newAdminConfig());
         setAdminManager(new AdminManager(getAdminConfig()));


### PR DESCRIPTION
I was able to run "gradle bootstrap" successfully with this; it was failing before the fix, working after it. 

This line oddly doesn't seem to impact Gradle deployment, which are sorting the databases.