### PR TITLE
Setting version back to 4.0.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=4.0.3.2
+version=4.0.3


### PR DESCRIPTION
This was mistakenly checked in while publishing localy builds of DHF