### PR TITLE
1551 mlLoadModules and mlWatch now work properly

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadHubModulesCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadHubModulesCommand.java
@@ -39,6 +39,9 @@ import org.springframework.stereotype.Component;
 import java.util.Map;
 import java.util.Properties;
 
+/**
+ * Handles loading modules that are contained within the DHF jar.
+ */
 @Component
 public class LoadHubModulesCommand extends AbstractCommand {
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -37,7 +37,7 @@ import com.marklogic.client.ext.SecurityContextType;
 import com.marklogic.client.ext.modulesloader.ssl.SimpleX509TrustManager;
 import com.marklogic.client.io.*;
 import com.marklogic.hub.deploy.commands.LoadHubModulesCommand;
-import com.marklogic.hub.deploy.commands.LoadUserStagingModulesCommand;
+import com.marklogic.hub.deploy.commands.LoadUserModulesCommand;
 import com.marklogic.hub.error.DataHubConfigurationException;
 import com.marklogic.hub.flow.CodeFormat;
 import com.marklogic.hub.flow.DataFormat;
@@ -115,7 +115,7 @@ public class HubTestBase {
     protected LoadHubModulesCommand loadHubModulesCommand;
 
     @Autowired
-    protected LoadUserStagingModulesCommand loadUserModulesCommand;
+    protected LoadUserModulesCommand loadUserModulesCommand;
 
     @Autowired
     protected Scaffolding scaffolding;

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserModulesCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserModulesCommandTest.java
@@ -34,11 +34,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ContextConfiguration(classes = ApplicationConfig.class)
 public class LoadUserModulesCommandTest extends HubTestBase {
 
-    public LoadUserStagingModulesCommand loadUserModulesCommand;
+    public LoadUserModulesCommand loadUserModulesCommand;
 
     @BeforeEach
     public void setup() {
-        loadUserModulesCommand = new LoadUserStagingModulesCommand();
+        loadUserModulesCommand = new LoadUserModulesCommand();
         loadUserModulesCommand.setHubConfig(getHubAdminConfig());
     }
 

--- a/ml-data-hub-plugin/build.gradle
+++ b/ml-data-hub-plugin/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     compile (project(':marklogic-data-hub')) {
         exclude group: 'ch.qos.logback'
     }
-    compile ('com.marklogic:ml-gradle:3.10.1') {
+    compile ('com.marklogic:ml-gradle:3.10.2') {
         exclude group: 'ch.qos.logback'
     }
     testCompile localGroovy()

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/DeployUserModulesTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/DeployUserModulesTask.groovy
@@ -17,20 +17,23 @@
 
 package com.marklogic.gradle.task
 
-
 import org.gradle.api.tasks.TaskAction
 
 class DeployUserModulesTask extends HubTask {
 
     @TaskAction
     void deployUserModules() {
-        def dh = getDataHub()
         if (!isHubInstalled()) {
             println("Data Hub is not installed.")
             return
         }
-        def cmd = getLoadUserStagingModulesCommand()
+
+        def cmd = getLoadUserModulesCommand()
         cmd.setForceLoad(true);
+
+        // This task is expected to only load modules from the hub-specific locations (plugins and entity-config)
+        // mlLoadModules should be used to load modules from all locations
+        cmd.setLoadAllModules(false)
 
         cmd.execute(getCommandContext())
 

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/HubTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/HubTask.groovy
@@ -23,7 +23,7 @@ import com.marklogic.appdeployer.command.CommandContext
 import com.marklogic.client.DatabaseClient
 import com.marklogic.hub.*
 import com.marklogic.hub.deploy.commands.LoadHubModulesCommand
-import com.marklogic.hub.deploy.commands.LoadUserStagingModulesCommand
+import com.marklogic.hub.deploy.commands.LoadUserModulesCommand
 import com.marklogic.hub.job.JobManager
 import com.marklogic.hub.scaffold.Scaffolding
 import org.gradle.api.DefaultTask
@@ -57,8 +57,8 @@ abstract class HubTask extends DefaultTask {
     }
 
     @Internal
-    LoadUserStagingModulesCommand getLoadUserStagingModulesCommand() {
-        getProject().property("loadUserStagingModulesCommand")
+    LoadUserModulesCommand getLoadUserModulesCommand() {
+        getProject().property("loadUserModulesCommand")
     }
 
     @Internal

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/HubWatchTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/HubWatchTask.groovy
@@ -17,33 +17,28 @@
 
 package com.marklogic.gradle.task
 
-import com.marklogic.hub.deploy.commands.LoadUserStagingModulesCommand
-import org.gradle.api.tasks.TaskAction
+import com.marklogic.gradle.task.client.WatchTask
+import com.marklogic.hub.deploy.commands.LoadUserModulesCommand
 
 /**
- * Runs an infinite loop, and each second, it loads any new/modified modules. Often useful to run with the Gradle "-i" flag
- * so you can see which modules are loaded.
- *
- * Depends on an instance of LoadModulesCommand being in the Gradle Project, which should have been placed there by
- * MarkLogicPlugin. This prevents this class from having to know how to construct a ModulesLoader.
+ * Extends ml-gradle's WatchTask so that after WatchTask loads modules, this task can invoke the custom DHF command for
+ * loading modules. The reason this is needed is because WatchTask doesn't just invoke all the commands in the
+ * "mlModuleCommands" list - it may be enhanced in the future to do that. But currently, it accesses the ModulesLoader
+ * that's created by LoadModulesCommand and invokes it.
  */
-class HubWatchTask extends HubTask {
+class HubWatchTask extends WatchTask {
 
-    long sleepTime = 1000
+    LoadUserModulesCommand command
 
-    @TaskAction
-    public void watchModules() {
+    @Override
+    void afterModulesLoaded() {
+        super.afterModulesLoaded()
 
-        LoadUserStagingModulesCommand command = new LoadUserStagingModulesCommand(getHubConfig())
-        println "Watching modules in paths: " + getHubConfig().projectDir
-
-        while (true) {
-            command.execute(getCommandContext())
-            try {
-                Thread.sleep(sleepTime);
-            } catch (InterruptedException ie) {
-                // Ignore
-            }
+        if (command == null) {
+            command = getProject().property("loadUserModulesCommand")
+            command.setWatchingModules(true)
         }
+
+        command.execute(getCommandContext())
     }
 }

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/SaveIndexes.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/SaveIndexes.groovy
@@ -17,12 +17,7 @@
 
 package com.marklogic.gradle.task
 
-import com.marklogic.hub.DataHub
 import com.marklogic.hub.EntityManager
-import com.marklogic.hub.deploy.commands.LoadUserStagingModulesCommand
-import com.marklogic.hub.impl.DataHubImpl
-import com.marklogic.hub.impl.EntityManagerImpl
-import com.marklogic.rest.util.ResourcesFragment
 
 import org.gradle.api.tasks.TaskAction
 

--- a/quick-start/src/main/java/com/marklogic/quickstart/service/DataHubService.java
+++ b/quick-start/src/main/java/com/marklogic/quickstart/service/DataHubService.java
@@ -20,7 +20,7 @@ import com.marklogic.appdeployer.command.Command;
 import com.marklogic.appdeployer.impl.SimpleAppDeployer;
 import com.marklogic.hub.DataHub;
 import com.marklogic.hub.HubConfig;
-import com.marklogic.hub.deploy.commands.LoadUserStagingModulesCommand;
+import com.marklogic.hub.deploy.commands.LoadUserModulesCommand;
 import com.marklogic.hub.deploy.util.HubDeployStatusListener;
 import com.marklogic.hub.error.CantUpgradeException;
 import com.marklogic.hub.impl.HubConfigImpl;
@@ -54,7 +54,7 @@ public class DataHubService {
     private DataHub dataHub;
 
     @Autowired
-    private LoadUserStagingModulesCommand loadUserModulesCommand;
+    private LoadUserModulesCommand loadUserModulesCommand;
 
     public boolean install(HubConfig config, HubDeployStatusListener listener) throws DataHubException {
         logger.info("Installing Data Hub");


### PR DESCRIPTION
Renamed LoadUserStagingModulesCommand to LoadHubUserCommand to make it more clear what it does (since it's not staging-specific). 

Depends on ml-gradle 3.10.2, which I just released, which provides a hook in WatchTask for HubWatchTask to use.