### PR TITLE
Wiring clients after changing hubConfig

### DIFF
--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/fullcycle/TlsTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/fullcycle/TlsTest.groovy
@@ -204,6 +204,9 @@ class TlsTest extends BaseTest {
                 mlManageClient.setManageConfig(mlManageConfig)
                 mlAdminManager.setAdminConfig(mlAdminConfig)
                 hubConfig.setAppConfig(mlAppConfig, true)
+                //To reset the clients with modified hub and app configs
+                flowManager.setupClient();
+                dataHub.wireClient();
             }
         '''
 


### PR DESCRIPTION
Wiring clients after changing hubConfig. TlsTest passes locally after this. 