### PR TITLE
Changing versions to "4.0.SNAPSHOT" and publishing the jars

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
-version=4.0.3
+version=4.0.SNAPSHOT
+publishUrl=file:../marklogic-data-hub/releases

--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -201,6 +201,17 @@ publishing {
             }
         }
     }
+    repositories {
+        maven {
+          if(project.hasProperty("mavenUser")) {
+            credentials {
+            username mavenUser
+            password mavenPassword
+            }
+          }
+          url publishUrl
+        }
+    }
 }
 
 bintray {

--- a/marklogic-data-hub/gradle.properties
+++ b/marklogic-data-hub/gradle.properties
@@ -12,7 +12,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-mlDHFVersion=4.0.3
+mlDHFVersion=4.0.SNAPSHOT
 mlHost=localhost
 mlAppName=data-hub
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -1326,7 +1326,7 @@ public class HubConfigImpl implements HubConfig
 
         // this lets debug builds work from an IDE
         if (version.equals("${project.version}")) {
-            version = "4.0.3";
+            version = "4.0.SNAPSHOT";
         }
         return version;
     }

--- a/marklogic-data-hub/src/main/resources/scaffolding/build_gradle
+++ b/marklogic-data-hub/src/main/resources/scaffolding/build_gradle
@@ -19,7 +19,7 @@ plugins {
 
     // This gradle plugin extends the ml-gradle plugin with
     // commands that make the Data Hub Framework do its magic
-    id 'com.marklogic.ml-data-hub' version '4.0.3'
+    id 'com.marklogic.ml-data-hub' version '4.0.SNAPSHOT'
 }
 
 repositories {
@@ -30,7 +30,7 @@ repositories {
 dependencies {
     // this allows you to write custom java code that depends
     // on the Data Hub Framework library
-    compile 'com.marklogic:marklogic-data-hub:4.0.3'
-    compile 'com.marklogic:marklogic-xcc:9.0.4'
+    compile 'com.marklogic:marklogic-data-hub:4.0.SNAPSHOT'
+    compile 'com.marklogic:marklogic-xcc:9.0.7'
 }
 

--- a/ml-data-hub-plugin/build.gradle
+++ b/ml-data-hub-plugin/build.gradle
@@ -109,6 +109,17 @@ publishing {
             artifact sourcesJar
         }
     }
+    repositories {
+        maven {
+          if(project.hasProperty("mavenUser")) {
+            credentials {
+            username mavenUser
+            password mavenPassword
+            }
+          }
+          url publishUrl
+        }
+    }
 }
 
 bintray {

--- a/ml-data-hub-plugin/gradle.properties
+++ b/ml-data-hub-plugin/gradle.properties
@@ -12,7 +12,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-mlDHFVersion=4.0.3
+mlDHFVersion=4.0.SNAPSHOT
 mlHost=localhost
 mlAppName=data-hub
 

--- a/quick-start/gradle.properties
+++ b/quick-start/gradle.properties
@@ -13,7 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # What version of DHF am I intending on targetting? Make sure you use the full SemVer x.x.x
-mlDHFVersion=4.0.3
+mlDHFVersion=4.0.SNAPSHOT
 
 mlHost=localhost
 mlAppName=data-hub


### PR DESCRIPTION
1. Changed versions to 4.0.SNAPSHOT (excluding example projects)
2. Changed xcc dependency version in scaffold to 9.0-7
3. Added info for publishing jars