### PR TITLE
Fixing hubInit when gradle.properties doesn't exist

### DIFF
--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/CreateEntityTaskTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/CreateEntityTaskTest.groovy
@@ -28,6 +28,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 class CreateEntityTaskTest extends BaseTest {
     def setupSpec() {
         createGradleFiles()
+        runTask('hubInit')
     }
 
     def "create entity with no name"() {

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/CreateInputFlowTaskTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/CreateInputFlowTaskTest.groovy
@@ -29,6 +29,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 class CreateInputFlowTaskTest extends BaseTest {
     def setupSpec() {
         createGradleFiles()
+        runTask('hubInit')
     }
 
     def "createInputFlow with no entityName"() {

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/CreateMappingTaskTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/CreateMappingTaskTest.groovy
@@ -28,6 +28,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 class CreateMappingTaskTest extends BaseTest {
     def setupSpec() {
         createGradleFiles()
+        runTask('hubInit')
     }
 
     def "create mapping with no name"() {


### PR DESCRIPTION
This requires the user to run "hubInit" if the project hasn't been initialized yet. 

Also, initHubProject is no longer called if the project has not been initialized. If the project hasn't been initialized and the user isn't running hubInit, then the refreshProject call would likely fail because gradle.properties likely isn't present.