### PR TITLE
1605 User amps are no longer deployed during the preinstall check

### DIFF
--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -123,7 +123,12 @@ class DataHubPlugin implements Plugin<Project> {
         project.task("hubDeleteModuleTimestampsFile", type: DeleteHubModuleTimestampsFileTask, group: deployGroup)
         project.tasks.mlDeleteModuleTimestampsFile.getDependsOn().add("hubDeleteModuleTimestampsFile")
 
-        project.tasks.hubPreInstallCheck.getDependsOn().add("mlDeploySecurity")
+        /**
+         * mlDeploySecurity can't be used here because it will deploy amps under src/main/ml-config, and those will fail
+         * to deploy since the modules database hasn't been created yet.
+         */
+        project.task("hubDeploySecurity", type: HubDeploySecurityTask)
+        project.tasks.hubPreInstallCheck.getDependsOn().add("hubDeploySecurity")
         project.tasks.mlDeploy.getDependsOn().add("hubPreInstallCheck")
 
         String flowGroup = "MarkLogic Data Hub Flow Management"

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/HubDeploySecurityTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/HubDeploySecurityTask.groovy
@@ -1,0 +1,25 @@
+package com.marklogic.gradle.task
+
+import com.marklogic.appdeployer.command.Command
+import com.marklogic.appdeployer.impl.SimpleAppDeployer
+import com.marklogic.hub.impl.DataHubImpl
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * This task is needed so that hubPreInstallCheck can depend on something that deploys all security resources except
+ * for amps - those can't be deployed until the modules database has been deployed. This code then mirrors what
+ * DataHubImpl.install in terms of getting the list of security commands (minus the one for amps) and executing them.
+ */
+class HubDeploySecurityTask extends HubTask {
+
+    @TaskAction
+    void deploySecurity() {
+        DataHubImpl dataHub = (DataHubImpl) getDataHub()
+        List<Command> securityCommands = dataHub.getSecurityCommandList()
+        def manageClient = getProject().property("mlManageClient")
+        def adminManager = getProject().property("mlAdminManager")
+        SimpleAppDeployer appDeployer = new SimpleAppDeployer(manageClient, adminManager)
+        appDeployer.setCommands(securityCommands)
+        appDeployer.deploy(getHubConfig().getAppConfig())
+    }
+}


### PR DESCRIPTION
This fixes a bug where the preinstall check would fail because it tried to deploy amps, but the modules database didn't exist yet.