### PR TITLE
DHFPROD-1597 Removed empty range-element-index array from staging-dat…

### DIFF
--- a/marklogic-data-hub/src/main/resources/hub-internal-config/databases/staging-database.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/databases/staging-database.json
@@ -1,6 +1,5 @@
 {
   "database-name": "%%mlStagingDbName%%",
-  "range-element-index": [],
   "schema-database": "%%mlStagingSchemasDbName%%",
   "triggers-database": "%%mlStagingTriggersDbName%%",
   "triple-index": true,


### PR DESCRIPTION
…abase

This avoids the chance of an unnecessary reindex due to this file removing all indexes