### PR TITLE
DHFPROD-1328 fix validating that new Flow name is not a duplicate

### DIFF
--- a/quick-start/src/main/ui/app/flows/flows.component.html
+++ b/quick-start/src/main/ui/app/flows/flows.component.html
@@ -39,7 +39,7 @@
                   <li
                     class="flow mdl-list__item"
                     [attr.data-flow-list]="type.toUpperCase()"
-                    [ngClass]="{'active': isActiveFlow(flow)}"
+                    [ngClass]="{'active': isActiveFlow(flow, type)}"
                     *ngFor="let flow of getFlows(entity, type)">
                     <div (click)="setFlow(flow, type.toUpperCase())" [attr.data-flow-name]="flow.flowName">
                       <span class="mdl-list__item-primary-content">

--- a/quick-start/src/main/ui/app/flows/flows.component.ts
+++ b/quick-start/src/main/ui/app/flows/flows.component.ts
@@ -279,9 +279,11 @@ export class FlowsComponent implements OnInit, OnDestroy {
     }
   }
 
-  isActiveFlow(flow: Flow): boolean {
-    return this.flow && this.flow.entityName === flow.entityName &&
-      this.flow.flowName === flow.flowName;
+  isActiveFlow(flow: Flow, flowType: string): boolean {
+    return this.flow && 
+      this.flow.entityName === flow.entityName &&
+      this.flow.flowName === flow.flowName &&
+      this.flowType.toUpperCase() === flowType.toUpperCase();
   }
 
   isActiveEntity(entity: Entity): boolean {
@@ -324,17 +326,15 @@ export class FlowsComponent implements OnInit, OnDestroy {
       providers: [
         { provide: 'flowType', useValue: flowType },
         { provide: 'actions', useValue: actions },
-        { provide: 'entity', useValue: entity}
+        { provide: 'entity', useValue: entity },
+        { provide: 'flows', useValue: this.getFlows(entity, flowType) }
       ],
       isModal: true
     });
   }
 
   getFlows(entity: Entity, flowType: string) {
-    if (flowType === 'Input') {
-      return entity.inputFlows;
-    }
-    return entity.harmonizeFlows;
+    return (flowType.toUpperCase() === 'INPUT') ? entity.inputFlows : entity.harmonizeFlows;
   }
 
   getFlowType(flow: Flow, entityName: string) {

--- a/quick-start/src/main/ui/app/new-flow/new-flow.component.html
+++ b/quick-start/src/main/ui/app/new-flow/new-flow.component.html
@@ -10,12 +10,17 @@
     <form (submit)="create()">
       <div class="modal-body">
         <div class="md-dialog-content" flex layout="column">
-          <mdl-textfield name="flowTypeInput" type="text"
+          <mdl-textfield 
+            [ngClass]="{ 'custom-invalid' : !isNameValid }"
+            name="flowTypeInput" 
+            type="text"
             required autofocus floating-label
             id="flowTypeInput"
             label="{{flowType}} Flow Name (required)"
             #flowTypeInput="ngModel"
-            [(ngModel)]="flow.flowName"></mdl-textfield>
+            [(ngModel)]="flow.flowName"
+            (keyup)="checkName()"></mdl-textfield>
+          <div *ngIf="!isNameValid" class="alert-text">{{ errorMsg }}</div>
           <ng-template [ngIf]="getMarkLogicVersion() >= 9">
             <label>Code Generation</label>
             <app-select-list
@@ -47,7 +52,7 @@
         </div>
       </div>
       <div class="mdl-dialog__actions">
-        <button type="submit" [disabled]="flowTypeInput && flowTypeInput.errors && flowTypeInput.errors.required" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect">Create</button>
+        <button type="submit" [disabled]="(flowTypeInput && flowTypeInput.errors && flowTypeInput.errors.required) || !isNameValid" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect">Create</button>
         <button type="button" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect" (click)="cancel()">Cancel</button>
       </div>
     </form>

--- a/quick-start/src/main/ui/app/new-flow/new-flow.component.scss
+++ b/quick-start/src/main/ui/app/new-flow/new-flow.component.scss
@@ -15,6 +15,15 @@
   mdl-textfield {
     width: 100%;
   }
+
+  /deep/ mdl-textfield.custom-invalid input.mdl-textfield__input {
+    border-bottom: 1px solid #a94442;
+  }
+
+  .alert-text {
+    margin-top:-20px;  /* position directly under the input */
+    color: #a94442;
+  }
 }
 
 /deep/ .mdl-textfield__label:after {


### PR DESCRIPTION
Added Flow name form validation.

The server treats INPUT flows differently from HARMONIZE flows (making requests to different endpoints when creating/modifying/deleting).  Also, flows are entity specific, so you can have a flow of the same name as long as they are for different entities.   

Given that, flow name duplication prevention in the UI only triggers among the flows of the same Entity and Flow type, since the server allows for the other instances mentioned above.