### PR TITLE
DHFPROD-1645 Added fix for which databases should have their indexes …

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/BuildPatternForDatabasesToUpdateIndexesForTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/BuildPatternForDatabasesToUpdateIndexesForTest.java
@@ -1,0 +1,28 @@
+package com.marklogic.hub.impl;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BuildPatternForDatabasesToUpdateIndexesForTest {
+
+    DataHubImpl dataHub = new DataHubImpl();
+
+    @Test
+    public void test() {
+        assertTrue(matches("staging-database.json"));
+        assertTrue(matches("final-database.json"));
+        assertTrue(matches("job-database.json"));
+
+        assertFalse(matches("schema-database.json"));
+        assertFalse(matches("triggers-database.json"));
+        assertFalse(matches("final-schemas-database.json"));
+        assertFalse(matches("final-triggers-database.json"));
+        assertFalse(matches("modules-database.json"));
+        assertFalse(matches("staging-schemas-database.json"));
+        assertFalse(matches("staging-triggers-database.json"));
+    }
+
+    private boolean matches(String filename) {
+        return dataHub.buildPatternForDatabasesToUpdateIndexesFor().matcher(filename).matches();
+    }
+}


### PR DESCRIPTION
…updated

I wasn't aware of this requirement, but I think the test case captures the desired functionality. 

Note that if a user uses a filename other than the ones this is looking for, it won't get processed, even if it's referring to the staging or final or job database. But I doubt that is common. 