### PR TITLE
Initialize 'hubAdminUserName', 'hubAdminRoleName'  and fix build.gradle

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -316,10 +316,11 @@ task testBootstrap(type: Test) {
 
 task setupSSL{
     doFirst{
-        com.marklogic.mgmt.ManageClient manageClient = new ManageClient(new com.marklogic.mgmt.ManageConfig(mlHost, 8002, mlSecurityUsername, mlSecurityPassword))
-        com.marklogic.mgmt.resource.hosts.HostManager hostManager = new HostManager(manageClient)
-        def bootStrapHost = hostManager.getHostNames().get(0)
+        def bootStrapHost = null
         if(sslRun || certAuth){
+            com.marklogic.mgmt.ManageClient manageClient = new ManageClient(new com.marklogic.mgmt.ManageConfig(mlHost, 8002, mlSecurityUsername, mlSecurityPassword))
+            com.marklogic.mgmt.resource.hosts.HostManager hostManager = new HostManager(manageClient)
+            bootStrapHost = hostManager.getHostNames().get(0)
             if(! bootStrapHost.toLowerCase().contains("marklogic.com")){
                 throw new GradleException("The test with current options will run only in marklogic.com domain")
             }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -1283,6 +1283,20 @@ public class HubConfigImpl implements HubConfig
         else {
             projectProperties.setProperty("mlHubUserName", hubUserName);
         }
+        
+        if (hubAdminRoleName == null) {
+            hubAdminRoleName = getEnvPropString(projectProperties, "mlHubAdminRole", environment.getProperty("mlHubAdminRole"));
+        }
+        else {
+            projectProperties.setProperty("mlHubAdminRole", hubAdminRoleName);
+        }
+
+        if (hubAdminUserName == null) {
+            hubAdminUserName = getEnvPropString(projectProperties, "mlHubAdminUserName", environment.getProperty("mlHubAdminUserName"));
+        }
+        else {
+            projectProperties.setProperty("mlHubAdminUserName", hubAdminUserName);
+        }
 
         if (modulePermissions == null) {
             modulePermissions = getEnvPropString(projectProperties, "mlModulePermissions", environment.getProperty("mlModulePermissions"));

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowManagerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowManagerTest.java
@@ -15,6 +15,7 @@
  */
 package com.marklogic.hub.flow;
 
+import com.marklogic.bootstrap.Installer;
 import com.marklogic.client.io.DOMHandle;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.hub.FlowManager;
@@ -26,6 +27,7 @@ import com.marklogic.hub.main.MainPlugin;
 import com.marklogic.hub.scaffold.Scaffolding;
 import org.apache.commons.io.FileUtils;
 import org.json.JSONException;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -56,6 +58,11 @@ public class FlowManagerTest extends HubTestBase {
 
     @Autowired
     private Scaffolding scaffolding;
+    
+    @BeforeAll
+    public static void runOnce() {
+        new Installer().deleteProjectDir();
+    }
 
     @BeforeEach
     public void setup() throws IOException {
@@ -309,6 +316,7 @@ public class FlowManagerTest extends HubTestBase {
         installModules();
         assertEquals(0, getStagingDocCount());
         assertEquals(2, getFinalDocCount());
+        getHubFlowRunnerConfig();
         Flow flow1 = fm.getFlow("test", "my-test-flow1");
         FlowRunner flowRunner = fm.newFlowRunner()
             .withFlow(flow1)
@@ -318,6 +326,7 @@ public class FlowManagerTest extends HubTestBase {
             .withDestinationDatabase(HubConfig.DEFAULT_STAGING_NAME);
         flowRunner.run();
         flowRunner.awaitCompletion();
+        getHubAdminConfig();
         assertEquals(2, getStagingDocCount());
         assertEquals(2, getFinalDocCount());
         assertXMLEqual(getXmlFromResource("flow-manager-test/harmonized/harmonized1.xml"), stagingDocMgr.read("/employee1.xml").next().getContent(new DOMHandle()).get() );
@@ -343,6 +352,7 @@ public class FlowManagerTest extends HubTestBase {
 
         assertEquals(2, getStagingDocCount());
         assertEquals(0, getFinalDocCount());
+        getHubFlowRunnerConfig();
         Flow flow1 = fm.getFlow("test", "my-test-flow-with-header");
         FlowRunner flowRunner = fm.newFlowRunner()
             .withFlow(flow1)
@@ -350,6 +360,7 @@ public class FlowManagerTest extends HubTestBase {
             .withThreadCount(1);
         flowRunner.run();
         flowRunner.awaitCompletion();
+        getHubAdminConfig();
         assertEquals(2, getStagingDocCount());
         assertEquals(2, getFinalDocCount());
         assertXMLEqual(getXmlFromResource("flow-manager-test/harmonized-with-header/harmonized1.xml"), finalDocMgr.read("/employee1.xml").next().getContent(new DOMHandle()).get() );
@@ -373,6 +384,7 @@ public class FlowManagerTest extends HubTestBase {
 
         assertEquals(2, getStagingDocCount());
         assertEquals(0, getFinalDocCount());
+        getHubFlowRunnerConfig();
         Flow flow1 = fm.getFlow("test", "my-test-flow-with-all");
         FlowRunner flowRunner = fm.newFlowRunner()
             .withFlow(flow1)
@@ -380,6 +392,7 @@ public class FlowManagerTest extends HubTestBase {
             .withThreadCount(1);
         flowRunner.run();
         flowRunner.awaitCompletion();
+        getHubAdminConfig();
         assertEquals(2, getStagingDocCount());
         assertEquals(2, getFinalDocCount());
         assertXMLEqual(getXmlFromResource("flow-manager-test/harmonized-with-all/harmonized1.xml"), finalDocMgr.read("/employee1.xml").next().getContent(new DOMHandle()).get() );

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/job/JobManagerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/job/JobManagerTest.java
@@ -92,6 +92,7 @@ public class JobManagerTest extends HubTestBase {
         HashMap<String, Object> options = new HashMap<>();
         options.put("name", "Bob Smith");
         options.put("age", 55);
+        getHubFlowRunnerConfig();
         FlowRunner flowRunner = fm.newFlowRunner()
             .withFlow(harmonizeFlow)
             .withBatchSize(10)
@@ -113,7 +114,7 @@ public class JobManagerTest extends HubTestBase {
             .onItemComplete(flowItemCompleteListener);
         flowRunner.run();
         flowRunner.awaitCompletion();
-        jobManager = JobManager.create(getHubAdminConfig().newJobDbClient());
+        jobManager = JobManager.create(getHubFlowRunnerConfig().newJobDbClient());
     }
 
     @AfterEach
@@ -124,6 +125,7 @@ public class JobManagerTest extends HubTestBase {
 			e.printStackTrace();
 		}
     	disableTracing();
+    	getHubAdminConfig();
     }
     private static void recordJobId(String jobId) {
         jobIds.add(jobId);

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/job/TracingTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/job/TracingTest.java
@@ -67,11 +67,13 @@ public class TracingTest extends HubTestBase {
             new File(PROJECT_PATH + "/plugins")
         );
         installUserModules(adminHubConfig, true);
+        //Disable tracing that may have been enabled in previous tests
+        Tracing.create(flowRunnerClient).disable();
      }
 
     @AfterEach
     public void afterEach() {
-    	disableTracing();
+        Tracing.create(flowRunnerClient).disable();
         clearDatabases(HubConfig.DEFAULT_JOB_NAME, HubConfig.DEFAULT_FINAL_NAME);
     }
 


### PR DESCRIPTION
This PR

1. Initializes 'hubAdminUserName', 'hubAdminRoleName'  so that user defined values are set and not the ones  from dhf-default.props.
2. Doesn't get 'bootStrapHost' if not required (it caused issues in DHS env when running test),