### PR TITLE
fixing #1736

### DIFF
--- a/marklogic-data-hub/src/main/resources/scaffolding/gradle-local_properties
+++ b/marklogic-data-hub/src/main/resources/scaffolding/gradle-local_properties
@@ -1,5 +1,5 @@
 # Put your overrides from gradle.properties here
 # Don't check this in to version control
 
-mlUsername=admin
-mlPassword=admin
+# mlUsername=admin
+# mlPassword=admin


### PR DESCRIPTION
comments out the scaffolded username/password in gradle-local-properties. Keeps user from getting bad auth on accident.