### PR TITLE
Support for ES models in content creation

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/extensions/scaffold-content.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/extensions/scaffold-content.xqy
@@ -338,6 +338,8 @@ service:generate-lets($model, $entity-type-name, $mapping, $entity)
     let $properties := map:get($entity-type, "properties")
     let $required-properties := (
       map:get($entity-type, "primaryKey"),
+    if (fn:empty(map:get($entity-type, "required"))) then ()
+    else 
       json:array-values(map:get($entity-type, "required"))
     )
     for $property-name in map:keys($properties)

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/extensions/scaffold-content.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/extensions/scaffold-content.xqy
@@ -338,7 +338,8 @@ service:generate-lets($model, $entity-type-name, $mapping, $entity)
     let $properties := map:get($entity-type, "properties")
     let $required-properties := (
       map:get($entity-type, "primaryKey"),
-    if (fn:empty(map:get($entity-type, "required"))) then ()
+    if (fn:empty(map:get($entity-type, "required"))) then 
+      ()
     else 
       json:array-values(map:get($entity-type, "required"))
     )

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/impl/hub-entities.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/impl/hub-entities.xqy
@@ -33,9 +33,9 @@ declare function hent:get-model($entity-name as xs:string)
 
 declare function hent:get-model($entity-name as xs:string, $used-models as xs:string*)
 {
-  let $model := fn:collection("http://marklogic.com/entity-services/models")[info/title = $entity-name]
+  let $model := fn:collection($ENTITY-MODEL-COLLECTION)[info/title = $entity-name]
   where fn:exists($model)
-   return
+  return
     let $model-map as map:map? := $model
     let $refs := $model//*[fn:local-name(.) = '$ref'][fn:starts-with(., "#/definitions")] ! fn:replace(., "#/definitions/", "")
     let $definitions := map:get($model-map, "definitions")


### PR DESCRIPTION
This PR enables 
1. content creation when ES models are submitted (models with internal and external references)
2. Continued support for DHF style models (one entity per file with/without references)

