### PR TITLE
 Revert Spring boot version upgrade for QS

### DIFF
--- a/quick-start/build.gradle
+++ b/quick-start/build.gradle
@@ -18,11 +18,11 @@
 import java.util.concurrent.Executors
 
 plugins {
-  id 'java'
-  id 'eclipse'
-  id 'idea'
-  id 'com.moowork.node' version '1.2.0'
-  id 'org.springframework.boot' version '2.0.6.RELEASE'
+    id 'java'
+    id 'eclipse'
+    id 'idea'
+    id 'com.moowork.node' version '1.2.0'
+    id 'org.springframework.boot' version '2.0.2.RELEASE'
   id "io.spring.dependency-management" version "1.0.5.RELEASE"
 }
 

--- a/quick-start/e2e/specs/auth/authenticated.ts
+++ b/quick-start/e2e/specs/auth/authenticated.ts
@@ -195,7 +195,7 @@ export default function(tmpDir) {
       let originalTimeout;
       originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
       console.log('original jasmine timeout: ' + originalTimeout);
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = 370000;
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = 420000;
       console.log('modified jasmine timeout: ' + jasmine.DEFAULT_TIMEOUT_INTERVAL);
       browser.wait(EC.presenceOf(loginPage.installProgress), 600000, 'install progress is not present');
       expect(loginPage.installProgress.isDisplayed()).toBe(true);

--- a/quick-start/e2e/specs/auth/authenticated.ts
+++ b/quick-start/e2e/specs/auth/authenticated.ts
@@ -205,7 +205,7 @@ export default function(tmpDir) {
     });
 
     it ('should complete the install and go to the dashboard',  async function() {
-      browser.driver.sleep(3000);
+      browser.driver.sleep(5000);
       console.log('clicking Finished button');
       await loginPage.clickFinished();
       console.log('loading dashboard page');


### PR DESCRIPTION
Spring boot upgrade, in turn, upgrades Apache Tomcat version as well, which is causing socket error issues.
Reverting to the older version for now.