### PR TITLE
Calling hubInstallModules in Installer class when running tests in DHS

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/Installer.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/Installer.java
@@ -17,7 +17,7 @@ public class Installer extends HubTestBase {
 
     private static Logger logger = LoggerFactory.getLogger(Installer.class);
 
-    public void setupProject() {       
+    public void setupProject() {
         createProjectDir();
     }
 
@@ -41,8 +41,11 @@ public class Installer extends HubTestBase {
 	            // this throws exception right now.
 	        } catch (Exception e) {
 	            logger.warn("Upgrade threw an exception during test bootstrapping");
-	
+
 	        }
+        }
+        if(getHubAdminConfig().getIsProvisionedEnvironment()) {
+            installHubModules();
         }
     }
 


### PR DESCRIPTION
Making sure DHF modules are installed before tests are run.