### PR TITLE
Loading to staging schemas db from database-specific directory

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'java'
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.7.2'
-    id 'com.marklogic.ml-gradle' version '3.8.2'
+    id 'com.marklogic.ml-gradle' version '3.11.0'
     id 'com.moowork.node' version '1.1.1'
     id 'org.springframework.boot' version '2.0.6.RELEASE'
     id "io.spring.dependency-management" version "1.0.5.RELEASE"
@@ -27,8 +27,8 @@ ext.junitPlatformVersion = '1.3.1'
 ext.junitJupiterVersion  = '5.3.1'
 
 dependencies {
-    compile 'com.marklogic:marklogic-client-api:4.1.1'
-    compile('com.marklogic:ml-app-deployer:3.10.1'){
+    compile 'com.marklogic:marklogic-client-api:4.1.2'
+    compile('com.marklogic:ml-app-deployer:3.11.0'){
         exclude group: 'org.springframework', module: 'spring-context'
     }
     compile group: 'org.springframework.boot', name: 'spring-boot-starter', version: '2.0.6.RELEASE'

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommand.java
@@ -16,9 +16,9 @@
 package com.marklogic.hub.deploy.commands;
 
 import com.marklogic.appdeployer.AppConfig;
+import com.marklogic.appdeployer.command.AbstractCommand;
 import com.marklogic.appdeployer.command.CommandContext;
 import com.marklogic.appdeployer.command.SortOrderConstants;
-import com.marklogic.appdeployer.command.modules.LoadModulesCommand;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.document.DocumentWriteSet;
 import com.marklogic.client.document.JSONDocumentManager;
@@ -50,7 +50,7 @@ import java.util.regex.Pattern;
  * Loads user artifacts like mappings and entities. This will be deployed after triggers
  */
 @Component
-public class LoadUserArtifactsCommand extends LoadModulesCommand {
+public class LoadUserArtifactsCommand extends AbstractCommand {
 
     @Autowired
     private HubConfig hubConfig;

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
@@ -61,6 +61,7 @@ public class HubProjectImpl implements HubProject {
     private String projectDirString;
     private Path projectDir;
     private Path pluginsDir;
+    private Path stagingSchemasDir;
 
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -105,7 +106,11 @@ public class HubProjectImpl implements HubProject {
         return getHubConfigDir().resolve("security");
     }
 
-    @Override public Path getHubSchemasDir() { return getHubConfigDir().resolve("schemas"); }
+    @Override public Path getHubSchemasDir() { return this.stagingSchemasDir; }
+
+    private void setHubSchemasDir(Path stagingSchemasDir) {
+        this.stagingSchemasDir = stagingSchemasDir ;
+    }
 
     @Override public Path getHubTriggersDir() {
     	return getHubConfigDir().resolve("triggers"); 
@@ -247,6 +252,7 @@ public class HubProjectImpl implements HubProject {
         getUserDatabaseDir().toFile().mkdirs();
 
         //scaffold schemas
+        setHubSchemasDir(getUserDatabaseDir().resolve(customTokens.get("%%mlStagingSchemasDbName%%")).resolve("schemas"));
         getHubSchemasDir().toFile().mkdirs();
         getUserSchemasDir().toFile().mkdirs();
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/DataHubInstallTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/DataHubInstallTest.java
@@ -104,7 +104,9 @@ public class DataHubInstallTest extends HubTestBase
             //userTriggersDir.toFile().mkdirs();
 
             //creating directories for adding staging schemas/ modules and trigger files
-            Path hubSchemasDir = project.getHubConfigDir().resolve("schemas");
+            Path hubSchemasDir = project.getUserDatabaseDir()
+                .resolve(HubConfig.DEFAULT_STAGING_SCHEMAS_DB_NAME)
+                .resolve("schemas");
             Path hubModulesDir = project.getHubStagingModulesDir();
             //Path hubTriggersDir = project.getHubConfigDir().resolve("triggers");
 
@@ -174,7 +176,8 @@ public class DataHubInstallTest extends HubTestBase
         
         //checking if triggers are written
         assertTrue(stagingTriggersClient.newServerEval().xquery("fn:count(fn:doc())").eval().next().getNumber().intValue() == 1);
-        assertTrue(finalTriggersClient.newServerEval().xquery("fn:count(fn:doc())").eval().next().getNumber().intValue() == 1);
+        //we add 3 triggers as part of installation
+        assertTrue(finalTriggersClient.newServerEval().xquery("fn:count(fn:doc())").eval().next().getNumber().intValue() == 4);
         
     }
 
@@ -211,7 +214,7 @@ public class DataHubInstallTest extends HubTestBase
         HubConfig hubConfig = getHubAdminConfig();
 
         int totalCount = getDocCount(HubConfig.DEFAULT_MODULES_DB_NAME, null);
-        installUserModules(hubConfig, true);
+        installUserModules(hubConfig, false);
 
         assertEquals(
             getResource("data-hub-test/plugins/entities/test-entity/harmonize/final/collector.xqy"),

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/UpgradeProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/UpgradeProjectTest.java
@@ -3,12 +3,14 @@ package com.marklogic.hub.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.hub.HubConfig;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -19,6 +21,12 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class UpgradeProjectTest {
 
+    private Map<String, String> createMap() {
+        Map<String,String> myMap = new HashMap<>();
+        myMap.put("%%mlStagingSchemasDbName%%", HubConfig.DEFAULT_STAGING_SCHEMAS_DB_NAME);
+        return myMap;
+    }
+
     @Test
     public void upgrade300ToCurrentVersion() throws Exception {
         final String projectPath = "build/tmp/upgrade-projects/dhf300";
@@ -28,8 +36,8 @@ public class UpgradeProjectTest {
 
         HubProjectImpl hubProject = new HubProjectImpl();
         hubProject.createProject(projectPath);
-        // The tokens map doesn't seem to matter for what we're testing here
-        hubProject.init(new HashMap<>());
+        // We require %%mlStagingSchemasDbName%% in the map for test. In real scenarios, its value will always be set.
+        hubProject.init(createMap());
         hubProject.upgradeProject();
 
         File srcDir = new File(projectDir, "src");
@@ -53,8 +61,8 @@ public class UpgradeProjectTest {
 
         HubProjectImpl hubProject = new HubProjectImpl();
         hubProject.createProject(projectPath);
-        // The tokens map doesn't seem to matter for what we're testing here
-        hubProject.init(new HashMap<>());
+        // We require %%mlStagingSchemasDbName%% in the map for test. In real scenarios, its value will always be set.
+        hubProject.init(createMap());
         hubProject.upgradeProject();
 
         File srcDir = new File(projectDir, "src");
@@ -71,6 +79,9 @@ public class UpgradeProjectTest {
 
     private void verifyInternalDatabases(File internalConfigDir) {
         File databasesDir = new File(internalConfigDir, "databases");
+
+        // old schemas doesn't exist
+        assertFalse(internalConfigDir.toPath().resolve("schemas").toFile().exists());
 
         File jobFile = new File(databasesDir, "job-database.json");
         assertTrue(jobFile.exists());
@@ -128,6 +139,8 @@ public class UpgradeProjectTest {
 
     private void verifyUserDatabases(File configDir) {
         File databasesDir = new File(configDir, "databases");
+        // new schemas path exists
+        assertTrue(databasesDir.toPath().resolve(HubConfig.DEFAULT_STAGING_SCHEMAS_DB_NAME).resolve("schemas").toFile().exists());
 
         File finalFile = new File(databasesDir, "final-database.json");
         assertTrue(finalFile.exists());

--- a/ml-data-hub-plugin/build.gradle
+++ b/ml-data-hub-plugin/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     compile (project(':marklogic-data-hub')) {
         exclude group: 'ch.qos.logback'
     }
-    compile ('com.marklogic:ml-gradle:3.10.2') {
+    compile ('com.marklogic:ml-gradle:3.11.0') {
         exclude group: 'ch.qos.logback'
     }
     testCompile localGroovy()

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -118,11 +118,13 @@ class DataHubPlugin implements Plugin<Project> {
             .mustRunAfter(["mlClearModulesDatabase"])
 
         // This isn't likely to be used, but it's being kept for regression purposes for now
-        project.task("hubDeployUserModules", group: deployGroup, type: DeployUserModulesTask, description: "Installs user modules from the plugins and src/main/entity-config directories.")
+        project.task("hubDeployUserModules", group: deployGroup, type: DeployUserModulesTask,
+            description: "Installs user modules from the plugins and src/main/entity-config directories.")
+            .finalizedBy(["hubDeployUserArtifacts"])
 
         project.task("hubDeployUserArtifacts", group: deployGroup, type: DeployUserArtifactsTask,
             description: "Installs user artifacts such as entities and mappings.")
-            .mustRunAfter(["hubDeployUserModules"])
+
 
         // HubWatchTask extends ml-gradle's WatchTask to ensure that modules are loaded from the hub-specific locations.
         project.tasks.replace("mlWatch", HubWatchTask)

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/DeployUserArtifactsTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/DeployUserArtifactsTask.groovy
@@ -22,7 +22,7 @@ import org.gradle.api.tasks.TaskAction
 class DeployUserArtifactsTask extends HubTask {
 
     @TaskAction
-    void deployUserModules() {
+    void deployUserArtifacts() {
         if (!isHubInstalled()) {
             println("Data Hub is not installed.")
             return

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/BaseTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/BaseTest.groovy
@@ -67,7 +67,7 @@ class BaseTest extends Specification {
     static final int MOD_COUNT_WITH_TRACE_MODULES = 26
     static final int MOD_COUNT = 5
     // this value under good security conditions is 2 because hub-admin-user cannot read options files directly.
-    static final int MOD_COUNT_NO_OPTIONS_NO_TRACES = 109
+    static final int MOD_COUNT_NO_OPTIONS_NO_TRACES = 111
     static final TemporaryFolder testProjectDir = new TemporaryFolder()
     static File buildFile
     static File propertiesFile


### PR DESCRIPTION
Loading to staging schemas db from database-specific directory

This PR

1. Scaffolds ml-config/databases//schemas for the purpose of loading schemas and stops scaffolding the existing hub-internal-config/schemas dir
2. Makes the same change to the test
3. Fixes another test (where triggers count was incorrect)
4. Updates ml-gradle and ml-app-deployer to 3.11.0 and java client to 4.1.2