### PR TITLE
DO-NOT-MERGE- Loading to staging schemas db from database-specific directory in 4.x

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'java'
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.7.2'
-    id 'com.marklogic.ml-gradle' version '3.8.2'
+    id 'com.marklogic.ml-gradle' version '3.11.0'
     id 'com.moowork.node' version '1.1.1'
     id 'org.springframework.boot' version '2.0.6.RELEASE'
     id "io.spring.dependency-management" version "1.0.5.RELEASE"
@@ -28,7 +28,7 @@ ext.junitJupiterVersion  = '5.3.1'
 
 dependencies {
     compile 'com.marklogic:marklogic-client-api:4.1.1'
-    compile('com.marklogic:ml-app-deployer:3.10.1'){
+    compile('com.marklogic:ml-app-deployer:3.11.0'){
         exclude group: 'org.springframework', module: 'spring-context'
     }
     compile group: 'org.springframework.boot', name: 'spring-boot-starter', version: '2.0.6.RELEASE'

--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -27,7 +27,7 @@ ext.junitPlatformVersion = '1.3.1'
 ext.junitJupiterVersion  = '5.3.1'
 
 dependencies {
-    compile 'com.marklogic:marklogic-client-api:4.1.1'
+    compile 'com.marklogic:marklogic-client-api:4.1.2'
     compile('com.marklogic:ml-app-deployer:3.11.0'){
         exclude group: 'org.springframework', module: 'spring-context'
     }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/HubProject.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/HubProject.java
@@ -80,7 +80,11 @@ public interface HubProject {
      * Gets the path for the hub/staging schemas directory
      *
      * @return the path for the hub/staging schemas directory
+     * @deprecated Since 4.2.0: users should use the ml-gradle supported <project_dir>/src/main/ml-config/databases/
+     * <STAGING_SCHEMAS_DB_NAME>/schemas path to deploy schemas
+     *
      */
+    @Deprecated
     Path getHubSchemasDir();
 
     /**

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
@@ -27,6 +27,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
@@ -61,7 +63,9 @@ public class HubProjectImpl implements HubProject {
     private String projectDirString;
     private Path projectDir;
     private Path pluginsDir;
-    private Path stagingSchemasDir;
+
+    @Autowired @Lazy
+    private HubConfigImpl hubConfig;
 
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -107,11 +111,7 @@ public class HubProjectImpl implements HubProject {
     }
 
     @Override
-    public Path getHubSchemasDir() { return this.stagingSchemasDir; }
-
-    private void setHubSchemasDir(Path stagingSchemasDir) {
-        this.stagingSchemasDir = stagingSchemasDir ;
-    }
+    public Path getHubSchemasDir() { return getUserDatabaseDir().resolve(hubConfig.getStagingSchemasDbName()).resolve("schemas"); }
 
     @Override public Path getHubTriggersDir() {
     	return getHubConfigDir().resolve("triggers"); 
@@ -253,7 +253,6 @@ public class HubProjectImpl implements HubProject {
         getUserDatabaseDir().toFile().mkdirs();
 
         //scaffold schemas
-        setHubSchemasDir(getUserDatabaseDir().resolve(customTokens.get("%%mlStagingSchemasDbName%%")).resolve("schemas"));
         getHubSchemasDir().toFile().mkdirs();
         getUserSchemasDir().toFile().mkdirs();
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
@@ -61,6 +61,7 @@ public class HubProjectImpl implements HubProject {
     private String projectDirString;
     private Path projectDir;
     private Path pluginsDir;
+    private Path stagingSchemasDir;
 
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -105,7 +106,12 @@ public class HubProjectImpl implements HubProject {
         return getHubConfigDir().resolve("security");
     }
 
-    @Override public Path getHubSchemasDir() { return getHubConfigDir().resolve("schemas"); }
+    @Override
+    public Path getHubSchemasDir() { return this.stagingSchemasDir; }
+
+    private void setHubSchemasDir(Path stagingSchemasDir) {
+        this.stagingSchemasDir = stagingSchemasDir ;
+    }
 
     @Override public Path getHubTriggersDir() {
     	return getHubConfigDir().resolve("triggers"); 
@@ -247,6 +253,7 @@ public class HubProjectImpl implements HubProject {
         getUserDatabaseDir().toFile().mkdirs();
 
         //scaffold schemas
+        setHubSchemasDir(getUserDatabaseDir().resolve(customTokens.get("%%mlStagingSchemasDbName%%")).resolve("schemas"));
         getHubSchemasDir().toFile().mkdirs();
         getUserSchemasDir().toFile().mkdirs();
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/DataHubInstallTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/DataHubInstallTest.java
@@ -104,7 +104,9 @@ public class DataHubInstallTest extends HubTestBase
             //userTriggersDir.toFile().mkdirs();
 
             //creating directories for adding staging schemas/ modules and trigger files
-            Path hubSchemasDir = project.getHubConfigDir().resolve("schemas");
+            Path hubSchemasDir = project.getUserDatabaseDir()
+                .resolve(HubConfig.DEFAULT_STAGING_SCHEMAS_DB_NAME)
+                .resolve("schemas");
             Path hubModulesDir = project.getHubStagingModulesDir();
             //Path hubTriggersDir = project.getHubConfigDir().resolve("triggers");
 
@@ -174,7 +176,8 @@ public class DataHubInstallTest extends HubTestBase
         
         //checking if triggers are written
         assertTrue(stagingTriggersClient.newServerEval().xquery("fn:count(fn:doc())").eval().next().getNumber().intValue() == 1);
-        assertTrue(finalTriggersClient.newServerEval().xquery("fn:count(fn:doc())").eval().next().getNumber().intValue() == 1);
+        //we add 3 triggers as part of installation
+        assertTrue(finalTriggersClient.newServerEval().xquery("fn:count(fn:doc())").eval().next().getNumber().intValue() == 4);
         
     }
 
@@ -211,7 +214,7 @@ public class DataHubInstallTest extends HubTestBase
         HubConfig hubConfig = getHubAdminConfig();
 
         int totalCount = getDocCount(HubConfig.DEFAULT_MODULES_DB_NAME, null);
-        installUserModules(hubConfig, true);
+        installUserModules(hubConfig, false);
 
         assertEquals(
             getResource("data-hub-test/plugins/entities/test-entity/harmonize/final/collector.xqy"),

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -206,6 +206,10 @@ public class HubTestBase {
         //dataHub.initProject();
         createProjectDir();
         adminHubConfig.createProject(PROJECT_PATH);
+        /* Since we access 'hubConfig' when initProject() is called, it must be populated with properties,
+           so refreshProject() has to be called, otherwise NPE will be thrown
+        */
+        adminHubConfig.refreshProject();
         if(! project.isInitialized()) {
             adminHubConfig.initHubProject();
         }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/UpgradeProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/UpgradeProjectTest.java
@@ -3,12 +3,14 @@ package com.marklogic.hub.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.hub.HubConfig;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -19,6 +21,12 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class UpgradeProjectTest {
 
+    private Map<String, String> createMap() {
+        Map<String,String> myMap = new HashMap<>();
+        myMap.put("%%mlStagingSchemasDbName%%", HubConfig.DEFAULT_STAGING_SCHEMAS_DB_NAME);
+        return myMap;
+    }
+
     @Test
     public void upgrade300ToCurrentVersion() throws Exception {
         final String projectPath = "build/tmp/upgrade-projects/dhf300";
@@ -28,8 +36,8 @@ public class UpgradeProjectTest {
 
         HubProjectImpl hubProject = new HubProjectImpl();
         hubProject.createProject(projectPath);
-        // The tokens map doesn't seem to matter for what we're testing here
-        hubProject.init(new HashMap<>());
+        // We require %%mlStagingSchemasDbName%% in the map for test. In real scenarios, its value will always be set.
+        hubProject.init(createMap());
         hubProject.upgradeProject();
 
         File srcDir = new File(projectDir, "src");
@@ -53,8 +61,8 @@ public class UpgradeProjectTest {
 
         HubProjectImpl hubProject = new HubProjectImpl();
         hubProject.createProject(projectPath);
-        // The tokens map doesn't seem to matter for what we're testing here
-        hubProject.init(new HashMap<>());
+        // We require %%mlStagingSchemasDbName%% in the map for test. In real scenarios, its value will always be set.
+        hubProject.init(createMap());
         hubProject.upgradeProject();
 
         File srcDir = new File(projectDir, "src");
@@ -71,6 +79,9 @@ public class UpgradeProjectTest {
 
     private void verifyInternalDatabases(File internalConfigDir) {
         File databasesDir = new File(internalConfigDir, "databases");
+
+        // old schemas doesn't exist
+        assertFalse(internalConfigDir.toPath().resolve("schemas").toFile().exists());
 
         File jobFile = new File(databasesDir, "job-database.json");
         assertTrue(jobFile.exists());
@@ -128,6 +139,8 @@ public class UpgradeProjectTest {
 
     private void verifyUserDatabases(File configDir) {
         File databasesDir = new File(configDir, "databases");
+        // new schemas path exists
+        assertTrue(databasesDir.toPath().resolve(HubConfig.DEFAULT_STAGING_SCHEMAS_DB_NAME).resolve("schemas").toFile().exists());
 
         File finalFile = new File(databasesDir, "final-database.json");
         assertTrue(finalFile.exists());

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/UpgradeProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/UpgradeProjectTest.java
@@ -38,6 +38,7 @@ public class UpgradeProjectTest  extends HubTestBase {
     @BeforeEach
     private void setUp() {
         deleteProjectDir();
+        resetProperties();
     }
 
     @AfterEach
@@ -57,9 +58,10 @@ public class UpgradeProjectTest  extends HubTestBase {
         FileUtils.deleteDirectory(projectDir);
         FileUtils.copyDirectory(Paths.get("src/test/resources/upgrade-projects/dhf300").toFile(), projectDir);
 
-        hubProject.createProject(projectPath);
-        // We don't need to pass any tokens
-        hubProject.init(new HashMap<>());
+        adminHubConfig.createProject(projectPath);
+        adminHubConfig.refreshProject();
+
+        adminHubConfig.initHubProject();
         hubProject.upgradeProject();
 
         File srcDir = new File(projectDir, "src");
@@ -81,9 +83,10 @@ public class UpgradeProjectTest  extends HubTestBase {
         FileUtils.deleteDirectory(projectDir);
         FileUtils.copyDirectory(Paths.get("src/test/resources/upgrade-projects/dhf403from300").toFile(), projectDir);
 
-        hubProject.createProject(projectPath);
-        // We don't need to pass any tokens
-        hubProject.init(new HashMap<>());
+        adminHubConfig.createProject(projectPath);
+        adminHubConfig.refreshProject();
+
+        adminHubConfig.initHubProject();
         hubProject.upgradeProject();
 
         File srcDir = new File(projectDir, "src");

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/UpgradeProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/UpgradeProjectTest.java
@@ -3,9 +3,18 @@ package com.marklogic.hub.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.hub.ApplicationConfig;
 import com.marklogic.hub.HubConfig;
+import com.marklogic.hub.HubProject;
+import com.marklogic.hub.HubTestBase;
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.File;
 import java.nio.file.Paths;
@@ -19,12 +28,26 @@ import static org.junit.jupiter.api.Assertions.*;
  * src/test/resources/upgrade-projects into the build directory (a non-version-controlled area) where it
  * can then be upgraded and verified.
  */
-public class UpgradeProjectTest {
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ApplicationConfig.class)
+public class UpgradeProjectTest  extends HubTestBase {
 
-    private Map<String, String> createMap() {
-        Map<String,String> myMap = new HashMap<>();
-        myMap.put("%%mlStagingSchemasDbName%%", HubConfig.DEFAULT_STAGING_SCHEMAS_DB_NAME);
-        return myMap;
+    @Autowired
+    private HubProject hubProject;
+
+    @BeforeEach
+    private void setUp() {
+        deleteProjectDir();
+    }
+
+    @AfterEach
+    private void cleanUp() {
+        resetProperties();
+        createProjectDir();
+        adminHubConfig.createProject(PROJECT_PATH);
+        adminHubConfig.refreshProject();
+        adminHubConfig.initHubProject();
+        getHubAdminConfig();
     }
 
     @Test
@@ -34,10 +57,9 @@ public class UpgradeProjectTest {
         FileUtils.deleteDirectory(projectDir);
         FileUtils.copyDirectory(Paths.get("src/test/resources/upgrade-projects/dhf300").toFile(), projectDir);
 
-        HubProjectImpl hubProject = new HubProjectImpl();
         hubProject.createProject(projectPath);
-        // We require %%mlStagingSchemasDbName%% in the map for test. In real scenarios, its value will always be set.
-        hubProject.init(createMap());
+        // We don't need to pass any tokens
+        hubProject.init(new HashMap<>());
         hubProject.upgradeProject();
 
         File srcDir = new File(projectDir, "src");
@@ -59,10 +81,9 @@ public class UpgradeProjectTest {
         FileUtils.deleteDirectory(projectDir);
         FileUtils.copyDirectory(Paths.get("src/test/resources/upgrade-projects/dhf403from300").toFile(), projectDir);
 
-        HubProjectImpl hubProject = new HubProjectImpl();
         hubProject.createProject(projectPath);
-        // We require %%mlStagingSchemasDbName%% in the map for test. In real scenarios, its value will always be set.
-        hubProject.init(createMap());
+        // We don't need to pass any tokens
+        hubProject.init(new HashMap<>());
         hubProject.upgradeProject();
 
         File srcDir = new File(projectDir, "src");

--- a/ml-data-hub-plugin/build.gradle
+++ b/ml-data-hub-plugin/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     compile (project(':marklogic-data-hub')) {
         exclude group: 'ch.qos.logback'
     }
-    compile ('com.marklogic:ml-gradle:3.10.2') {
+    compile ('com.marklogic:ml-gradle:3.11.0') {
         exclude group: 'ch.qos.logback'
     }
     testCompile localGroovy()

--- a/quick-start/src/main/java/com/marklogic/quickstart/web/ProjectsController.java
+++ b/quick-start/src/main/java/com/marklogic/quickstart/web/ProjectsController.java
@@ -19,6 +19,7 @@ package com.marklogic.quickstart.web;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.annotations.Since;
 import com.marklogic.appdeployer.AppConfig;
 import com.marklogic.hub.DataHub;
 import com.marklogic.hub.impl.HubConfigImpl;
@@ -99,6 +100,10 @@ public class ProjectsController {
         try {
             hubConfig = om.readerForUpdating(hubConfig).readValue(hubConfigDelta);
             hubConfig.createProject(project.path);
+            /* Since we access 'hubConfig' when initProject() is called, it must be populated with properties,
+               so refreshProject() has to be called, otherwise NPE will be thrown
+             */
+            hubConfig.refreshProject();
             dataHub.initProject();
             return project;
         } catch (Exception e) {

--- a/quick-start/src/main/java/com/marklogic/quickstart/web/ProjectsController.java
+++ b/quick-start/src/main/java/com/marklogic/quickstart/web/ProjectsController.java
@@ -19,7 +19,6 @@ package com.marklogic.quickstart.web;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.annotations.Since;
 import com.marklogic.appdeployer.AppConfig;
 import com.marklogic.hub.DataHub;
 import com.marklogic.hub.impl.HubConfigImpl;


### PR DESCRIPTION
This PR 
In order to maintain backward compatibility , schemas added to both hub-internal-config/schemas and ml-config/databases/<staging_schemas_db_name>/schemas will be deployed though we are scaffolding only the latter.

1. Upgrades ml-gradle, ml-app-deployer to 3.11 , java client to 4.1.2
2. Deprecates getHubSchemasDir() (Users can still deploy to staging schemas db from hub-internal-config/schemas to maintain backward compatibility though it is not scaffolded)
3. Fixes QS , tests