### PR TITLE
Loading to staging schemas db from database-specific directory in develop

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/HubProject.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/HubProject.java
@@ -77,13 +77,6 @@ public interface HubProject {
     Path getHubDatabaseDir();
 
     /**
-     * Gets the path for the hub/staging schemas directory
-     *
-     * @return the path for the hub/staging schemas directory
-     */
-    Path getHubSchemasDir();
-
-    /**
      * Gets the path for the hub servers directory
      *
      * @return the path for the hub servers database directory

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -586,8 +586,6 @@ public class DataHubImpl implements DataHub {
 
         updateServerCommandList(commandMap);
 
-        updateSchemaCommandList(commandMap);
-
         updateModuleCommandList(commandMap);
 
         // DHF has no use case for the "deploy REST API server" commands provided by ml-gradle
@@ -643,19 +641,6 @@ public class DataHubImpl implements DataHub {
             }
         }
         commandMap.put(key, newCommands);
-    }
-
-    /**
-     * The existing "LoadSchemasCommand" is based on the ml-config path and the AppConfig object should set the default
-     * schemas database name to that of the final schemas database. Thus, we just need to add a hub-specific command for
-     * loading staging schemas from a different path and into the staging schemas database.
-     *
-     * @param commandMap
-     */
-    private void updateSchemaCommandList(Map<String, List<Command>> commandMap) {
-        List<Command> commands = commandMap.get("mlSchemaCommands");
-        final String hubSchemasPath = hubConfig.getHubConfigDir().resolve("schemas").toString();
-        commands.add(new LoadHubSchemasCommand(hubSchemasPath, hubConfig.getStagingSchemasDbName()));
     }
 
     /**

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
@@ -107,8 +107,6 @@ public class HubProjectImpl implements HubProject {
         return getHubConfigDir().resolve("security");
     }
 
-    @Override public Path getHubSchemasDir() { return getHubConfigDir().resolve("schemas"); }
-
     @Override public Path getHubTriggersDir() {
     	return getHubConfigDir().resolve("triggers"); 
     }
@@ -264,7 +262,7 @@ public class HubProjectImpl implements HubProject {
         getUserDatabaseDir().toFile().mkdirs();
 
         //scaffold schemas
-        getHubSchemasDir().toFile().mkdirs();
+        getUserDatabaseDir().resolve(customTokens.get("%%mlStagingSchemasDbName%%")).resolve("schemas").toFile().mkdirs();
         getUserSchemasDir().toFile().mkdirs();
 
         //create hub triggers

--- a/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/DataHubInstallTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/DataHubInstallTest.java
@@ -104,7 +104,9 @@ public class DataHubInstallTest extends HubTestBase
             //userTriggersDir.toFile().mkdirs();
 
             //creating directories for adding staging schemas/ modules and trigger files
-            Path hubSchemasDir = project.getHubConfigDir().resolve("schemas");
+            Path hubSchemasDir = project.getUserDatabaseDir()
+                .resolve(HubConfig.DEFAULT_STAGING_SCHEMAS_DB_NAME)
+                .resolve("schemas");
             Path hubModulesDir = project.getHubStagingModulesDir();
             //Path hubTriggersDir = project.getHubConfigDir().resolve("triggers");
 


### PR DESCRIPTION
This PR

1. Removes getHubSchemasDir(), usage of hub-internal-config/schemas and scaffolds ml-config/databases/<staging_db_name>/schemas for deploying to staging schemas db. Upgrade to 5.x will require manual copying of schemas from hub-internal-config/schemas to the destination dir.
2. Fixes the test that are affected as a result