### PR TITLE
wait after checking entity box

### DIFF
--- a/quick-start/e2e/specs/run/run.ts
+++ b/quick-start/e2e/specs/run/run.ts
@@ -43,12 +43,14 @@ export default function(tmpDir) {
       browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
       expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 456');
       // verify entity only checkbox
-      await browsePage.entitiesOnlyChkBox().click()
+      await browsePage.entitiesOnlyChkBox().click();
+      browser.sleep(5000);
       browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
       // verify it's returning the entities only result
       expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 450');
       // clear the checkbox, results should include non-entities
-      await browsePage.entitiesOnlyChkBox().click()
+      await browsePage.entitiesOnlyChkBox().click();
+      browser.sleep(5000);
       browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
       expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 456');
       await browsePage.databaseDropDown().click();


### PR DESCRIPTION
This PR adds a wait after checking the entity-only box. Sometimes on jenkins the spinner keeps spinning while waiting for the result. This will fix the one failure on jenkins