### PR TITLE
Fix for DHFPROD-1773, DHFPROD-1746

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateHubTDETemplateCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateHubTDETemplateCommand.java
@@ -77,7 +77,9 @@ public class GenerateHubTDETemplateCommand extends GenerateModelArtifactsCommand
                     File esModel;
                     try {
                         //Write the ES model to a temp file
-                        esModel = File.createTempFile("es-", f.getName());
+                        String tempDir = System.getProperty("java.io.tmpdir");
+                        String fileName = f.getName();
+                        esModel = new File(tempDir, fileName);
                         FileUtils.writeStringToFile(esModel, generateModel(f));
                     } catch (IOException e) {
                         throw new RuntimeException("Unable to generate ES model");

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateHubTDETemplateCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateHubTDETemplateCommand.java
@@ -19,6 +19,7 @@ import com.marklogic.appdeployer.AppConfig;
 import com.marklogic.appdeployer.command.CommandContext;
 import com.marklogic.appdeployer.command.es.GenerateModelArtifactsCommand;
 import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.eval.EvalResultIterator;
 import com.marklogic.client.ext.es.CodeGenerationRequest;
 import com.marklogic.client.ext.es.EntityServicesManager;
 import com.marklogic.client.ext.es.GeneratedCode;
@@ -116,7 +117,11 @@ public class GenerateHubTDETemplateCommand extends GenerateModelArtifactsCommand
         String xquery = "import module namespace hent = \"http://marklogic.com/data-hub/hub-entities\"\n" +
             "at \"/data-hub/4/impl/hub-entities.xqy\";\n" +
             String.format("hent:get-model(\"%s\")", extactEntityNameFromFilename(f.getName()).get());
-        return  hubConfig.newStagingClient().newServerEval().xquery(xquery).eval().next().getString();
+        EvalResultIterator resp = hubConfig.newStagingClient().newServerEval().xquery(xquery).eval();
+        if (resp.hasNext()) {
+            return resp.next().getString();
+        }
+        return null ;
     }
 
     public String getEntityNames() {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateHubTDETemplateCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateHubTDETemplateCommand.java
@@ -80,6 +80,11 @@ public class GenerateHubTDETemplateCommand extends GenerateModelArtifactsCommand
                         String tempDir = System.getProperty("java.io.tmpdir");
                         String fileName = f.getName();
                         esModel = new File(tempDir, fileName);
+                        String modelString = generateModel(f);
+                        if(modelString == null) {
+                            logger.warn(f.getName() + " is not deployed to the database");
+                            continue;
+                        }
                         FileUtils.writeStringToFile(esModel, generateModel(f));
                     } catch (IOException e) {
                         throw new RuntimeException("Unable to generate ES model");


### PR DESCRIPTION
This PR fixes

1. creates temp file with same name as entity file so that models written to final db by ml-app-deployer continue to have the same name as before and not get prepended by temp file name (/marklogic.com/entity-services/models/e2eentity.entity.json)
2. DHFPROD-1773- handles NPE when entities are on disk and not in db