### PR TITLE
Remove hub-internal-config/schemas as part of upgrade

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
@@ -410,6 +410,9 @@ public class HubProjectImpl implements HubProject {
         deleteObsoleteServerFilesFromHubInternalConfig();
         deleteObsoleteDatabaseFilesFromMlConfig();
 
+        //remove hub-internal-config/schemas dir
+        deleteObsoleteDirsFromHubInternalConfig();
+
     }
 
     @Override  public String getHubModulesDeployTimestampFile() {
@@ -717,6 +720,22 @@ public class HubProjectImpl implements HubProject {
                 f.delete();
             }
         }
+    }
+
+    private void deleteObsoleteDirsFromHubInternalConfig() {
+        File dir = getHubConfigDir().resolve("schemas").toFile();
+        if (dir.exists()) {
+            if (logger.isInfoEnabled()) {
+                logger.info("Deleting hub-internal-config/schemas dir because it is no longer used");
+            }
+            try {
+                FileUtils.deleteDirectory(dir);
+            } catch (IOException e) {
+                logger.error("Unable to delete "+ dir.getName());
+                throw new RuntimeException(e);
+            }
+        }
+
     }
 
     @Override

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
@@ -731,7 +731,7 @@ public class HubProjectImpl implements HubProject {
             try {
                 FileUtils.deleteDirectory(dir);
             } catch (IOException e) {
-                logger.error("Unable to delete "+ dir.getName());
+                logger.error("Unable to delete "+ dir.getAbsolutePath());
                 throw new RuntimeException(e);
             }
         }


### PR DESCRIPTION
This is part of DHFPROD-1764 that got missed earlier. During upgrade from 4.x to 5.x , hub-internal-config/schemas is removed as the path no longer works