### PR TITLE
Do a case insensitive equality check for entity name when creating an…

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/impl/flow-lib.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/impl/flow-lib.xqy
@@ -98,15 +98,28 @@ declare function flow:get-flow-nocache(
 {
 
   hul:run-in-modules(function() {
-    /hub:flow[
-      hub:entity = $entity-name and
+    let $flow := /hub:flow[
+    fn:lower-case(hub:entity) = fn:lower-case($entity-name) and
       hub:name = $flow-name]
-      [
+    [
+    if (fn:exists($flow-type)) then
+      hub:type = $flow-type
+    else
+      fn:true()
+    ]
+    return
+      if ((fn:count($flow)) > 1) then
+        /hub:flow[
+        hub:entity = $entity-name and
+          hub:name = $flow-name]
+        [
         if (fn:exists($flow-type)) then
           hub:type = $flow-type
         else
           fn:true()
-      ]
+        ]
+      else
+        $flow
   }) ! hul:deep-copy(.)
 };
 

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/impl/hub-entities.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/impl/hub-entities.xqy
@@ -33,7 +33,13 @@ declare function hent:get-model($entity-name as xs:string)
 
 declare function hent:get-model($entity-name as xs:string, $used-models as xs:string*)
 {
-  let $model := fn:collection($ENTITY-MODEL-COLLECTION)[info/title = $entity-name]
+  let $model :=
+    let $_ := fn:collection($ENTITY-MODEL-COLLECTION)[lower-case(info/title) = lower-case($entity-name)]
+    return
+      if (fn:count($_) > 1) then
+        fn:collection($ENTITY-MODEL-COLLECTION)[info/title = $entity-name]
+      else
+        $_
   where fn:exists($model)
   return
     let $model-map as map:map? := $model


### PR DESCRIPTION
Do a case insensitive equality check for entity name when creating and running flows , if it returns more than one result, revert to strict check.