### PR TITLE
DHFPROD-1870 Manage Flows fixes

### DIFF
--- a/quick-start/src/main/ui/app/components/flows-new/manage-flows.module.ts
+++ b/quick-start/src/main/ui/app/components/flows-new/manage-flows.module.ts
@@ -5,19 +5,23 @@ import {MaterialModule} from "../theme/material.module";
 import {ManageFlowsUiComponent} from "./manage-flows/ui/manage-flows-ui.component";
 import {ConfirmationDialogComponent} from "../common";
 import {NewFlowDialogComponent} from "./manage-flows/ui/new-flow-dialog.component";
+import {StepIconsUiComponent} from "./manage-flows/ui/step-icons-ui.component";
 import {HttpClientModule} from "@angular/common/http";
+import {CommonModule} from '@angular/common';
 
 @NgModule({
   declarations: [
     ConfirmationDialogComponent,
     NewFlowDialogComponent,
     ManageFlowsUiComponent,
-    ManageFlowsComponent
+    ManageFlowsComponent,
+    StepIconsUiComponent
   ],
   imports     : [
     MaterialModule,
     RouterModule,
-    HttpClientModule
+    HttpClientModule,
+    CommonModule
   ],
   providers   : [
   ],

--- a/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.html
+++ b/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.html
@@ -11,12 +11,17 @@
             Manage Flows
           </span>
         </div>
-        <span class="fill-space"></span>
         <button mat-raised-button
-                class="add-flow-button"
+                class="new-flow-button"
                 (click)="openNewFlowDialog()"
         >
           <span>NEW FLOW</span>
+        </button>
+        <span class="fill-space"></span>
+        <button mat-raised-button
+                class="redeploy-button"
+        >
+          <span>REDEPLOY</span>
         </button>
       </mat-toolbar>
     </div>

--- a/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.html
+++ b/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.html
@@ -108,7 +108,7 @@
 
         <!-- Actions Column -->
         <ng-container matColumnDef="actions">
-          <mat-header-cell *matHeaderCellDef>Actions</mat-header-cell>
+          <mat-header-cell *matHeaderCellDef></mat-header-cell>
           <mat-cell *matCellDef="let flow">
             <button mat-raised-button
                     class="run-flow-button"

--- a/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.html
+++ b/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.html
@@ -81,7 +81,7 @@
           <mat-header-cell *matHeaderCellDef mat-sort-header="lastJobFinished">Last Job Finished</mat-header-cell>
           <mat-cell *matCellDef="let flow">
             <a>
-              {{flow.lastJobFinished}}
+              {{friendlyDate(flow.lastJobFinished)}}
             </a>
           </mat-cell>
         </ng-container>

--- a/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.html
+++ b/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.html
@@ -32,7 +32,12 @@
         <ng-container matColumnDef="name">
           <mat-header-cell *matHeaderCellDef mat-sort-header>Name</mat-header-cell>
           <mat-cell *matCellDef="let flow">
-            <a routerLink="/edit-flow">{{flow.name}}</a>
+            <div class="name-container">
+              <a routerLink="/edit-flow">{{flow.name}}</a>
+              <step-icons-ui
+                [steps]="flow.steps"
+              ></step-icons-ui>
+            </div>
           </mat-cell>
         </ng-container>
 

--- a/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.scss
+++ b/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.scss
@@ -164,3 +164,11 @@ $header-height: 100px !default;
   position: relative;
   width: 240px;
 }
+
+.logo {
+  padding-right: 30px;
+}
+
+.mat-column-actions .mat-icon {
+  cursor: pointer;
+}

--- a/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.scss
+++ b/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.scss
@@ -159,3 +159,8 @@ $header-height: 100px !default;
 .fill-space {
   flex: 1 1 auto;
 }
+
+.name-container {
+  position: relative;
+  width: 240px;
+}

--- a/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.ts
+++ b/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.ts
@@ -3,6 +3,7 @@ import {MatDialog, MatPaginator, MatSort, MatTable, MatTableDataSource} from "@a
 import {ConfirmationDialogComponent} from "../../../common";
 import {NewFlowDialogComponent} from "./new-flow-dialog.component";
 import {Flow} from "../../models/flow.model";
+import * as moment from 'moment';
 
 @Component({
   selector: 'flows-page-ui',
@@ -70,4 +71,9 @@ export class ManageFlowsUiComponent implements OnInit, AfterViewInit {
     this.updateDataSource();
     this.table.renderRows();
   }
+
+  friendlyDate(dt): string {
+    return moment(dt).fromNow();
+  }
+
 }

--- a/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/step-icons-ui.component.html
+++ b/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/step-icons-ui.component.html
@@ -1,0 +1,6 @@
+<div class="step-icons">
+  <div
+    *ngFor="let step of steps; let i = index;"
+    class="step-icon {{step.type}}"
+  ></div>
+</div>

--- a/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/step-icons-ui.component.scss
+++ b/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/step-icons-ui.component.scss
@@ -1,0 +1,28 @@
+.step-icons {
+  position: absolute;
+  left: 0;
+  top: 10px;
+}
+
+.step-icon {
+  height: 5px;
+  width: 20px;
+  display: inline-block;
+  margin-right: 3px;
+}
+
+.ingestion {
+  background-color: #AD1457;
+}
+
+.mapping {
+  background-color: #3F51B5;
+}
+
+.mastering {
+  background-color: #009688;
+}
+
+.custom {
+  background-color: #F4511E;
+}

--- a/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/step-icons-ui.component.ts
+++ b/quick-start/src/main/ui/app/components/flows-new/manage-flows/ui/step-icons-ui.component.ts
@@ -1,0 +1,11 @@
+import {Component, Input} from "@angular/core";
+
+@Component({
+  selector: 'step-icons-ui',
+  templateUrl: './step-icons-ui.component.html',
+  styleUrls: ['./step-icons-ui.component.scss']
+})
+export class StepIconsUiComponent {
+  @Input() steps: Array<Object> = new Array<Object>();
+
+}


### PR DESCRIPTION
This PR adds a component for color icons under the name values in the Manage Flows table.

It also makes changes based on meeting with @sbayatpur:

- Add a Redeploy button to top (this action was by itself under a header menu in the wireframes, remove this header menu)
- Add friendly datetime display for Last Job Finished
- Remove "Actions" label from Actions column