### PR TITLE
DHFPROD-1679: Start of UI for matching config page

### DIFF
--- a/quick-start/src/main/ui/app/app.module.ts
+++ b/quick-start/src/main/ui/app/app.module.ts
@@ -86,6 +86,7 @@ import {MapComponent, MappingsComponent} from './components/mappings';
 import {NewMapComponent} from "./components/mappings/new-map.component";
 import {FlowsUiComponent} from './components/flows/ui';
 import {ManageFlowsModule, EditFlowModule} from "./components/flows-new";
+import {MatchingModule} from "./components/flows-new/edit-flow/mastering/matching.module";
 
 @NgModule({
   declarations: [
@@ -182,7 +183,8 @@ import {ManageFlowsModule, EditFlowModule} from "./components/flows-new";
     TooltipModule.forRoot(),
     ThemeModule,
     ManageFlowsModule,
-    EditFlowModule
+    EditFlowModule,
+    MatchingModule
   ],
   providers: [
     AUTH_PROVIDERS,

--- a/quick-start/src/main/ui/app/app.routes.ts
+++ b/quick-start/src/main/ui/app/app.routes.ts
@@ -12,6 +12,7 @@ import {NoContentComponent} from './components/no-content';
 import {EditFlowComponent} from './components/flows-new/edit-flow/edit-flow.component';
 import {AuthGuard} from './services/auth/auth-guard.service';
 import {ManageFlowsComponent} from "./components/flows-new/manage-flows/manage-flows.component";
+import {MatchingComponent} from "./components/flows-new/edit-flow/mastering/matching.component";
 
 export const ROUTES: Routes = [
   { path: '', component: DashboardComponent, canActivate: [AuthGuard] },
@@ -33,6 +34,7 @@ export const ROUTES: Routes = [
   { path: 'manage-flows', component: ManageFlowsComponent, canActivate: [AuthGuard]},
   { path: 'flows/:entityName/:flowName/:flowType', component: FlowsComponent, canActivate: [AuthGuard] },
   { path: 'edit-flow/:flowId', component: EditFlowComponent, canActivate: [AuthGuard] },
+  { path: 'matching/:stepId', component: MatchingComponent, canActivate: [AuthGuard] },
   { path: 'jobs', component: JobsComponent, canActivate: [AuthGuard] },
   { path: 'traces', component: TracesComponent, canActivate: [AuthGuard] },
   { path: 'traces/:id', component: TraceViewerComponent, canActivate: [AuthGuard] },

--- a/quick-start/src/main/ui/app/components/flows-new/edit-flow/mastering/matching.component.ts
+++ b/quick-start/src/main/ui/app/components/flows-new/edit-flow/mastering/matching.component.ts
@@ -1,0 +1,68 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { ActivatedRoute, Params } from '@angular/router';
+import { MatchingUiComponent } from "./ui/matching-ui.component";
+import { matchingData } from "../../models/matching.data";
+import { Matching } from "../../models/matching.model";
+import { MatchOptions } from "../../models/match-options.model";
+import { MatchThresholds } from "../../models/match-thresholds.model";
+
+@Component({
+  selector: 'app-matching',
+  template: `
+  <app-matching-ui
+    [matchOptions]="matchOptions"
+    [matchThresholds]="matchThresholds"
+    (createOption)="this.createOption($event)"
+    (saveOption)="this.saveOption($event)"
+    (deleteOption)="this.deleteOption($event)"
+  ></app-matching-ui>
+`
+})
+export class MatchingComponent implements OnInit {
+
+  @ViewChild(MatchingUiComponent) matchingUi: MatchingUiComponent;
+
+  public stepId: string;
+  public matchOptions: MatchOptions;
+  public matchThresholds: MatchThresholds;
+
+  constructor(
+    private activatedRoute: ActivatedRoute
+  ) { }
+
+  ngOnInit() {
+
+    this.stepId = this.activatedRoute.snapshot.paramMap.get('stepId');
+    console.log('stepId:', this.stepId);
+
+    // TODO Retrieve matching data from the backend based on stepId
+    let matching = Matching.fromConfig(matchingData);
+    console.log(matching);
+
+    // Parse matching data and instantiate models for UI
+    this.matchOptions = MatchOptions.fromMatching(matching);
+    console.log(this.matchOptions);
+
+    this.matchThresholds = MatchThresholds.fromJSON(matching);
+    console.log(this.matchThresholds);
+  }
+
+  createOption(event): void {
+    console.log('createOption', event);
+    this.matchOptions.addOption(event);
+    this.matchingUi.renderRows();
+  }
+
+  saveOption(event): void {
+    console.log('saveOption', event);
+    this.matchOptions.updateOption(event, event.index);
+    this.matchingUi.renderRows();
+  }
+
+  deleteOption(index): void {
+    console.log(index);
+    this.matchOptions.deleteOption(index);
+    this.matchingUi.renderRows();
+  }
+
+}

--- a/quick-start/src/main/ui/app/components/flows-new/edit-flow/mastering/matching.module.ts
+++ b/quick-start/src/main/ui/app/components/flows-new/edit-flow/mastering/matching.module.ts
@@ -1,0 +1,31 @@
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {RouterModule} from '@angular/router';
+import {MaterialModule} from "../../../theme/material.module";
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+
+import {MatchingComponent} from './matching.component';
+import {MatchingUiComponent} from './ui/matching-ui.component';
+
+import {AddMatchOptionDialogComponent} from './ui/add-match-option-dialog.component';
+
+@NgModule({
+  declarations: [
+    MatchingComponent,
+    MatchingUiComponent,
+    AddMatchOptionDialogComponent
+  ],
+  imports     : [
+    CommonModule,
+    RouterModule,
+    MaterialModule,
+    FormsModule,
+    ReactiveFormsModule
+  ],
+  providers   : [
+  ],
+  entryComponents: [
+    AddMatchOptionDialogComponent
+  ]
+})
+export class MatchingModule {}

--- a/quick-start/src/main/ui/app/components/flows-new/edit-flow/mastering/ui/add-match-option-dialog.component.html
+++ b/quick-start/src/main/ui/app/components/flows-new/edit-flow/mastering/ui/add-match-option-dialog.component.html
@@ -1,0 +1,73 @@
+<h1 mat-dialog-title>{{getDialogTitle()}}</h1>
+<div mat-dialog-content [formGroup]="form" class="content">
+  <mat-form-field>
+    <mat-select placeholder="Match Type" formControlName="matchType">
+      <mat-option value="exact">Exact</mat-option>
+      <mat-option value="synonym">Synonym</mat-option>
+      <mat-option value="double metaphone">Double Metaphone</mat-option>
+      <mat-option value="zip">Zip</mat-option>
+      <mat-option value="custom">Custom</mat-option>
+    </mat-select>
+  </mat-form-field>
+  <mat-form-field layout-fill>
+    <mat-label>Property to Match</mat-label>
+    <input matInput formControlName="propertyName"/>
+  </mat-form-field>
+  <mat-form-field layout-fill>
+    <mat-label>Weight</mat-label>
+    <input matInput formControlName="weight"/>
+  </mat-form-field>
+
+  <div *ngIf="getMatchType() === 'synonym'">
+    <mat-form-field layout-fill>
+      <mat-label>Thesaurus URI</mat-label>
+      <input matInput formControlName="thesaurus"/>
+    </mat-form-field>
+    <mat-form-field layout-fill>
+      <mat-label>Filter</mat-label>
+      <input matInput formControlName="filter"/>
+    </mat-form-field>
+  </div>
+
+  <div *ngIf="getMatchType() === 'double metaphone'">
+    <mat-form-field layout-fill>
+      <mat-label>Dictionary URI</mat-label>
+      <input matInput formControlName="dictionary"/>
+    </mat-form-field>
+    <mat-form-field layout-fill>
+      <mat-label>Distance Threshold</mat-label>
+      <input matInput formControlName="distanceThreshold"/>
+    </mat-form-field>
+    <mat-form-field layout-fill>
+      <mat-label>Collation</mat-label>
+      <input matInput formControlName="collation"/>
+    </mat-form-field>
+  </div>
+
+  <div *ngIf="getMatchType() === 'zip'">
+    <mat-form-field layout-fill>
+      <mat-label>5-matches-9 Boost</mat-label>
+      <input matInput formControlName="zip5match9"/>
+    </mat-form-field>
+    <mat-form-field layout-fill>
+      <mat-label>9-matches-5 Weight</mat-label>
+      <input matInput formControlName="zip9match5"/>
+    </mat-form-field>
+  </div>
+
+  <div *ngIf="getMatchType() === 'custom'">
+    <mat-form-field layout-fill>
+      <mat-label>URI</mat-label>
+      <input matInput formControlName="customUri"/>
+    </mat-form-field>
+    <mat-form-field layout-fill>
+      <mat-label>Function</mat-label>
+      <input matInput formControlName="customFunction"/>
+    </mat-form-field>
+  </div>
+
+</div>
+<mat-dialog-actions class="bottom">
+  <button mat-button (click)="onCancel()">Cancel</button>
+  <button mat-button (click)="onSave()">{{getSubmitButtonTitle()}}</button>
+</mat-dialog-actions>

--- a/quick-start/src/main/ui/app/components/flows-new/edit-flow/mastering/ui/add-match-option-dialog.component.scss
+++ b/quick-start/src/main/ui/app/components/flows-new/edit-flow/mastering/ui/add-match-option-dialog.component.scss
@@ -1,0 +1,3 @@
+h2 {
+  margin-left: 5%;
+}

--- a/quick-start/src/main/ui/app/components/flows-new/edit-flow/mastering/ui/add-match-option-dialog.component.ts
+++ b/quick-start/src/main/ui/app/components/flows-new/edit-flow/mastering/ui/add-match-option-dialog.component.ts
@@ -1,0 +1,71 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+import { MatchingUiComponent } from './matching-ui.component';
+import { MatchOption } from "../../../models/match-options.model";
+import { FormBuilder, FormGroup, Validators } from "@angular/forms";
+
+export interface DialogData {
+  stepName: string;
+  stepType: string;
+}
+
+@Component({
+  selector: 'app-add-match-option-dialog',
+  templateUrl: './add-match-option-dialog.component.html',
+  styleUrls: ['./add-match-option-dialog.component.scss'],
+})
+export class AddMatchOptionDialogComponent {
+
+  form: FormGroup;
+
+  constructor(
+    private fb: FormBuilder,
+    public dialogRef: MatDialogRef<AddMatchOptionDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: any) {
+  }
+
+  ngOnInit() {
+    this.form = this.fb.group({
+      propertyName: [this.data.option ? this.data.option.propertyName.join(', ') : '', Validators.required],
+      matchType: [this.data.option ? this.data.option.matchType : ''],
+      weight: [this.data.option ? this.data.option.weight : ''],
+      thesaurus: [this.data.option ? this.data.option.thesaurus : ''],
+      filter: [this.data.option ? this.data.option.filter : ''],
+      dictionary: [this.data.option ? this.data.option.dictionary : ''],
+      distanceThreshold: [this.data.option ? this.data.option.distanceThreshold : ''],
+      collation: [this.data.option ? this.data.option.collation : ''],
+      zip5match9: [this.data.option ? this.data.option.zip5match9 : ''],
+      zip9match5: [this.data.option ? this.data.option.zip9match5 : ''],
+      customUri: [this.data.option ? this.data.option.customUri : ''],
+      customFunction: [this.data.option ? this.data.option.customFunction : ''],
+      index: this.data.index
+    })
+  }
+
+  onNoClick(): void {
+    this.dialogRef.close();
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(null);
+  }
+
+  getDialogTitle(){
+    return this.data.option ? 'Add Match Option' : 'New Match Option';
+  }
+
+  getSubmitButtonTitle() {
+    return this.data.option ? 'Save' : 'Create';
+  }
+
+  getMatchType() {
+    return (this.data.option && this.data.option.matchType) ?
+      this.data.option.matchType : 'exact';
+  }
+
+  onSave() {
+    console.log('onSave', this.form);
+    this.dialogRef.close(this.form.value);
+  }
+
+}

--- a/quick-start/src/main/ui/app/components/flows-new/edit-flow/mastering/ui/matching-ui.component.html
+++ b/quick-start/src/main/ui/app/components/flows-new/edit-flow/mastering/ui/matching-ui.component.html
@@ -1,0 +1,181 @@
+<div class="matching">
+
+
+<div id="matching-page" class="page-layout carded fullwidth">
+
+  <!-- CENTER -->
+  <div class="center">
+
+    <!-- HEADER -->
+    <div class="header accent">
+      <mat-toolbar style="background: transparent">
+        <div class="logo">
+          <span class="logo-text h1">
+            Match Options
+          </span>
+        </div>
+        <button mat-raised-button
+                class="new-option-button"
+                (click)="openMatchOptionDialog(null)"
+        >
+          <span>ADD</span>
+        </button>
+        <span class="fill-space"></span>
+      </mat-toolbar>
+    </div>
+    <!-- / HEADER -->
+
+    <div class="content-card">
+
+      <mat-table class="matching-table"
+                 #table [dataSource]="dataSource" matSort>
+
+        <!-- Property to Match Column -->
+        <ng-container matColumnDef="propertyName">
+          <mat-header-cell *matHeaderCellDef mat-sort-header>Property to Match</mat-header-cell>
+          <mat-cell *matCellDef="let mOpt">
+            <a>
+              {{mOpt.propertyName.join(', ')}}
+          </a>
+          </mat-cell>
+        </ng-container>
+
+        <!-- Match Type Column -->
+        <ng-container matColumnDef="matchType">
+          <mat-header-cell *matHeaderCellDef mat-sort-header>Match Type</mat-header-cell>
+          <mat-cell *matCellDef="let mOpt">
+            <a class="capitalize">
+              {{mOpt.matchType}}
+            </a>
+          </mat-cell>
+        </ng-container>
+
+        <!-- Weight Column -->
+        <ng-container matColumnDef="weight">
+          <mat-header-cell *matHeaderCellDef mat-sort-header>Weight</mat-header-cell>
+          <mat-cell *matCellDef="let mOpt">
+            <a>
+              {{mOpt.weight}}
+            </a>
+          </mat-cell>
+        </ng-container>
+
+        <!-- Other Column -->
+        <ng-container matColumnDef="other">
+          <mat-header-cell *matHeaderCellDef>Other</mat-header-cell>
+          <mat-cell *matCellDef="let mOpt">
+
+            <div *ngIf="mOpt.matchType === 'exact'">
+              <div>&nbsp;</div>
+            </div>
+            <div *ngIf="mOpt.matchType === 'reduce'">
+              <div>&nbsp;</div>
+            </div>
+            <div *ngIf="mOpt.matchType === 'synonym'">
+              <div>
+                <span class="otherLabel">Thesaurus:</span>
+                <a>{{truncate(mOpt.thesaurus, 40)}}</a>
+              </div>
+              <div>
+                <span class="otherLabel">Filter:</span>
+                <a>{{mOpt.filter}}</a>
+              </div>
+            </div>
+            <div *ngIf="mOpt.matchType === 'double metaphone'">
+              <div>
+                <span class="otherLabel">Dictionary:</span> <a>{{truncate(mOpt.dictionary, 40)}}</a>
+              </div>
+              <div>
+                <span class="otherLabel">Distance Threshold:</span>
+                <a>{{mOpt.distanceThreshold}}</a>
+              </div>
+              <div>
+                <span class="otherLabel">Collation:</span>
+                <a title="{{mOpt.collation}}">
+                  {{truncate(mOpt.collation, 40)}}
+                </a>
+              </div>
+            </div>
+            <div *ngIf="mOpt.matchType === 'custom'">
+              <div>
+                <span class="otherLabel">URI:</span>
+                <a>{{truncate(mOpt.customUri, 40)}}</a>
+              </div>
+              <div>
+                <span class="otherLabel">Function:</span>
+                <a>{{mOpt.customFunction}}</a>
+              </div>
+            </div>
+            <div *ngIf="mOpt.matchType === 'zip'">
+              <div>
+                <span class="otherLabel">5-matches-9 Boost:</span>
+                <a>{{mOpt.zip5match9}}</a>
+              </div>
+              <div>
+                <span class="otherLabel">9-matches-5 Weight:</span>
+                <a>{{mOpt.zip9match5}}</a>
+              </div>
+            </div>
+
+          </mat-cell>
+        </ng-container>
+
+        <!-- Actions Column -->
+        <ng-container matColumnDef="actions">
+          <mat-header-cell *matHeaderCellDef>Actions</mat-header-cell>
+          <mat-cell *matCellDef="let mOpt; let i = index">
+            <mat-icon class="match-menu-icon" [matMenuTriggerFor]="matchMenu" [matMenuTriggerData]="{mOpt: mOpt, i: i}"
+                      disableRipple>more_vert</mat-icon>
+          </mat-cell>
+        </ng-container>
+
+        <mat-header-row *matHeaderRowDef="displayedColumns; sticky:true"></mat-header-row>
+        <mat-row *matRowDef="let mOpt; columns: displayedColumns;">
+        </mat-row>
+
+      </mat-table>
+
+      <mat-paginator #paginator
+                     [length]="matchOptions.length"
+                     [pageIndex]="0"
+                     [pageSize]="5"
+                     [pageSizeOptions]="[3, 5, 15, 30]">
+      </mat-paginator>
+
+    </div>
+  </div>
+</div>
+
+<mat-menu #matchMenu="matMenu">
+  <ng-template matMenuContent let-mOpt="mOpt" let-i="i">
+    <div mat-menu-item (click)="openMatchOptionDialog(mOpt, i)">Edit Settings {{index}}</div>
+    <div mat-menu-item (click)="openConfirmDialog(i)">Delete</div>
+  </ng-template>
+</mat-menu>
+
+<h2>Match Thresholds</h2>
+
+<button (click)="openMatchThresholdDialog(null)">
+  <span>ADD</span>
+</button>
+
+<table border=1>
+  <thead>
+    <tr>
+      <th>Threshold Name</th>
+      <th>Weight</th>
+      <th>Action</th>
+      <td>&nbsp;</td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr *ngFor="let mThr of matchThresholds.thresholds; let i = index;">
+      <td>{{mThr.label}}</td>
+      <td>{{mThr.above}}</td>
+      <td>{{mThr.action}}</td>
+      <td>...</td>
+    </tr>
+  </tbody>
+</table>
+
+</div>

--- a/quick-start/src/main/ui/app/components/flows-new/edit-flow/mastering/ui/matching-ui.component.html
+++ b/quick-start/src/main/ui/app/components/flows-new/edit-flow/mastering/ui/matching-ui.component.html
@@ -16,7 +16,7 @@
         </div>
         <button mat-raised-button
                 class="new-option-button"
-                (click)="openMatchOptionDialog(null)"
+                (click)="openMatchOptionDialog(null, null)"
         >
           <span>ADD</span>
         </button>
@@ -155,7 +155,7 @@
 
 <h2>Match Thresholds</h2>
 
-<button (click)="openMatchThresholdDialog(null)">
+<button>
   <span>ADD</span>
 </button>
 

--- a/quick-start/src/main/ui/app/components/flows-new/edit-flow/mastering/ui/matching-ui.component.scss
+++ b/quick-start/src/main/ui/app/components/flows-new/edit-flow/mastering/ui/matching-ui.component.scss
@@ -1,0 +1,179 @@
+.matching {
+  padding: 10px 40px;
+}
+
+.otherLabel {
+  display: inline-block;
+  width: 160px;
+}
+
+$header-height: 100px !default;
+
+button {
+  outline: none;
+}
+
+.page-layout {
+  position: relative;
+  overflow: hidden;
+
+  // Carded layout
+  &.carded {
+    display: flex;
+    flex-direction: column;
+    flex: 1 0 auto;
+    width: 100%;
+    min-width: 100%;
+
+    // Top bg
+    > .top-bg {
+      position: absolute;
+      z-index: 1;
+      top: 0;
+      right: 0;
+      left: 0;
+    }
+
+    // Fullwidth
+    &.fullwidth {
+
+      // Center
+      > .center {
+        display: flex;
+        flex-direction: column;
+        flex: 1 0 auto;
+        position: relative;
+        z-index: 2;
+        padding: 0 32px;
+        width: 100%;
+        min-width: 0;
+        max-width: 100%;
+        height: 100%;
+        max-height: 100%;
+
+        > .header {
+          height: $header-height !important;
+          min-height: $header-height !important;
+          max-height: $header-height!important;
+        }
+
+        > .content-card {
+          display: flex;
+          flex-direction: column;
+          flex: 1 0 auto;
+          overflow: hidden;
+
+          > .content {
+            flex: 1 0 auto;
+          }
+        }
+      }
+    }
+  }
+}
+
+.matching-table {
+  flex: 1 1 auto;
+  border-bottom: 1px solid rgba(0, 0, 0, .12);
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+
+  a {
+    color: black;
+  }
+
+  a:hover {
+    text-decoration-color: blue;
+  }
+
+  .mat-header-row {
+    min-height: 64px;
+  }
+
+  .flow {
+    position: relative;
+    cursor: pointer;
+    height: 84px;
+  }
+
+  .mat-cell {
+    min-width: 0;
+    display: flex;
+    align-items: center;
+  }
+
+  .mat-column-propertyName {
+    flex: 0 1 200px;
+  }
+
+  .mat-column-matchType {
+    flex: 0 1 180px;
+  }
+
+  .mat-column-weight {
+    flex: 0 1 100px;
+  }
+
+  .mat-column-other {
+    flex: 0 1 480px;
+  }
+
+  .mat-column-actions {
+    flex: 0 1 80px;
+  }
+
+  .mat-header-cell .mat-icon {
+    cursor: pointer;
+  }
+
+  .logo {
+    padding-right: 30px;
+  }
+
+  .run-flow-button {
+    margin: 0 15px 0 7px;
+  }
+
+  .actions-menu-icon {
+    margin-left: 10px;
+  }
+
+  .quantity-indicator {
+    display: inline-block;
+    vertical-align: middle;
+    width: 8px;
+    height: 8px;
+    border-radius: 4px;
+    margin-right: 8px;
+
+    & + span {
+      display: inline-block;
+      vertical-align: middle;
+    }
+  }
+
+  .active-icon {
+    border-radius: 50%;
+  }
+}
+
+.fill-space {
+  flex: 1 1 auto;
+}
+
+.name-container {
+  position: relative;
+  width: 240px;
+}
+
+.logo {
+  padding-right: 30px;
+}
+
+.mat-column-actions .mat-icon {
+  cursor: pointer;
+}
+
+.capitalize {
+   text-transform: capitalize;
+}

--- a/quick-start/src/main/ui/app/components/flows-new/edit-flow/mastering/ui/matching-ui.component.ts
+++ b/quick-start/src/main/ui/app/components/flows-new/edit-flow/mastering/ui/matching-ui.component.ts
@@ -1,0 +1,92 @@
+import { Component, Input, Output, EventEmitter, OnInit, ViewChild } from '@angular/core';
+import { MatDialog, MatPaginator, MatSort, MatTable, MatTableDataSource} from "@angular/material";
+import { MatchOption } from "../../../models/match-options.model";
+import { AddMatchOptionDialogComponent } from './add-match-option-dialog.component';
+import { ConfirmationDialogComponent } from "../../../../common";
+
+@Component({
+  selector: 'app-matching-ui',
+  templateUrl: './matching-ui.component.html',
+  styleUrls: ['./matching-ui.component.scss'],
+})
+export class MatchingUiComponent {
+  displayedColumns = ['propertyName', 'matchType', 'weight', 'other', 'actions'];
+  @Input() step: any;
+  @Input() matchOptions: any;
+  @Input() matchThresholds: any;
+
+  @Output() createOption = new EventEmitter();
+  @Output() saveOption = new EventEmitter();
+  @Output() deleteOption = new EventEmitter();
+
+  dataSource: MatTableDataSource<MatchOption>;
+
+  @ViewChild(MatTable) table: MatTable<any>;
+
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+
+  @ViewChild(MatSort) sort: MatSort;
+
+  constructor(
+    public dialog: MatDialog
+  ) {}
+
+  ngOnInit() {
+    console.log('this.matchOptions', this.matchOptions);
+    this.dataSource = new MatTableDataSource<MatchOption>(this.matchOptions.options);
+  }
+
+  ngAfterViewInit() {
+    this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
+  }
+
+  openMatchOptionDialog(optionToEdit: MatchOption, index: number): void {
+    const dialogRef = this.dialog.open(AddMatchOptionDialogComponent, {
+      width: '500px',
+      data: {option: optionToEdit, index: index}
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (!!result) {
+        if (optionToEdit) {
+          console.log('saveOption');
+          this.saveOption.emit(result);
+        }else{
+          console.log('createOption');
+          this.createOption.emit(result);
+        }
+      }
+    });
+  }
+
+  openConfirmDialog(index): void {
+    const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
+      width: '350px',
+      data: {title: 'Delete Match Option', confirmationMessage: `Delete the option?`}
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if(!!result){
+        this.deleteOption.emit(index);
+      }
+    });
+  }
+
+  // TODO Use TruncateCharactersPipe
+  truncate(value: string, limit: number, trail: string = '...'): string {
+    return value.length > limit ?
+      value.substring(0, limit) + trail :
+      value;
+  }
+
+  updateDataSource() {
+    this.dataSource.data = this.matchOptions['options'];
+  }
+
+  renderRows(): void {
+    this.updateDataSource();
+    this.table.renderRows();
+  }
+
+}

--- a/quick-start/src/main/ui/app/components/flows-new/models/match-options.model.ts
+++ b/quick-start/src/main/ui/app/components/flows-new/models/match-options.model.ts
@@ -1,0 +1,134 @@
+import { Matching } from "./matching.model";
+
+/**
+ * Represents a set of match options for UI display.
+ */
+export class MatchOptions {
+  public options: Array<MatchOption> = [];
+
+  /**
+   * Construct match options based on a JSON matching configuration.
+   */
+  static fromMatching(matching: Matching) {
+    const result = new MatchOptions();
+    const algs = matching.algorithms['algorithm'];
+    let mOpt;
+    if (matching.scoring && matching.scoring['add']) {
+      matching.scoring['add'].forEach(a => {
+        result.options.push(MatchOption.fromMatching(a, algs));
+      })
+    }
+    if (matching.scoring && matching.scoring['expand']) {
+      matching.scoring['expand'].forEach(a => {
+        result.options.push(MatchOption.fromMatching(a, algs));
+      })
+    }
+    if (matching.scoring && matching.scoring['reduce']) {
+      matching.scoring['reduce'].forEach(a => {
+        result.options.push(MatchOption.fromMatching(a, algs));
+      })
+    }
+    return result;
+  }
+
+  /**
+   * Add a new match option.
+   */
+  addOption(opt) {
+    this.options.push(new MatchOption(opt));
+  }
+
+  /**
+   * Update a match option.
+   */
+  updateOption(opt, index) {
+    let mOpt = new MatchOption(opt);
+    this.options.splice(index, 1, mOpt);
+  }
+
+  /**
+   * Delete a match option.
+   */
+  deleteOption(index) {
+    this.options.splice(index, 1);
+  }
+
+}
+
+/**
+ * Represents a match option for UI display.
+ */
+export class MatchOption {
+  public matchType: string;
+  public propertyName: Array<string>;
+  public weight: number;
+  public algorithmRef: string;
+  public thesaurus: string;
+  public filter: string;
+  public dictionary: string;
+  public distanceThreshold: string;
+  public collation: string;
+  public zip5match9: number;
+  public zip9match5: number;
+  public customUri: string;
+  public customFunction: string;
+
+  constructor (mOpt: any = {}) {
+    if (mOpt.matchType) this.matchType = mOpt.matchType;
+    if (mOpt.propertyName) this.propertyName = [mOpt.propertyName];
+    if (mOpt.weight) this.weight = mOpt.weight;
+    if (mOpt.algorithmRef) this.algorithmRef = mOpt.algorithmRef;
+    if (mOpt.thesaurus) this.thesaurus = mOpt.thesaurus;
+    if (mOpt.filter) this.filter = mOpt.filter;
+    if (mOpt.dictionary) this.dictionary = mOpt.dictionary;
+    if (mOpt.distanceThreshold) this.distanceThreshold = mOpt.distanceThreshold;
+    if (mOpt.collation) this.collation = mOpt.collation;
+    if (mOpt.zip5match9) this.zip5match9 = mOpt.zip5match9;
+    if (mOpt.zip9match5) this.zip9match5 = mOpt.zip9match5;
+    if (mOpt.customUri) this.customUri = mOpt.customUri;
+    if (mOpt.customFunction) this.customFunction = mOpt.customFunction;
+  }
+
+  /**
+   * Construct a match option from matching configuration data.
+   */
+  static fromMatching(mOpt: any, algs: any) {
+    const result = new MatchOption(mOpt);
+    result.matchType = "custom"; // default
+    if (mOpt.algorithmRef === undefined) {
+      result.matchType = 'exact';
+    }
+    switch(mOpt.algorithmRef) {
+      case "thesaurus":
+        result.matchType = "synonym";
+        break;
+      case "double-metaphone":
+        result.matchType = "double metaphone";
+        break;
+      case "zip-match":
+        result.matchType = "zip";
+        break;
+      case "standard-reduction":
+        result.matchType = "reduce";
+        break;
+    }
+    if (result.matchType === 'reduce' && mOpt.allMatch.property) {
+      result.propertyName = mOpt.allMatch.property
+    }
+    if (mOpt.zip) {
+      mOpt.zip.forEach(z => {
+        if (z.origin === 5) result.zip5match9 = z.weight;
+        if (z.origin === 9) result.zip9match5 = z.weight;
+      })
+    }
+    if (result.matchType === 'custom') {
+      let alg = algs.find(a => {
+        return a.name === mOpt.algorithmRef;
+      });
+      if (alg.at) result.customUri = alg.at;
+      if (alg.function) result.customFunction = alg.function;
+    }
+    return result;
+  }
+
+}

--- a/quick-start/src/main/ui/app/components/flows-new/models/match-thresholds.model.ts
+++ b/quick-start/src/main/ui/app/components/flows-new/models/match-thresholds.model.ts
@@ -1,0 +1,29 @@
+import { Matching } from "./matching.model";
+
+export class MatchThresholds {
+  public thresholds: Array<MatchThreshold> = [];
+
+  static fromJSON(matching: Matching) {
+    const result = new MatchThresholds();
+    if (matching.thresholds && matching.thresholds['threshold']) {
+      matching.thresholds['threshold'].forEach(t => {
+        result.thresholds.push(new MatchThreshold(t));
+      })
+    }
+    return result;
+  }
+
+}
+
+export class MatchThreshold {
+  public label: Array<string>;
+  public above: string;
+  public action: string;
+
+  constructor(mThr: any) {
+    if (mThr.label) this.label = mThr.label;
+    if (mThr.above) this.above = mThr.above;
+    if (mThr.action) this.action = mThr.action;
+  }
+
+}

--- a/quick-start/src/main/ui/app/components/flows-new/models/matching.data.ts
+++ b/quick-start/src/main/ui/app/components/flows-new/models/matching.data.ts
@@ -1,0 +1,159 @@
+export const matchingData = {
+  "propertyDefs": {
+    "property": [
+      {
+        "namespace": "",
+        "localname": "ssn",
+        "name": "ssn"
+      },
+      {
+        "namespace": "",
+        "localname": "firstName",
+        "name": "firstName"
+      },
+      {
+        "namespace": "",
+        "localname": "lastName",
+        "name": "lastName"
+      },
+      {
+        "namespace": "",
+        "localname": "addr",
+        "name": "addr"
+      },
+      {
+        "namespace": "",
+        "localname": "city",
+        "name": "city"
+      },
+      {
+        "namespace": "",
+        "localname": "state",
+        "name": "state"
+      },
+      {
+        "namespace": "",
+        "localname": "postal",
+        "name": "postal"
+      }
+    ]
+  },
+  "algorithms": {
+    "algorithm": [
+      {
+        "name": "standard-reduction",
+        "function": "standard-reduction"
+      },
+      {
+        "name": "double-metaphone",
+        "at": "/com.marklogic.smart-mastering/algorithms/double-metaphone.xqy",
+        "function": "double-metaphone"
+      },
+      {
+        "name": "thesaurus",
+        "at": "/com.marklogic.smart-mastering/algorithms/thesaurus.xqy",
+        "function": "thesaurus"
+      },
+      {
+        "name": "zip-match",
+        "at": "/com.marklogic.smart-mastering/algorithms/zip.xqy",
+        "function": "zip-match"
+      },
+      {
+        "name": "customOption",
+        "at": "/directory/customOption.sjs",
+        "function": "customOption"
+      }
+    ]
+  },
+  "collections": {
+    "content": [
+      "mdm-content"
+    ]
+  },
+  "scoring": {
+    "add": [
+      {
+        "propertyName": "ssn",
+        "weight": "10"
+      },
+      {
+        "propertyName": "postal",
+        "weight": "5"
+      }
+    ],
+    "expand": [
+      {
+        "propertyName": "firstName",
+        "algorithmRef": "thesaurus",
+        "weight": "5",
+        "thesaurus": "/directory/thesaurus.xml",
+        "filter": ""
+      },
+      {
+        "propertyName": "lastName",
+        "algorithmRef": "double-metaphone",
+        "weight": "2",
+        "dictionary": "/directory/dictionary.xml",
+        "distanceThreshold": "30",
+        "collation": "http://marklogic.com/collation/codepoint"
+      },
+      {
+        "propertyName": "state",
+        "algorithmRef": "customOption",
+        "weight": "1"
+      },
+      {
+        "propertyName": "postal",
+        "algorithmRef": "zip-match",
+        "zip": [
+          { "origin": 5, "weight": 3 },
+          { "origin": 9, "weight": 2 }
+        ]
+      }
+    ],
+    "reduce": [
+      {
+        "algorithmRef": "standard-reduction",
+        "weight": "4",
+        "allMatch": {
+          "property": [
+            "lastName",
+            "addr"
+          ]
+        }
+      }
+    ]
+  },
+  "actions": {
+    "action": [
+      {
+        "name": "customAction",
+        "at": "/directory/customAction.sjs",
+        "function": "customAction"
+      }
+    ]
+  },
+  "thresholds": {
+    "threshold": [
+      {
+        "above": "20",
+        "label": "Definite Match",
+        "action": "merge"
+      },
+      {
+        "above": "10",
+        "label": "Likely Match",
+        "action": "notify"
+      },
+      {
+        "above": "7",
+        "label": "Custom Match",
+        "action": "customAction"
+      }
+    ]
+  },
+  "tuning": {
+    "maxScan": "200"
+  }
+};

--- a/quick-start/src/main/ui/app/components/flows-new/models/matching.model.ts
+++ b/quick-start/src/main/ui/app/components/flows-new/models/matching.model.ts
@@ -1,0 +1,297 @@
+import { MatchOption } from "./match-options.model";
+
+/**
+ * Represents a Smart Mastering matching configuration.
+ * @see https://marklogic-community.github.io/smart-mastering-core/docs/matching-options/
+ */
+export class Matching {
+  public dataFormat: string = 'json';
+  public propertyDefs: Object = { property: [] };
+  public algorithms: Object = { algorithm: [] };
+  public collections: Object = { content: [] };
+  public scoring: Object = {
+    add: [],
+    expand: [],
+    reduce: []
+  };
+  public actions: Object = { action: [] };
+  public thresholds: Object = { threshold: [] };
+  public tuning: Object = { maxScan: 200 };
+  constructor() {}
+
+  /**
+   * Construct based on a JSON matching configuration.
+   */
+  static fromConfig(config) {
+    const result = new Matching();
+    if(config.dataFormat) {
+      result.dataFormat = config.dataFormat;
+    }
+    if (config.propertyDefs && config.propertyDefs.property) {
+      config.propertyDefs.property.forEach(p => {
+        result.propertyDefs['property'].push(new Property(p));
+      })
+    }
+    if (config.algorithms && config.algorithms.algorithm) {
+      config.algorithms.algorithm.forEach(a => {
+        result.algorithms['algorithm'].push(new Algorithm(a));
+      })
+    }
+    if(config.collections.content) {
+      result.collections['content'] = config.collections.content;
+    }
+    if (config.scoring && config.scoring.add) {
+      config.scoring.add.forEach(a => {
+        result.scoring['add'].push(new Add(a));
+      })
+    }
+    if (config.scoring && config.scoring.expand) {
+      config.scoring.expand.forEach(e => {
+        result.scoring['expand'].push(new Expand(e));
+      })
+    }
+    if (config.scoring && config.scoring.reduce) {
+      config.scoring.reduce.forEach(r => {
+        result.scoring['reduce'].push(new Reduce(r));
+      })
+    }
+    if (config.actions && config.actions.action) {
+      config.actions.action.forEach(a => {
+        result.actions['action'].push(new Action(a));
+      })
+    }
+    if (config.thresholds && config.thresholds.threshold) {
+      config.thresholds.threshold.forEach(t => {
+        result.thresholds['threshold'].push(new Threshold(t));
+      })
+    }
+    if(config.tuning.maxScan) {
+      result.tuning['maxScan'] = config.tuning.maxScan;
+    }
+    return result;
+  }
+
+  /**
+   * Add a property name definition.
+   */
+  addProperty(name) {
+    let found = this.propertyDefs['property'].find(p => {
+      return p.name === name;
+    });
+    if (!found) {
+      let prop = new Property({ localname: name, name: name });
+      this.propertyDefs['property'].push(prop);
+    }
+  }
+
+  /**
+   * Add an algorithm definition.
+   */
+  addAlgorithm(name, at, fn) {
+    let alg = new Algorithm({ name: name, at: at, function: fn });
+    this.algorithms['algorithm'].push(alg);
+  }
+
+  /**
+   * Add definitions for the included algorithms.
+   */
+  addAlgorithmDefaults() {
+    let defaultAlgs = [
+      ['double-metaphone', '/com.marklogic.smart-mastering/algorithms/double-metaphone.xqy'],
+      ['thesaurus', '/com.marklogic.smart-mastering/algorithms/thesaurus.xqy'],
+      ['zip-match', '/com.marklogic.smart-mastering/algorithms/zip.xqy'],
+    ]
+    defaultAlgs.forEach(a => {
+      this.addAlgorithm(a[0], a[1], a[0]);
+    })
+  }
+
+  /**
+   * Add a match option.
+   */
+  addOption(mOpt: MatchOption) {
+    let opt;
+    switch(mOpt.matchType) {
+      case "exact":
+        opt = new Add({
+          propertyName: mOpt.propertyName[0],
+          weight: mOpt.weight
+        });
+        this.scoring['add'].push(opt);
+        break;
+      case "synonym":
+        opt = new Expand({
+          propertyName: mOpt.propertyName[0],
+          algorithmRef: mOpt.algorithmRef,
+          weight: mOpt.weight,
+          thesaurus: mOpt.thesaurus,
+          filter: mOpt.filter
+        });
+        this.scoring['expand'].push(opt);
+        break;
+      case "double metaphone":
+        opt = new Expand({
+          propertyName: mOpt.propertyName[0],
+          algorithmRef: mOpt.algorithmRef,
+          weight: mOpt.weight,
+          dictionary: mOpt.dictionary,
+          distanceThreshold: mOpt.distanceThreshold,
+          collation: mOpt.collation
+        });
+        this.scoring['expand'].push(opt);
+        break;
+      case "zip":
+        opt = new Expand({
+          propertyName: mOpt.propertyName[0],
+          algorithmRef: mOpt.algorithmRef,
+          zip: [
+            { origin: 5, weight: mOpt.zip5match9 },
+            { origin: 9, weight: mOpt.zip9match5 }
+          ]
+        });
+        this.scoring['expand'].push(opt);
+        break;
+      case "reduce":
+        opt = new Reduce({
+          algorithmRef: mOpt.algorithmRef,
+          weight: mOpt.weight,
+          allMatch: {
+            property: mOpt.propertyName
+          }
+        });
+        this.scoring['expand'].push(opt);
+        break;
+      case "custom":
+        this.addAlgorithm(mOpt.customFunction, mOpt.customUri, mOpt.customFunction)
+        opt = new Expand({
+          propertyName: mOpt.propertyName[0],
+          algorithmRef: mOpt.algorithmRef,
+          weight: mOpt.weight
+        });
+        this.scoring['expand'].push(opt);
+        break;
+    }
+  }
+
+}
+
+/**
+ * Represents a property definition in matching options.
+ */
+export class Property {
+  public namespace: string;
+  public localname: string;
+  public name: string;
+  constructor(p) {
+    if (p.namespace) this.namespace = p.namespace;
+    if (p.localname) this.localname = p.localname;
+    if (p.name) this.name = p.name;
+  }
+}
+
+/**
+ * Represents an algorithm definition in matching options.
+ */
+export class Algorithm {
+  public name: string;
+  public namespace: string;
+  public function: string;
+  public at: string;
+  constructor(a) {
+    if (a.name) this.name = a.name;
+    if (a.function) this.function = a.function;
+    if (a.at) this.at = a.at;
+  }
+}
+
+/**
+ * Represents an add (aka exact) match definition in matching options.
+ */
+export class Add {
+  public propertyName: string;
+  public weight: number;
+  constructor(a) {
+    if (a.propertyName) this.propertyName = a.propertyName;
+    if (a.weight) this.weight = a.weight;
+  }
+}
+
+/**
+ * Represents an expand match definition in matching options.
+ * Expand types include: synonym, double metaphone, zip code, custom
+ */
+export class Expand {
+  public propertyName: string;
+  public algorithmRef: string;
+  public weight: number;
+  public thesaurus: string;
+  public filter: string;
+  public dictionary: string;
+  public distanceThreshold: string;
+  public collation: string;
+  public zip: Array<Object>;
+  constructor(e) {
+    if (e.propertyName) this.propertyName = e.propertyName;
+    if (e.algorithmRef) this.algorithmRef = e.algorithmRef;
+    if (e.weight) this.weight = e.weight;
+    if (e.thesaurus) this.thesaurus = e.thesaurus;
+    if (e.filter) this.filter = e.filter;
+    if (e.dictionary) this.dictionary = e.dictionary;
+    if (e.distanceThreshold) this.distanceThreshold = e.distanceThreshold;
+    if (e.collation) this.collation = e.collation;
+    if (e.zip) {
+      this.zip = [];
+      e.zip.forEach(z => { this.zip.push(z); })
+    }
+  }
+}
+
+/**
+ * Represents an reduce match definition in matching options.
+ */
+export class Reduce {
+  public algorithmRef: string;
+  public weight: number;
+  public allMatch: Object = {
+    property: []
+  };
+  constructor(r) {
+    if (r.algorithmRef) this.algorithmRef = r.algorithmRef;
+    if (r.weight) this.weight = r.weight;
+    if (r.allMatch.property) this.allMatch['property'] = r.allMatch.property;
+  }
+}
+
+/**
+ * Represents a custom action for thresholds in matching options.
+ */
+export class Action {
+  public name: string;
+  public at: string;
+  public function: string;
+  constructor(a) {
+    if (a.name) this.name = a.name;
+    if (a.at) this.at = a.at;
+    if (a.function) this.function = a.function;
+  }
+}
+
+/**
+ * Represents a threshold in matching options.
+ */
+export class Threshold {
+  public above: number;
+  public label: string;
+  public action: string;
+  public thresholdType: string;
+  constructor(t) {
+    if (t.above) this.above = t.above;
+    if (t.label) this.label = t.label;
+    if (t.action) this.action = t.action;
+    if (t.action && (t.action !== 'merge' && t.action !== 'notify')) {
+      this.thresholdType = 'custom';
+    } else {
+      this.thresholdType = t.action;
+    }
+  }
+}


### PR DESCRIPTION
Initially developing matching config as standalone page (set up a temporary route). Will eventually place in into Edit Flow bottom configuration pane, see: https://project.marklogic.com/jira/browse/DHFPROD-1815

Access current work here: http://localhost:4200/#/matching/{stepid}

(Value of {stepid} currently doesn't matter.)

Summary of work so far:

- Material design table and dialog boxes for Match Options
- Starter HTML table for Match Thresholds
- Hardcoded data for now
- Data model based on Smart Mastering configuration JSON