### PR TITLE
Update flows routing

### DIFF
--- a/quick-start/src/main/ui/app/app.routes.ts
+++ b/quick-start/src/main/ui/app/app.routes.ts
@@ -30,8 +30,8 @@ export const ROUTES: Routes = [
     ]
   },
   { path: 'mappings/map', component: MapComponent, canActivate: [AuthGuard] },
-  { path: 'flows', component: FlowsComponent, canActivate: [AuthGuard] },
-  { path: 'manage-flows', component: ManageFlowsComponent, canActivate: [AuthGuard]},
+  { path: 'flows-old', component: FlowsComponent, canActivate: [AuthGuard] },
+  { path: 'flows', component: ManageFlowsComponent, canActivate: [AuthGuard]},
   { path: 'flows/:entityName/:flowName/:flowType', component: FlowsComponent, canActivate: [AuthGuard] },
   { path: 'edit-flow/:flowId', component: EditFlowComponent, canActivate: [AuthGuard] },
   { path: 'matching/:stepId', component: MatchingComponent, canActivate: [AuthGuard] },


### PR DESCRIPTION
Via change in app.routes.ts:
/flows now goes to new Manage Flows view (i.e., top-nav link).
/flows-old now goes to old Flows view.

No change to underlying component file structure (for now).