### PR TITLE
Flow Runner improvements (fixing GitHub issue #1825 etc)

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/FlowManager.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/FlowManager.java
@@ -34,6 +34,12 @@ public interface FlowManager {
     String FLOW_FILE_EXTENSION = ".flow.json";
 
     /**
+     * Set the HubConfig
+     *
+     * @param hubConfig - the hubConfig to use
+     */
+    void setHubConfig(HubConfig hubConfig);
+    /**
      * Retrieves a named flow
      * @param flowName - name of the flow
      * @return a flow object

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/FlowRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/FlowRunner.java
@@ -20,14 +20,23 @@ import com.marklogic.client.datamovement.JobTicket;
 import com.marklogic.hub.job.Job;
 
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Executes a flow with options
  */
 public interface FlowRunner {
 
+    /**
+     * Should we always write a document to the jobs database or only in case of a failure?
+     *
+     * @param onlyWriteJobOnFailure true -> only write job on failure, else always
+     * @return the flow runner object
+     */
+    FlowRunner withOnlyWriteJobOnFailure(boolean onlyWriteJobOnFailure);
     /**
      * Sets the flow to be used with the flow runner
      * @param flow the flow object to be used
@@ -133,12 +142,22 @@ public interface FlowRunner {
      * @param unit the time unit of the timeout argument
      *
      * @throws InterruptedException if interrupted while waiting
+     * @throws TimeoutException if an timeout occurred.
      */
-    void awaitCompletion(long timeout, TimeUnit unit) throws InterruptedException;
+    void awaitCompletion(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException;
 
     /**
      * Runs the flow and creates the job
      * @return Job object for the flow that is run
      */
     Job run();
+
+    /**
+     * Runs the flow and creates the job. This bypasses the collector
+     *
+     * @params uris the ids to pass to the harmonization flow
+     *
+     * @return Job object for the flow that is run
+     */
+    Job run(Collection<String> uris);
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/impl/FlowRunnerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/impl/FlowRunnerImpl.java
@@ -35,23 +35,18 @@ import com.marklogic.hub.job.Job;
 import com.marklogic.hub.flow.FlowItemFailureListener;
 import com.marklogic.hub.job.JobStatus;
 
+import java.util.*;
+import java.util.concurrent.TimeoutException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Vector;
-import java.util.UUID;
-import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 public class FlowRunnerImpl implements FlowRunner {
-
     private static final int DEFAULT_BATCH_SIZE = 100;
     private static final int DEFAULT_THREAD_COUNT = 4;
     private static final int MAX_ERROR_MESSAGES = 10;
@@ -65,7 +60,7 @@ public class FlowRunnerImpl implements FlowRunner {
     private boolean stopOnFailure = false;
     private String jobId;
     private boolean isFullOutput = false;
-
+    private boolean onlyWriteJobOnFailure = false;
 
     private int step = 1;
 
@@ -76,6 +71,8 @@ public class FlowRunnerImpl implements FlowRunner {
 
     private HubConfig hubConfig;
     private Thread runningThread = null;
+    private DataMovementManager dataMovementManager = null;
+    private QueryBatcher queryBatcher = null;
 
     public FlowRunnerImpl(HubConfig hubConfig) {
         this.hubConfig = hubConfig;
@@ -95,6 +92,12 @@ public class FlowRunnerImpl implements FlowRunner {
 
     public FlowRunner withJobId(String jobId) {
         this.jobId = jobId;
+        return this;
+    }
+
+    @Override
+    public FlowRunner withOnlyWriteJobOnFailure(boolean onlyWriteJobOnFailure) {
+        this.onlyWriteJobOnFailure = onlyWriteJobOnFailure;
         return this;
     }
 
@@ -162,38 +165,59 @@ public class FlowRunnerImpl implements FlowRunner {
     public void awaitCompletion() {
         try {
             awaitCompletion(Long.MAX_VALUE, TimeUnit.DAYS);
-        } catch (InterruptedException e) {
+        } catch (InterruptedException| TimeoutException e) {
         }
     }
 
     @Override
-    public void awaitCompletion(long timeout, TimeUnit unit) throws InterruptedException {
+    public void awaitCompletion(long timeout, TimeUnit unit) throws InterruptedException,TimeoutException {
         if (runningThread != null) {
-            runningThread.join(unit.convert(timeout, TimeUnit.MILLISECONDS));
+            runningThread.join(unit.convert(timeout, unit));
+            if (runningThread.getState() != Thread.State.TERMINATED) {
+                if ( dataMovementManager != null && queryBatcher != null ) {
+                    dataMovementManager.stopJob(queryBatcher);
+                }
+                runningThread.interrupt();
+                throw new TimeoutException("Timeout occurred after "+timeout+" "+unit.toString());
+            }
         }
     }
 
     @Override
     public Job run() {
-        Job job = Job.withFlow(flow);
-        if(this.jobId == null) {
-            jobId = UUID.randomUUID().toString();
+        runningThread = null;
+        Job job = createJob();
+        Collection<String> uris = null;
+        try {
+            uris = runCollector();
+        } catch (Exception e) {
+            job.setCounts(0,0, 0, 0, 0)
+                .withStatus(JobStatus.FAILED.toString());
+            StringWriter errors = new StringWriter();
+            e.printStackTrace(new PrintWriter(errors));
+            job.withJobOutput(errors.toString());
+            return job;
         }
-        job.withJobId(jobId);
+        this.runHarmonizer(job,uris);
+        return job;
+    }
+
+    @Override
+    public Job run(Collection uris) {
+        runningThread = null;
+        Job job = createJob();
+        return this.runHarmonizer(job,uris);
+    }
+
+    private Collection<String> runCollector() throws Exception {
         Collector c = new CollectorImpl(this.flow, jobId);
         c.setHubConfig(hubConfig);
         c.setClient(stagingClient);
 
-        AtomicLong successfulEvents = new AtomicLong(0);
-        AtomicLong failedEvents = new AtomicLong(0);
-        AtomicLong successfulBatches = new AtomicLong(0);
-        AtomicLong failedBatches = new AtomicLong(0);
-
         if (options == null) {
             options = new HashMap<>();
-        }
-        else {
-            if(options.get("fullOutput") != null) {
+        } else {
+            if (options.get("fullOutput") != null) {
                 isFullOutput = Boolean.parseBoolean(options.get("fullOutput").toString());
             }
         }
@@ -204,24 +228,32 @@ public class FlowRunnerImpl implements FlowRunner {
         });
 
         final DiskQueue<String> uris;
-        try {
-            uris = c.run(this.flow.getName(),  String.valueOf(step), this.jobId, options);
-        } catch (Exception e) {
-            job.setCounts(0, 0, 0, 0)
-                .withStatus(JobStatus.FAILED.toString());
+        uris = c.run(this.flow.getName(), String.valueOf(step), this.jobId, options);
+        return uris;
+    }
 
-            StringWriter errors = new StringWriter();
-            e.printStackTrace(new PrintWriter(errors));
-            job.withJobOutput(errors.toString());
-            return job;
-        }
-
+    private Job runHarmonizer(Job job,Collection uris) {
+        AtomicLong successfulEvents = new AtomicLong(0);
+        AtomicLong failedEvents = new AtomicLong(0);
+        AtomicLong successfulBatches = new AtomicLong(0);
+        AtomicLong failedBatches = new AtomicLong(0);
         flowStatusListeners.forEach((FlowStatusListener listener) -> {
             listener.onStatusChange(job.getJobId(), 0, "starting step execution");
         });
+
+        if ( uris == null || uris.size() == 0 ) {
+            flowStatusListeners.forEach((FlowStatusListener listener) -> {
+                listener.onStatusChange(job.getJobId(), 100, "(collector returned 0 items)");
+            });
+            flowFinishedListeners.forEach((FlowFinishedListener::onFlowFinished));
+            job.setCounts(0,0,0,0,0);
+            job.withStatus(JobStatus.COMPLETED_PREFIX+step);
+            return job;
+        }
+
         Vector<String> errorMessages = new Vector<>();
 
-        DataMovementManager dataMovementManager = stagingClient.newDataMovementManager();
+        dataMovementManager = stagingClient.newDataMovementManager();
 
         double batchCount = Math.ceil((double) uris.size() / (double) batchSize);
 
@@ -230,7 +262,7 @@ public class FlowRunnerImpl implements FlowRunner {
         ConcurrentHashMap<DatabaseClient, FlowResource> databaseClientMap = new ConcurrentHashMap<>();
         Map<String,Object> fullResponse = new HashMap<>();
         ObjectMapper mapper = new ObjectMapper();
-        QueryBatcher queryBatcher = dataMovementManager.newQueryBatcher(uris.iterator())
+        queryBatcher = dataMovementManager.newQueryBatcher(uris.iterator())
             .withBatchSize(batchSize)
             .withThreadCount(threadCount)
             .withJobId(job.getJobId())
@@ -329,11 +361,11 @@ public class FlowRunnerImpl implements FlowRunner {
             } else if (failedEvents.get() > 0 && successfulEvents.get() > 0) {
                 status = JobStatus.FINISHED_WITH_ERRORS.toString();
             } else if ((failedEvents.get() == 0 && successfulEvents.get() > 0) || uris.size() == 0) {
-                status = "completed step " + step ;
+                status = JobStatus.COMPLETED_PREFIX + step ;
             } else {
                 status = JobStatus.FAILED.toString();
             }
-            job.setCounts(successfulEvents.get(), failedEvents.get(), successfulBatches.get(), failedBatches.get());
+            job.setCounts(uris.size(),successfulEvents.get(), failedEvents.get(), successfulBatches.get(), failedBatches.get());
             job.withStatus(status);
             jobUpdate.postJobs(jobId, status, step);
             if (errorMessages.size() > 0) {
@@ -345,6 +377,15 @@ public class FlowRunnerImpl implements FlowRunner {
         });
 
         runningThread.start();
+        return job;
+    }
+
+    private Job createJob() {
+        Job job = Job.withFlow(flow);
+        if (this.jobId == null) {
+            jobId = UUID.randomUUID().toString();
+        }
+        job.withJobId(jobId);
         return job;
     }
 
@@ -420,9 +461,15 @@ public class FlowRunnerImpl implements FlowRunner {
         }
 
         private void postJobs(String jobId, String status, int step) {
+            if ( onlyWriteJobOnFailure ) {
+                if ( status.equals(JobStatus.FINISHED.toString())  ||
+                     status.startsWith(JobStatus.COMPLETED_PREFIX) ) {
+                    return;
+                }
+            }
             params = new RequestParameters();
             params.put("jobid", jobId);
-            params.put("status", status);
+            params.put("status", status.toString());
             params.put("step", String.valueOf(step));
             try {
                 this.getServices().post(params, new StringHandle("{}").withFormat(Format.JSON));

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/FlowManagerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/FlowManagerImpl.java
@@ -49,6 +49,10 @@ public class FlowManagerImpl implements FlowManager {
     @Autowired
     private HubConfig hubConfig;
 
+    public void setHubConfig(HubConfig hubConfig) {
+        this.hubConfig = hubConfig;
+    }
+
     @Override
     public Flow getFlow(String flowName) {
         Path flowPath = Paths.get(hubConfig.getFlowsDir().toString(), flowName + FLOW_FILE_EXTENSION);

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -816,6 +816,8 @@ public class HubConfigImpl implements HubConfig
         return mlPassword;
     }
 
+    public void setHost(String host ) { this.host = host; }
+
     public void setMlUsername(String mlUsername) {
         this.mlUsername = mlUsername;
     }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/job/Job.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/job/Job.java
@@ -28,13 +28,21 @@ public class Job {
 
     private List<String> jobOutput;
     private Map<String, Object> fullOutput;
-    private String status ;
+    private String status;
 
+    private long totalEvents = 0;
     private long successfulEvents = 0;
     private long failedEvents = 0;
     private long successfulBatches = 0;
     private long failedBatches = 0;
+    private boolean success = false;
 
+    /**
+     * @return true if the job ran without errors, false otherwise.
+     */
+    public boolean isSuccess() {
+        return success;
+    }
 
     public Job withJobId(String jobId) {
         this.jobId = jobId;
@@ -67,10 +75,12 @@ public class Job {
 
     public Job withStatus(String status) {
         this.status = status;
+        success = status.startsWith(JobStatus.COMPLETED_PREFIX);
         return this;
     }
 
-    public Job setCounts(long successfulEvents, long failedEvents, long successfulBatches, long failedBatches) {
+    public Job setCounts(long totalEvents,long successfulEvents, long failedEvents, long successfulBatches, long failedBatches) {
+        this.totalEvents = totalEvents;
         this.successfulEvents = successfulEvents;
         this.failedEvents = failedEvents;
         this.successfulBatches = successfulBatches;
@@ -107,6 +117,8 @@ public class Job {
     public long getFailedEvents() {
         return failedEvents;
     }
+
+    public long getTotalEvents() {  return totalEvents; }
 
     public long getSuccessfulBatches() {
         return successfulBatches;

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/job/JobStatus.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/job/JobStatus.java
@@ -26,4 +26,7 @@ public enum JobStatus {
     public String toString() {
         return this.type;
     }
+
+    public static final String COMPLETED_PREFIX = "completed step ";
+
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/legacy/LegacyFlowManager.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/legacy/LegacyFlowManager.java
@@ -16,6 +16,7 @@
 
 package com.marklogic.hub.legacy;
 
+import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.legacy.flow.LegacyFlow;
 import com.marklogic.hub.legacy.flow.LegacyFlowRunner;
 import com.marklogic.hub.legacy.flow.FlowType;
@@ -29,6 +30,12 @@ import java.util.List;
  * Manages existing flows and creates flow runners to execute flows.
  */
 public interface LegacyFlowManager {
+
+    /**
+     * Set HubConfig
+     * @param hubConfig
+     */
+    void setHubConfig(HubConfig hubConfig);
 
     /**
      * Turns an XML document into a flow

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/legacy/impl/LegacyFlowManagerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/legacy/impl/LegacyFlowManagerImpl.java
@@ -63,7 +63,10 @@ public class LegacyFlowManagerImpl extends ResourceManager implements LegacyFlow
         super();
     }
 
-    
+    public void setHubConfig(HubConfig hubConfig) {
+        this.hubConfig = hubConfig;
+    }
+
     public void setupClient() {
         this.stagingClient = hubConfig.newStagingClient();
         this.stagingClient.init(NAME, this);


### PR DESCRIPTION
-	It optimized execution for maximum performance:
o	There is now an option to write only a job to the job database in case of a failure. This speeds up execution.  By default this is turned off (so always write to Jobs database). 

FlowRunner withOnlyWriteJobOnFailure(boolean onlyWriteJobOnFailure);

o	If the collector returns nothing, we bypass DMSDK/runningThread construction and immediately return a finished job. 
-	There is now support to run an Harmonization flow, without invoking the collector, e.g. in case you already know the harmonization ids via:
-	
-	Job run(Collection<String> uris);

-	Job has now a totalEvents count. That is because total cannot be guaranteed to be success + failed. 
-	awaitCompletion has now a bug fixed around timeUnits (it was passed but not used)
-	awaitCompletion now throws a TimeoutException in case of a Timeout, and it stops the underlying querybatcher properly. 
-	Some setters added to support hard-wiring instead of relying/requiring Spring Autowiring. 
