### PR TITLE
DHFPROD-1872: Fix how tests are run

### DIFF
--- a/web/e2e/specs/auth/authenticated.ts
+++ b/web/e2e/specs/auth/authenticated.ts
@@ -31,7 +31,7 @@ export default function(tmpDir) {
     });
 
     it ('Has the correct current folder', function() {
-      expect(loginPage.currentFolderValue).toContain('quick-start');
+      expect(loginPage.currentFolderValue).toContain('web');
     });
 
     it ('Should select the temp folder', async function() {

--- a/web/e2e/specs/index.ts
+++ b/web/e2e/specs/index.ts
@@ -18,36 +18,37 @@ let tmpobj = tmp.dirSync({ unsafeCleanup: true });
 fs.copySync('e2e/qa-data/data/input', path.join(tmpobj.name, 'input'));
 console.log('DIR: ' + tmpobj.name);
 
-describe('QuickStart', function () {
+describe('DataHub', function () {
   beforeAll(function (done) {
     //apply custom matchers
     jasmine.addMatchers(CUSTOM_MATCHERS)
 
-    let yargs = require('yargs').argv
+    /*let yargs = require('yargs').argv
     let width = typeof yargs.width === 'number' ? yargs.width : 1920
-    let height = typeof yargs.height === 'number' ? yargs.height : 1080
+    let height = typeof yargs.height === 'number' ? yargs.height : 1080*/
 
     request({
       url: `http://localhost:8080/api/projects/reset`
     }, function (error, response, body) {
 
-      browser.get('/');
+      browser.driver.get('http://localhost:8080')
+        .then(() => browser.driver.manage().deleteAllCookies())
+        .then(() => $('body').isPresent())
+        .then(() => {}, () => {})
+        .then(() => done())
 
-      browser.driver.manage().deleteAllCookies();
-
-      $('body').isPresent().then(() => {}, () => {})
-      .then(() => browser.driver.getCapabilities())
-      .then(caps => {
-        console.log('browserName:' + caps.get('browserName'));
-        pages.browserName =yargs.browserName
-        pages.baseUrl =yargs.baseUrl
-        console.log(`pages.baseUrl: ${pages.baseUrl}`);
-      })
+      //.then(() => browser.driver.getCapabilities())
+      //.then(caps => {
+      //  console.log('browserName:' + caps.get('browserName'));
+      //  pages.browserName =yargs.browserName
+      //  pages.baseUrl =yargs.baseUrl
+      //  console.log(`pages.baseUrl: ${pages.baseUrl}`);
+      //})
       // our Jenkins machine runs with a pretty low resolution, and we also
       // have an app that's misbehaving in smaller windows, so this is a delicate
       // setting
-      .then(() => browser.driver.manage().window().maximize())
-      .then(() => done())
+      //.then(() => browser.driver.manage().window().maximize())
+      //.then(() => done())
     });
   });
 
@@ -62,5 +63,5 @@ describe('QuickStart', function () {
   //jobs();
   //runTraces();
   //mappings();
-  //uninstall(tmpobj.name);
+  uninstall(tmpobj.name);
 });

--- a/web/e2e/specs/uninstall/uninstall.ts
+++ b/web/e2e/specs/uninstall/uninstall.ts
@@ -2,18 +2,28 @@ import {  browser, ExpectedConditions as EC} from 'protractor';
 import loginPage from '../../page-objects/auth/login';
 import settingsPage from '../../page-objects/settings/settings';
 import appPage from '../../page-objects/appPage';
+import dashboardPage from "../../page-objects/dashboard/dashboard";
 const fs = require('fs-extra');
 
 export default function(tmpDir) {
   describe('Uninstall', () => {
-    it ('should go to the settings page', async function() {
-      browser.get('http://localhost:8080/#/settings');
+    beforeAll(() => {
+      loginPage.isLoaded();
+    });
+
+    it('Should login to the settings page', async function() {
+      await loginPage.browseButton.click();
+      await loginPage.setCurrentFolder(tmpDir);
+      await loginPage.clickNext('ProjectDirTab');
+      browser.wait(EC.elementToBeClickable(loginPage.environmentTab));
+      await loginPage.clickNext('EnvironmentTab');
+      browser.wait(EC.visibilityOf(loginPage.loginTab));
+      await loginPage.login();
       await appPage.settingsTab.click();
       settingsPage.isLoaded();
     });
 
     it ('should click the uninstall button', async function() {
-      browser.get('http://localhost:8080/#/settings');
       await settingsPage.uninstallButton.click();
       browser.wait(EC.elementToBeClickable(settingsPage.uninstallConfirmation));
       await settingsPage.uninstallConfirmation.click();
@@ -25,7 +35,8 @@ export default function(tmpDir) {
     });
 
     it ('should uninstall the hub', function() {
-      loginPage.isLoadedWithtimeout(240000);
+      //loginPage.isLoadedWithtimeout(240000);
+      browser.wait(EC.elementToBeClickable(loginPage.browseButton));
     });
 
     it ('should remove the temp folder', function() {


### PR DESCRIPTION
Changes made so that tests can run in jenkins reliably. Once they do will create another PR ready to be merged for 1872 that has some tests and page objects for manage flow page.

Jenkins tests will now run in port 4200, since there is a blocker issue in running them on 8080.