### PR TITLE
DHFPROD-2066: Start updated Jobs table

### DIFF
--- a/web/src/main/ui/app/app.module.ts
+++ b/web/src/main/ui/app/app.module.ts
@@ -65,6 +65,7 @@ import {JobService} from './components/jobs/jobs.service';
 import {JobListenerService} from './components/jobs/job-listener.service';
 import {MapService} from './components/mappings/map.service';
 import {ManageFlowsService} from './components/flows-new/services/manage-flows.service';
+import {ManageJobsService} from './components/jobs-new/manage-jobs.service';
 import {ProjectService} from './services/projects';
 import {STOMPService} from './services/stomp';
 import {ClipboardDirective} from './directives/clipboard/clipboard.directive';
@@ -81,6 +82,7 @@ import {MapComponent, MappingsComponent} from './components/mappings';
 import {NewMapComponent} from "./components/mappings/new-map.component";
 import {FlowsUiComponent} from './components/flows/ui';
 import {EditFlowModule, ManageFlowsModule} from "./components/flows-new";
+import {ManageJobsModule} from "./components/jobs-new/manage-jobs.module";
 import {FolderBrowserModule} from "./components/folder-browser/folder-browser.module";
 
 @NgModule({
@@ -174,6 +176,7 @@ import {FolderBrowserModule} from "./components/folder-browser/folder-browser.mo
     ThemeModule,
     ManageFlowsModule,
     EditFlowModule,
+    ManageJobsModule,
     FolderBrowserModule
   ],
   providers: [
@@ -185,6 +188,7 @@ import {FolderBrowserModule} from "./components/folder-browser/folder-browser.mo
     JobListenerService,
     MapService,
     ManageFlowsService,
+    ManageJobsService,
     ProjectService,
     SettingsService,
     STOMPService,

--- a/web/src/main/ui/app/app.routes.ts
+++ b/web/src/main/ui/app/app.routes.ts
@@ -12,6 +12,7 @@ import {NoContentComponent} from './components/no-content';
 import {EditFlowComponent} from './components/flows-new/edit-flow/edit-flow.component';
 import {AuthGuard} from './services/auth/auth-guard.service';
 import {ManageFlowsComponent} from "./components/flows-new/manage-flows/manage-flows.component";
+import {ManageJobsComponent} from "./components/jobs-new/manage-jobs.component";
 
 export const ROUTES: Routes = [
   { path: '', component: DashboardComponent, canActivate: [AuthGuard] },
@@ -33,7 +34,8 @@ export const ROUTES: Routes = [
   { path: 'flows', component: ManageFlowsComponent, canActivate: [AuthGuard]},
   { path: 'flows/:entityName/:flowName/:flowType', component: FlowsComponent, canActivate: [AuthGuard] },
   { path: 'edit-flow/:flowId', component: EditFlowComponent, canActivate: [AuthGuard] },
-  { path: 'jobs', component: JobsComponent, canActivate: [AuthGuard] },
+  { path: 'jobs', component: ManageJobsComponent, canActivate: [AuthGuard] },
+  { path: 'jobs-old', component: JobsComponent, canActivate: [AuthGuard] },
   { path: 'traces', component: TracesComponent, canActivate: [AuthGuard] },
   { path: 'traces/:id', component: TraceViewerComponent, canActivate: [AuthGuard] },
   { path: 'browse', component: SearchComponent, canActivate: [AuthGuard] },

--- a/web/src/main/ui/app/components/jobs-new/jobs.data.ts
+++ b/web/src/main/ui/app/components/jobs-new/jobs.data.ts
@@ -1,0 +1,59 @@
+export const jobsData = [
+
+  {
+    "jobId": "7e59df5c-3e9f-4109-bb8e-f52cb926aa8e",
+    "flow": "Order Flow 01",
+    "targetEntity": "Order",
+    "user": "admin",
+    "lastAttemptedStep": 3,
+    "lastCompletedStep": 3,
+    "jobStatus": "finished",
+    "timeStarted": "2019-03-20T09:54:31.330356-07:00",
+    "timeEnded": "2019-03-20T10:54:35.385579-07:00",
+    "committed": 100,
+    "errors": 3
+  },
+
+  {
+    "jobId": "f745f0a4-6f43-42ad-981d-ecef5c581650",
+    "flow": "Order Flow 01",
+    "targetEntity": "Order",
+    "user": "admin",
+    "lastAttemptedStep": 3,
+    "lastCompletedStep": 3,
+    "jobStatus": "finished",
+    "timeStarted": "2019-03-19T07:54:31.330356-07:00",
+    "timeEnded": "2019-03-19T08:23:35.385579-07:00",
+    "committed": 90,
+    "errors": 13
+  },
+
+  {
+    "jobId": "45011709-2198-436f-8585-8a880e32806a",
+    "flow": "Customer Flow",
+    "targetEntity": "Customer",
+    "user": "admin",
+    "lastAttemptedStep": 3,
+    "lastCompletedStep": 2,
+    "jobStatus": "failed",
+    "timeStarted": "2019-03-11T01:54:31.330356-07:00",
+    "timeEnded": "2019-03-16T13:54:35.385579-07:00",
+    "committed": 123456,
+    "errors": 1014
+  },
+
+  {
+    "jobId": "12345678-1234-1234-1234-1234567890ab",
+    "flow": "Another Flow",
+    "targetEntity": "Order",
+    "user": "admin",
+    "lastAttemptedStep": 1,
+    "lastCompletedStep": 1,
+    "jobStatus": "finished",
+    "timeStarted": "2018-03-11T01:54:31.330356-07:00",
+    "timeEnded": "2018-03-16T13:54:35.385579-07:00",
+    "committed": 321,
+    "errors": 0
+  }
+
+];

--- a/web/src/main/ui/app/components/jobs-new/manage-jobs.component.ts
+++ b/web/src/main/ui/app/components/jobs-new/manage-jobs.component.ts
@@ -1,0 +1,44 @@
+import { Component, ViewChild } from "@angular/core";
+import { ManageJobsService } from "./manage-jobs.service";
+import { ManageJobsUiComponent } from "./ui/manage-jobs-ui.component";
+import * as _ from "lodash";
+
+@Component({
+  selector: 'jobs-page',
+  template: `
+    <jobs-page-ui
+      [jobs]="this.jobs"
+    >
+    </jobs-page-ui>
+  `
+})
+export class ManageJobsComponent {
+
+  @ViewChild(ManageJobsUiComponent)
+  jobsPageUi: ManageJobsUiComponent;
+
+  jobs = [];
+
+  constructor(
+    private manageJobsService: ManageJobsService
+  ) {
+  }
+
+  ngOnInit() {
+    this.getJobs();
+  }
+
+  getJobs() {
+    // this.manageJobsService.getJobs().subscribe(resp => {
+    //   _.remove(this.jobs, () => {
+    //     return true;
+    //   });
+    //   _.forEach(resp, job => {
+    //     this.jobs.push(Job.fromJSON(job));
+    //   });
+    //   this.jobsPageUi.renderRows();
+    // });
+    this.jobs = this.manageJobsService.getJobs();
+    console.log(this.jobs);
+  }
+}

--- a/web/src/main/ui/app/components/jobs-new/manage-jobs.module.ts
+++ b/web/src/main/ui/app/components/jobs-new/manage-jobs.module.ts
@@ -1,0 +1,35 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { ManageJobsComponent } from "./manage-jobs.component";
+import { MaterialModule } from "../theme/material.module";
+import { ManageJobsUiComponent } from "./ui/manage-jobs-ui.component";
+import { AppCommonModule } from "../common";
+import { HttpClientModule } from "@angular/common/http";
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+//import { TruncateCharactersPipe } from '../../pipes/truncate';
+import { EditFlowModule } from '../flows-new/edit-flow/edit-flow.module';
+@NgModule({
+  declarations: [
+    //OutputDialogComponent,
+    //TruncateCharactersPipe,
+    ManageJobsUiComponent,
+    ManageJobsComponent
+  ],
+  imports     : [
+    MaterialModule,
+    RouterModule,
+    HttpClientModule,
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    AppCommonModule,
+    EditFlowModule
+  ],
+  providers   : [
+  ],
+  entryComponents: [
+    //OutputDialogComponent
+  ]
+})
+export class ManageJobsModule {}

--- a/web/src/main/ui/app/components/jobs-new/manage-jobs.service.ts
+++ b/web/src/main/ui/app/components/jobs-new/manage-jobs.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { jobsData } from './jobs.data';
+
+@Injectable()
+export class ManageJobsService {
+
+  constructor(
+    private http: HttpClient,
+  ) {
+  }
+
+  getJobs() {
+    console.log('GET /api/jobs');
+    // TODO pull from endpoint
+    //return this.http.get<Array<Object>>('api/jobs');
+    return jobsData;
+  }
+
+  // getJobById(id: string) {
+  //   console.log('GET /api/jobs/' + id);
+  //   return this.http.get('api/jobs/' + id);
+  // }
+
+  // deleteJob(id: string) {
+  //   console.log('DELETE /api/jobs/' + id);
+  //   return this.http.delete('api/jobs/' + id);
+  // }
+
+}

--- a/web/src/main/ui/app/components/jobs-new/ui/manage-jobs-ui.component.html
+++ b/web/src/main/ui/app/components/jobs-new/ui/manage-jobs-ui.component.html
@@ -1,0 +1,157 @@
+<div id="jobs-page" class="page-layout carded fullwidth">
+
+  <!-- CENTER -->
+  <div class="center">
+
+    <!-- HEADER -->
+    <div class="header accent">
+      <mat-toolbar style="background: transparent">
+        <h1>Jobs</h1>
+      </mat-toolbar>
+    </div>
+    <!-- / HEADER -->
+
+    <div class="content-card">
+
+      <div id="filters">
+        <span class="filter-label">Filters</span>
+        <mat-form-field id="name-filter">
+          <mat-select id="name-filter-type" value="" placeholder="Flow Name" (selectionChange)="applyFilter('flow', $event.value)">
+            <mat-option class="name-option" *ngFor="let val of getMenuVals('flow')" [value]="val">{{val ? val : 'All'}}</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field id="target-entity-filter">
+          <mat-select id="target-entity-filter-type" value="" placeholder="Target Entity" (selectionChange)="applyFilter('targetEntity', $event.value)">
+            <mat-option class="target-entity-option" *ngFor="let val of getMenuVals('targetEntity')" [value]="val">{{val ? val : 'All'}}</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field id="status-filter">
+          <mat-select id="status-filter-type" value="" placeholder="Status" (selectionChange)="applyFilter('jobStatus', $event.value)">
+            <mat-option class="status-option" *ngFor="let val of getMenuVals('jobStatus')" [value]="val">{{val ? val : 'All'}}</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field id="text-filter">
+          <input matInput (keyup)="applyFilter('text', $event.target.value)" placeholder="Text">
+        </mat-form-field>
+
+      </div>
+
+
+      <mat-table id="jobs-table"
+                 class="jobs-table"
+                 #table [dataSource]="dataSource"
+                 matSort>
+
+        <!-- Name Column -->
+        <ng-container matColumnDef="name">
+          <mat-header-cell id="job-name-sort-btn" *matHeaderCellDef mat-sort-header>Flow Name/Job ID</mat-header-cell>
+          <mat-cell class="job-name" *matCellDef="let job">
+            <div class="name-container">
+              <div class="flow-name">
+                <a [routerLink]="">{{job.flow}}</a>
+              </div>
+              <div class="job-id">
+                {{job.jobId | truncate : 40}}
+              </div>
+            </div>
+          </mat-cell>
+        </ng-container>
+
+        <!-- Target Entity -->
+        <ng-container matColumnDef="targetEntity">
+          <mat-header-cell id="job-entity-sort-btn" *matHeaderCellDef mat-sort-header>Target Entity</mat-header-cell>
+          <mat-cell class="job-entity" *matCellDef="let job">
+            {{job.targetEntity}}
+          </mat-cell>
+        </ng-container>
+
+        <!-- Status Column -->
+        <ng-container matColumnDef="jobStatus">
+          <mat-header-cell id="job-status-sort-btn" *matHeaderCellDef mat-sort-header>Status</mat-header-cell>
+          <mat-cell class="job-status" *matCellDef="let job">
+            {{job.jobStatus}}
+          </mat-cell>
+        </ng-container>
+
+        <!-- Ended Column -->
+        <ng-container matColumnDef="timeEnded">
+          <mat-header-cell id="jobs-ended-sort-btn" *matHeaderCellDef mat-sort-header>Ended</mat-header-cell>
+          <mat-cell class="job-ended" *matCellDef="let job">
+            {{friendlyDate(job.timeEnded)}}
+          </mat-cell>
+        </ng-container>
+
+        <!-- Duration Column -->
+        <ng-container matColumnDef="duration">
+          <mat-header-cell id="job-duration-sort-btn" *matHeaderCellDef mat-sort-header>Duration</mat-header-cell>
+          <mat-cell class="job-duration" *matCellDef="let job">
+            {{friendlyDuration(job.timeStarted, job.timeEnded)}}
+          </mat-cell>
+        </ng-container>
+
+        <!-- Committed Column -->
+        <ng-container matColumnDef="committed">
+          <mat-header-cell id="job-committed-sort-btn" *matHeaderCellDef mat-sort-header>Committed</mat-header-cell>
+          <mat-cell class="job-committed" *matCellDef="let job">
+            <a *ngIf="job.committed !== 0" [routerLink]="">
+              {{job.committed | number}}
+            </a>
+            <span *ngIf="job.committed === 0">
+              {{job.committed}}
+            </span>
+          </mat-cell>
+        </ng-container>
+
+        <!-- Errors Column -->
+        <ng-container matColumnDef="errors">
+          <mat-header-cell id="job-errors-sort-btn" *matHeaderCellDef mat-sort-header>Errors</mat-header-cell>
+          <mat-cell class="job-errors" *matCellDef="let job">
+            <a *ngIf="job.errors !== 0" [routerLink]="">
+              {{job.errors | number}}
+            </a>
+            <span *ngIf="job.errors === 0">
+              {{job.errors}}
+            </span>
+            <span></span>
+          </mat-cell>
+        </ng-container>
+
+        <!-- Actions Column -->
+        <ng-container matColumnDef="actions">
+          <mat-header-cell *matHeaderCellDef>Actions</mat-header-cell>
+          <mat-cell class="job-actions" *matCellDef="let job">
+            <mat-icon class="job-menu" [matMenuTriggerFor]="jobMenu" [matMenuTriggerData]="{job: job}"
+                      disableRipple>more_vert</mat-icon>
+          </mat-cell>
+        </ng-container>
+
+        <mat-header-row *matHeaderRowDef="displayedColumns; sticky:true"></mat-header-row>
+        <mat-row
+          *matRowDef="let job; columns: displayedColumns;"
+          class="{{ 'job-' + job.flow.toLowerCase().split(' ').join('-') }}"
+        >
+        </mat-row>
+
+      </mat-table>
+
+      <mat-paginator id="job-pagination"
+                     #paginator
+                     [length]="jobs.length"
+                     [pageIndex]="0"
+                     [pageSize]="5"
+                     [pageSizeOptions]="[3, 5, 15, 30]">
+      </mat-paginator>
+
+    </div>
+  </div>
+</div>
+
+<mat-menu class="job-menu-dialog" #jobMenu="matMenu">
+  <ng-template matMenuContent let-job="job">
+    <div class="job-menu-output -btn" mat-menu-item (click)="openOutputDialog(job)">Output</div>
+    <div class="job-menu-view-btn" mat-menu-item (click)="viewFlow(job)">View Flow</div>
+  </ng-template>
+</mat-menu>

--- a/web/src/main/ui/app/components/jobs-new/ui/manage-jobs-ui.component.scss
+++ b/web/src/main/ui/app/components/jobs-new/ui/manage-jobs-ui.component.scss
@@ -1,0 +1,235 @@
+$header-height: 70px !default;
+
+button {
+  outline: none;
+}
+
+#jobs-page {
+  padding: 10px 3% 20px 3%;
+  font-family: "Roboto", "Helvetica Neue", "Arial", sans-serif;
+  .center .header .mat-toolbar-single-row {
+    padding: 0 !important;
+  }
+
+}
+
+/* HEADER ROW HEIGHT */
+.jobs-table .mat-header-row {
+  min-height: 48px !important;
+  /deep/ button.mat-sort-header-button {
+    outline: none !important;
+  }
+}
+
+/* BODY ROW HEIGHT */
+.jobs-table .mat-row {
+  min-height: 42px !important;
+  button {
+    height: 32px !important;
+    line-height: 32px !important;
+  }
+}
+
+/* PAGINATOR ROW HEIGHT */
+/deep/ .mat-paginator-container {
+  min-height: 48px !important;
+  .mat-paginator-page-size-select {
+    margin: 2px 4px -4px 4px !important;
+  }
+}
+
+.name-container {
+  line-height: 16px;
+  .job-id {
+    font-size: 12px;
+    color: #666;
+  }
+}
+
+
+#filters {
+  .filter-label {
+    display: inline-block;
+    margin: 14px 10px 0 0;
+    font-size: 16px;
+    font-weight: 500;
+  }
+  display: flex;
+  justify-content: flex-end;
+  .mat-form-field {
+    width: 200px;
+    margin-left: 20px;
+  }
+}
+
+.page-layout {
+  position: relative;
+  overflow: hidden;
+
+  // Carded layout
+  &.carded {
+    display: flex;
+    flex-direction: column;
+    flex: 1 0 auto;
+    width: 100%;
+    min-width: 100%;
+
+    // Top bg
+    > .top-bg {
+      position: absolute;
+      z-index: 1;
+      top: 0;
+      right: 0;
+      left: 0;
+    }
+
+    // Fullwidth
+    &.fullwidth {
+
+      // Center
+      > .center {
+        display: flex;
+        flex-direction: column;
+        flex: 1 0 auto;
+        position: relative;
+        z-index: 2;
+        padding: 0 32px;
+        width: 100%;
+        min-width: 0;
+        max-width: 100%;
+        height: 100%;
+        max-height: 100%;
+
+        > .header {
+          height: $header-height !important;
+          min-height: $header-height !important;
+          max-height: $header-height!important;
+        }
+
+        > .content-card {
+          display: flex;
+          flex-direction: column;
+          flex: 1 0 auto;
+          overflow: hidden;
+
+          > .content {
+            flex: 1 0 auto;
+          }
+        }
+      }
+    }
+  }
+}
+
+.jobs-table {
+  flex: 1 1 auto;
+  border-bottom: 1px solid rgba(0, 0, 0, .12);
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+
+  a:hover {
+    text-decoration: none;
+    color: #6d8ba5;
+  }
+
+  a {
+    color: #2a4356;
+  }
+
+  .mat-header-row {
+    min-height: 64px;
+  }
+
+  /* .flow {
+    position: relative;
+    cursor: pointer;
+    height: 84px;
+  } */
+
+  .mat-cell {
+    min-width: 0;
+    display: flex;
+    align-items: center;
+  }
+
+  .mat-column-name {
+    flex: 0 1 300px;
+  }
+
+  /* .mat-column-targetEntity {
+    flex: 0 1 120px;
+  }
+
+  .mat-column-status {
+    flex: 0 1 120px;
+  }
+
+  .mat-column-ended {
+    flex: 0 1 100px;
+  }
+
+  .mat-column-duration {
+    flex: 0 1 220px;
+  } */
+
+  .mat-column-committed {
+    flex: 0 1 100px;
+  }
+
+  .mat-column-errors {
+    flex: 0 1 100px;
+  }
+
+  .mat-column-actions {
+    flex: 0 1 80px;
+  }
+
+  .mat-header-cell .mat-icon {
+    cursor: pointer;
+  }
+
+  .actions-menu-icon {
+    margin-left: 10px;
+  }
+
+  .quantity-indicator {
+    display: inline-block;
+    vertical-align: middle;
+    width: 8px;
+    height: 8px;
+    border-radius: 4px;
+    margin-right: 8px;
+
+    & + span {
+      display: inline-block;
+      vertical-align: middle;
+    }
+  }
+
+  .active-icon {
+    border-radius: 50%;
+  }
+}
+
+.fill-space {
+  flex: 1 1 auto;
+}
+
+.name-container {
+  position: relative;
+  width: 240px;
+}
+
+.header h1 {
+  padding-right: 30px;
+  font-size: 32px;
+  font-weight: 500;
+}
+
+.mat-column-actions .mat-icon {
+  cursor: pointer;
+}
+
+.capitalize {
+   text-transform: capitalize;
+}

--- a/web/src/main/ui/app/components/jobs-new/ui/manage-jobs-ui.component.ts
+++ b/web/src/main/ui/app/components/jobs-new/ui/manage-jobs-ui.component.ts
@@ -1,0 +1,122 @@
+import {AfterViewInit, Component, EventEmitter, Input, OnInit, Output, ViewChild} from "@angular/core";
+import {MatDialog, MatPaginator, MatSort, MatTable, MatTableDataSource} from "@angular/material";
+import {ConfirmationDialogComponent} from "../../common";
+//import {OutputDialogComponent} from "./output-dialog.component";
+//import {Flow} from "../../models/flow.model";
+import * as moment from 'moment';
+import { differenceInSeconds,
+         differenceInMinutes,
+         differenceInHours,
+         differenceInDays } from 'date-fns';
+
+@Component({
+  selector: 'jobs-page-ui',
+  templateUrl: './manage-jobs-ui.component.html',
+  styleUrls: ['./manage-jobs-ui.component.scss']
+})
+export class ManageJobsUiComponent implements OnInit, AfterViewInit {
+  displayedColumns = ['name', 'targetEntity', 'jobStatus', 'timeEnded', 'duration', 'committed', 'errors', 'actions'];
+  filterValues = {};
+  @Input() jobs: Array<any> = [];
+
+  dataSource: MatTableDataSource<any>;
+
+  @ViewChild(MatTable) table: MatTable<any>;
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatSort) sort: MatSort;
+
+  constructor(public dialog: MatDialog){
+  }
+
+  ngOnInit() {
+    this.dataSource = new MatTableDataSource<any>(this.jobs);
+    this.dataSource.sortingDataAccessor = (item, property) => {
+      switch (property) {
+        case 'name':
+          return item['flow'];
+        case 'duration':
+          return differenceInSeconds(item['timeStarted'], item['timeEnded']);
+        default: return item[property];
+      }
+    };
+  }
+
+  ngAfterViewInit() {
+    this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
+  }
+
+  updateDataSource() {
+    this.dataSource.data = this.jobs;
+  }
+
+  applyFilter(menu: string, value: string) {
+    this.filterValues[menu] = value;
+    // Check all filters across data source
+    this.dataSource.filterPredicate = (data: any, filterValues: string) => {
+      filterValues = JSON.parse(filterValues);
+      let result = true;
+      // If text entered, default to false and then check for matches
+      if (filterValues['text']) {
+        result = false;
+        if (data['flow'].indexOf(filterValues['text']) != -1 ||
+            data['jobId'].indexOf(filterValues['text']) != -1 ||
+            data['targetEntity'].indexOf(filterValues['text']) != -1 ||
+            data['jobStatus'].indexOf(filterValues['text']) != -1 ||
+            data['committed'].toString().indexOf(filterValues['text']) != -1 ||
+            data['errors'].toString().indexOf(filterValues['text']) != -1) {
+          result = true;
+        }
+      }
+      // If menu selected, set to false if no match
+      if (filterValues['flow'] &&
+          data['flow'].indexOf(filterValues['flow']) == -1) {
+        result = false;
+      }
+      if (filterValues['targetEntity'] &&
+          data['targetEntity'].indexOf(filterValues['targetEntity']) == -1) {
+        result = false;
+      }
+      if (filterValues['jobStatus'] &&
+          data['jobStatus'].indexOf(filterValues['jobStatus']) == -1) {
+        result = false;
+      }
+      return result;
+    }
+    this.dataSource.filter = JSON.stringify(this.filterValues)
+  }
+
+  openOutputDialog(job) {
+    // TODO open output popup
+    return false;
+  }
+
+  viewFlow(job) {
+    // TODO route to flow view
+    return false;
+  }
+
+  renderRows(): void {
+    this.updateDataSource();
+    this.table.renderRows();
+  }
+
+  friendlyDate(dt): string {
+    return (dt) ? moment(dt).fromNow() : '';
+  }
+
+  friendlyDuration(dt1, dt2): any {
+    return (dt1 && dt2) ?
+      moment.duration(moment(dt1).diff(moment(dt2))).humanize() :
+      '';
+  }
+
+  getMenuVals(prop) {
+    let set = new Set();
+    this.jobs.forEach(j => set.add(j[prop]));
+    let arr = Array.from(set);
+    arr.unshift('');
+    return arr;
+  }
+
+}


### PR DESCRIPTION
Adds new Jobs view with Material Design table displaying jobs. Components are here:
app/components/jobs-new

Route is here:
http://localhost:4200/#/jobs

Old Jobs route has been changed to here:
http://localhost:4200/#/jobs-old

Currently working with static array of jobs data here:
app/components/jobs-new/jobs.data.ts

Next steps:
- Hook up to endpoint that delivers mock job data
- Add output data for display in output popup
- Add status data for display in status popup
- Add bulk-action column
- Add Job Details table