### PR TITLE
Add Job Details view

### DIFF
--- a/web/src/main/ui/app/app.routes.ts
+++ b/web/src/main/ui/app/app.routes.ts
@@ -13,6 +13,7 @@ import {EditFlowComponent} from './components/flows-new/edit-flow/edit-flow.comp
 import {AuthGuard} from './services/auth/auth-guard.service';
 import {ManageFlowsComponent} from "./components/flows-new/manage-flows/manage-flows.component";
 import {ManageJobsComponent} from "./components/jobs-new/manage-jobs.component";
+import {JobDetailsComponent} from "./components/jobs-new/job-details.component";
 
 export const ROUTES: Routes = [
   { path: '', component: DashboardComponent, canActivate: [AuthGuard] },
@@ -36,6 +37,7 @@ export const ROUTES: Routes = [
   { path: 'edit-flow/:flowId', component: EditFlowComponent, canActivate: [AuthGuard] },
   { path: 'jobs', component: ManageJobsComponent, canActivate: [AuthGuard] },
   { path: 'jobs-old', component: JobsComponent, canActivate: [AuthGuard] },
+  { path: 'jobs/:jobId', component: JobDetailsComponent, canActivate: [AuthGuard] },
   { path: 'traces', component: TracesComponent, canActivate: [AuthGuard] },
   { path: 'traces/:id', component: TraceViewerComponent, canActivate: [AuthGuard] },
   { path: 'browse', component: SearchComponent, canActivate: [AuthGuard] },

--- a/web/src/main/ui/app/components/jobs-new/job-details.component.ts
+++ b/web/src/main/ui/app/components/jobs-new/job-details.component.ts
@@ -1,0 +1,47 @@
+import { Component, ViewChild } from "@angular/core";
+import { ActivatedRoute, Router } from '@angular/router';
+import { ManageJobsService } from "./manage-jobs.service";
+import { JobDetailsUiComponent } from "./ui/job-details-ui.component";
+import * as _ from "lodash";
+
+@Component({
+  selector: 'job-details-page',
+  template: `
+    <job-details-page-ui
+      [job]="this.job"
+    >
+    </job-details-page-ui>
+  `
+})
+export class JobDetailsComponent {
+
+  @ViewChild(JobDetailsUiComponent)
+  jobDetailsPageUi: JobDetailsUiComponent;
+
+  jobId: string;
+  job: any;
+
+  constructor(
+    private manageJobsService: ManageJobsService,
+    private activatedRoute: ActivatedRoute,
+    private router: Router
+  ) {
+  }
+
+  ngOnInit() {
+    this.getJob();
+  }
+  getJob() {
+    this.jobId = this.activatedRoute.snapshot.paramMap.get('jobId');
+
+    // GET job by ID
+    // if (this.jobId) {
+    //   this.manageJobsService.getJobById(this.jobId).subscribe( resp => {
+    //     console.log('job by id response', resp);
+    //     this.job = Job.fromJSON(resp);
+    //   });
+    // }
+    this.job = this.manageJobsService.getJobById(this.jobId);
+    console.log('this.job', this.job);
+  }
+}

--- a/web/src/main/ui/app/components/jobs-new/job.data.ts
+++ b/web/src/main/ui/app/components/jobs-new/job.data.ts
@@ -1,0 +1,69 @@
+export const jobData = {
+
+    "jobId": "7e59df5c-3e9f-4109-bb8e-f52cb926aa8e",
+    "flow": "Order Flow 01",
+    "targetEntity": "Order",
+    "user": "admin",
+    "lastAttemptedStep": 2,
+    "lastCompletedStep": 1,
+    "jobStatus": "finished",
+    "timeStarted": "2019-03-20T09:54:31.330356-07:00",
+    "timeEnded": "2019-03-20T10:54:35.385579-07:00",
+    "committed": 100,
+    "errors": 3,
+    "steps": [
+      {
+        "stepNumber": 1,
+        "type": "ingest",
+        "name": "default-ingest",
+        "stepName": "Flow 01 Ingest Step",
+        "identifier": null,
+        "retryLimit": 0,
+        "options": {
+          "outputFormat": "json",
+          "collections": "defaultIngest"
+        },
+        "stepStatus": "finished",
+        "timeStarted": "2019-03-20T09:54:31.330356-07:00",
+        "timeEnded": "2019-03-20T10:10:05.123456-07:00",
+        "committed": 13429,
+        "errors": 0
+      },
+      {
+        "stepNumber": 2,
+        "type": "mapping",
+        "name": "default-mapping",
+        "stepName": "Flow 01 Mapping Step",
+        "identifier": null,
+        "retryLimit": 0,
+        "options": {
+          "outputFormat": "json",
+          "collections": "Flow 01 Ingest Step",
+          "targetEntity": "Order"
+        },
+        "stepStatus": "failed",
+        "timeStarted": "2019-03-20T10:10:05.123456-07:00",
+        "timeEnded": "2019-03-20T10:54:35.385579-07:00",
+        "committed": 286,
+        "errors": 3
+      },
+      {
+        "stepNumber": 3,
+        "type": "mastering",
+        "name": "default-mastering",
+        "stepName": "Flow 01 Mastering Step",
+        "identifier": null,
+        "retryLimit": 0,
+        "options": {
+          "outputFormat": "json",
+          "collections": "Flow 01 Mapping Step",
+          "targetEntity": "Order"
+        },
+        "stepStatus": null,
+        "timeStarted": null,
+        "timeEnded": null,
+        "committed": null,
+        "errors": null
+      }
+    ]
+};

--- a/web/src/main/ui/app/components/jobs-new/manage-jobs.module.ts
+++ b/web/src/main/ui/app/components/jobs-new/manage-jobs.module.ts
@@ -1,8 +1,10 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { ManageJobsComponent } from "./manage-jobs.component";
+import { JobDetailsComponent } from "./job-details.component";
 import { MaterialModule } from "../theme/material.module";
 import { ManageJobsUiComponent } from "./ui/manage-jobs-ui.component";
+import { JobDetailsUiComponent } from "./ui/job-details-ui.component";
 import { AppCommonModule } from "../common";
 import { HttpClientModule } from "@angular/common/http";
 import { CommonModule } from '@angular/common';
@@ -14,7 +16,9 @@ import { EditFlowModule } from '../flows-new/edit-flow/edit-flow.module';
     //OutputDialogComponent,
     //TruncateCharactersPipe,
     ManageJobsUiComponent,
-    ManageJobsComponent
+    ManageJobsComponent,
+    JobDetailsUiComponent,
+    JobDetailsComponent
   ],
   imports     : [
     MaterialModule,

--- a/web/src/main/ui/app/components/jobs-new/manage-jobs.service.ts
+++ b/web/src/main/ui/app/components/jobs-new/manage-jobs.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { jobsData } from './jobs.data';
+import { jobData } from './job.data';
 
 @Injectable()
 export class ManageJobsService {
@@ -17,10 +18,12 @@ export class ManageJobsService {
     return jobsData;
   }
 
-  // getJobById(id: string) {
-  //   console.log('GET /api/jobs/' + id);
-  //   return this.http.get('api/jobs/' + id);
-  // }
+  getJobById(id: string) {
+    console.log('GET /api/jobs/' + id);
+    // TODO pull from endpoint
+    //return this.http.get('api/jobs/' + id);
+    return jobData;
+  }
 
   // deleteJob(id: string) {
   //   console.log('DELETE /api/jobs/' + id);

--- a/web/src/main/ui/app/components/jobs-new/ui/job-details-ui.component.html
+++ b/web/src/main/ui/app/components/jobs-new/ui/job-details-ui.component.html
@@ -1,0 +1,182 @@
+<div id="job-details-page" class="page-layout carded fullwidth">
+
+  <div class="back-link">
+    <a [routerLink]="['/jobs']">
+      <span class="back-symbol">&lt;</span> Jobs
+    </a>
+  </div>
+
+  <!-- CENTER -->
+  <div class="center">
+
+    <!-- HEADER -->
+    <div class="header accent">
+      <mat-toolbar style="background: transparent">
+        <h1>Job Details</h1>
+      </mat-toolbar>
+    </div>
+    <!-- / HEADER -->
+
+    <div class="content-card">
+
+      <div id="job-summary">
+        <section class="name">
+          <div class="flow-name">
+            {{job.flow}}
+          </div>
+          <div class="job-id">
+            {{job.jobId}}
+          </div>
+        </section>
+        <section>
+          <div class="status">
+            <span class="label medium">Status</span>{{job.jobStatus}}
+          </div>
+          <div class="target-entity">
+            <span class="label medium">Target Entity</span>{{job.targetEntity}}
+          </div>
+        </section>
+        <section>
+          <div class="ended">
+            <span class="label">Ended</span>{{friendlyDate(job.timeEnded)}}
+          </div>
+          <div class="duration">
+            <span class="label">Duration</span>{{friendlyDuration(job.timeStarted, job.timeEnded)}}
+          </div>
+        </section>
+        <section>
+          <div class="committed">
+            <span class="label">Committed</span>
+            <a *ngIf="job.committed !== 0" [routerLink]="">
+              {{job.committed | number}}
+            </a>
+            <span *ngIf="job.committed === 0">
+              {{job.committed}}
+            </span>
+          </div>
+          <div class="errors">
+            <span class="label">Errors</span>
+            <a *ngIf="job.errors !== 0" [routerLink]="">
+              {{job.errors | number}}
+            </a>
+            <span *ngIf="job.errors === 0">
+              {{job.errors}}
+            </span>
+          </div>
+        </section>
+      </div>
+
+      <mat-table id="job-details-table"
+                 class="job-details-table"
+                 #table [dataSource]="dataSource"
+                 matSort>
+
+        <!-- Name Column -->
+        <ng-container matColumnDef="name">
+          <mat-header-cell id="job-name-sort-btn" *matHeaderCellDef mat-sort-header>Step Name</mat-header-cell>
+          <mat-cell class="step-name" *matCellDef="let step">
+            <div class="name-container">
+              {{step.stepName}}
+            </div>
+          </mat-cell>
+        </ng-container>
+
+        <!-- Target Entity -->
+        <ng-container matColumnDef="targetEntity">
+          <mat-header-cell id="step-entity-sort-btn" *matHeaderCellDef mat-sort-header>Target Entity</mat-header-cell>
+          <mat-cell class="step-entity" *matCellDef="let step">
+            {{step.options.targetEntity}}
+          </mat-cell>
+        </ng-container>
+
+        <!-- Status Column -->
+        <ng-container matColumnDef="stepStatus">
+          <mat-header-cell id="step-status-sort-btn" *matHeaderCellDef mat-sort-header>Status</mat-header-cell>
+          <mat-cell class="step-status" *matCellDef="let step">
+            <span *ngIf="step.stepStatus">
+              {{step.stepStatus}}
+            </span>
+            <span *ngIf="!step.stepStatus" >
+              not run
+            </span>
+          </mat-cell>
+        </ng-container>
+
+        <!-- Ended Column -->
+        <ng-container matColumnDef="timeEnded">
+          <mat-header-cell id="step-ended-sort-btn" *matHeaderCellDef mat-sort-header>Ended</mat-header-cell>
+          <mat-cell class="step-ended" *matCellDef="let step">
+            {{friendlyDate(step.timeEnded)}}
+          </mat-cell>
+        </ng-container>
+
+        <!-- Duration Column -->
+        <ng-container matColumnDef="duration">
+          <mat-header-cell id="step-duration-sort-btn" *matHeaderCellDef mat-sort-header>Duration</mat-header-cell>
+          <mat-cell class="step-duration" *matCellDef="let step">
+            {{friendlyDuration(step.timeStarted, step.timeEnded)}}
+          </mat-cell>
+        </ng-container>
+
+        <!-- Committed Column -->
+        <ng-container matColumnDef="committed">
+          <mat-header-cell id="step-committed-sort-btn" *matHeaderCellDef mat-sort-header>Committed</mat-header-cell>
+          <mat-cell class="step-committed" *matCellDef="let step">
+            <a *ngIf="step.committed !== 0" [routerLink]="">
+              {{step.committed | number}}
+            </a>
+            <span *ngIf="step.committed === 0">
+              {{step.committed}}
+            </span>
+          </mat-cell>
+        </ng-container>
+
+        <!-- Errors Column -->
+        <ng-container matColumnDef="errors">
+          <mat-header-cell id="step-errors-sort-btn" *matHeaderCellDef mat-sort-header>Errors</mat-header-cell>
+          <mat-cell class="step-errors" *matCellDef="let step">
+            <a *ngIf="step.errors !== 0" [routerLink]="">
+              {{step.errors | number}}
+            </a>
+            <span *ngIf="step.errors === 0">
+              {{step.errors}}
+            </span>
+            <span></span>
+          </mat-cell>
+        </ng-container>
+
+        <!-- Actions Column -->
+        <ng-container matColumnDef="actions">
+          <mat-header-cell *matHeaderCellDef>Actions</mat-header-cell>
+          <mat-cell class="step-actions" *matCellDef="let step">
+            <mat-icon class="step-menu" [matMenuTriggerFor]="jobMenu" [matMenuTriggerData]="{step: step}"
+                      disableRipple>more_vert</mat-icon>
+          </mat-cell>
+        </ng-container>
+
+        <mat-header-row *matHeaderRowDef="displayedColumns; sticky:true"></mat-header-row>
+        <mat-row
+          *matRowDef="let step; columns: displayedColumns;"
+          class="{{ 'step-' + step.stepName.toLowerCase().split(' ').join('-') }}"
+        >
+        </mat-row>
+
+      </mat-table>
+
+      <mat-paginator id="step-pagination"
+                     #paginator
+                     [length]="job.steps.length"
+                     [pageIndex]="0"
+                     [pageSize]="5"
+                     [pageSizeOptions]="[3, 5, 15, 30]">
+      </mat-paginator>
+
+    </div>
+  </div>
+</div>
+
+<mat-menu class="step-menu-dialog" #jobMenu="matMenu">
+  <ng-template matMenuContent let-step="step">
+    <div class="step-menu-output-btn" mat-menu-item (click)="openOutputDialog(step)">Output</div>
+  </ng-template>
+</mat-menu>

--- a/web/src/main/ui/app/components/jobs-new/ui/job-details-ui.component.scss
+++ b/web/src/main/ui/app/components/jobs-new/ui/job-details-ui.component.scss
@@ -4,17 +4,66 @@ button {
   outline: none;
 }
 
-#jobs-page {
+#job-details-page {
   padding: 10px 3% 20px 3%;
   font-family: "Roboto", "Helvetica Neue", "Arial", sans-serif;
   .center .header .mat-toolbar-single-row {
     padding: 0 !important;
   }
 
+  .back-link {
+    font-size: 14px;
+    margin: 5px 0 0 30px;
+  }
+
+  .back-symbol {
+    display: inline-block;
+    position: relative;
+    top: -1px;
+  }
+
+  #job-summary {
+    width: 100%;
+    margin-bottom: 10px;
+    section {
+      position: relative;
+      float: left;
+      width: 200px;
+      .label {
+        display: inline-block;
+        font-size: 12px;
+        color: #666;
+        margin-right: 5px;
+        width: 60px;
+      }
+      .label.medium {
+        width: 75px;
+      }
+      .flow-name{
+        font-size: 18px;
+        font-weight: 500;
+      }
+      .job-id {
+        font-size: 12px;
+        color: #333;
+      }
+    }
+    section.name {
+      width: 280px;
+      line-height: 22px;
+    }
+  }
+  a:hover {
+    text-decoration: none;
+    color: #6d8ba5;
+  }
+  a {
+    color: #2a4356;
+  }
 }
 
 /* HEADER ROW HEIGHT */
-.jobs-table .mat-header-row {
+.job-details-table .mat-header-row {
   min-height: 48px !important;
   /deep/ button.mat-sort-header-button {
     outline: none !important;
@@ -22,7 +71,7 @@ button {
 }
 
 /* BODY ROW HEIGHT */
-.jobs-table .mat-row {
+.job-details-table .mat-row {
   min-height: 42px !important;
   button {
     height: 32px !important;
@@ -46,18 +95,17 @@ button {
   }
 }
 
+
 #filters {
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: -30px;
   .filter-label {
     display: inline-block;
-    margin: 8px 10px 0 0;
+    margin: 14px 10px 0 0;
     font-size: 16px;
     font-weight: 500;
   }
+  display: flex;
+  justify-content: flex-end;
   .mat-form-field {
-    font-size: 14px;
     width: 200px;
     margin-left: 20px;
   }
@@ -122,7 +170,7 @@ button {
   }
 }
 
-.jobs-table {
+.job-details-table {
   flex: 1 1 auto;
   border-bottom: 1px solid rgba(0, 0, 0, .12);
   overflow: auto;

--- a/web/src/main/ui/app/components/jobs-new/ui/job-details-ui.component.ts
+++ b/web/src/main/ui/app/components/jobs-new/ui/job-details-ui.component.ts
@@ -1,0 +1,74 @@
+import {AfterViewInit, Component, EventEmitter, Input, OnInit, Output, ViewChild} from "@angular/core";
+import {MatDialog, MatPaginator, MatSort, MatTable, MatTableDataSource} from "@angular/material";
+import {ConfirmationDialogComponent} from "../../common";
+//import {OutputDialogComponent} from "./output-dialog.component";
+//import {Flow} from "../../models/flow.model";
+import * as moment from 'moment';
+import { differenceInSeconds,
+         differenceInMinutes,
+         differenceInHours,
+         differenceInDays } from 'date-fns';
+
+@Component({
+  selector: 'job-details-page-ui',
+  templateUrl: './job-details-ui.component.html',
+  styleUrls: ['./job-details-ui.component.scss']
+})
+export class JobDetailsUiComponent implements OnInit, AfterViewInit {
+  displayedColumns = ['name', 'targetEntity', 'stepStatus', 'timeEnded', 'duration', 'committed', 'errors', 'actions'];
+  filterValues = {};
+  @Input() job: any;
+
+  dataSource: MatTableDataSource<any>;
+
+  @ViewChild(MatTable) table: MatTable<any>;
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatSort) sort: MatSort;
+
+  constructor(public dialog: MatDialog){
+  }
+
+  ngOnInit() {
+    console.log('this.job', this.job);
+    this.dataSource = new MatTableDataSource<any>(this.job['steps']);
+    // this.dataSource.sortingDataAccessor = (item, property) => {
+    //   switch (property) {
+    //     case 'name':
+    //       return item['flow'];
+    //     case 'duration':
+    //       return differenceInSeconds(item['timeStarted'], item['timeEnded']);
+    //     default: return item[property];
+    //   }
+    // };
+  }
+
+  ngAfterViewInit() {
+    this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
+  }
+
+  updateDataSource() {
+    this.dataSource.data = this.job;
+  }
+
+  openOutputDialog(job) {
+    // TODO open output popup
+    return false;
+  }
+
+  renderRows(): void {
+    this.updateDataSource();
+    this.table.renderRows();
+  }
+
+  friendlyDate(dt): string {
+    return (dt) ? moment(dt).fromNow() : '';
+  }
+
+  friendlyDuration(dt1, dt2): any {
+    return (dt1 && dt2) ?
+      moment.duration(moment(dt1).diff(moment(dt2))).humanize() :
+      '';
+  }
+
+}

--- a/web/src/main/ui/app/components/jobs-new/ui/manage-jobs-ui.component.html
+++ b/web/src/main/ui/app/components/jobs-new/ui/manage-jobs-ui.component.html
@@ -6,39 +6,43 @@
     <!-- HEADER -->
     <div class="header accent">
       <mat-toolbar style="background: transparent">
+
         <h1>Jobs</h1>
+
+        <span class="fill-space"></span>
+
+        <div id="filters">
+
+          <span class="filter-label">Filters</span>
+          <mat-form-field id="name-filter">
+            <mat-select id="name-filter-type" value="" placeholder="Flow Name" (selectionChange)="applyFilter('flow', $event.value)">
+              <mat-option class="name-option" *ngFor="let val of getMenuVals('flow')" [value]="val">{{val ? val : 'All'}}</mat-option>
+            </mat-select>
+          </mat-form-field>
+
+          <mat-form-field id="target-entity-filter">
+            <mat-select id="target-entity-filter-type" value="" placeholder="Target Entity" (selectionChange)="applyFilter('targetEntity', $event.value)">
+              <mat-option class="target-entity-option" *ngFor="let val of getMenuVals('targetEntity')" [value]="val">{{val ? val : 'All'}}</mat-option>
+            </mat-select>
+          </mat-form-field>
+
+          <mat-form-field id="status-filter">
+            <mat-select id="status-filter-type" value="" placeholder="Status" (selectionChange)="applyFilter('jobStatus', $event.value)">
+              <mat-option class="status-option" *ngFor="let val of getMenuVals('jobStatus')" [value]="val">{{val ? val : 'All'}}</mat-option>
+            </mat-select>
+          </mat-form-field>
+
+          <mat-form-field id="text-filter">
+            <input matInput (keyup)="applyFilter('text', $event.target.value)" placeholder="Text">
+          </mat-form-field>
+
+        </div>
+
       </mat-toolbar>
     </div>
     <!-- / HEADER -->
 
     <div class="content-card">
-
-      <div id="filters">
-        <span class="filter-label">Filters</span>
-        <mat-form-field id="name-filter">
-          <mat-select id="name-filter-type" value="" placeholder="Flow Name" (selectionChange)="applyFilter('flow', $event.value)">
-            <mat-option class="name-option" *ngFor="let val of getMenuVals('flow')" [value]="val">{{val ? val : 'All'}}</mat-option>
-          </mat-select>
-        </mat-form-field>
-
-        <mat-form-field id="target-entity-filter">
-          <mat-select id="target-entity-filter-type" value="" placeholder="Target Entity" (selectionChange)="applyFilter('targetEntity', $event.value)">
-            <mat-option class="target-entity-option" *ngFor="let val of getMenuVals('targetEntity')" [value]="val">{{val ? val : 'All'}}</mat-option>
-          </mat-select>
-        </mat-form-field>
-
-        <mat-form-field id="status-filter">
-          <mat-select id="status-filter-type" value="" placeholder="Status" (selectionChange)="applyFilter('jobStatus', $event.value)">
-            <mat-option class="status-option" *ngFor="let val of getMenuVals('jobStatus')" [value]="val">{{val ? val : 'All'}}</mat-option>
-          </mat-select>
-        </mat-form-field>
-
-        <mat-form-field id="text-filter">
-          <input matInput (keyup)="applyFilter('text', $event.target.value)" placeholder="Text">
-        </mat-form-field>
-
-      </div>
-
 
       <mat-table id="jobs-table"
                  class="jobs-table"
@@ -51,7 +55,9 @@
           <mat-cell class="job-name" *matCellDef="let job">
             <div class="name-container">
               <div class="flow-name">
-                <a [routerLink]="">{{job.flow}}</a>
+                <a [routerLink]="['/jobs', job.jobId]">
+                  {{job.flow}}
+                </a>
               </div>
               <div class="job-id">
                 {{job.jobId | truncate : 40}}
@@ -115,7 +121,6 @@
             <span *ngIf="job.errors === 0">
               {{job.errors}}
             </span>
-            <span></span>
           </mat-cell>
         </ng-container>
 


### PR DESCRIPTION
New Job Details view is linked from entries in Jobs table.

Currently gets job data from a static file:
app/components/jobs-new/job.data.ts

TODO:
- Hook up view to mock job data (via services calls)
- Status values should popup status details (at least for failed statuses)
- Committed non-zero values should link to Browse Data view for those documents
- Errors non-zero values should link to error information