### PR TITLE
DHFPROD-2158: Validate mapping (and other step) data

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/match-options.model.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/match-options.model.ts
@@ -101,6 +101,26 @@ export class MatchOption {
         return prop.name;
       })
     }
+    // Set algorithmRef based on matchType
+    if (!mOpt.algorithmRef) {
+      switch(mOpt.matchType) {
+        case "synonym":
+          this.algorithmRef = "thesaurus";
+          break;
+        case "double metaphone":
+          this.algorithmRef = "double-metaphone";
+          break;
+        case "zip":
+          this.algorithmRef = "zip-match";
+          break;
+        case "reduce":
+          this.algorithmRef = "standard-reduction";
+          break;
+        case "custom":
+          this.algorithmRef = mOpt.customFunction;
+          break;
+      }
+    }
   }
 
   /**

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/merge-strategies-ui.component.scss
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/merge-strategies-ui.component.scss
@@ -268,3 +268,11 @@ button {
   background-color: #2a4356 !important;
   box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12) !important;
 }
+
+/deep/ #merge-strategy-default .mat-radio-button.mat-accent.mat-radio-checked div.mat-radio-outer-circle {
+  border-color: #6d8ba5 !important;
+}
+
+/deep/ #merge-strategy-default .mat-radio-button.mat-accent div.mat-radio-inner-circle {
+  background-color: #6d8ba5 !important;
+}

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog.component.html
@@ -1,36 +1,46 @@
 <h1 mat-dialog-title>{{data.title}}</h1>
 <div id="step-dialog" mat-dialog-content class="content" [formGroup]="newStepForm">
-  <mat-form-field>
+
+  <mat-form-field class="ng-invalid">
     <mat-select id="step-type" class="type-select" placeholder="Step Type" (selectionChange)="stepTypeChange()" formControlName="type" required>
       <mat-option class="type-option" *ngFor="let option of stepOptions" [value]="option">{{option}}</mat-option>
     </mat-select>
   </mat-form-field>
+
+  <div *ngIf="newStepForm.value.type">
+
   <mat-form-field class="">
     <input id="step-name" matInput formControlName="name" placeholder="Name" required>
   </mat-form-field>
+
   <mat-form-field class="">
     <input id="step-description" matInput formControlName="description" placeholder="Description">
-    <mat-hint>Optional</mat-hint>
   </mat-form-field>
+
   <div *ngIf="newStepForm.value.type != 'ingest'">
-    <label>Source Type: </label>
+    <label class="source-type-label">
+      Source Type
+      <span *ngIf="newStepForm.value.type != 'custom'" class="source-req">*</span>
+    </label>
     <mat-radio-group id="step-source-type" [(ngModel)]="selectedSource" [ngModelOptions]="{standalone: true}">
       <mat-radio-button id="step-source-type-collection-radio" value="collection">Collection</mat-radio-button>
       <mat-radio-button id="step-source-type-query-radio" value="query">Query</mat-radio-button>
     </mat-radio-group>
   </div>
+
   <mat-form-field *ngIf="selectedSource === 'collection' && newStepForm.value.type != 'ingest'">
-    <mat-select id="step-source-collection" formControlName="sourceCollection" [(value)]="sourceCollection" class="type-select" placeholder="Source Collection">
+    <mat-select id="step-source-collection" formControlName="sourceCollection" [(value)]="sourceCollection" class="type-select" placeholder="Source Collection" [required]="newStepForm.value.type === 'mapping' || newStepForm.value.type === 'mastering'">
       <mat-option class="type-option" *ngFor="let collection of data.collections" [value]="collection">{{collection}}</mat-option>
     </mat-select>
   </mat-form-field>
 
-  <mat-form-field id="step-source-query" *ngIf="selectedSource === 'query'  && newStepForm.value.type != 'ingest'" >
-    <textarea matInput placeholder="Source Query" formControlName="sourceQuery"></textarea>
+  <mat-form-field id="step-source-query" *ngIf="selectedSource === 'query' && newStepForm.value.type != 'ingest'" >
+    <textarea matInput placeholder="Source Query" formControlName="sourceQuery" [required]="newStepForm.value.type === 'mapping' || newStepForm.value.type === 'mastering'"></textarea>
   </mat-form-field>
 
   <mat-form-field>
-    <mat-select id="step-target-entity" placeholder="Target Entity" formControlName="targetEntity">
+    <mat-select id="step-target-entity" placeholder="Target Entity" formControlName="targetEntity" [required]="newStepForm.value.type === 'mapping' || newStepForm.value.type === 'mastering'">
+      <mat-option [value]=""></mat-option>
       <mat-option *ngFor="let entity of data.entities" [value]="entity.name">{{entity.name}}</mat-option>
     </mat-select>
   </mat-form-field>
@@ -39,7 +49,7 @@
     <mat-expansion-panel>
       <mat-expansion-panel-header>
         <mat-panel-title>
-          Advanced Settings (optional)
+          Advanced Settings
         </mat-panel-title>
       </mat-expansion-panel-header>
 
@@ -55,8 +65,11 @@
       </mat-form-field>
     </mat-expansion-panel>
   </mat-accordion>
+
+  </div>
+
 </div>
 <div mat-dialog-actions class="bottom">
   <button id="step-cancel-btn" mat-raised-button color="primary" (click)="onNoClick()">CANCEL</button>
-  <button id="step-save-btn" mat-raised-button color="primary" (click)="onSave()">SAVE</button>
+  <button id="step-save-btn" mat-raised-button color="primary" (click)="onSave()" [disabled]="newStepForm.invalid">SAVE</button>
 </div>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog.component.scss
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog.component.scss
@@ -36,3 +36,21 @@ h1.mat-dialog-title {
   margin-right: -4px;
   justify-content: flex-end;
 }
+
+.source-type-label {
+  position: relative;
+  top: -3px;
+  .source-req {
+    font-size: 11px;
+    position: relative;
+    top: -2px;
+  }
+}
+
+/deep/ #step-source-type .mat-radio-button.mat-accent.mat-radio-checked div.mat-radio-outer-circle {
+  border-color: #6d8ba5 !important;
+}
+
+/deep/ #step-source-type .mat-radio-button.mat-accent div.mat-radio-inner-circle {
+  background-color: #6d8ba5 !important;
+}

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog.component.ts
@@ -6,6 +6,7 @@ import { Step } from '../../models/step.model';
 import { Options } from '../../models/step-options.model';
 import { Matching } from '../mastering/matching/matching.model';
 import { Merging } from '../mastering/merging/merging.model';
+import { NewStepDialogValidator } from '../../validators/new-step-dialog.validator';
 
 export interface DialogData {
   title: string;
@@ -43,15 +44,15 @@ export class NewStepDialogComponent implements OnInit {
       this.newStep = this.data.step;
     }
     this.newStepForm = this.formBuilder.group({
-      name: [this.data.step ? this.data.step.name : '', Validators.required],
       type: [this.data.step ? this.data.step.type : '', Validators.required],
+      name: [this.data.step ? this.data.step.name : '', Validators.required],
       description: [this.data.step ? this.data.step.description : ''],
       sourceQuery: [this.data.step ? this.data.step.options.sourceQuery : ''],
       sourceCollection: [this.data.step ? this.data.step.options.sourceCollection : ''],
       targetEntity: [this.data.step ? this.data.step.options.targetEntity : ''],
       sourceDatabase: [this.data.step ? this.data.step.sourceDatabase : ''],
       targetDatabase: [this.data.step ? this.data.step.targetDatabase : '']
-    });
+    }, { validators: NewStepDialogValidator });
     if (this.data.step && this.data.step.options.sourceCollection) {
       this.selectedSource = 'collection';
     } else if (this.data.step && this.data.step.options.sourceQuery) {
@@ -89,6 +90,13 @@ export class NewStepDialogComponent implements OnInit {
     }
   }
   onSave() {
+    // Validate
+    if (this.newStepForm.value.name === '' ||
+        this.newStepForm.value.type === '' ||
+        this.newStepForm.errors) {
+       return;
+    }
+    // Populate step and close dialog
     this.newStep.name = this.newStepForm.value.name;
     this.newStep.type = this.newStepForm.value.type;
     this.newStep.description = this.newStepForm.value.description;
@@ -103,10 +111,7 @@ export class NewStepDialogComponent implements OnInit {
     this.newStep.options.targetEntity = this.newStepForm.value.targetEntity;
     this.newStep.sourceDatabase = this.newStepForm.value.sourceDatabase;
     this.newStep.targetDatabase = this.newStepForm.value.targetDatabase;
-    // TODO more complete validation
-    if (this.newStep.name !== '' && this.newStep.type !== '') {
-      this.dialogRef.close(this.newStep);
-    }
+    this.dialogRef.close(this.newStep);
   }
 
 }

--- a/web/src/main/ui/app/components/flows-new/models/step.model.ts
+++ b/web/src/main/ui/app/components/flows-new/models/step.model.ts
@@ -7,6 +7,7 @@ export class Step {
   public description: string = '';
   public sourceDatabase: string = '';
   public targetDatabase: string;
+  public targetEntity: string;
   public language: string;
   public isValid: boolean = false;
   public version: string;

--- a/web/src/main/ui/app/components/flows-new/validators/new-step-dialog.validator.ts
+++ b/web/src/main/ui/app/components/flows-new/validators/new-step-dialog.validator.ts
@@ -1,0 +1,17 @@
+import { FormGroup } from '@angular/forms';
+import * as _ from "lodash";
+
+export function NewStepDialogValidator(group: FormGroup) {
+  let errors = {};
+  if (group.value.type === 'mapping' ||
+      group.value.type === 'mastering') {
+    if (!group.value.targetEntity) {
+      errors['noTargetEntity'] = true;
+    }
+    if (!group.value.sourceCollection &&
+        !group.value.sourceQuery) {
+      errors['noSource'] = true;
+    }
+  }
+  return _.isEmpty(errors) ? null : errors;
+}


### PR DESCRIPTION
Adds validation when creating or editing a step. This was required as part of the mapping step update because missing data (target entity, source information) leads to a broken config view for mapping:

- Updates to new-step-dialog to ensure complete data is submitted.
- Custom validator checks for target entity and source data.
- Save button in new-step-dialog is disabled until data is valid
- Mark required fields in new-step-dialog with asterisk (i.e. the radio buttons label).
- For a new step, present a Step Type menu in the dialog and display the rest of the inputs after the type has been selected.

Follows guidelines described in the spreadsheet:

https://project.marklogic.com/jira/browse/DHFPROD-2148

To test, create or edit a step and test that empty required fields cannot be submitted.