### PR TITLE
DHFPROD-2144: Remove tooltips and tooltip icons

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/custom/ui/custom-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/custom/ui/custom-ui.component.html
@@ -1,4 +1,9 @@
 <div layout-padding layout="column" class="custom-page">
+  <!-- <info-label
+    labelText="Modules Database"
+    tooltipPlacement="right"
+    tooltipText="Tooltip here about Module Database"
+  ></info-label> -->
   <div class="label">Modules Database</div>
   <mat-form-field class="read-only" appearance="outline" layout-fill>
     <input

--- a/web/src/main/ui/app/components/flows-new/edit-flow/custom/ui/custom-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/custom/ui/custom-ui.component.html
@@ -1,9 +1,5 @@
 <div layout-padding layout="column" class="custom-page">
-  <info-label
-    labelText="Modules Database"
-    tooltipPlacement="right"
-    tooltipText="Tooltip here about Module Database"
-  ></info-label>
+  <div class="label">Modules Database</div>
   <mat-form-field class="read-only" appearance="outline" layout-fill>
     <input
       id="custom-module"
@@ -12,11 +8,7 @@
       [readonly]="true"
     />
   </mat-form-field>
-  <info-label
-    labelText="Custom Module URI"
-    tooltipPlacement="right"
-    tooltipText="Tooltip here about Custom Module URI"
-  ></info-label>
+  <div class="label">Custom Module URI</div>
   <mat-form-field appearance="outline" >
     <input
       id="custom-module-uri"

--- a/web/src/main/ui/app/components/flows-new/edit-flow/custom/ui/custom-ui.component.scss
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/custom/ui/custom-ui.component.scss
@@ -19,3 +19,10 @@ mat-form-field {
     margin-right: 5px;
   }
 }
+
+div.label {
+  padding-top: 15px;
+  padding-bottom: 0px;
+  font-size: 20px;
+  font-weight: normal;
+}

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ingest/ui/ingest-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ingest/ui/ingest-ui.component.html
@@ -1,20 +1,13 @@
 <div layout-padding layout="column" class="ingest-page">
-    <info-label
-      [labelText]="config.inputFilePath.label"
-      tooltipPlacement="right"
-      [tooltipText]="config.inputFilePath.description"
-    ></info-label>
+
+    <div class="label">{{config.inputFilePath.label}}</div>
     <app-folder-browser
       [startPath]="step.options.input_file_path"
       (folderChosen)="changeFolder($event)"
       showFiles="true"
     ></app-folder-browser>
 
-    <info-label
-      [labelText]="config.fileTypes.label"
-      tooltipPlacement="right"
-      [tooltipText]="config.fileTypes.description"
-    ></info-label>
+    <div class="label">{{config.fileTypes.label}}</div>
     <mat-form-field layout-fill appearance="outline">
       <mat-select
         id="file_type_select"
@@ -31,11 +24,7 @@
       </mat-select>
     </mat-form-field>
 
-    <info-label
-      [labelText]="config.outputDocTypes.label"
-      tooltipPlacement="right"
-      [tooltipText]="config.outputDocTypes.description"
-    ></info-label>
+    <div class="label">{{config.outputDocTypes.label}}</div>
     <mat-form-field layout-fill appearance="outline">
       <mat-select
         id="doc_type_select"
@@ -52,14 +41,10 @@
       </mat-select>
     </mat-form-field>
 
-    <info-label
-      [labelText]="config.outputPermissions.label"
-      tooltipPlacement="right"
-      [tooltipText]="config.outputPermissions.description"
-    ></info-label>
+    <div class="label">{{config.outputPermissions.label}}</div>
     <mat-form-field layout-fill appearance="outline">
       <input
-        id="output_permissions" 
+        id="output_permissions"
         matInput
         [(ngModel)]="this.step.options.output_permissions"
         name="permissions"

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ingest/ui/ingest-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ingest/ui/ingest-ui.component.html
@@ -1,5 +1,11 @@
 <div layout-padding layout="column" class="ingest-page">
 
+    <!-- TODO reconsider adding tooltips for inputs
+    <info-label
+      [labelText]="config.inputFilePath.label"
+      tooltipPlacement="right"
+      [tooltipText]="config.inputFilePath.description"
+    ></info-label> -->
     <div class="label">{{config.inputFilePath.label}}</div>
     <app-folder-browser
       [startPath]="step.options.input_file_path"

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ingest/ui/ingest-ui.component.scss
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ingest/ui/ingest-ui.component.scss
@@ -5,3 +5,10 @@
 app-folder-browser {
   max-width: 700px;
 }
+
+div.label {
+  padding-top: 15px;
+  padding-bottom: 0px;
+  font-size: 20px;
+  font-weight: normal;
+}


### PR DESCRIPTION
Most of the current tooltips apply to MLCP command-line settings or are empty so we’re going to remove them for the initial release.