### PR TITLE
DHFPROD-1417: Updating flow tests to have correct permissions

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowManagerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowManagerTest.java
@@ -127,7 +127,7 @@ public class FlowManagerTest extends HubTestBase {
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME);
         DocumentMetadataHandle meta = new DocumentMetadataHandle();
         meta.getCollections().add("tester");
-        meta.getPermissions().add(getDataHubAdminConfig().getFlowDeveloperRoleName(), READ, UPDATE, EXECUTE);
+        meta.getPermissions().add(getDataHubAdminConfig().getFlowOperatorRoleName(), READ, UPDATE, EXECUTE);
         installStagingDoc("/employee1.xml", meta, "flow-manager-test/input/employee1.xml");
         installStagingDoc("/employee2.xml", meta, "flow-manager-test/input/employee2.xml");
     }
@@ -136,7 +136,7 @@ public class FlowManagerTest extends HubTestBase {
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME);
         DocumentMetadataHandle meta = new DocumentMetadataHandle();
         meta.getCollections().add("tester");
-        meta.getPermissions().add(getDataHubAdminConfig().getFlowDeveloperRoleName(), READ, UPDATE, EXECUTE);
+        meta.getPermissions().add(getDataHubAdminConfig().getFlowOperatorRoleName(), READ, UPDATE, EXECUTE);
         installFinalDoc("/employee1.xml", meta, "flow-manager-test/input/employee1.xml");
         installFinalDoc("/employee2.xml", meta, "flow-manager-test/input/employee2.xml");
     }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunnerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunnerTest.java
@@ -80,7 +80,7 @@ public class FlowRunnerTest extends HubTestBase {
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME);
         DocumentMetadataHandle meta = new DocumentMetadataHandle();
         meta.getCollections().add("tester");
-        meta.getPermissions().add(getDataHubAdminConfig().getFlowDeveloperRoleName(), READ, UPDATE, EXECUTE);
+        meta.getPermissions().add(getDataHubAdminConfig().getFlowOperatorRoleName(), READ, UPDATE, EXECUTE);
         installStagingDoc("/employee1.xml", meta, "flow-runner-test/input/employee1.xml");
         installStagingDoc("/employee2.xml", meta, "flow-runner-test/input/employee2.xml");
     }


### PR DESCRIPTION
Fixing the FlowManager and FlowRunner test as they were failing in DHS with flow-developer-role does not exist. On ingestion the permissions being set was that of flow-developer-role instead of flow-operator-role. Fixed that.