### PR TITLE
DHFPROD-2092: Handle duplicate default merge strategies

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/merge-strategies-ui.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/merge-strategies-ui.component.ts
@@ -77,7 +77,7 @@ export class MergeStrategiesUiComponent {
 
   openDefaultMergeStartegyPopup(strategy, index): void {
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      width: '350px',
+      width: '390px',
       data: {
         title: 'Update Default Merge Strategy',
         confirmationMessage: `A default merge strategy already exists. Do you want to replace it?`

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/merge-strategies-ui.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/merge-strategies-ui.component.ts
@@ -29,6 +29,7 @@ export class MergeStrategiesUiComponent {
   public valueFocus: object = {};
 
   public timestampOrig: string;
+  public mergeStrategyMod: MergeStrategy;
 
   constructor(
     public dialog: MatDialog
@@ -55,10 +56,39 @@ export class MergeStrategiesUiComponent {
         if (strategyToEdit) {
           console.log('updateStrategy');
           this.updateStrategy.emit({str: result.str, index: result.index});
-        }else{
-          console.log('createStrategy');
-          this.createStrategy.emit(result);
+        } else {
+          if (result.str.default === 'true' &&  (this.mergeStrategies.strategies && this.findStrategyIndex('default') > -1)) {
+            console.log('update existing default Strategy ??');
+            this.openDefaultMergeStartegyPopup(result.str, this.findStrategyIndex('default'));
+          } else {
+            console.log('createStrategy');
+            this.createStrategy.emit(result);
+          }
         }
+      }
+    });
+  }
+
+  findStrategyIndex(strategyName) {
+    return this.mergeStrategies.strategies.findIndex(s => {
+      return s.name === strategyName;
+    });
+  }
+
+  openDefaultMergeStartegyPopup(strategy, index): void {
+    const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
+      width: '350px',
+      data: {
+        title: 'Update Default Merge Strategy',
+        confirmationMessage: `A default merge strategy already exists. Do you want to replace it?`
+      }
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      console.log('result', result);
+      if (result) {
+        this.updateStrategy.emit({str: strategy, index: index});
+      } else {
+        return false;
       }
     });
   }


### PR DESCRIPTION
Recognize when user is creating a second merge strategy and have them confirm the new one will replace the old one.