### PR TITLE
DHFPROD-2198: Handle no-jobs case for UI display

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/stepper.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/stepper.component.html
@@ -21,14 +21,17 @@
           color="primary"
           (click)="this.stopClicked()">STOP</button>
         <div id="latest-job-info">
-          <a id="latest-job-status" class="capitalize" *ngIf="flow.latestJob" [routerLink]="['/jobs', flow.latestJob.id]">
-          {{flow.latestJob.status}}</a>
+          <a id="latest-job-status" *ngIf="flow.latestJob && flow.latestJob.id" [routerLink]="['/jobs', flow.latestJob.id]">
+          {{formatStatus(flow.latestJob.status)}}</a>
+          <span id="latest-job-status" *ngIf="!flow.latestJob || !flow.latestJob.id">
+          Never run</span>
           <div id="job-started-timestamp" *ngIf="flow.latestJob" class="text item">
             <span *ngIf="flow.latestJob.status === 'running'">Started {{friendlyDate(flow.latestJob.startTime)}}</span>
-            <span *ngIf="flow.latestJob.status !== 'running'">Ended {{friendlyDate(flow.latestJob.endTime)}}</span>
+            <span *ngIf="flow.latestJob.status !== null">Ended {{friendlyDate(flow.latestJob.endTime)}}</span>
           </div>
         </div>
-        <a id="view-jobs-btn" *ngIf="flow.latestJob" class="text item" [routerLink]="['/jobs']" [queryParams]="{flowName:flow.name}">View Jobs</a>
+        <a id="view-jobs-btn" *ngIf="flow.latestJob && flow.latestJob.id" class="text item view-jobs" [routerLink]="['/jobs']" [queryParams]="{flowName:flow.name}">View Jobs</a>
+        <span id="view-jobs-btn-disabled" *ngIf="!flow.latestJob || !flow.latestJob.id" class="text item view-jobs-disabled">View Jobs</span>
         <div class="icon-container">
           <mat-icon id="flow-menu" class="flow-menu-icon item" [matMenuTriggerFor]="flowMenu">more_vert</mat-icon>
           <mat-icon id="flow-expand-collapse-btn" class="flow-menu-icon item" (click)="this.toggleBody()">{{ this.showBody ? 'expand_less' : 'expand_more' }}</mat-icon>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/stepper.component.scss
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/stepper.component.scss
@@ -230,16 +230,16 @@ mat-icon {
 }
 
 #latest-job-info {
-  width: 313px;
+  width: 335px;
   #latest-job-status,
   #job-started-timestamp {
     display: inline-block;
   }
   #latest-job-status {
-    padding: 0 15px;
+    padding: 0 10px;
   }
 }
 
-.capitalize:first-letter {
-   text-transform: capitalize;
+.view-jobs-disabled {
+  color: #ccc;
 }

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/stepper.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/stepper.component.ts
@@ -3,6 +3,7 @@ import { CdkStepper } from '@angular/cdk/stepper';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import * as moment from 'moment';
 import { StepType } from '../../models/step.model';
+import * as _ from "lodash";
 
 @Component({
   selector: 'app-stepper',
@@ -78,5 +79,8 @@ export class StepperComponent extends CdkStepper implements OnChanges, AfterCont
   }
   friendlyDate(dt): string {
     return (dt) ? moment(dt).fromNow() : '';
+  }
+  formatStatus(status):string {
+    return _.capitalize(status.replace(/_/g,' '));
   }
 }

--- a/web/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.html
@@ -61,9 +61,9 @@
         <!-- Status Column -->
         <ng-container matColumnDef="status">
           <mat-header-cell id="flow-status-sort-btn" *matHeaderCellDef mat-sort-header>Status</mat-header-cell>
-          <mat-cell class="flow-status capitalize" *matCellDef="let flow">
-            <span class="capitalize" *ngIf="flow.latestJob">{{flow.status}}</span>
-            <span class="capitalize" *ngIf="!flow.latestJob">Never run</span>
+          <mat-cell class="flow-status" *matCellDef="let flow">
+            <span *ngIf="flow.latestJob">{{formatStatus(flow.status)}}</span>
+            <span *ngIf="!flow.latestJob">Never run</span>
           </mat-cell>
         </ng-container>
 
@@ -92,7 +92,7 @@
         <ng-container matColumnDef="docsCommitted">
           <mat-header-cell id="flow-docs-committed-sort-btn" *matHeaderCellDef mat-sort-header>Committed</mat-header-cell>
           <mat-cell class="flow-docs-committed" *matCellDef="let flow" fxHide fxShow.gt-md>
-            <a *ngIf="flow.latestJob && flow.latestJob.successfulEvents > 0" [routerLink]="['/browse']" [queryParams]="{Collection:flow.latestJob.id}">{{flow.latestJob.successfulEvents | number}}</a>
+            <a *ngIf="flow.latestJob && flow.latestJob.id && flow.latestJob.successfulEvents > 0" [routerLink]="['/browse']" [queryParams]="{Collection:flow.latestJob.id}">{{flow.latestJob.successfulEvents | number}}</a>
             <span *ngIf="flow.latestJob && flow.latestJob.successfulEvents <= 0">{{flow.latestJob.successfulEvents | number}}</span>
           </mat-cell>
         </ng-container>
@@ -101,7 +101,7 @@
         <ng-container matColumnDef="docsFailed">
           <mat-header-cell id="flow-docs-failed-sort-btn" *matHeaderCellDef mat-sort-header>Failed</mat-header-cell>
           <mat-cell class="flow-docs-failed" *matCellDef="let flow">
-            <a *ngIf="flow.latestJob && flow.latestJob.failedEvents > 0" [routerLink]="">
+            <a *ngIf="flow.latestJob && flow.latestJob.id && flow.latestJob.failedEvents > 0" [routerLink]="">
               {{flow.latestJob.failedEvents | number}}
             </a>
             <span *ngIf="flow.latestJob && flow.latestJob.failedEvents <= 0">

--- a/web/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.scss
+++ b/web/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.scss
@@ -210,10 +210,6 @@ button {
   cursor: pointer;
 }
 
-.capitalize:first-letter {
-   text-transform: capitalize;
-}
-
 /deep/ #flow-last-job-finished-sort-btn.mat-header-cell,
 /deep/ .mat-cell.flow-last-job-finished {
   padding-left: 30px;

--- a/web/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.ts
+++ b/web/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.ts
@@ -4,6 +4,7 @@ import {ConfirmationDialogComponent} from "../../../common";
 import {FlowSettingsDialogComponent} from "./flow-settings-dialog.component";
 import {Flow} from "../../models/flow.model";
 import * as moment from 'moment';
+import * as _ from "lodash";
 import {RunFlowDialogComponent} from "../../edit-flow/ui/run-flow-dialog.component";
 
 @Component({
@@ -105,7 +106,9 @@ export class ManageFlowsUiComponent implements OnInit, AfterViewInit {
   }
 
   friendlyDate(dt): string {
-    return (dt) ? moment(dt).fromNow() : '';
+    return (dt) ? _.capitalize(moment(dt).fromNow()) : '';
   }
-
+  formatStatus(status):string {
+    return _.capitalize(status.replace(/_/g,' '));
+  }
 }


### PR DESCRIPTION
Edit Flow view when no jobs:
- Display gray “View Jobs” text (no link)
- Don’t display timestamp or timestamp prefix
- Display “Never run” as status

Manage Flows view:
- Display “Never run” as status

Generally:
- Display status with spaces (convert underscores) and capitalization of first word, e.g.: “Finished with errors”
- Display friendly timestamps with spaces and capitalization of first word, e.g.: “An hour ago”
- Handle linking correctly by checking for null properties in latestJob object