### PR TITLE
DHFPROD-2176: Manage mappings separately from mapping steps

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog-ui.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog-ui.component.ts
@@ -53,12 +53,11 @@ export class NewStepDialogUiComponent implements OnInit {
       sourceDatabase: [this.step ? this.step.sourceDatabase : ''],
       targetDatabase: [this.step ? this.step.targetDatabase : '']
     }, { validators: NewStepDialogValidator });
-    // This no longer works since there is no source collection parameter
-    // if (this.step && this.step.options.sourceCollection) {
-    //   this.selectedSource = 'collection';
-    // } else if (this.step && this.step.options.sourceQuery) {
-    //   this.selectedSource = 'query';
-    // }
+    if (this.step && this.step.options.sourceCollection) {
+      this.selectedSource = 'collection';
+    } else if (this.step && this.step.options.sourceQuery) {
+      this.selectedSource = 'query';
+    }
   }
   getNameErrorMessage() {
     const errorCodes = [
@@ -118,7 +117,7 @@ export class NewStepDialogUiComponent implements OnInit {
       this.newStep.options.sourceQuery = this.newStepForm.value.sourceQuery;
       this.newStep.options.sourceCollection = '';
     } else {
-      const ctsUri = `cts.uris(null, null, cts.collectionQuery(${this.newStepForm.value.sourceCollection}))`;
+      const ctsUri = `cts.uris(null, null, cts.collectionQuery([\'${this.newStepForm.value.sourceCollection}\']))`;
       this.newStep.options.sourceQuery = ctsUri;
       this.newStep.options.sourceCollection = this.newStepForm.value.sourceCollection;
     }

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/step.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/step.component.html
@@ -20,6 +20,7 @@
       <div id="step-type-mapping-container" *ngIf="step.stepDefinitionType === stepType.MAPPING">
         <app-mapping
           [step]="step"
+          [flow]="flow"
           (saveStep)="saveStep($event)"
         ></app-mapping>
       </div>

--- a/web/src/main/ui/app/components/flows-new/services/manage-flows.service.ts
+++ b/web/src/main/ui/app/components/flows-new/services/manage-flows.service.ts
@@ -77,4 +77,15 @@ export class ManageFlowsService {
     console.log(`POST api/flows/${flowId}/stop`);
     return this.http.post(`api/flows/${flowId}/stop`, {});
   }
+
+  saveMap(mapName, map) {
+    let parsedMap = JSON.parse(map);
+    return this.http.post('api/current-project/mappings/' + mapName, parsedMap);
+  }
+  getMap(mapName) {
+    return this.http.get('api/current-project/mappings/' + mapName);
+  }
+  deleteMap(mapName) {
+    return this.http.delete('api/current-project/mappings/' + mapName);
+  }
 }


### PR DESCRIPTION
Mapping information is being stored separately from the mapping step it is associated with. In the step, a reference to the mapping is stored in a "mapping" subobject. The following changes support this:

- Upon mapping step creation, save new mapping and then update step
- Upon mapping update (e.g., menu selection), save updated mapping and update step
- As part of initialization in mapping component, load map from mapping endpoint
- Get connection info for mapping UI from mapping artifact instead of step
- Fix mapping source collection handling in new-step-dialog

Note: I was able to run the mapping step successfully with these updates, but only sporadically.