### PR TITLE
DHFPROD-2217: Fix latest-job timestamp display

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/stepper.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/stepper.component.html
@@ -26,8 +26,8 @@
           <span id="latest-job-status" *ngIf="!flow.latestJob || !flow.latestJob.id">
           Never run</span>
           <div id="job-started-timestamp" *ngIf="flow.latestJob" class="text item">
-            <span *ngIf="status[0] === 'running'">Started {{friendlyDate(flow.latestJob.startTime)}}</span>
-            <span *ngIf="status[0] !== 'running'">Ended {{friendlyDate(flow.latestJob.endTime)}}</span>
+            <span *ngIf="flow.latestJob.status === 'running'">Started {{friendlyDate(flow.latestJob.startTime)}}</span>
+            <span *ngIf="flow.latestJob.status !== null">Ended {{friendlyDate(flow.latestJob.endTime)}}</span>
           </div>
         </div>
         <a id="view-jobs-btn" *ngIf="flow.latestJob && flow.latestJob.id" class="text item view-jobs" [routerLink]="['/jobs']" [queryParams]="{flowName:flow.name}">View Jobs</a>


### PR DESCRIPTION
In stepper header, don’t show “Ended” prefix when there is no timestamp to display.