### PR TITLE
DHFPROD-2103: Mastering validation

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.html
@@ -13,7 +13,7 @@
   </mat-form-field>
 
   <mat-form-field *ngIf="selectedType !== 'reduce'" layout-fill>
-    <mat-select id="match-option-property" placeholder="Property to Match" formControlName="propertyName" [(value)]="propertyName">
+    <mat-select id="match-option-property" placeholder="Property to Match" formControlName="propertyName" [(value)]="propertyName" required>
       <mat-option class="type-option" *ngFor="let prop of data.entityProps" [value]="prop.name">{{prop.name}}</mat-option>
     </mat-select>
   </mat-form-field>
@@ -44,7 +44,8 @@
 
   <mat-form-field *ngIf="selectedType !== 'zip'" layout-fill>
     <mat-label>Weight</mat-label>
-    <input id="match-option-weight" matInput formControlName="weight"/>
+    <input id="match-option-weight" matInput formControlName="weight" required />
+    <mat-error id="step-name-error" *ngIf="form.get('weight').invalid">A number is required</mat-error>
   </mat-form-field>
 
   <div *ngIf="selectedType === 'synonym'">
@@ -101,6 +102,6 @@
 </div>
 
 <mat-dialog-actions align="end" class="bottom">
-  <button mat-raised-button color="primary" id="match-option-cancel-btn" mat-button (click)="onCancel()">CANCEL</button>
-  <button mat-raised-button color="primary" id="match-option-save-btn" mat-button (click)="onSave()">{{getSubmitButtonTitle()}}</button>
+  <button mat-raised-button color="primary" id="match-option-cancel-btn" (click)="onCancel()">CANCEL</button>
+  <button mat-raised-button color="primary" id="match-option-save-btn" [disabled]="!form.valid" (click)="onSave()">{{getSubmitButtonTitle()}}</button>
 </mat-dialog-actions>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.html
@@ -13,7 +13,7 @@
   </mat-form-field>
 
   <mat-form-field *ngIf="selectedType !== 'reduce'" layout-fill>
-    <mat-select id="match-option-property" placeholder="Property to Match" formControlName="propertyName" [(value)]="propertyName" required>
+    <mat-select id="match-option-property" placeholder="Property to Match *" formControlName="propertyName" [(value)]="propertyName">
       <mat-option class="type-option" *ngFor="let prop of data.entityProps" [value]="prop.name">{{prop.name}}</mat-option>
     </mat-select>
   </mat-form-field>
@@ -31,7 +31,7 @@
       *ngFor="let prop of this.propertiesReduce.controls; let i = index;">
       <div [formGroupName]="i" class="prop-group">
         <mat-form-field layout-fill>
-          <mat-select class="match-option-property-reduce" placeholder="Property Name" formControlName="name">
+          <mat-select class="match-option-property-reduce" placeholder="Property Name{{(i === 0) ? ' *' : ''}}" formControlName="name">
             <mat-option class="type-option" *ngFor="let prop of data.entityProps" [value]="prop.name">{{prop.name}}</mat-option>
           </mat-select>
         </mat-form-field>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.html
@@ -45,7 +45,7 @@
   <mat-form-field *ngIf="selectedType !== 'zip'" layout-fill>
     <mat-label>Weight</mat-label>
     <input id="match-option-weight" matInput formControlName="weight" required />
-    <mat-error id="step-name-error" *ngIf="form.get('weight').invalid">A number is required</mat-error>
+    <mat-error id="match-option-weight-error" *ngIf="form.get('weight').invalid">A number is required</mat-error>
   </mat-form-field>
 
   <div *ngIf="selectedType === 'synonym'">

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.ts
@@ -3,6 +3,7 @@ import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
 import { MatchOption } from "../match-options.model";
 import { FormBuilder, FormGroup, FormArray, FormControl, Validators } from "@angular/forms";
 import { WeightValidator } from '../../../../validators/weight.validator';
+import { AddMatchOptionValidator } from '../../../../validators/add-match-option.validator';
 import { forOwn } from 'lodash';
 
 export interface DialogData {
@@ -30,8 +31,7 @@ export class AddMatchOptionDialogComponent {
 
   ngOnInit() {
     this.form = this.fb.group({
-      propertyName: [this.data.option ? this.data.option.propertyName[0] : '',
-        [Validators.required]],
+      propertyName: [this.data.option ? this.data.option.propertyName[0] : ''],
       matchType: [this.data.option ? this.data.option.matchType : 'exact'],
       weight: [this.data.option ? this.data.option.weight : '',
         [Validators.required, WeightValidator]],
@@ -47,7 +47,7 @@ export class AddMatchOptionDialogComponent {
       customNs: [this.data.option ? this.data.option.customNs : ''],
       index: this.data.index,
       entityProps:  [this.data.entityProps ? this.data.entityProps : []]
-    })
+    }, { validators: AddMatchOptionValidator })
     this.selectedType = (this.data.option && this.data.option.matchType) ?
       this.data.option.matchType : 'exact';
     this.form.setControl('propertiesReduce', this.createProps());

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.ts
@@ -2,7 +2,8 @@ import { Component, Inject, OnInit } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
 import { MatchOption } from "../match-options.model";
 import { FormBuilder, FormGroup, FormArray, FormControl, Validators } from "@angular/forms";
-import {forOwn} from 'lodash';
+import { WeightValidator } from '../../../../validators/weight.validator';
+import { forOwn } from 'lodash';
 
 export interface DialogData {
   stepName: string;
@@ -29,9 +30,11 @@ export class AddMatchOptionDialogComponent {
 
   ngOnInit() {
     this.form = this.fb.group({
-      propertyName: [this.data.option ? this.data.option.propertyName[0] : ''],
+      propertyName: [this.data.option ? this.data.option.propertyName[0] : '',
+        [Validators.required]],
       matchType: [this.data.option ? this.data.option.matchType : 'exact'],
-      weight: [this.data.option ? this.data.option.weight : ''],
+      weight: [this.data.option ? this.data.option.weight : '',
+        [Validators.required, WeightValidator]],
       thesaurus: [this.data.option ? this.data.option.thesaurus : ''],
       filter: [this.data.option ? this.data.option.filter : ''],
       dictionary: [this.data.option ? this.data.option.dictionary : ''],

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-threshold-dialog.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-threshold-dialog.component.html
@@ -7,7 +7,7 @@
   <mat-form-field layout-fill>
     <mat-label>Weight</mat-label>
     <input id="match-threshold-weight" matInput formControlName="above" required />
-    <mat-error id="step-name-error" *ngIf="form.get('above').invalid">A number is required</mat-error>
+    <mat-error id="match-threshold-weight-error" *ngIf="form.get('above').invalid">A number is required</mat-error>
   </mat-form-field>
   <mat-form-field layout-fill>
     <mat-select id="match-threshold-action" placeholder="Action" formControlName="action" [(value)]="selectedAction" required>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-threshold-dialog.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-threshold-dialog.component.html
@@ -2,14 +2,15 @@
 <div id="match-threshold-dialog" mat-dialog-content [formGroup]="form" class="content">
   <mat-form-field layout-fill>
     <mat-label>Name</mat-label>
-    <input id="match-threshold-name" matInput formControlName="label"/>
+    <input id="match-threshold-name" matInput formControlName="label" required />
   </mat-form-field>
   <mat-form-field layout-fill>
     <mat-label>Weight</mat-label>
-    <input id="match-threshold-weight" matInput formControlName="above"/>
+    <input id="match-threshold-weight" matInput formControlName="above" required />
+    <mat-error id="step-name-error" *ngIf="form.get('above').invalid">A number is required</mat-error>
   </mat-form-field>
   <mat-form-field layout-fill>
-    <mat-select id="match-threshold-action" placeholder="Action" formControlName="action" [(value)]="selectedAction">
+    <mat-select id="match-threshold-action" placeholder="Action" formControlName="action" [(value)]="selectedAction" required>
       <mat-option value="merge">Merge</mat-option>
       <mat-option value="notify">Notify</mat-option>
       <mat-option value="custom">Custom</mat-option>
@@ -32,6 +33,6 @@
 </div>
 
 <mat-dialog-actions align="end" class="bottom">
-  <button mat-raised-button color="primary" id="match-threshold-cancel-btn" mat-button (click)="onCancel()">CANCEL</button>
-  <button mat-raised-button color="primary" id="match-threshold-save-btn" mat-button (click)="onSave()">{{getSubmitButtonTitle()}}</button>
+  <button mat-raised-button color="primary" id="match-threshold-cancel-btn" (click)="onCancel()">CANCEL</button>
+  <button mat-raised-button color="primary" id="match-threshold-save-btn" [disabled]="!form.valid" (click)="onSave()">{{getSubmitButtonTitle()}}</button>
 </mat-dialog-actions>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-threshold-dialog.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-threshold-dialog.component.ts
@@ -2,6 +2,7 @@ import { Component, Inject, OnInit } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
 import { MatchThreshold } from "../match-thresholds.model";
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
+import { WeightValidator } from '../../../../validators/weight.validator';
 
 export interface DialogData {
   stepName: string;
@@ -26,9 +27,12 @@ export class AddMatchThresholdDialogComponent {
 
   ngOnInit() {
     this.form = this.fb.group({
-      label: [this.data.option ? this.data.option.label : ''],
-      above: [this.data.option ? this.data.option.above : ''],
-      action: [this.data.option ? this.data.option.action : ''],
+      label: [this.data.option ? this.data.option.label : '',
+        [Validators.required]],
+      above: [this.data.option ? this.data.option.above : '',
+        [Validators.required, WeightValidator]],
+      action: [this.data.option ? this.data.option.action : '',
+        [Validators.required]],
       customUri: [this.data.option ? this.data.option.customUri : ''],
       customFunction: [this.data.option ? this.data.option.customFunction : ''],
       customNs: [this.data.option ? this.data.option.customNs : ''],

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-collection-dialog.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-collection-dialog.component.ts
@@ -2,6 +2,7 @@ import { Component, Inject, OnInit } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
 import { MergeCollection } from "../merge-collections.model";
 import { FormBuilder, FormGroup, FormArray, FormControl, Validators } from "@angular/forms";
+import { WeightValidator } from '../../../../validators/weight.validator';
 import { forOwn } from 'lodash';
 
 export interface DialogData {

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-collection-dialog.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-collection-dialog.component.ts
@@ -31,7 +31,7 @@ export class AddMergeCollectionDialogComponent {
 
   ngOnInit() {
     this.form = this.fb.group({
-      event: [this.data.collection ? this.data.collection.event : ''],
+      event: [this.data.collection ? this.data.collection.event : 'onMerge'],
       add: [this.data.collection ? this.data.collection.add : ''],
       remove: [this.data.collection ? this.data.collection.remove : ''],
       set: [this.data.collection ? this.data.collection.set : ''],

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-option-dialog.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-option-dialog.component.html
@@ -18,6 +18,7 @@
   <mat-form-field *ngIf="selectedType !== 'strategy' && selectedType !== 'custom'" layout-fill>
     <mat-label>Max Values</mat-label>
     <input id="merge-option-max-values" matInput formControlName="maxValues"/>
+    <mat-error id="merge-option-max-values-error" *ngIf="form.get('maxValues').invalid">Enter a number</mat-error>
   </mat-form-field>
 
   <mat-form-field *ngIf="selectedType !== 'strategy' && selectedType !== 'custom'" layout-fill>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-option-dialog.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-option-dialog.component.html
@@ -24,6 +24,7 @@
   <mat-form-field *ngIf="selectedType !== 'strategy' && selectedType !== 'custom'" layout-fill>
     <mat-label>Max Sources</mat-label>
     <input id="merge-option-max-sources" matInput formControlName="maxSources"/>
+    <mat-error id="merge-option-max-sources-error" *ngIf="form.get('maxSources').invalid">Enter a number</mat-error>
   </mat-form-field>
 
   <div *ngIf="selectedType !== 'strategy' && selectedType !== 'custom'" id="source-weights">
@@ -44,6 +45,8 @@
         <mat-form-field>
           <mat-label>Weight</mat-label>
           <input [class]="'source-weights-weight-' + i" matInput formControlName="weight"/>
+          <!-- TODO validate weights in SourceWeight options -->
+          <mat-error id="'source-weights-weight-' + i + '-error" *ngIf="sourceWeights.controls[i].get('weight').invalid">Enter a number</mat-error>
         </mat-form-field>
         <button [id]="'remove-merge-option-source-weight-btn-' + i" mat-icon-button (click)="onRemoveSourceWeight(i)">
           <mat-icon>remove_circle</mat-icon>
@@ -55,6 +58,7 @@
   <mat-form-field *ngIf="selectedType !== 'strategy' && selectedType !== 'custom'" layout-fill>
     <mat-label>Length Weight</mat-label>
     <input id="merge-option-length" matInput formControlName="length"/>
+    <mat-error id="merge-option-length-error" *ngIf="form.get('length').invalid">Enter a number</mat-error>
   </mat-form-field>
 
   <mat-form-field *ngIf="selectedType === 'strategy'"  layout-fill>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-option-dialog.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-option-dialog.component.html
@@ -10,7 +10,7 @@
   </mat-form-field>
 
   <mat-form-field layout-fill>
-    <mat-select id="merge-option-property" placeholder="Property to Merge" formControlName="propertyName" [(value)]="propertyName">
+    <mat-select id="merge-option-property" placeholder="Property to Merge" formControlName="propertyName" [(value)]="propertyName" required>
       <mat-option [id]="'merge-option-property-' + prop.name" *ngFor="let prop of data.entityProps" [value]="prop.name">{{prop.name}}</mat-option>
     </mat-select>
   </mat-form-field>
@@ -82,6 +82,6 @@
 </div>
 
 <mat-dialog-actions align="end" class="bottom">
-  <button mat-raised-button color="primary" id="merge-option-cancel-btn" mat-button (click)="onCancel()">CANCEL</button>
-  <button mat-raised-button color="primary" id="merge-option-save-btn" mat-button (click)="onSave()">{{getSubmitButtonTitle()}}</button>
+  <button mat-raised-button color="primary" id="merge-option-cancel-btn" (click)="onCancel()">CANCEL</button>
+  <button mat-raised-button color="primary" id="merge-option-save-btn" [disabled]="!form.valid" (click)="onSave()">{{getSubmitButtonTitle()}}</button>
 </mat-dialog-actions>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-option-dialog.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-option-dialog.component.ts
@@ -2,6 +2,7 @@ import { Component, Inject, OnInit } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
 import { MergeOption } from "../merge-options.model";
 import { FormBuilder, FormGroup, FormArray, FormControl, Validators } from "@angular/forms";
+import { WeightValidator } from '../../../../validators/weight.validator';
 import { forOwn } from 'lodash';
 
 export interface DialogData {
@@ -36,7 +37,8 @@ export class AddMergeOptionDialogComponent {
         [Validators.required]],
       mergeType: [this.data.option ? this.data.option.mergeType : 'standard'],
       algorithmRef: [this.data.option ? this.data.option.algorithmRef : ''],
-      maxValues: [this.data.option ? this.data.option.maxValues : ''],
+      maxValues: [this.data.option ? this.data.option.maxValues : '',
+        [WeightValidator]],
       maxSources: [this.data.option ? this.data.option.maxSources : ''],
       length: [(this.data.option && this.data.option.length) ? this.data.option.length.weight : ''],
       strategy: [this.data.option ? this.data.option.strategy : ''],

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-option-dialog.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-option-dialog.component.ts
@@ -32,8 +32,9 @@ export class AddMergeOptionDialogComponent {
   ngOnInit() {
     console.log('this.data.option', this.data.option);
     this.form = this.fb.group({
-      propertyName: [this.data.option ? this.data.option.propertyName : ''],
-      mergeType: [this.data.option ? this.data.option.mergeType : 'exact'],
+      propertyName: [this.data.option ? this.data.option.propertyName : '',
+        [Validators.required]],
+      mergeType: [this.data.option ? this.data.option.mergeType : 'standard'],
       algorithmRef: [this.data.option ? this.data.option.algorithmRef : ''],
       maxValues: [this.data.option ? this.data.option.maxValues : ''],
       maxSources: [this.data.option ? this.data.option.maxSources : ''],

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-option-dialog.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-option-dialog.component.ts
@@ -3,6 +3,7 @@ import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
 import { MergeOption } from "../merge-options.model";
 import { FormBuilder, FormGroup, FormArray, FormControl, Validators } from "@angular/forms";
 import { WeightValidator } from '../../../../validators/weight.validator';
+import { SourceWeightValidator } from '../../../../validators/source-weight.validator';
 import { forOwn } from 'lodash';
 
 export interface DialogData {
@@ -39,8 +40,10 @@ export class AddMergeOptionDialogComponent {
       algorithmRef: [this.data.option ? this.data.option.algorithmRef : ''],
       maxValues: [this.data.option ? this.data.option.maxValues : '',
         [WeightValidator]],
-      maxSources: [this.data.option ? this.data.option.maxSources : ''],
-      length: [(this.data.option && this.data.option.length) ? this.data.option.length.weight : ''],
+      maxSources: [this.data.option ? this.data.option.maxSources : '',
+        [WeightValidator]],
+      length: [(this.data.option && this.data.option.length) ? this.data.option.length.weight : '',
+        [WeightValidator]],
       strategy: [this.data.option ? this.data.option.strategy : ''],
       customUri: [this.data.option ? this.data.option.customUri : ''],
       customFunction: [this.data.option ? this.data.option.customFunction : ''],
@@ -73,7 +76,7 @@ export class AddMergeOptionDialogComponent {
     return this.fb.group({
       source: source,
       weight: weight
-    });
+    }, { validators: SourceWeightValidator });
   }
 
   onAddSourceWeight() {

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-strategy-dialog.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-strategy-dialog.component.html
@@ -10,7 +10,10 @@
   </div>
 
   <mat-form-field *ngIf="selectedDefault === 'false'" layout-fill>
-    <mat-label>Name</mat-label>
+    <mat-label>
+      Name
+      <span class="name-req">*</span>
+    </mat-label>
     <input id="merge-strategy-name" matInput formControlName="name"/>
   </mat-form-field>
 
@@ -58,6 +61,6 @@
 </div>
 
 <mat-dialog-actions align="end" class="bottom">
-  <button mat-raised-button color="primary" id="merge-strategy-cancel-btn" mat-button (click)="onCancel()">CANCEL</button>
-  <button mat-raised-button color="primary" id="merge-strategy-save-btn" mat-button (click)="onSave()">{{getSubmitButtonTitle()}}</button>
+  <button mat-raised-button color="primary" id="merge-strategy-cancel-btn" (click)="onCancel()">CANCEL</button>
+  <button mat-raised-button color="primary" id="merge-strategy-save-btn" [disabled]="!form.valid" (click)="onSave()">{{getSubmitButtonTitle()}}</button>
 </mat-dialog-actions>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-strategy-dialog.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-strategy-dialog.component.html
@@ -20,11 +20,13 @@
   <mat-form-field layout-fill>
     <mat-label>Max Values</mat-label>
     <input id="merge-strategy-max-values" matInput formControlName="maxValues"/>
+    <mat-error id="merge-strategy-max-values-error" *ngIf="form.get('maxValues').invalid">Enter a number</mat-error>
   </mat-form-field>
 
   <mat-form-field layout-fill>
     <mat-label>Max Sources</mat-label>
     <input id="merge-strategy-max-sources" matInput formControlName="maxSources"/>
+    <mat-error id="merge-strategy-max-sources-error" *ngIf="form.get('maxSources').invalid">Enter a number</mat-error>
   </mat-form-field>
 
   <div id="merge-strategy-source-weights-container">
@@ -43,6 +45,7 @@
         </mat-form-field>
         <mat-icon></mat-icon>
         <mat-form-field>
+          <!-- TODO validate weights in SourceWeight options -->
           <mat-label>Weight</mat-label>
           <input [class]="'source-weights-weight-' + i" matInput formControlName="weight"/>
         </mat-form-field>
@@ -56,6 +59,7 @@
   <mat-form-field layout-fill>
     <mat-label>Length Weight</mat-label>
     <input id="merge-strategy-length" matInput formControlName="length"/>
+    <mat-error id="merge-strategy-length-error" *ngIf="form.get('length').invalid">Enter a number</mat-error>
   </mat-form-field>
 
 </div>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-strategy-dialog.component.scss
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-strategy-dialog.component.scss
@@ -41,3 +41,9 @@ mat-radio-group {
 mat-radio-button {
     margin-left: 10px;
 }
+
+.name-req {
+  font-size: 11px;
+  position: relative;
+  top: -2px;
+}

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-strategy-dialog.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-strategy-dialog.component.ts
@@ -3,6 +3,8 @@ import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
 import { MergeStrategy } from "../merge-strategies.model";
 import { FormBuilder, FormGroup, FormArray, FormControl, Validators } from "@angular/forms";
 import { AddMergeStrategyValidator } from '../../../../validators/add-merge-strategy.validator';
+import { WeightValidator } from '../../../../validators/weight.validator';
+import { SourceWeightValidator } from '../../../../validators/source-weight.validator';
 import { forOwn } from 'lodash';
 
 export interface DialogData {
@@ -35,9 +37,12 @@ export class AddMergeStrategyDialogComponent {
       name: [this.data.strategy && !this.data.strategy.default ? this.data.strategy.name : ''],
       default: [this.data.strategy && this.data.strategy.default ? 'true' : 'false'],
       algorithmRef: [this.data.strategy ? this.data.strategy.algorithmRef : ''],
-      maxValues: [this.data.strategy ? this.data.strategy.maxValues : ''],
-      maxSources: [this.data.strategy ? this.data.strategy.maxSources : ''],
-      length: [(this.data.strategy && this.data.strategy.length) ? this.data.strategy.length.weight : ''],
+      maxValues: [this.data.strategy ? this.data.strategy.maxValues : '',
+        [WeightValidator]],
+      maxSources: [this.data.strategy ? this.data.strategy.maxSources : '',
+        [WeightValidator]],
+      length: [(this.data.strategy && this.data.strategy.length) ? this.data.strategy.length.weight : '',
+        [WeightValidator]],
       customUri: [this.data.strategy ? this.data.strategy.customUri : ''],
       customFunction: [this.data.strategy ? this.data.strategy.customFunction : ''],
       index: this.data.index
@@ -64,7 +69,7 @@ export class AddMergeStrategyDialogComponent {
     return this.fb.group({
       source: source,
       weight: weight
-    });
+    }, { validators: SourceWeightValidator });
   }
 
   onAddSourceWeight() {

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-strategy-dialog.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/add-merge-strategy-dialog.component.ts
@@ -2,6 +2,7 @@ import { Component, Inject, OnInit } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
 import { MergeStrategy } from "../merge-strategies.model";
 import { FormBuilder, FormGroup, FormArray, FormControl, Validators } from "@angular/forms";
+import { AddMergeStrategyValidator } from '../../../../validators/add-merge-strategy.validator';
 import { forOwn } from 'lodash';
 
 export interface DialogData {
@@ -40,7 +41,7 @@ export class AddMergeStrategyDialogComponent {
       customUri: [this.data.strategy ? this.data.strategy.customUri : ''],
       customFunction: [this.data.strategy ? this.data.strategy.customFunction : ''],
       index: this.data.index
-    })
+    }, { validators: AddMergeStrategyValidator })
     this.selectedDefault = (this.data.strategy && this.data.strategy.default) ?
       'true' : 'false';
     this.form.setControl('sourceWeights', this.createSourceWeights());

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog-ui.component.html
@@ -14,7 +14,6 @@
   </mat-form-field>
   <mat-form-field class="">
     <input id="step-description" matInput formControlName="description" placeholder="Description">
-    <mat-hint>Optional</mat-hint>
   </mat-form-field>
   <div *ngIf="newStepForm.value.stepDefinitionType !== stepType.INGESTION">
     <label>Source Type: </label>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog-ui.component.html
@@ -4,7 +4,7 @@
   <mat-form-field class="ng-invalid">
     <mat-select id="step-type" class="type-select" placeholder="Step Type" (selectionChange)="stepTypeChange()"
                 formControlName="stepDefinitionType" required>
-      <mat-option class="type-option" *ngFor="let option of stepOptions" [value]="option">{{option}}</mat-option>
+      <mat-option class="type-option" *ngFor="let option of stepOptions" [value]="option">{{capitalFirstLetter(option)}}</mat-option>
     </mat-select>
   </mat-form-field>
   <div *ngIf="newStepForm.value.stepDefinitionType">

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog-ui.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog-ui.component.ts
@@ -65,9 +65,9 @@ export class NewStepDialogUiComponent implements OnInit {
   }
   getNameErrorMessage() {
     const errorCodes = [
-      {code: 'required', message: 'You must enter a value'},
-      {code: 'pattern', message: 'Not a valid name. It must start with a symbol, have zero or more alphanumeric characters. Only \'_\' or \'-\' are allowed.'},
-      {code: 'forbiddenName', message: 'This name already exist in the flow'}
+      {code: 'required', message: 'You must enter a value.'},
+      {code: 'pattern', message: 'Only letters, numbers, \"_\" and \"-\" allowed and must start with a letter.'},
+      {code: 'forbiddenName', message: 'This step name already exists in the flow.'}
     ];
     const nameCtrl = this.newStepForm.get('name');
     if (!nameCtrl) {
@@ -132,5 +132,8 @@ export class NewStepDialogUiComponent implements OnInit {
     if (this.newStep.name !== '') {
       this.saveClicked.emit(this.newStep);
     }
+  }
+  capitalFirstLetter(str) {
+    return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
   }
 }

--- a/web/src/main/ui/app/components/flows-new/manage-flows/ui/flow-settings-dialog.component.html
+++ b/web/src/main/ui/app/components/flows-new/manage-flows/ui/flow-settings-dialog.component.html
@@ -2,16 +2,16 @@
 <div id="flow-dialog" mat-dialog-content [formGroup]="form" class="content">
   <mat-form-field layout-fill>
     <mat-label>Flow name</mat-label>
-    <input id="flow-name" matInput formControlName="name"/>
+    <input id="flow-name" matInput formControlName="name" required />
   </mat-form-field>
   <mat-form-field layout-fill>
-    <mat-label>Description (optional)</mat-label>
+    <mat-label>Description</mat-label>
     <input id="flow-desc" matInput formControlName="description"/>
   </mat-form-field>
   <mat-expansion-panel>
     <mat-expansion-panel-header>
       <mat-panel-title>
-        Advanced Settings (optional)
+        Advanced Settings
       </mat-panel-title>
     </mat-expansion-panel-header>
     <mat-form-field layout-fill>

--- a/web/src/main/ui/app/components/flows-new/validators/add-match-option.validator.ts
+++ b/web/src/main/ui/app/components/flows-new/validators/add-match-option.validator.ts
@@ -1,0 +1,16 @@
+import { FormGroup } from '@angular/forms';
+import * as _ from "lodash";
+
+export function AddMatchOptionValidator(group: FormGroup) {
+  let errors = {};
+  if (group.value.matchType === 'reduce' && group.controls.propertiesReduce) {
+    if (!group.controls.propertiesReduce.value[0].name) {
+      errors['noReduceName'] = true;
+    }
+  } else {
+    if (!group.value.propertyName) {
+      errors['noPropName'] = true;
+    }
+  }
+  return _.isEmpty(errors) ? null : errors;
+}

--- a/web/src/main/ui/app/components/flows-new/validators/add-merge-strategy.validator.ts
+++ b/web/src/main/ui/app/components/flows-new/validators/add-merge-strategy.validator.ts
@@ -1,0 +1,12 @@
+import { FormGroup } from '@angular/forms';
+import * as _ from "lodash";
+
+export function AddMergeStrategyValidator(group: FormGroup) {
+  let errors = {};
+  if (group.value.default === 'false') {
+    if (!group.value.name) {
+      errors['noName'] = true;
+    }
+  }
+  return _.isEmpty(errors) ? null : errors;
+}

--- a/web/src/main/ui/app/components/flows-new/validators/source-weight.validator.ts
+++ b/web/src/main/ui/app/components/flows-new/validators/source-weight.validator.ts
@@ -1,0 +1,15 @@
+import { FormGroup } from '@angular/forms';
+import * as _ from "lodash";
+
+// TODO validate weights in SourceWeight options
+export function SourceWeightValidator(group: FormGroup) {
+  let errors = {};
+  let regex = /^\d+$/;
+  let weight = group.value['weight'];
+  if (weight && (isNaN(weight) || !regex.test(weight.toString()))) {
+    errors['invalidSourceWeight'] = true;
+  }
+  // TODO uncomment to enable validation
+  // return _.isEmpty(errors) ? null : errors;
+  return null;
+}

--- a/web/src/main/ui/app/components/flows-new/validators/weight.validator.ts
+++ b/web/src/main/ui/app/components/flows-new/validators/weight.validator.ts
@@ -4,7 +4,7 @@ import * as _ from "lodash";
 export function WeightValidator(control: FormControl) {
   let errors = {};
   let regex = /^\d+$/;
-  if (control.value && isNaN(control.value) || !regex.test(control.value.toString())) {
+  if (control.value && (isNaN(control.value) || !regex.test(control.value.toString()))) {
     errors['invalidWeight'] = true;
   }
   return _.isEmpty(errors) ? null : errors;

--- a/web/src/main/ui/app/components/flows-new/validators/weight.validator.ts
+++ b/web/src/main/ui/app/components/flows-new/validators/weight.validator.ts
@@ -1,0 +1,11 @@
+import { FormControl } from '@angular/forms';
+import * as _ from "lodash";
+
+export function WeightValidator(control: FormControl) {
+  let errors = {};
+  let regex = /^\d+$/;
+  if (isNaN(control.value) || !regex.test(control.value.toString())) {
+    errors['invalidWeight'] = true;
+  }
+  return _.isEmpty(errors) ? null : errors;
+}

--- a/web/src/main/ui/app/components/flows-new/validators/weight.validator.ts
+++ b/web/src/main/ui/app/components/flows-new/validators/weight.validator.ts
@@ -4,7 +4,7 @@ import * as _ from "lodash";
 export function WeightValidator(control: FormControl) {
   let errors = {};
   let regex = /^\d+$/;
-  if (isNaN(control.value) || !regex.test(control.value.toString())) {
+  if (control.value && isNaN(control.value) || !regex.test(control.value.toString())) {
     errors['invalidWeight'] = true;
   }
   return _.isEmpty(errors) ? null : errors;


### PR DESCRIPTION
Add rudimentary validation in mastering forms for most important fields.

**Match Option** dialog:
- Property name (required)
- Weight (required and number)

**Match Threshold** dialog:
- Name (required)
- Weight (required and number)
- Action (required)

**Merge Option** dialog:
- Property to Merge (required)
- Make "Standard" default type

**Merge Strategy** dialog:
- Name (required)

**Merge Collections** dialog:
- Make "onMerge" default event

Other minor content fixes:
- Use capitalized step names in New Step menu. (NOTE: This is a change to the label (menu) text, not the selection value that is passed under the covers.)
- Edit step name error messages for conciseness and grammar.
- Remove “optional” labeling in forms where required inputs are already denoted.