### PR TITLE
DHFPROD-2280: Do not require target entity for custom step.

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog-ui.component.html
@@ -33,7 +33,7 @@
   </mat-form-field>
 
   <mat-form-field *ngIf="newStepForm.value.stepDefinitionType !== stepType.INGESTION">
-    <mat-select id="step-target-entity" placeholder="Target Entity" required formControlName="targetEntity">
+    <mat-select id="step-target-entity" placeholder="Target Entity" formControlName="targetEntity" [required]="newStepForm.value.stepDefinitionType === stepType.MAPPING || newStepForm.value.stepDefinitionType === stepType.MASTERING">
       <mat-option *ngFor="let entity of entities" [value]="entity.name">{{entity.name}}</mat-option>
     </mat-select>
   </mat-form-field>


### PR DESCRIPTION
With this fix, target entity is still an option for Custom step but not required. Required for Mapping and Mastering. You can click between step types while creating a new step and it should work OK.