### PR TITLE
DHFPROD-2278: editing ingest can cause source/target DB to become NullNode

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/StepRunnerFactory.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/StepRunnerFactory.java
@@ -1,5 +1,6 @@
 package com.marklogic.hub.step;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.HubConfig;
@@ -67,10 +68,10 @@ public class StepRunnerFactory {
 
         stepRunner.withThreadCount(threadCount);
 
-        if(step.getOptions().get("sourceDatabase") != null) {
+        if(nodeIsNotNull(step.getOptions().get("sourceDatabase"))) {
             sourceDatabase = ((TextNode)step.getOptions().get("sourceDatabase")).asText();
         }
-        else if(stepDef.getOptions().get("sourceDatabase") != null) {
+        else if(nodeIsNotNull(stepDef.getOptions().get("sourceDatabase"))) {
             sourceDatabase = ((TextNode)stepDef.getOptions().get("sourceDatabase")).asText();
         }
         else {
@@ -78,10 +79,10 @@ public class StepRunnerFactory {
         }
         stepRunner.withSourceClient(hubConfig.newStagingClient(sourceDatabase));
 
-        if(step.getOptions().get("targetDatabase") != null) {
+        if(nodeIsNotNull(step.getOptions().get("targetDatabase"))) {
             targetDatabase = ((TextNode)step.getOptions().get("targetDatabase")).asText();
         }
-        else if(stepDef.getOptions().get("targetDatabase") != null) {
+        else if(nodeIsNotNull(stepDef.getOptions().get("targetDatabase"))) {
             targetDatabase = ((TextNode)stepDef.getOptions().get("targetDatabase")).asText();
         }
         else {
@@ -102,4 +103,7 @@ public class StepRunnerFactory {
         return stepRunner;
     }
 
+    private boolean nodeIsNotNull(Object jsonNode) {
+        return !(jsonNode == null || ((JsonNode) jsonNode).isNull());
+    }
 }

--- a/web/src/main/java/com/marklogic/hub/web/model/FlowStepModel.java
+++ b/web/src/main/java/com/marklogic/hub/web/model/FlowStepModel.java
@@ -11,13 +11,14 @@ import com.marklogic.hub.step.impl.Step;
 import com.marklogic.hub.util.json.JSONObject;
 import com.marklogic.hub.web.model.FlowJobModel.FlowJobs;
 import com.marklogic.hub.web.model.FlowJobModel.LatestJob;
+import org.apache.commons.io.FileUtils;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Paths;
 import java.util.*;
-import org.apache.commons.io.FileUtils;
 
 public class FlowStepModel {
     private String id;
@@ -171,7 +172,7 @@ public class FlowStepModel {
                 sm.id = step.getName() + "-" + stepType;
             }
             sm.stepDefinitionType = stepType;
-            if (step.getOptions() != null && step.getOptions().get("targetEntity") != null) {
+            if (step.getOptions() != null && nodeIsNotNull(step.getOptions().get("targetEntity"))) {
                 sm.targetEntity = ((TextNode) step.getOptions().get("targetEntity")).asText();
             }
             stepModels.add(sm);
@@ -230,5 +231,9 @@ public class FlowStepModel {
         }
 
         pw.close();
+    }
+    // TODO create shared function as this is in StepRunnerFactory as well
+    private static boolean nodeIsNotNull(Object jsonNode) {
+        return !(jsonNode == null || ((JsonNode) jsonNode).isNull());
     }
 }


### PR DESCRIPTION
@ayuwono I encountered this NullNode issue when attempting working on the issue with Output Replace URI and items not being mastered. I'm seeing mastering working with Output URI Replacement now that I've worked through that error. I'm not confident that this address the issue you were seeing, though. Can you check? Thanks!