### PR TITLE
DHFPROD-2299: Hide links to committed/failed docs from a job

### DIFF
--- a/web/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/manage-flows/ui/manage-flows-ui.component.html
@@ -92,8 +92,9 @@
         <ng-container matColumnDef="docsCommitted">
           <mat-header-cell id="flow-docs-committed-sort-btn" *matHeaderCellDef mat-sort-header>Committed</mat-header-cell>
           <mat-cell class="flow-docs-committed" *matCellDef="let flow" fxHide fxShow.gt-md>
-            <a *ngIf="flow.latestJob && flow.latestJob.id && flow.latestJob.successfulEvents > 0" [routerLink]="['/browse']" [queryParams]="{Collection:flow.latestJob.id}">{{flow.latestJob.successfulEvents | number}}</a>
-            <span *ngIf="flow.latestJob && flow.latestJob.successfulEvents <= 0">{{flow.latestJob.successfulEvents | number}}</span>
+            <!-- TODO link to committed docs from a job -->
+            <!-- <a *ngIf="flow.latestJob && flow.latestJob.id && flow.latestJob.successfulEvents > 0" [routerLink]="['/browse']" [queryParams]="{Collection:flow.latestJob.id}">{{flow.latestJob.successfulEvents | number}}</a> -->
+            <span>{{flow.latestJob.successfulEvents | number}}</span>
           </mat-cell>
         </ng-container>
 
@@ -101,10 +102,11 @@
         <ng-container matColumnDef="docsFailed">
           <mat-header-cell id="flow-docs-failed-sort-btn" *matHeaderCellDef mat-sort-header>Failed</mat-header-cell>
           <mat-cell class="flow-docs-failed" *matCellDef="let flow">
-            <a *ngIf="flow.latestJob && flow.latestJob.id && flow.latestJob.failedEvents > 0" [routerLink]="">
+            <!-- TODO link to failed docs from a job -->
+            <!-- <a *ngIf="flow.latestJob && flow.latestJob.id && flow.latestJob.failedEvents > 0" [routerLink]="">
               {{flow.latestJob.failedEvents | number}}
-            </a>
-            <span *ngIf="flow.latestJob && flow.latestJob.failedEvents <= 0">
+            </a> -->
+            <span>
               {{flow.latestJob.failedEvents | number}}
             </span>
           </mat-cell>

--- a/web/src/main/ui/app/components/jobs-new/ui/job-details-ui.component.html
+++ b/web/src/main/ui/app/components/jobs-new/ui/job-details-ui.component.html
@@ -41,19 +41,21 @@
         <section>
           <div class="committed">
             <span class="label medium">Committed</span>
-            <a *ngIf="job.successfulEvents !== 0" [routerLink]="['/browse']" [queryParams]="{Collection:job.id}">
+            <!-- TODO link to committed docs from a job -->
+            <!-- <a *ngIf="job.successfulEvents !== 0" [routerLink]="['/browse']" [queryParams]="{Collection:job.id}">
               {{job.successfulEvents | number}}
-            </a>
-            <span *ngIf="job.successfulEvents === 0">
+            </a> -->
+            <span>
               {{job.successfulEvents}}
             </span>
           </div>
           <div class="errors">
             <span class="label medium">Failed</span>
-            <a *ngIf="job.failedEvents !== 0" [routerLink]="">
+            <!-- TODO link to committed docs from a job -->
+            <!-- <a *ngIf="job.failedEvents !== 0" [routerLink]="">
               {{job.failedEvents | number}}
-            </a>
-            <span *ngIf="job.failedEvents === 0">
+            </a> -->
+            <span>
               {{job.failedEvents  }}
             </span>
           </div>
@@ -129,10 +131,11 @@
         <ng-container matColumnDef="committed">
           <mat-header-cell id="step-committed-sort-btn" *matHeaderCellDef mat-sort-header>Committed</mat-header-cell>
           <mat-cell class="step-committed" *matCellDef="let step">
-            <a *ngIf="step.successfulEvents !== 0" [routerLink]="['/browse']" [queryParams]="{Collection:job.id}">
+            <!-- TODO link to committed docs from a job -->
+            <!-- <a *ngIf="step.successfulEvents !== 0" [routerLink]="['/browse']" [queryParams]="{Collection:job.id}">
               {{step.successfulEvents | number}}
-            </a>
-            <span *ngIf="step.successfulEvents === 0">
+            </a> -->
+            <span>
               {{step.successfulEvents}}
             </span>
           </mat-cell>
@@ -142,10 +145,11 @@
         <ng-container matColumnDef="errors">
           <mat-header-cell id="step-errors-sort-btn" *matHeaderCellDef mat-sort-header>Failed</mat-header-cell>
           <mat-cell class="step-errors" *matCellDef="let step">
-            <a *ngIf="step.failedEvents !== 0" [routerLink]="">
+            <!-- TODO link to failed docs from a job -->
+            <!-- <a *ngIf="step.failedEvents !== 0" [routerLink]="">
               {{step.failedEvents | number}}
-            </a>
-            <span *ngIf="step.failedEvents === 0">
+            </a> -->
+            <span>
               {{step.failedEvents}}
             </span>
           </mat-cell>

--- a/web/src/main/ui/app/components/jobs-new/ui/manage-jobs-ui.component.html
+++ b/web/src/main/ui/app/components/jobs-new/ui/manage-jobs-ui.component.html
@@ -104,10 +104,11 @@
         <ng-container matColumnDef="committed">
           <mat-header-cell id="job-committed-sort-btn" *matHeaderCellDef mat-sort-header>Committed</mat-header-cell>
           <mat-cell class="job-committed" *matCellDef="let job">
-            <a *ngIf="job.successfulEvents !== 0" [routerLink]="['/browse']" [queryParams]="{Collection:job.id}">
+            <!-- TODO link to committed docs from a job -->
+            <!-- <a *ngIf="job.successfulEvents !== 0" [routerLink]="['/browse']" [queryParams]="{Collection:job.id}">
               {{job.successfulEvents | number}}
-            </a>
-            <span *ngIf="job.successfulEvents === 0">
+            </a> -->
+            <span>
               {{job.successfulEvents}}
             </span>
           </mat-cell>
@@ -117,10 +118,11 @@
         <ng-container matColumnDef="errors">
           <mat-header-cell id="job-errors-sort-btn" *matHeaderCellDef mat-sort-header>Failed</mat-header-cell>
           <mat-cell class="job-errors" *matCellDef="let job">
-            <a *ngIf="job.failedEvents !== 0" [routerLink]="">
+            <!-- TODO link to failed docs from a job -->
+            <!-- <a *ngIf="job.failedEvents !== 0" [routerLink]="">
               {{job.failedEvents | number}}
-            </a>
-            <span *ngIf="job.failedEvents === 0">
+            </a> -->
+            <span>
               {{job.failedEvents}}
             </span>
           </mat-cell>


### PR DESCRIPTION
In QuickStart, display number values for flow docs but do not link to Browse Data view since we currently cannot show those docs via a constrained search query. Affected views:

- Manage Flows
- Jobs
- Job Details