### PR TITLE
DHFPROD-2232: Add property check when parsing match options

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/matching.model.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/matching.model.ts
@@ -38,7 +38,7 @@ export class Matching {
         result.algorithms['algorithm'].push(new Algorithm(a));
       })
     }
-    if(config.collections.content) {
+    if(config.collections && config.collections.content) {
       result.collections['content'] = config.collections.content;
     }
     if (config.scoring && config.scoring.add) {

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/match-options-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/match-options-ui.component.html
@@ -18,7 +18,7 @@
     <!-- / HEADER -->
 
     <div *ngIf="!targetEntity">
-      Configuring match options requires a target entity. The target entity "{{targetEntityName}}" is not defined. Define it in the <a [routerLink]="['/entities']">Entities</a> view.
+      Configuring match options requires a target entity. Define it in the <a [routerLink]="['/entities']">Entities</a> view.
     </div>
 
     <div [ngClass]="{ hidden: !targetEntity}" class="content-card">

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/merge-options-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/merge-options-ui.component.html
@@ -18,7 +18,7 @@
     <!-- / HEADER -->
 
     <div *ngIf="!targetEntity">
-      Configuring merge options requires a target entity. The target entity "{{targetEntityName}}" is not defined. Define it in the <a [routerLink]="['/entities']">Entities</a> view.
+      Configuring merge options requires a target entity. Define it in the <a [routerLink]="['/entities']">Entities</a> view.
     </div>
 
     <div [ngClass]="{ hidden: !targetEntity}" class="content-card">


### PR DESCRIPTION
Check for config.collections in model.

This was an unexpectedly easy fix.