### PR TITLE
DHFPROD-2261: Add 'stepStartTime' and 'stepEndTime' to the job doc

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/RunStepResponse.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/RunStepResponse.java
@@ -20,7 +20,9 @@ import com.marklogic.hub.flow.Flow;
 import com.marklogic.hub.job.JobStatus;
 import com.marklogic.hub.step.impl.Step;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -43,8 +45,11 @@ public class RunStepResponse {
     private long failedBatches = 0;
     private boolean success = false;
 
-    private Flow flow;
+    private String stepStartTime;
+    private String stepEndTime;
 
+    private Flow flow;
+    private static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
 
     /**
      * @return true if the job ran without errors, false otherwise.
@@ -62,6 +67,7 @@ public class RunStepResponse {
         RunStepResponse runStepResponse = new RunStepResponse();
         runStepResponse.flowName = flow.getName();
         runStepResponse.flow = flow;
+        runStepResponse.stepStartTime = DATE_TIME_FORMAT.format(new Date());
         return runStepResponse;
     }
 
@@ -164,7 +170,6 @@ public class RunStepResponse {
         this.stepDefinitionType = stepDefinitionType;
     }
 
-
     public String getStepDefinitionName() {
         return stepDefinitionName;
     }
@@ -173,12 +178,28 @@ public class RunStepResponse {
         this.stepDefinitionName = stepDefinitionName;
     }
 
+    public String getStepStartTime() {
+        return stepStartTime;
+    }
+
+    public String getStepEndTime() {
+        return stepEndTime;
+    }
+
+    public void setStepStartTime(String stepStartTime) {
+        this.stepStartTime = stepStartTime;
+    }
+
+    public void setStepEndTime(String stepEndTime) {
+        this.stepEndTime = stepEndTime;
+    }
 
     @Override
     public String toString() {
         return String.format("[flowName: %s, stepName: %s, stepDefinitionName %s, stepDefinitionType %s, success: %s, " +
                 "status: %s, totalEvents: %d, successfulEvents: %d, " + "failedEvents: %d, successfulBatches: %d, " +
-                "failedBatches: %d]", flowName, stepName, stepDefinitionName, stepDefinitionType, String.valueOf(success),
-            status, totalEvents, successfulEvents, failedEvents, successfulBatches, failedBatches);
+                "failedBatches: %d, stepStartTime: %d , stepEndTime: %d]", flowName, stepName, stepDefinitionName,
+            stepDefinitionType, String.valueOf(success), status, totalEvents, successfulEvents, failedEvents,
+            successfulBatches, failedBatches, stepStartTime, stepStartTime);
     }
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
@@ -31,13 +31,13 @@ import com.marklogic.hub.collector.Collector;
 import com.marklogic.hub.collector.DiskQueue;
 import com.marklogic.hub.collector.impl.CollectorImpl;
 import com.marklogic.hub.flow.Flow;
-import com.marklogic.hub.step.RunStepResponse;
 import com.marklogic.hub.job.JobStatus;
 import com.marklogic.hub.job.JobUpdate;
 import com.marklogic.hub.step.*;
 import com.marklogic.hub.util.json.JSONObject;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -59,7 +59,7 @@ public class QueryStepRunner implements StepRunner {
     private boolean stopOnFailure = false;
     private String jobId;
     private boolean isFullOutput = false;
-
+    private static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
 
     private String step = "1";
 
@@ -215,6 +215,7 @@ public class QueryStepRunner implements StepRunner {
         } catch (Exception e) {
             runStepResponse.setCounts(0,0, 0, 0, 0)
                 .withStatus(JobStatus.FAILED_PREFIX + step);
+            runStepResponse.setStepEndTime(DATE_TIME_FORMAT.format(new Date()));
             StringWriter errors = new StringWriter();
             e.printStackTrace(new PrintWriter(errors));
             runStepResponse.withStepOutput(errors.toString());
@@ -291,6 +292,7 @@ public class QueryStepRunner implements StepRunner {
             stepFinishedListeners.forEach((StepFinishedListener::onStepFinished));
             runStepResponse.setCounts(0,0,0,0,0);
             runStepResponse.withStatus(JobStatus.COMPLETED_PREFIX + step);
+            runStepResponse.setStepEndTime(DATE_TIME_FORMAT.format(new Date()));
             try {
                 jobUpdate.postJobs(jobId, JobStatus.COMPLETED_PREFIX + step, step);
             }
@@ -419,6 +421,7 @@ public class QueryStepRunner implements StepRunner {
 
             runStepResponse.setCounts(uris.size(),successfulEvents.get(), failedEvents.get(), successfulBatches.get(), failedBatches.get());
             runStepResponse.withStatus(stepStatus);
+            runStepResponse.setStepEndTime(DATE_TIME_FORMAT.format(new Date()));
 
             try {
                 jobUpdate.postJobs(jobId, stepStatus, step, (JobStatus.COMPLETED_PREFIX + step).equalsIgnoreCase(stepStatus) ? step : null);

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -69,7 +70,7 @@ public class WriteStepRunner implements StepRunner {
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     private String step = "1";
-
+    private static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
     private List<StepItemCompleteListener> stepItemCompleteListeners = new ArrayList<>();
     private List<StepItemFailureListener> stepItemFailureListeners = new ArrayList<>();
     private List<StepStatusListener> stepStatusListeners = new ArrayList<>();
@@ -319,6 +320,7 @@ public class WriteStepRunner implements StepRunner {
         } catch (Exception e) {
             runStepResponse.setCounts(0,0, 0, 0, 0)
                 .withStatus(JobStatus.FAILED_PREFIX + step);
+            runStepResponse.setStepEndTime(DATE_TIME_FORMAT.format(new Date()));
             StringWriter errors = new StringWriter();
             e.printStackTrace(new PrintWriter(errors));
             runStepResponse.withStepOutput(errors.toString());
@@ -387,6 +389,7 @@ public class WriteStepRunner implements StepRunner {
             stepFinishedListeners.forEach((StepFinishedListener::onStepFinished));
             runStepResponse.setCounts(0,0,0,0,0);
             runStepResponse.withStatus(JobStatus.COMPLETED_PREFIX + step);
+            runStepResponse.setStepEndTime(DATE_TIME_FORMAT.format(new Date()));
             try {
                 jobUpdate.postJobs(jobId, JobStatus.COMPLETED_PREFIX + step, step);
             }
@@ -536,6 +539,7 @@ public class WriteStepRunner implements StepRunner {
 
             runStepResponse.setCounts(successfulEvents.get() + failedEvents.get(),successfulEvents.get(), failedEvents.get(), successfulBatches.get(), failedBatches.get());
             runStepResponse.withStatus(stepStatus);
+            runStepResponse.setStepEndTime(DATE_TIME_FORMAT.format(new Date()));
             try {
                 jobUpdate.postJobs(jobId, stepStatus, step, stepStatus.equalsIgnoreCase(JobStatus.COMPLETED_PREFIX + step) ? step : null);
             }


### PR DESCRIPTION
Add 'stepStartTime' and 'stepEndTime' to the job doc.
Since step info is stored only in memory on client and job doc is created on server, the first step start time will be < job start time. So , after talking with @aebadirad , the first step time is set to job start time temporarily