### PR TITLE
DHFPROD-2304: Show start and end times in Job Details

### DIFF
--- a/web/src/main/ui/app/components/jobs-new/ui/job-details-ui.component.html
+++ b/web/src/main/ui/app/components/jobs-new/ui/job-details-ui.component.html
@@ -122,7 +122,7 @@
           <mat-header-cell id="step-duration-sort-btn" *matHeaderCellDef mat-sort-header>Duration</mat-header-cell>
           <mat-cell class="step-duration" *matCellDef="let step">
             <span class="capitalize">
-              {{friendlyDuration(step.startTime, step.EndTime)}}
+              {{friendlyDuration(step.startTime, step.endTime)}}
             </span>
           </mat-cell>
         </ng-container>


### PR DESCRIPTION
Typo fix. Now the times should appear if available since those properties are coming from the jobs endpoint.