### PR TITLE
DHFPROD-2296: Hide step validity icon in flow UI

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/stepper.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/stepper.component.html
@@ -58,8 +58,9 @@
               <div class="header">
                 <div class="step-type step-title {{stepsArray[i].stepDefinitionType.toLowerCase()}}">{{stepsArray[i].stepDefinitionType}}</div>
                 <div class="step-icons header-icons">
-                  <mat-icon *ngIf="stepsArray[i].isValid" class="step-valid check-icon">check_circle</mat-icon>
-                  <mat-icon *ngIf="!stepsArray[i].isValid"  class="step-invalid grey-icon">lens</mat-icon>
+                  <!-- TODO display validity icon when functionality works DHFPROD-2296 -->
+                  <!-- <mat-icon *ngIf="stepsArray[i].isValid" class="step-valid check-icon">check_circle</mat-icon>
+                  <mat-icon *ngIf="!stepsArray[i].isValid"  class="step-invalid grey-icon">lens</mat-icon> -->
                   <mat-icon *ngIf="!flow.latestJob || status[0] !== 'running'" (click)="deleteStepClicked(stepsArray[i])" class="step-delete delete-icon">delete</mat-icon>
                 </div>
               </div>


### PR DESCRIPTION
The icon serves no purpose currently since the underlying property is passed back as true no matter what.