### PR TITLE
DHFPROD-2367: Set null value for keys in steps if not set by the UI

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/AbstractStepDefinition.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/AbstractStepDefinition.java
@@ -220,13 +220,37 @@ public abstract class AbstractStepDefinition implements StepDefinition {
     }
 
     public StepDefinition transformFromStep(StepDefinition stepDefinition, Step step) {
-        stepDefinition.setName(step.getName());
-        stepDefinition.setBatchSize(step.getBatchSize());
-        stepDefinition.setDescription(step.getDescription());
-        stepDefinition.setThreadCount(step.getThreadCount());
-        stepDefinition.setOptions(step.getOptions());
-        stepDefinition.setModulePath(step.getModulePath());
-        stepDefinition.setCustomHook(step.getCustomHook());
+        if (step.getName() != null) {
+            stepDefinition.setName(step.getName());
+        }
+
+        if (step.getBatchSize() != null) {
+            stepDefinition.setBatchSize(step.getBatchSize());
+        }
+
+        if (step.getDescription() != null) {
+            stepDefinition.setDescription(step.getDescription());
+        }
+
+        if (step.getThreadCount() != null) {
+            stepDefinition.setThreadCount(step.getThreadCount());
+        }
+
+        if (step.getOptions() != null) {
+            stepDefinition.setOptions(step.getOptions());
+        }
+
+        if (step.getModulePath() != null) {
+            stepDefinition.setModulePath(step.getModulePath());
+        }
+
+        if (step.getCustomHook() != null) {
+            stepDefinition.setCustomHook(step.getCustomHook());
+        }
+
+        if (step.getRetryLimit() != null) {
+            stepDefinition.setRetryLimit(step.getRetryLimit());
+        }
 
         return stepDefinition;
     }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/Step.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/Step.java
@@ -28,7 +28,7 @@ public class Step {
     private String description;
     private Map<String, Object> options;
     private JsonNode customHook;
-    private int retryLimit;
+    private Integer retryLimit;
     private Integer batchSize;
     private Integer threadCount;
     private String stepDefinitionName;
@@ -72,11 +72,11 @@ public class Step {
         this.customHook = customHook;
     }
 
-    public int getRetryLimit() {
+    public Integer getRetryLimit() {
         return retryLimit;
     }
 
-    public void setRetryLimit(int retryLimit) {
+    public void setRetryLimit(Integer retryLimit) {
         this.retryLimit = retryLimit;
     }
 

--- a/marklogic-data-hub/src/main/resources/hub-internal-artifacts/step-definitions/ingestion/marklogic/default-ingestion.step.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-artifacts/step-definitions/ingestion/marklogic/default-ingestion.step.json
@@ -4,6 +4,9 @@
   "type": "INGESTION",
   "version": 1,
   "modulePath": "/data-hub/5/builtins/steps/ingestion/default/main.sjs",
+  "retryLimit" : 0,
+  "batchSize" : 100,
+  "threadCount" : 4,
   "customHook": {},
   "fileLocations": {
     "inputFileType": "json"

--- a/marklogic-data-hub/src/main/resources/hub-internal-artifacts/step-definitions/mapping/marklogic/default-mapping.step.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-artifacts/step-definitions/mapping/marklogic/default-mapping.step.json
@@ -4,6 +4,9 @@
   "type": "MAPPING",
   "version": 1,
   "modulePath": "/data-hub/5/builtins/steps/mapping/default/main.sjs",
+  "retryLimit" : 0,
+  "batchSize" : 100,
+  "threadCount" : 4,
   "options": {
     "sourceDatabase": "data-hub-STAGING",
     "targetDatabase": "data-hub-FINAL",

--- a/marklogic-data-hub/src/main/resources/hub-internal-artifacts/step-definitions/mastering/marklogic/default-mastering.step.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-artifacts/step-definitions/mastering/marklogic/default-mastering.step.json
@@ -4,6 +4,9 @@
   "type": "MASTERING",
   "version": 1,
   "modulePath": "/data-hub/5/builtins/steps/mastering/default/main.sjs",
+  "retryLimit" : 0,
+  "batchSize" : 100,
+  "threadCount" : 4,
   "options": {
     "acceptsBatch": true,
     "stepUpdate": true,

--- a/marklogic-data-hub/src/test/resources/flow-runner-test/flows/testFlow.flow.json
+++ b/marklogic-data-hub/src/test/resources/flow-runner-test/flows/testFlow.flow.json
@@ -13,6 +13,9 @@
         "outputURIReplacement": ".*/input,''"
       },
       "customHook": {},
+      "retryLimit" : null,
+      "batchSize" : null,
+      "threadCount" : null,
       "options": {
         "outputFormat": "xml",
         "collections": ["xml-coll"]
@@ -30,6 +33,9 @@
       "stepDefinitionType": "INGESTION",
       "name": "csv",
       "customHook": {},
+      "retryLimit" : null,
+      "batchSize" : null,
+      "threadCount" : null,
       "fileLocations": {
         "inputFilePath": "input",
         "inputFileType": "csv",
@@ -45,6 +51,9 @@
       "stepDefinitionType": "MAPPING",
       "name": "json-map",
       "customHook": {},
+      "retryLimit" : null,
+      "batchSize" : null,
+      "threadCount" : null,
       "options": {}
     },
     "5": {
@@ -61,6 +70,9 @@
         "sourceQuery": "cts.collectionQuery('xml-coll')"
       },
       "customHook": {},
+      "retryLimit" : null,
+      "batchSize" : null,
+      "threadCount" : null,
       "modulePath": "/data-hub/5/builtins/steps/mapping/default/main.sjs"
     }
   }

--- a/marklogic-data-hub/src/test/resources/flow-runner-test/step-definitions/json-ingestion.step.json
+++ b/marklogic-data-hub/src/test/resources/flow-runner-test/step-definitions/json-ingestion.step.json
@@ -5,6 +5,9 @@
   "version": 1,
   "modulePath": "/data-hub/5/builtins/steps/ingestion/default/main.sjs",
   "customHook": {},
+  "retryLimit" : 0,
+  "batchSize" : 100,
+  "threadCount" : 4,
   "fileLocations": {
     "inputFilePath": "input",
     "inputFileType": "json",

--- a/marklogic-data-hub/src/test/resources/flow-runner-test/step-definitions/json-mapping.step.json
+++ b/marklogic-data-hub/src/test/resources/flow-runner-test/step-definitions/json-mapping.step.json
@@ -1,7 +1,11 @@
 {
+  "language": "zxx",
   "name": "json-mapping",
   "type": "MAPPING",
   "version": 1,
+  "retryLimit" : 0,
+  "batchSize" : 100,
+  "threadCount" : 4,
   "options": {
     "outputFormat": "json",
     "collections": ["json-map"],
@@ -11,6 +15,5 @@
     },
     "sourceQuery": "cts.collectionQuery('json-coll')"
   },
-  "language": "zxx",
   "modulePath": "/data-hub/5/builtins/steps/mapping/default/main.sjs"
 }

--- a/web/src/main/java/com/marklogic/hub/web/model/StepModel.java
+++ b/web/src/main/java/com/marklogic/hub/web/model/StepModel.java
@@ -262,6 +262,12 @@ public class StepModel {
             defaultStep.setFileLocations(step.getFileLocations());
         }
 
+        // Overwrite fields
+        defaultStep.setRetryLimit(step.getRetryLimit());
+        defaultStep.setThreadCount(step.getThreadCount());
+        defaultStep.setBatchSize(step.getBatchSize());
+        defaultStep.setModulePath(step.getModulePath());
+
         return defaultStep;
     }
 }


### PR DESCRIPTION
-Steps now have nulls in batchSize, threadCount, retryLimit if not set

-Steps now don't have modulePath unless it's a CUSTOM step.

-Step-defs have defaults values for all keys.