### PR TITLE
DHFPROD-2207: Accounting for custom group name during pre-install check

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -67,7 +67,6 @@ import org.springframework.web.client.HttpServerErrorException;
 import javax.annotation.PostConstruct;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -110,7 +109,21 @@ public class DataHubImpl implements DataHub {
         this._manageClient = hubConfig.getManageClient();
         this._adminManager = hubConfig.getAdminManager();
         this._databaseManager = new DatabaseManager(_manageClient);
-        this._serverManager = new ServerManager(_manageClient);
+        this._serverManager = constructServerManager(_manageClient, hubConfig);
+    }
+
+    /**
+     * Need to account for the group name in case the user has overridden the name of the "Default" group.
+     *
+     * @param manageClient
+     * @param hubConfig
+     * @return
+     */
+    protected ServerManager constructServerManager(ManageClient manageClient, HubConfig hubConfig) {
+        AppConfig appConfig = hubConfig.getAppConfig();
+        return appConfig != null ?
+            new ServerManager(manageClient, appConfig.getGroupName()) :
+            new ServerManager(manageClient);
     }
 
     @Override

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/ConstructServerManagerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/ConstructServerManagerTest.java
@@ -1,0 +1,48 @@
+package com.marklogic.hub.impl;
+
+import com.marklogic.appdeployer.AppConfig;
+import com.marklogic.mgmt.ManageClient;
+import com.marklogic.mgmt.resource.appservers.ServerManager;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConstructServerManagerTest {
+
+    private DataHubImpl dataHub = new DataHubImpl();
+    private HubConfigImpl hubConfig = new HubConfigImpl();
+
+    // A valid ManageClient isn't needed for the purposes of this test class
+    private ManageClient manageClient = null;
+
+    @Test
+    public void appConfigIsNull() {
+        Assertions.assertNull(hubConfig.getAppConfig(),
+            "The AppConfig is expected to be null on a new HubConfigImpl instance");
+
+        ServerManager mgr = dataHub.constructServerManager(manageClient, hubConfig);
+        assertEquals("/manage/v2/servers/Admin/properties?group-id=Default", mgr.getPropertiesPath("Admin"),
+            "With no AppConfig, the path for an app server should use the Default group");
+    }
+
+    @Test
+    public void appConfigHasNoGroupName() {
+        hubConfig.setAppConfig(new AppConfig(), true);
+
+        ServerManager mgr = dataHub.constructServerManager(manageClient, hubConfig);
+        assertEquals("/manage/v2/servers/Admin/properties?group-id=Default", mgr.getPropertiesPath("Admin"),
+            "If the group name isn't overridden, then the path for an app server should use the Default group");
+    }
+
+    @Test
+    public void appConfigHasOverriddenGroupName() {
+        AppConfig appConfig = new AppConfig();
+        appConfig.setGroupName("CustomGroupName");
+        hubConfig.setAppConfig(appConfig, true);
+
+        ServerManager mgr = dataHub.constructServerManager(manageClient, hubConfig);
+        assertEquals("/manage/v2/servers/Admin/properties?group-id=CustomGroupName", mgr.getPropertiesPath("Admin"),
+            "If group name is overridden on the AppConfig, then its value should be used in the path for an app server");
+    }
+}


### PR DESCRIPTION
I opted for a simple unit test for this, as I didn't want to modify groupName on hubConfig.appConfig and risk messing up other tests. 

Will create a separate PR for merging these changes into the develop branch. 