### PR TITLE
DHFPROD-2331: Set all step/flow start/end times to server

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/collector/Collector.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/collector/Collector.java
@@ -59,5 +59,5 @@ public interface Collector {
      * @param options - options Map for running the step
      * @return a list of uris as strings in a diskqueue object
      */
-    DiskQueue<String> run(String flow, String step, String jobId, Map<String, Object> options);
+    DiskQueue<String> run(String flow, String step, Map<String, Object> options);
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/collector/impl/CollectorImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/collector/impl/CollectorImpl.java
@@ -65,23 +65,13 @@ public class CollectorImpl implements Collector {
 
     private Flow flow = null;
 
-
-    public String getJobId() {
-        return jobId;
-    }
-
-    private String jobId;
-
     private static Logger logger = LoggerFactory.getLogger(CollectorImpl.class);
-
 
     public CollectorImpl() {}
 
-    public CollectorImpl(Flow flow, String jobId) {
+    public CollectorImpl(Flow flow) {
         this.flow = flow;
-        this.jobId = jobId;
     }
-
 
     @Override
     public void setHubConfig(HubConfig config) { this.hubConfig = config; }
@@ -103,7 +93,7 @@ public class CollectorImpl implements Collector {
 
 
     @Override
-    public DiskQueue<String> run(String flow, String step, String jobId, Map<String, Object> options) {
+    public DiskQueue<String> run(String flow, String step, Map<String, Object> options) {
         try {
             DiskQueue<String> results = new DiskQueue<>(5000);
 
@@ -115,7 +105,7 @@ public class CollectorImpl implements Collector {
 
             RestTemplate template = newRestTemplate(  ((HubConfigImpl) hubConfig).getMlUsername(), ( (HubConfigImpl) hubConfig).getMlPassword());
             String uriString = String.format(
-                "%s://%s:%d%s?flow-name=%s&database=%s&step=%s&job-id=%s",
+                "%s://%s:%d%s?flow-name=%s&database=%s&step=%s",
                 client.getSecurityContext().getSSLContext() != null ? "https" : "http",
                 client.getHost(),
                 client.getPort(),
@@ -123,8 +113,7 @@ public class CollectorImpl implements Collector {
 
                 URLEncoder.encode(flow, "UTF-8"),
                 URLEncoder.encode(client.getDatabase(), "UTF-8"),
-                URLEncoder.encode(step, "UTF-8"),
-                URLEncoder.encode(jobId, "UTF-8")
+                URLEncoder.encode(step, "UTF-8")
             );
             if (options != null) {
                 ObjectMapper objectMapper = new ObjectMapper();

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/RunFlowResponse.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/RunFlowResponse.java
@@ -1,5 +1,6 @@
 package com.marklogic.hub.flow;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.marklogic.hub.step.RunStepResponse;
 
 import java.util.HashMap;
@@ -14,12 +15,18 @@ public class RunFlowResponse {
     String flowName;
     String jobStatus;
     String startTime;
+    String lastAttemptedStep;
+    String lastCompletedStep;
+    String user;
     Map<String, RunStepResponse> stepResponses;
 
     public RunFlowResponse(String jobId) {
         this.jobId = jobId;
     }
 
+    RunFlowResponse() {}
+
+    @JsonProperty("flow")
     public String getFlowName() {
         return flowName;
     }
@@ -36,20 +43,46 @@ public class RunFlowResponse {
         this.jobStatus = jobStatus;
     }
 
+    @JsonProperty("timeStarted")
     public String getStartTime() {
         return startTime;
     }
 
-    public void setStartTime(String startTime) {
-        this.startTime = startTime;
-    }
-
+    @JsonProperty("timeEnded")
     public String getEndTime() {
         return endTime;
     }
 
     public void setEndTime(String endTime) {
         this.endTime = endTime;
+    }
+
+    public void setStartTime(String startTime) {
+        this.startTime = startTime;
+    }
+
+    public String getLastAttemptedStep() {
+        return lastAttemptedStep;
+    }
+
+    public void setLastAttemptedStep(String lastAttemptedStep) {
+        this.lastAttemptedStep = lastAttemptedStep;
+    }
+
+    public String getLastCompletedStep() {
+        return lastCompletedStep;
+    }
+
+    public void setLastCompletedStep(String lastCompletedStep) {
+        this.lastCompletedStep = lastCompletedStep;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
     }
 
     public Map<String, RunStepResponse> getStepResponses() {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/impl/FlowRunnerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/impl/FlowRunnerImpl.java
@@ -335,24 +335,6 @@ public class FlowRunnerImpl implements FlowRunner{
                 logger.error(e.getMessage());
             }
             finally {
-                if (!isJobSuccess.get()) {
-                    try {
-                        flowStatusListeners.forEach((FlowStatusListener listener) -> {
-                            listener.onStatusChanged(jobId, runningStep, jobStatus, currPercentComplete[0], currSuccessfulEvents[0], currFailedEvents[0], JobStatus.FAILED.toString());
-                        });
-                    } catch (Exception ex) {
-                        logger.error(ex.getMessage());
-                    }
-                } else {
-                    try {
-                        flowStatusListeners.forEach((FlowStatusListener listener) -> {
-                            listener.onStatusChanged(jobId, runningStep, jobStatus, currPercentComplete[0], currSuccessfulEvents[0], currFailedEvents[0], JobStatus.FINISHED.toString());
-                        });
-                    } catch (Exception ex) {
-                        logger.error(ex.getMessage());
-                    }
-                }
-
                 JsonNode jobNode = null;
                 try {
                     jobNode = jobDocManager.getJobs(jobId);
@@ -372,6 +354,24 @@ public class FlowRunnerImpl implements FlowRunner{
                     }
                     catch (Exception e) {
                         logger.error(e.getMessage());
+                    }
+                }
+
+                if (!isJobSuccess.get()) {
+                    try {
+                        flowStatusListeners.forEach((FlowStatusListener listener) -> {
+                            listener.onStatusChanged(jobId, runningStep, jobStatus, currPercentComplete[0], currSuccessfulEvents[0], currFailedEvents[0], JobStatus.FAILED.toString());
+                        });
+                    } catch (Exception ex) {
+                        logger.error(ex.getMessage());
+                    }
+                } else {
+                    try {
+                        flowStatusListeners.forEach((FlowStatusListener listener) -> {
+                            listener.onStatusChanged(jobId, runningStep, jobStatus, currPercentComplete[0], currSuccessfulEvents[0], currFailedEvents[0], JobStatus.FINISHED.toString());
+                        });
+                    } catch (Exception ex) {
+                        logger.error(ex.getMessage());
                     }
                 }
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/job/JobDocManager.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/job/JobDocManager.java
@@ -12,64 +12,62 @@ import com.marklogic.client.util.RequestParameters;
 import com.marklogic.hub.step.RunStepResponse;
 import com.marklogic.hub.util.json.JSONObject;
 
-import java.util.Map;
-
-public class JobUpdate extends ResourceManager {
+public class JobDocManager extends ResourceManager {
     private static final String NAME = "ml:jobs";
 
     private RequestParameters params;
 
-    public JobUpdate(DatabaseClient client) {
+    public JobDocManager(DatabaseClient client) {
         super();
         client.init(NAME, this);
     }
 
-    public void postJobs(String jobId, String status, String step) {
+    //Update job status
+    public JsonNode postJobs(String jobId, String status) {
         params = new RequestParameters();
         params.put("jobid", jobId);
         params.put("status", status);
-        params.put("step", step);
+        ResourceServices.ServiceResultIterator resultItr = null;
         try {
-            this.getServices().post(params, new StringHandle("{}").withFormat(Format.JSON));
+            resultItr =  this.getServices().post(params, new StringHandle("{}").withFormat(Format.JSON));
         }
         catch (Exception e) {
             throw new RuntimeException("Unable to update the job document");
         }
+        if (resultItr == null || ! resultItr.hasNext()) {
+            return null;
+        }
+        ResourceServices.ServiceResult res = resultItr.next();
+        return res.getContent(new JacksonHandle()).get();
     }
 
-    public void postJobs(String jobId, String status, String step, Map<String, RunStepResponse> stepResponses) {
-        params = new RequestParameters();
-        params.put("jobid", jobId);
-        params.put("status", status);
-        params.put("step", step);
-        try {
-            params.put("stepResponses", JSONObject.writeValueAsString(stepResponses));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-        try {
-            this.getServices().post(params, new StringHandle("{}").withFormat(Format.JSON));
-        }
-        catch (Exception e) {
-            throw new RuntimeException("Unable to update the job document");
-        }
-    }
-
-    public void postJobs(String jobId, String status, String step, String lastCompleted) {
+    //Called when step execution starts/ completes
+    public JsonNode postJobs(String jobId, String status, String step, String lastCompleted, RunStepResponse stepResponse) {
         params = new RequestParameters();
         params.put("jobid", jobId);
         params.put("status", status);
         params.put("step", step);
         params.put("lastCompleted", lastCompleted);
         try {
-            this.getServices().post(params, new StringHandle("{}").withFormat(Format.JSON));
+            params.put("stepResponse", JSONObject.writeValueAsString(stepResponse));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        ResourceServices.ServiceResultIterator resultItr = null;
+        try {
+            resultItr =  this.getServices().post(params, new StringHandle("{}").withFormat(Format.JSON));
         }
         catch (Exception e) {
             throw new RuntimeException("Unable to update the job document");
         }
+        if (resultItr == null || ! resultItr.hasNext()) {
+            return null;
+        }
+        ResourceServices.ServiceResult res = resultItr.next();
+        return res.getContent(new JacksonHandle()).get();
     }
 
-    public void postJobs(String jobId, String flow) {
+    public void createJob(String jobId, String flow) {
         params = new RequestParameters();
         params.put("jobid", jobId);
         params.put("flow-name", flow);

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/RunStepResponse.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/RunStepResponse.java
@@ -16,13 +16,12 @@
 package com.marklogic.hub.step;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.marklogic.hub.error.DataHubConfigurationException;
 import com.marklogic.hub.flow.Flow;
 import com.marklogic.hub.job.JobStatus;
 import com.marklogic.hub.step.impl.Step;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -45,11 +44,18 @@ public class RunStepResponse {
     private long failedBatches = 0;
     private boolean success = false;
 
+    public void setStepStartTime(String stepStartTime) {
+        this.stepStartTime = stepStartTime;
+    }
+
+    public void setStepEndTime(String stepEndTime) {
+        this.stepEndTime = stepEndTime;
+    }
+
     private String stepStartTime;
     private String stepEndTime;
 
     private Flow flow;
-    private static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
 
     /**
      * @return true if the job ran without errors, false otherwise.
@@ -67,11 +73,13 @@ public class RunStepResponse {
         RunStepResponse runStepResponse = new RunStepResponse();
         runStepResponse.flowName = flow.getName();
         runStepResponse.flow = flow;
-        runStepResponse.stepStartTime = DATE_TIME_FORMAT.format(new Date());
         return runStepResponse;
     }
 
     public RunStepResponse withStep(String stepNum) {
+        if(flow == null){
+            throw new DataHubConfigurationException("Flow has to be set before setting step");
+        }
         Step step = this.flow.getStep(stepNum);
         this.stepName = step.getName();
         this.stepDefinitionName = step.getStepDefinitionName();
@@ -98,7 +106,7 @@ public class RunStepResponse {
     }
 
     public RunStepResponse withStatus(String status) {
-        if(status.contains(JobStatus.COMPLETED_PREFIX) || status.contains(JobStatus.FINISHED.toString())) {
+        if(status.contains(JobStatus.COMPLETED_PREFIX)) {
             this.success = true;
         }
         this.status = status;
@@ -158,24 +166,12 @@ public class RunStepResponse {
         return stepName;
     }
 
-    public void setStepName(String stepName) {
-        this.stepName = stepName;
-    }
-
     public String getStepDefinitionType() {
         return stepDefinitionType;
     }
 
-    public void setStepDefinitionType(String stepDefinitionType) {
-        this.stepDefinitionType = stepDefinitionType;
-    }
-
     public String getStepDefinitionName() {
         return stepDefinitionName;
-    }
-
-    public void setStepDefinitionName(String stepDefinitionName) {
-        this.stepDefinitionName = stepDefinitionName;
     }
 
     public String getStepStartTime() {
@@ -186,13 +182,6 @@ public class RunStepResponse {
         return stepEndTime;
     }
 
-    public void setStepStartTime(String stepStartTime) {
-        this.stepStartTime = stepStartTime;
-    }
-
-    public void setStepEndTime(String stepEndTime) {
-        this.stepEndTime = stepEndTime;
-    }
 
     @Override
     public String toString() {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
@@ -458,17 +458,18 @@ public class QueryStepRunner implements StepRunner {
                 jobDoc = jobDocManager.postJobs(jobId, stepStatus, step, (JobStatus.COMPLETED_PREFIX + step).equalsIgnoreCase(stepStatus) ? step : null, runStepResponse);
             }
             catch (Exception e) {
-                throw e;
+                logger.error(e.getMessage());
             }
-
-            try {
-                RunStepResponse tempResp =  StepRunnerUtil.getResponse(jobDoc, step);
-                runStepResponse.setStepStartTime(tempResp.getStepStartTime());
-                runStepResponse.setStepEndTime(tempResp.getStepEndTime());
-            }
-            catch (Exception ex)
-            {
-                logger.error(ex.getMessage());
+            if(jobDoc != null) {
+                try {
+                    RunStepResponse tempResp =  StepRunnerUtil.getResponse(jobDoc, step);
+                    runStepResponse.setStepStartTime(tempResp.getStepStartTime());
+                    runStepResponse.setStepEndTime(tempResp.getStepEndTime());
+                }
+                catch (Exception ex)
+                {
+                    logger.error(ex.getMessage());
+                }
             }
         });
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
@@ -273,7 +273,7 @@ public class QueryStepRunner implements StepRunner {
     }
 
     private Collection<String> runCollector() throws Exception {
-        Collector c = new CollectorImpl(this.flow, jobId);
+        Collector c = new CollectorImpl(this.flow);
         c.setHubConfig(hubConfig);
         c.setClient(stagingClient);
 
@@ -284,7 +284,7 @@ public class QueryStepRunner implements StepRunner {
         final DiskQueue<String> uris ;
         try {
             if(! isStopped.get()) {
-                uris = c.run(this.flow.getName(), step, this.jobId, options);
+                uris = c.run(this.flow.getName(), step, options);
             }
             else {
                 uris = null;

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/StepRunnerUtil.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/StepRunnerUtil.java
@@ -1,0 +1,61 @@
+package com.marklogic.hub.step.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marklogic.client.ResourceNotFoundException;
+import com.marklogic.hub.flow.Flow;
+import com.marklogic.hub.job.JobDocManager;
+import com.marklogic.hub.job.JobStatus;
+import com.marklogic.hub.step.RunStepResponse;
+
+import java.util.UUID;
+
+public class StepRunnerUtil {
+
+    protected static RunStepResponse getResponse(JsonNode jobNode, String step){
+        RunStepResponse stepDoc;
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            stepDoc = objectMapper.treeToValue(jobNode.get("job").get("stepResponses").get(step), RunStepResponse.class);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return stepDoc;
+    }
+
+    protected static RunStepResponse createStepResponse(Flow flow, String step, String jobId) {
+        RunStepResponse runStepResponse = RunStepResponse.withFlow(flow).withStep(step);
+        if (jobId == null) {
+            jobId = UUID.randomUUID().toString();
+        }
+        runStepResponse.withJobId(jobId);
+        return runStepResponse;
+    }
+
+    protected static String jsonToString(JsonNode node) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.writeValueAsString(node);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected static void initializeStepRun(JobDocManager jobDocManager, RunStepResponse runStepResponse, Flow flow, String step, String jobId) {
+        try{
+            jobDocManager.getJobs(jobId);
+        }
+        catch(ResourceNotFoundException e) {
+            jobDocManager.createJob(jobId,flow.getName());
+        }
+        try {
+            jobDocManager.postJobs(jobId, JobStatus.RUNNING_PREFIX + step, step, null, runStepResponse);
+        }
+        catch (Exception ex) {
+            throw ex;
+        }
+    }
+
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
@@ -562,17 +562,18 @@ public class WriteStepRunner implements StepRunner {
                 jobDoc = jobDocManager.postJobs(jobId, stepStatus, step, stepStatus.equalsIgnoreCase(JobStatus.COMPLETED_PREFIX + step) ? step : null, runStepResponse);
             }
             catch (Exception e) {
-                throw e;
+                logger.error(e.getMessage());
             }
-
-            try {
-                RunStepResponse tempResp =  StepRunnerUtil.getResponse(jobDoc, step);
-                runStepResponse.setStepStartTime(tempResp.getStepStartTime());
-                runStepResponse.setStepEndTime(tempResp.getStepEndTime());
-            }
-            catch (Exception ex)
-            {
-                logger.error(ex.getMessage());
+            if(jobDoc != null) {
+                try {
+                    RunStepResponse tempResp =  StepRunnerUtil.getResponse(jobDoc, step);
+                    runStepResponse.setStepStartTime(tempResp.getStepStartTime());
+                    runStepResponse.setStepEndTime(tempResp.getStepEndTime());
+                }
+                catch (Exception ex)
+                {
+                    logger.error(ex.getMessage());
+                }
             }
         });
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.datamovement.*;
 import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.document.ServerTransform;
@@ -33,8 +32,8 @@ import com.marklogic.hub.collector.DiskQueue;
 import com.marklogic.hub.collector.impl.FileCollector;
 import com.marklogic.hub.error.DataHubConfigurationException;
 import com.marklogic.hub.flow.Flow;
+import com.marklogic.hub.job.JobDocManager;
 import com.marklogic.hub.job.JobStatus;
-import com.marklogic.hub.job.JobUpdate;
 import com.marklogic.hub.step.*;
 import com.marklogic.hub.util.json.JSONObject;
 import org.apache.commons.io.FilenameUtils;
@@ -81,7 +80,7 @@ public class WriteStepRunner implements StepRunner {
     private DataMovementManager dataMovementManager = null;
     private WriteBatcher writeBatcher = null;
     private String inputFilePath = null;
-    private JobUpdate jobUpdate ;
+    private JobDocManager jobDocManager;
     private String outputCollections;
     private String outputPermissions;
     private String inputFileType;
@@ -238,8 +237,8 @@ public class WriteStepRunner implements StepRunner {
     @Override
     public RunStepResponse run() {
         runningThread = null;
-        RunStepResponse runStepResponse = createStepResponse();
-        jobUpdate = new JobUpdate(hubConfig.newJobDbClient());
+        RunStepResponse runStepResponse = StepRunnerUtil.createStepResponse(flow, step, jobId);
+        jobDocManager = new JobDocManager(hubConfig.newJobDbClient());
 
         JsonNode comboOptions = null;
         try {
@@ -303,43 +302,50 @@ public class WriteStepRunner implements StepRunner {
 
         Collection<String> uris = null;
         //If current step is the first run step, a job doc is created
-        try{
-            jobUpdate.getJobs(jobId);
-        }
-        catch(ResourceNotFoundException e) {
-            jobUpdate.postJobs(jobId,flow.getName());
-        }
         try {
-            jobUpdate.postJobs(jobId, JobStatus.RUNNING_PREFIX + step, step);
+            StepRunnerUtil.initializeStepRun(jobDocManager, runStepResponse, flow, step, jobId);
         }
-        catch (Exception ex) {
-            throw ex;
+        catch (Exception e){
+            throw e;
         }
+
         try {
             uris = runFileCollector();
         } catch (Exception e) {
             runStepResponse.setCounts(0,0, 0, 0, 0)
                 .withStatus(JobStatus.FAILED_PREFIX + step);
-            runStepResponse.setStepEndTime(DATE_TIME_FORMAT.format(new Date()));
             StringWriter errors = new StringWriter();
             e.printStackTrace(new PrintWriter(errors));
             runStepResponse.withStepOutput(errors.toString());
+            JsonNode jobDoc = null;
             try {
-                jobUpdate.postJobs(jobId, JobStatus.FAILED_PREFIX + step, step);
+                jobDoc = jobDocManager.postJobs(jobId, JobStatus.FAILED_PREFIX + step, step, null, runStepResponse);
             }
             catch (Exception ex) {
                 throw ex;
             }
-            return runStepResponse;
+            //If not able to read the step resp from the job doc, send the in-memory resp without start/end time
+            try {
+                return StepRunnerUtil.getResponse(jobDoc, step);
+            }
+            catch (Exception ex)
+            {
+                return runStepResponse;
+            }
         }
-        this.runIngester(runStepResponse,uris);
-        return runStepResponse;
+        return this.runIngester(runStepResponse,uris);
     }
 
     @Override
     public RunStepResponse run(Collection<String> uris) {
         runningThread = null;
-        RunStepResponse runStepResponse = createStepResponse();
+        RunStepResponse runStepResponse = StepRunnerUtil.createStepResponse(flow, step, jobId);
+        try {
+            StepRunnerUtil.initializeStepRun(jobDocManager, runStepResponse, flow, step, jobId);
+        }
+        catch (Exception e){
+            throw e;
+        }
         return this.runIngester(runStepResponse,uris);
     }
 
@@ -389,14 +395,20 @@ public class WriteStepRunner implements StepRunner {
             stepFinishedListeners.forEach((StepFinishedListener::onStepFinished));
             runStepResponse.setCounts(0,0,0,0,0);
             runStepResponse.withStatus(JobStatus.COMPLETED_PREFIX + step);
-            runStepResponse.setStepEndTime(DATE_TIME_FORMAT.format(new Date()));
+            JsonNode jobDoc;
             try {
-                jobUpdate.postJobs(jobId, JobStatus.COMPLETED_PREFIX + step, step);
+                jobDoc = jobDocManager.postJobs(jobId, JobStatus.COMPLETED_PREFIX + step, step, step, runStepResponse);
             }
             catch (Exception e) {
+                throw e;
             }
-
-            return runStepResponse;
+            try {
+                return StepRunnerUtil.getResponse(jobDoc, step);
+            }
+            catch (Exception ex)
+            {
+                return runStepResponse;
+            }
         }
 
         Vector<String> errorMessages = new Vector<>();
@@ -539,18 +551,28 @@ public class WriteStepRunner implements StepRunner {
 
             runStepResponse.setCounts(successfulEvents.get() + failedEvents.get(),successfulEvents.get(), failedEvents.get(), successfulBatches.get(), failedBatches.get());
             runStepResponse.withStatus(stepStatus);
-            runStepResponse.setStepEndTime(DATE_TIME_FORMAT.format(new Date()));
-            try {
-                jobUpdate.postJobs(jobId, stepStatus, step, stepStatus.equalsIgnoreCase(JobStatus.COMPLETED_PREFIX + step) ? step : null);
-            }
-            catch (Exception e) {
-                throw e;
-            }
             if (errorMessages.size() > 0) {
                 runStepResponse.withStepOutput(errorMessages);
             }
             if(isFullOutput) {
                 runStepResponse.withFullOutput(fullResponse);
+            }
+            JsonNode jobDoc = null;
+            try {
+                jobDoc = jobDocManager.postJobs(jobId, stepStatus, step, stepStatus.equalsIgnoreCase(JobStatus.COMPLETED_PREFIX + step) ? step : null, runStepResponse);
+            }
+            catch (Exception e) {
+                throw e;
+            }
+
+            try {
+                RunStepResponse tempResp =  StepRunnerUtil.getResponse(jobDoc, step);
+                runStepResponse.setStepStartTime(tempResp.getStepStartTime());
+                runStepResponse.setStepEndTime(tempResp.getStepEndTime());
+            }
+            catch (Exception ex)
+            {
+                logger.error(ex.getMessage());
             }
         });
 
@@ -673,15 +695,6 @@ public class WriteStepRunner implements StepRunner {
                 listener.onStatusChange(jobId, percentComplete, JobStatus.RUNNING_PREFIX + step, successfulEvents.get(), failedEvents.get(), "Ingesting");
             });
         }
-    }
-
-    private RunStepResponse createStepResponse() {
-        RunStepResponse runStepResponse = RunStepResponse.withFlow(flow).withStep(step);
-        if (this.jobId == null) {
-            jobId = UUID.randomUUID().toString();
-        }
-        runStepResponse.withJobId(jobId);
-        return runStepResponse;
     }
 
     private String jsonToString(Map map) {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/endpoints/collector.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/endpoints/collector.sjs
@@ -28,7 +28,6 @@ const requestParams = new Map();
 parameters.queryParameter(requestParams, "flow-name",fn.true(),fn.false())
 parameters.queryParameter(requestParams, "options",fn.false(),fn.false())
 parameters.queryParameter(requestParams, "step",fn.false(),fn.false())
-parameters.queryParameter(requestParams, "job-id",fn.true(),fn.false())
 parameters.queryParameter(requestParams, "database",fn.true(),fn.false())
 
 if(method === 'GET') {
@@ -37,8 +36,6 @@ if(method === 'GET') {
   if (!step) {
     step = 1;
   }
-  const jobId = requestParams["job-id"];
-  const database = requestParams.database;
   let options = requestParams.options ? JSON.parse(requestParams.options) : {};
 
   let flowDoc= datahub.flow.getFlow(flowName);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/endpoints/collector.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/endpoints/collector.sjs
@@ -41,13 +41,6 @@ if(method === 'GET') {
   const database = requestParams.database;
   let options = requestParams.options ? JSON.parse(requestParams.options) : {};
 
-  let jobDoc = datahub.jobs.getJobDocWithId(jobId);
-  try {
-    datahub.jobs.updateJob(jobId, jobDoc.job.lastAttemptedStep, jobDoc.job.lastCompletedStep, "running step " + step);
-  } catch (err) {
-    datahub.jobs.createJob(flowName, jobId);
-    datahub.jobs.updateJob(jobId, 0, 0, "running step " + step);
-  }
   let flowDoc= datahub.flow.getFlow(flowName);
   let resp;
   if (!fn.exists(flowDoc)) {
@@ -81,21 +74,16 @@ if(method === 'GET') {
           //TODO log error message from 'err'
 
           datahub.debug.log(err);
-          let jobDoc = datahub.jobs.getJobDocWithId(jobId);
-          datahub.jobs.updateJob(jobId, step, jobDoc.job.lastCompletedStep, "failed");
           resp = fn.error(null, 'RESTAPI-INVALIDREQ', err);
         }
       } else {
         resp = fn.error(null, "RESTAPI-SRVEXERR", Sequence.from([404, "Not Found", "The collector query was empty"]));
         datahub.debug.log("The collector query was empty");
-        let jobDoc = datahub.jobs.getJobDocWithId(jobId);
-        datahub.jobs.updateJob(jobId, step, jobDoc.job.lastCompletedStep, "failed");
       }
     } else {
       resp = fn.error(null, "RESTAPI-SRVEXERR", Sequence.from([404, "Not Found", "The requested step was not found"]));
       datahub.debug.log("The requested step was not found");
-      let jobDoc = datahub.jobs.getJobDocWithId(jobId);
-      datahub.jobs.updateJob(jobId, step, jobDoc.job.lastCompletedStep, "failed");
+
     }
   }
   resp

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/jobs.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/jobs.sjs
@@ -47,7 +47,8 @@ class Jobs {
        lastCompletedStep: 0 ,
        jobStatus: "started" ,
        timeStarted:  fn.currentDateTime(),
-       timeEnded: "N/A"
+       timeEnded: "N/A",
+       stepResponses :{}
      }
     };
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunnerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunnerTest.java
@@ -24,6 +24,7 @@ import com.marklogic.hub.flow.impl.FlowRunnerImpl;
 import com.marklogic.hub.impl.FlowManagerImpl;
 import com.marklogic.hub.impl.HubConfigImpl;
 import com.marklogic.hub.job.JobStatus;
+import com.marklogic.hub.step.RunStepResponse;
 import com.marklogic.hub.step.StepDefinition;
 import org.apache.commons.io.FileUtils;
 import org.custommonkey.xmlunit.XMLUnit;
@@ -93,6 +94,14 @@ public class FlowRunnerTest extends HubTestBase {
         Assertions.assertTrue(getDocCount(HubConfig.DEFAULT_FINAL_NAME, "json-map") == 1);
         Assertions.assertTrue(getDocCount(HubConfig.DEFAULT_FINAL_NAME, "xml-map") == 1);
         Assertions.assertTrue(JobStatus.FINISHED.toString().equalsIgnoreCase(resp.getJobStatus()));
+        Assertions.assertNotNull(resp.getUser());
+        Assertions.assertNotNull(resp.getStartTime());
+        Assertions.assertNotNull(resp.getEndTime());
+        Assertions.assertNotNull(resp.getLastAttemptedStep());
+        Assertions.assertNotNull(resp.getLastCompletedStep());
+        RunStepResponse stepResp = resp.getStepResponses().get("1");
+        Assertions.assertNotNull(stepResp.getStepStartTime());
+        Assertions.assertNotNull(stepResp.getStepEndTime());
     }
 
     @Test
@@ -217,9 +226,6 @@ public class FlowRunnerTest extends HubTestBase {
         RunFlowResponse resp = fr.runFlow("testFlow",steps, UUID.randomUUID().toString(), opts, stepConfig);
         fr.awaitCompletion();
 
-
-        fr.awaitCompletion();
-
         Assertions.assertTrue(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "binary-text-collection") == 0);
         Assertions.assertTrue(JobStatus.FINISHED.toString().equalsIgnoreCase(resp.getJobStatus()));
     }
@@ -277,5 +283,4 @@ public class FlowRunnerTest extends HubTestBase {
         Assertions.assertTrue(JobStatus.FINISHED.toString().equalsIgnoreCase(resp.getJobStatus()));
         Assertions.assertTrue(JobStatus.FINISHED.toString().equalsIgnoreCase(resp1.getJobStatus()));
     }
-
 }


### PR DESCRIPTION
This PR,

1. Remove job doc creation/updating from collector 
2. Moves all step/flow start/end times to server- changes to extensions/jobs.sjs to handle creation/updating of stepresponse in the job doc at the start of step (when status is changed to "running step #" ) and at the end of step (when status is changed to "completed (or other statuses) step #" ) 
3. Corresponding changes to FlowRunner, Write/QueryStepRunners
4. Adds lastAttemptedStep, lastCompletedStep, user info to RunFLowResponse
5. Refactor code (JobUpdate renamed to JobDocManager and move common methods in Write/QueryStepRunner to StepRunnerUtil)