### PR TITLE
DHFPROD-2377: reload mapping after flow run

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/edit-flow.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/edit-flow.component.ts
@@ -21,6 +21,7 @@ import * as _ from "lodash";
     [entities]="entities"
     [selectedStepId]="selectedStepId"
     [projectDirectory]="projectDirectory"
+    [flowEnded]="flowEnded"
     (saveFlow)="saveFlow($event)"
     (stopFlow)="stopFlow($event)"
     (runFlow)="runFlow($event)"
@@ -46,6 +47,7 @@ export class EditFlowComponent implements OnInit, OnDestroy {
   collections: string[] = [];
   entities: Array<Entity> = new Array<Entity>();
   projectDirectory: string;
+  flowEnded: string = '';
   stepType: typeof StepType = StepType;
   constructor(
    private manageFlowsService: ManageFlowsService,
@@ -136,6 +138,10 @@ export class EditFlowComponent implements OnInit, OnDestroy {
       console.log('run flow resp', resp);
       this.runningJobService.pollFlowById(runObject.id).subscribe( poll => {
         this.flow = Flow.fromJSON(poll);
+        // set flag on flow job end
+        if (!this.runningJobService.checkJobStatus(this.flow) && (this.flow.latestJob !== null)) {
+          this.flowEnded = this.flow.latestJob.id;
+        }
       });
     });
   }

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mapping/mapping.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mapping/mapping.component.ts
@@ -233,6 +233,7 @@ export class MappingComponent implements OnInit {
         this.sourceDbType = 'FINAL';
       }
       this.loadEntity();
+      this.loadMap();
     }
   }
 

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/edit-flow-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/edit-flow-ui.component.html
@@ -25,6 +25,7 @@
         [collections]="collections" 
         [entities]="entities"
         [projectDirectory]="projectDirectory"
+        [flowEnded]="flowEnded"
         (updateStep)="updateStep($event)"
       ></app-step>
     </cdk-step>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/edit-flow-ui.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/edit-flow-ui.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
 import { Router } from '@angular/router';
 import { MatDialog } from '@angular/material';
 import { NewStepDialogComponent } from './new-step-dialog.component';
@@ -13,7 +13,7 @@ import { Step } from '../../models/step.model';
   templateUrl: './edit-flow-ui.component.html',
   styleUrls: ['./edit-flow-ui.component.scss'],
 })
-export class EditFlowUiComponent {
+export class EditFlowUiComponent implements OnChanges {
 
   @Input() flow: Flow;
   @Input() flowNames: string[];
@@ -23,6 +23,7 @@ export class EditFlowUiComponent {
   @Input() collections: any;
   @Input() selectedStepId: any;
   @Input() projectDirectory: any;
+  @Input() flowEnded: any;
   @Output() runFlow = new EventEmitter();
   @Output() stopFlow = new EventEmitter();
   @Output() saveFlow = new EventEmitter();
@@ -36,6 +37,12 @@ export class EditFlowUiComponent {
     public dialog: MatDialog,
     private router: Router
   ) {}
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes && changes.flowEnded) {
+      this.flowEnded = changes.flowEnded.currentValue;
+    }
+  }
 
   openStepDialog(index): void {
     const dialogRef = this.dialog.open(NewStepDialogComponent, {

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/step.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/step.component.ts
@@ -18,6 +18,7 @@ export class StepComponent implements OnChanges {
   @Input() entities: any;
   @Input() projectDirectory: any;
   @Input() selectedStepId: string;
+  @Input() flowEnded: string;
   @Output() updateStep = new EventEmitter();
 
   @ViewChild(IngestComponent) ingestionStep: IngestComponent;
@@ -41,7 +42,12 @@ export class StepComponent implements OnChanges {
       setTimeout(() => {
         this.masteringTabGroup.realignInkBar();  
       }, 100);
-    }    
+    }
+    if (changes.flowEnded) {
+      // reload mapping in case of new source docs
+      if (this.mappingStep)
+        this.mappingStep.loadMap();
+    }
   }
 
   toggleBody() {


### PR DESCRIPTION
Running a flow can ingest sample documents required for mapping.
Account for this by reloading any mapping steps when a job ends.

1. edit-flow.component sets flowEnded flag with job ID at end of job
2. flowEnded passed to edit-flow-ui.component, which recognizes change in value
3. flowEnded passed to step.component, which triggers mapping load on change if mapping step

Screencast: https://drive.google.com/file/d/1to9CTpCugHLNLEPVKBJ5Z5xKh0WZqcqP/view