### PR TITLE
DHFPROD-2407: Adding missing data to default flow template

### DIFF
--- a/marklogic-data-hub/src/main/resources/scaffolding/defaultFlow.flow.json
+++ b/marklogic-data-hub/src/main/resources/scaffolding/defaultFlow.flow.json
@@ -8,7 +8,7 @@
   },
   "steps": {
     "1": {
-      "name": "default-ingestion-step",
+      "name": "ingestion-step",
       "description": "This is the default ingestion step",
       "stepDefinitionName": "default-ingestion",
       "stepDefinitionType": "INGESTION",
@@ -28,7 +28,7 @@
       }
     },
     "2": {
-      "name": "default-mapping-step",
+      "name": "mapping-step",
       "description": "This is the default mapping step",
       "stepDefinitionName": "default-mapping",
       "stepDefinitionType": "MAPPING",
@@ -40,6 +40,7 @@
           "default-mapping",
           "mdm-content"
         ],
+        "targetEntity": "entity-name",
         "mapping": {
           "name": "mapping-name",
           "version": 1
@@ -47,7 +48,7 @@
       }
     },
     "3": {
-      "name": "default-mastering-step",
+      "name": "mastering-step",
       "description": "This is the default mastering step",
       "stepDefinitionName": "default-mastering",
       "stepDefinitionType": "MASTERING",
@@ -58,7 +59,49 @@
         "sourceQuery": "cts.andQuery([cts.collectionQuery('default-mapping'),cts.collectionQuery('mdm-content')])",
         "collections": [
           "default-mastering, mastered"
-        ]
+        ],
+        "mergeOptions" : {
+          "matchOptions" : "",
+          "propertyDefs" : {
+            "properties" : [ ],
+            "namespaces" : { }
+          },
+          "algorithms" : {
+            "stdAlgorithm" : {
+              "timestamp" : { }
+            },
+            "custom" : [ ],
+            "collections" : { }
+          },
+          "mergeStrategies" : [ ],
+          "merging" : [ ]
+        },
+        "matchOptions" : {
+          "dataFormat": "json",
+          "propertyDefs": {
+            "property": []
+          },
+          "algorithms": {
+            "algorithm": []
+          },
+          "collections": {
+            "content": []
+          },
+          "scoring": {
+            "add": [],
+            "expand": [],
+            "reduce": []
+          },
+          "actions": {
+            "action": []
+          },
+          "thresholds": {
+            "threshold": []
+          },
+          "tuning": {
+            "maxScan": 200
+          }
+        }
       }
     }
   }

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/CreateFlowTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/CreateFlowTask.groovy
@@ -32,7 +32,7 @@ class CreateFlowTask extends HubTask {
                 scaffolding.createDefaultFlow(flowName.toString())
 
                 println "IMPORTANT: Your new flow configuration file \"flows/" + flowName + ".flow.json\" contains step templates with " +
-                    "example values. The flow will not run as is. " +
+                    "example values, such as 'inputFilePath' and 'entity-name'. The flow will not run as is. " +
                     "You MUST customize the steps for your project before running the flow."
             }
         }

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/matching.model.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/matching.model.ts
@@ -66,7 +66,7 @@ export class Matching {
         result.thresholds['threshold'].push(new Threshold(t));
       })
     }
-    if(config.tuning.maxScan) {
+    if(config.tuning && config.tuning.maxScan) {
       result.tuning['maxScan'] = config.tuning.maxScan;
     }
     return result;


### PR DESCRIPTION
Also ensuring that config.tuning exists before checking for maxScan. 

Note that this does not yet generate a mapping file. I believe the current expectation, based on the warning message generated by hubCreateFlow, is that the user must either provide a mapping file or removing the mapping step.

Also - @akshaysonvane is putting together a separate PR for allowing for steps with a name starting with "default-" to work properly. I skirted around that issue by modifying the default flow template so that no steps have a name starting with "default-". 