### PR TITLE
DHFPROD-2399: fix to browse pagination when going back/forth

### DIFF
--- a/web/src/main/ui/app/components/pagination/pagination.component.ts
+++ b/web/src/main/ui/app/components/pagination/pagination.component.ts
@@ -25,7 +25,7 @@ export class PaginationComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes: any) {
-    if (changes.total || changes.pageLength) {
+    if (changes.total || changes.pageLength || changes.start) {
       this.calculatePaging();
     }
   }


### PR DESCRIPTION
Pagination when going from the document details to browser page list fixed.  Page # now resets to first page or results, which is the same page as being shown in the list.