### PR TITLE
DHFPROD-2407: Handle a flow with a non-existent target entity

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/mapping/mapping.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mapping/mapping.component.ts
@@ -132,17 +132,19 @@ export class MappingComponent implements OnInit {
   loadSampleDoc() {
     let self = this;
     this.searchService.getResultsByQuery(this.step.options.sourceDatabase, this.step.options.sourceQuery, 1).subscribe(response => {
-        self.targetEntity.hasDocs = (response.length > 0);
-        // Can only load sample doc if docs exist
-        if (self.targetEntity.hasDocs) {
-          if (!this.mapping.sourceURI) {
-            this.sampleDocURI = response[0].uri;
-          } else {
-            this.sampleDocURI = this.mapping.sourceURI;
-          }
-          this.editURIVal = this.sampleDocURI;
-          this.loadSampleDocByURI(this.sampleDocURI, '', {}, false);
+        if (self.targetEntity) {
+          self.targetEntity.hasDocs = (response.length > 0);
+          // Can only load sample doc if docs exist
+          if (self.targetEntity.hasDocs) {
+            if (!this.mapping.sourceURI) {
+              this.sampleDocURI = response[0].uri;
+            } else {
+              this.sampleDocURI = this.mapping.sourceURI;
+            }
+            this.editURIVal = this.sampleDocURI;
+            this.loadSampleDocByURI(this.sampleDocURI, '', {}, false);
 
+          }
         }
       },
       () => {},

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/mapping-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/mapping-ui.component.html
@@ -1,7 +1,11 @@
 <div layout-padding layout="column" class="map-page">
 
+  <div *ngIf="!targetEntity" class="map-container">
+    <em>Before configuring this mapping you must set a target entity. You can create new entities in the <a [routerLink]="['/entities']">Entities</a> view.</em>
+  </div>
+
   <div *ngIf="targetEntity && !targetEntity.hasDocs" class="map-container">
-    <p>Before configuring this mapping you must ingest source documents</p>
+    <em>Before configuring this mapping you must ingest source documents.</em>
   </div>
 
   <div [ngClass]="{ hidden: !(targetEntity && targetEntity.hasDocs)}" class="map-container">

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/mapping-ui.component.scss
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/mapping-ui.component.scss
@@ -30,6 +30,14 @@ div.item-title {
   }
 }
 
+a:hover {
+  text-decoration: none;
+  color: #6d8ba5;
+}
+a {
+  color: #2a4356;
+}
+
 p.item-identifying-info {
   font-weight: bold;
   margin: 0 0 14px 2px;


### PR DESCRIPTION
Gradle-generated flows may have a non-existent target entity set for mapping steps.
Check for this in the mapping step component and display appropriate messaging in UI.