### PR TITLE
Adding 'flowName' to stepResponse

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/RunStepResponse.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/RunStepResponse.java
@@ -132,6 +132,10 @@ public class RunStepResponse {
         return jobId;
     }
 
+    public String getFlowName() {
+        return flowName;
+    }
+
     public Map<String, Object> getFullOutput() {
         return fullOutput;
     }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
@@ -405,14 +405,16 @@ public class WriteStepRunner implements StepRunner {
             runStepResponse.withStatus(JobStatus.COMPLETED_PREFIX + step);
             JsonNode jobDoc;
             try {
-                try {
-                    jobDoc = jobDocManager.postJobs(jobId, JobStatus.COMPLETED_PREFIX + step, step, step, runStepResponse);
-                } catch (Exception e) {
-                    throw e;
-                }
+                jobDoc = jobDocManager.postJobs(jobId, JobStatus.COMPLETED_PREFIX + step, step, step, runStepResponse);
+            }
+            catch (Exception e) {
+                throw e;
+            }
+            try {
                 return StepRunnerUtil.getResponse(jobDoc, step);
-            } catch (Exception ex) {
-            } finally {
+            }
+            catch (Exception ex)
+            {
                 return runStepResponse;
             }
         }


### PR DESCRIPTION
As per https://github.com/marklogic/marklogic-data-hub/pull/2470#discussion_r282583017, flowName is needed in stepResponse. so, adding 'flowName' to stepResponse