### PR TITLE
DHFPROD-2501: If 'uris'is null and job is stopped return the response immediately

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
@@ -309,16 +309,26 @@ public class QueryStepRunner implements StepRunner {
             listener.onStatusChange(runStepResponse.getJobId(), 0, JobStatus.RUNNING_PREFIX + step, 0,0, "starting step execution");
         });
 
-        if ( !isStopped.get() && (uris == null || uris.size() == 0 )) {
+        if (uris == null || uris.size() == 0) {
+            JsonNode jobDoc = null;
+            final String stepStatus;
+            if(isStopped.get()) {
+                stepStatus = JobStatus.CANCELED_PREFIX + step;
+            }
+            else {
+                stepStatus = JobStatus.COMPLETED_PREFIX + step;
+            }
+
             stepStatusListeners.forEach((StepStatusListener listener) -> {
-                listener.onStatusChange(runStepResponse.getJobId(), 100, JobStatus.COMPLETED_PREFIX + step, 0, 0, "collector returned 0 items");
+                listener.onStatusChange(runStepResponse.getJobId(), 100, stepStatus, 0, 0,
+                    (JobStatus.COMPLETED_PREFIX.contains(stepStatus)? "collector returned 0 items" : "job was stopped"));
             });
             stepFinishedListeners.forEach((StepFinishedListener::onStepFinished));
             runStepResponse.setCounts(0,0,0,0,0);
-            runStepResponse.withStatus(JobStatus.COMPLETED_PREFIX + step);
-            JsonNode jobDoc = null;
+            runStepResponse.withStatus(stepStatus);
+
             try {
-                jobDoc = jobDocManager.postJobs(jobId, JobStatus.COMPLETED_PREFIX + step, step, step, runStepResponse);
+                jobDoc = jobDocManager.postJobs(jobId, stepStatus, step, JobStatus.COMPLETED_PREFIX.contains(stepStatus)? step : null, runStepResponse);
             }
             catch (Exception e) {
                 throw e;

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
@@ -321,14 +321,14 @@ public class QueryStepRunner implements StepRunner {
 
             stepStatusListeners.forEach((StepStatusListener listener) -> {
                 listener.onStatusChange(runStepResponse.getJobId(), 100, stepStatus, 0, 0,
-                    (JobStatus.COMPLETED_PREFIX.contains(stepStatus)? "collector returned 0 items" : "job was stopped"));
+                    (stepStatus.contains(JobStatus.COMPLETED_PREFIX) ? "collector returned 0 items" : "job was stopped"));
             });
             stepFinishedListeners.forEach((StepFinishedListener::onStepFinished));
             runStepResponse.setCounts(0,0,0,0,0);
             runStepResponse.withStatus(stepStatus);
 
             try {
-                jobDoc = jobDocManager.postJobs(jobId, stepStatus, step, JobStatus.COMPLETED_PREFIX.contains(stepStatus)? step : null, runStepResponse);
+                jobDoc = jobDocManager.postJobs(jobId, stepStatus, step, stepStatus.contains(JobStatus.COMPLETED_PREFIX) ? step : null, runStepResponse);
             }
             catch (Exception e) {
                 throw e;

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
@@ -409,14 +409,14 @@ public class WriteStepRunner implements StepRunner {
 
             stepStatusListeners.forEach((StepStatusListener listener) -> {
                 listener.onStatusChange(runStepResponse.getJobId(), 100, stepStatus, 0, 0,
-                    (JobStatus.COMPLETED_PREFIX.contains(stepStatus)? "provided file path returned 0 items" : "job was stopped"));
+                    (stepStatus.contains(JobStatus.COMPLETED_PREFIX) ? "provided file path returned 0 items" : "job was stopped"));
             });
             stepFinishedListeners.forEach((StepFinishedListener::onStepFinished));
             runStepResponse.setCounts(0,0,0,0,0);
             runStepResponse.withStatus(stepStatus);
 
             try {
-                jobDoc = jobDocManager.postJobs(jobId, stepStatus, step, JobStatus.COMPLETED_PREFIX.contains(stepStatus)? step : null, runStepResponse);
+                jobDoc = jobDocManager.postJobs(jobId, stepStatus, step, stepStatus.contains(JobStatus.COMPLETED_PREFIX) ? step : null, runStepResponse);
             }
             catch (Exception e) {
                 throw e;

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
@@ -396,16 +396,27 @@ public class WriteStepRunner implements StepRunner {
         stepStatusListeners.forEach((StepStatusListener listener) -> {
             listener.onStatusChange(runStepResponse.getJobId(), 0, JobStatus.RUNNING_PREFIX + step, 0, 0, "starting step execution");
         });
-        if ( !isStopped.get() && (uris == null || uris.size() == 0 )) {
+
+        if (uris == null || uris.size() == 0 ) {
+            JsonNode jobDoc = null;
+            final String stepStatus;
+            if(isStopped.get()) {
+                stepStatus = JobStatus.CANCELED_PREFIX + step;
+            }
+            else {
+                stepStatus = JobStatus.COMPLETED_PREFIX + step;
+            }
+
             stepStatusListeners.forEach((StepStatusListener listener) -> {
-                listener.onStatusChange(runStepResponse.getJobId(), 100, JobStatus.COMPLETED_PREFIX + step, 0, 0, "provided file path returned 0 items");
+                listener.onStatusChange(runStepResponse.getJobId(), 100, stepStatus, 0, 0,
+                    (JobStatus.COMPLETED_PREFIX.contains(stepStatus)? "provided file path returned 0 items" : "job was stopped"));
             });
             stepFinishedListeners.forEach((StepFinishedListener::onStepFinished));
             runStepResponse.setCounts(0,0,0,0,0);
-            runStepResponse.withStatus(JobStatus.COMPLETED_PREFIX + step);
-            JsonNode jobDoc;
+            runStepResponse.withStatus(stepStatus);
+
             try {
-                jobDoc = jobDocManager.postJobs(jobId, JobStatus.COMPLETED_PREFIX + step, step, step, runStepResponse);
+                jobDoc = jobDocManager.postJobs(jobId, stepStatus, step, JobStatus.COMPLETED_PREFIX.contains(stepStatus)? step : null, runStepResponse);
             }
             catch (Exception e) {
                 throw e;


### PR DESCRIPTION
If 'uris'is null and job is stopped return the response immediately. We can run this on win/linux cluster and ensure tests are running in cluster as well before merging