### PR TITLE
E2E UI scenario with multiple flows and csv docs

### DIFF
--- a/web/e2e/page-objects/jobs/manageJobs.ts
+++ b/web/e2e/page-objects/jobs/manageJobs.ts
@@ -81,7 +81,7 @@ export class ManageJobs extends AppPage {
   }
 
   get textFilter() {
-    return element(by.css("#filter-by-text input"));
+    return element(by.id("filter-by-text"));
   }
 
   async setTextFilter(input: string) {

--- a/web/e2e/page-objects/steps/masteringStep.ts
+++ b/web/e2e/page-objects/steps/masteringStep.ts
@@ -8,7 +8,7 @@ export class MasteringStep extends AppPage {
    * @param option = [Matching/Merging]
    */  
   masteringTab(option: string) {
-    return element(by.cssContainingText("mat-tab-label-content", option));  
+    return element(by.cssContainingText(".mat-tab-label-content", option));  
   }
 
   /**
@@ -732,7 +732,7 @@ export class MasteringStep extends AppPage {
     return element(by.id("merge-option-max-values"));    
   }
 
-  async setMergeOptionDialogMaxValues(value: string) {
+  async setMergeOptionDialogMaxValues(value: number) {
     let inputField = this.mergeOptionDialogMaxValues;
     await inputField.clear();
     return await inputField.sendKeys(value);
@@ -742,7 +742,7 @@ export class MasteringStep extends AppPage {
     return element(by.id("merge-option-max-sources"));    
   }
 
-  async setMergeOptionDialogMaxSources(value: string) {
+  async setMergeOptionDialogMaxSources(value: number) {
     let inputField = this.mergeOptionDialogMaxSources;
     await inputField.clear();
     return await inputField.sendKeys(value);
@@ -754,7 +754,7 @@ export class MasteringStep extends AppPage {
     return element(by.id("merge-option-length"));    
   }
 
-  async setMergeOptionDialogLength(value: string) {
+  async setMergeOptionDialogLength(value: number) {
     let inputField = this.mergeOptionDialogLength;
     await inputField.clear();
     return await inputField.sendKeys(value);
@@ -1018,7 +1018,7 @@ export class MasteringStep extends AppPage {
   // Merge Collections
 
   get mergeCollectionsAddButton() {
-    return element(by.css("#merge-collections button.new-strategy-button"));
+    return element(by.css("#merge-collections button.new-collection-button"));
   }
 
   async clickMergeCollectionsAddButton() {
@@ -1164,8 +1164,100 @@ export class MasteringStep extends AppPage {
     let menuOption = this.mergeCollectionDialogEventOptions(option);
     return await menuOption.click();
   }
+  
+  /*
+  * collectionNumber starts with 0
+  */
+  
+  // Collection To Add
 
-  // TO DO add, remove, set collections
+  collectionToAdd(collectionNumber: number) {
+    return element(by.css(`#merge-collection-add-container div.add-group[ng-reflect-name="${collectionNumber}"] .add-key-${collectionNumber}`));
+  }
+
+  get addCollectionToAddButton() {
+    return element(by.id("merge-collection-add-add-btn"));
+  }
+
+  async clickAddCollectionToAddButton() {
+    let button = this.addCollectionToAddButton;
+    return await button.click();
+  }
+
+  async setCollectionToAdd(collectionNumber: number, collectionName: string) {
+    let inputField = this.collectionToAdd(collectionNumber);
+    await inputField.clear();
+    return await inputField.sendKeys(collectionName);
+  }
+
+  removeCollectionToAddButton(collectionNumber: number) {
+    return element(by.css(`#merge-collection-add-container div.add-group[ng-reflect-name="${collectionNumber}"] .add-remove-collection-btn`));
+  }
+
+  async clickRemoveCollectionToAddButton(collectionNumber: number) {
+    let button = this.removeCollectionToAddButton(collectionNumber);
+    return await button.click();
+  }
+
+  // Collection To Remove
+
+  collectionToRemove(collectionNumber: number) {
+    return element(by.css(`#merge-collection-remove-container div.remove-group[ng-reflect-name="${collectionNumber}"] .remove-key-${collectionNumber}`));
+  }
+
+  get addCollectionToRemoveButton() {
+    return element(by.id("merge-collection-add-remove-btn"));
+  }
+
+  async clickAddCollectionToRemoveButton() {
+    let button = this.addCollectionToRemoveButton;
+    return await button.click();
+  }
+
+  async setCollectionToRemove(collectionNumber: number, collectionName: string) {
+    let inputField = this.collectionToRemove(collectionNumber);
+    await inputField.clear();
+    return await inputField.sendKeys(collectionName);
+  }
+
+  removeCollectionToRemoveButton(collectionNumber: number) {
+    return element(by.css(`#merge-collection-remove-container div.remove-group[ng-reflect-name="${collectionNumber}"] .remove-remove-collection-btn`));
+  }
+
+  async clickRemoveCollectionToRemoveButton(collectionNumber: number) {
+    let button = this.removeCollectionToRemoveButton(collectionNumber);
+    return await button.click();
+  }
+
+  // Collection to Set
+  
+  collectionToSet(collectionNumber: number) {
+    return element(by.css(`#merge-collection-set-container div.set-group[ng-reflect-name="${collectionNumber}"] .set-key-${collectionNumber}`));
+  }
+
+  get addCollectionToSetButton() {
+    return element(by.id("merge-collection-add-set-btn"));
+  }
+
+  async clickAddCollectionToSetButton() {
+    let button = this.addCollectionToSetButton;
+    return await button.click();
+  }
+
+  async setCollectionToSet(collectionNumber: number, collectionName: string) {
+    let inputField = this.collectionToSet(collectionNumber);
+    await inputField.clear();
+    return await inputField.sendKeys(collectionName);
+  }
+
+  removeCollectionToSetButton(collectionNumber: number) {
+    return element(by.css(`#merge-collection-set-container div.set-group[ng-reflect-name="${collectionNumber}"] .set-remove-collection-btn`));
+  }
+
+  async clickRemoveCollectionToSetButton(collectionNumber: number) {
+    let button = this.removeCollectionToSetButton(collectionNumber);
+    return await button.click();
+  }
 
   /**
    * @param option = [cancel/save]

--- a/web/e2e/specs/scenarios/index.ts
+++ b/web/e2e/specs/scenarios/index.ts
@@ -1,7 +1,9 @@
 import simpleJson from './simpleJson'
+import multiFlows from './multiFlows'
 
 export default function(qaProjectDir) {
-  describe('simpleJson', function() {
+  describe('scenarios', function() {
     simpleJson(qaProjectDir);
+    multiFlows(qaProjectDir);
   })
 }

--- a/web/e2e/specs/scenarios/multiFlows.ts
+++ b/web/e2e/specs/scenarios/multiFlows.ts
@@ -1,0 +1,619 @@
+import {  browser, by, ExpectedConditions as EC} from 'protractor';
+import loginPage from '../../page-objects/auth/login';
+import dashboardPage from '../../page-objects/dashboard/dashboard';
+import entityPage from '../../page-objects/entities/entities';
+import appPage from '../../page-objects/appPage';
+import manageFlowPage from "../../page-objects/flows/manageFlows";
+import editFlowPage from '../../page-objects/flows/editFlow';
+import stepsPage from '../../page-objects/steps/steps';
+import ingestStepPage from '../../page-objects/steps/ingestStep';
+import mappingStepPage from '../../page-objects/steps/mappingStep';
+import masteringStepPage from '../../page-objects/steps/masteringStep';
+import manageJobsPage from '../../page-objects/jobs/manageJobs';
+import jobDetailsPage from '../../page-objects/jobs/jobDetails';
+import browsePage from '../../page-objects/browse/browse';
+
+export default function(qaProjectDir) {
+    describe('E2E Multiple Flows', () => {
+        beforeAll(() => {
+          browser.refresh();
+        });
+
+        xit('should login and go to entities page', async function() {
+            //await loginPage.browseButton.click();
+            await loginPage.setCurrentFolder(qaProjectDir);
+            await loginPage.clickNext('ProjectDirTab');
+            browser.wait(EC.elementToBeClickable(loginPage.environmentTab));
+            await loginPage.clickNext('EnvironmentTab');
+            browser.wait(EC.visibilityOf(loginPage.loginTab));
+            await loginPage.login();
+            dashboardPage.isLoaded();
+        });
+
+        it ('should create Customer entity', async function() {
+            await appPage.entitiesTab.click();
+            browser.wait(EC.visibilityOf(entityPage.toolsButton));
+            await entityPage.toolsButton.click();
+            await entityPage.newEntityButton.click();
+            await entityPage.entityTitle.sendKeys('Customer');
+            let lastProperty = entityPage.lastProperty;
+            // add id property
+            await entityPage.addProperty.click();
+            await entityPage.getPropertyName(lastProperty).sendKeys('id');
+            await entityPage.getPropertyType(lastProperty).element(by.cssContainingText('option', 'string')).click();
+            // add firstname property
+            await entityPage.addProperty.click();
+            lastProperty = entityPage.lastProperty;
+            await entityPage.getPropertyName(lastProperty).sendKeys('firstname');
+            await entityPage.getPropertyType(lastProperty).element(by.cssContainingText('option', 'string')).click();
+            // add lastname property
+            await entityPage.addProperty.click();
+            lastProperty = entityPage.lastProperty;
+            await entityPage.getPropertyName(lastProperty).sendKeys('lastname');
+            await entityPage.getPropertyType(lastProperty).element(by.cssContainingText('option', 'string')).click();
+            // add email property
+            await entityPage.addProperty.click();
+            lastProperty = entityPage.lastProperty;
+            await entityPage.getPropertyName(lastProperty).sendKeys('email');
+            await entityPage.getPropertyType(lastProperty).element(by.cssContainingText('option', 'string')).click();
+            // add zip property
+            await entityPage.addProperty.click();
+            lastProperty = entityPage.lastProperty;
+            await entityPage.getPropertyName(lastProperty).sendKeys('zip');
+            await entityPage.getPropertyType(lastProperty).element(by.cssContainingText('option', 'string')).click();
+            await entityPage.saveEntity.click();
+            browser.wait(EC.elementToBeClickable(entityPage.confirmDialogYesButton));
+            await entityPage.confirmDialogYesButton.click();
+            browser.wait(EC.visibilityOf(entityPage.getEntityBox('Customer')));
+            await entityPage.toolsButton.click();
+        });
+
+        it('should create Advantage Flow', async function() {
+            await appPage.flowsTab.click();
+            await manageFlowPage.clickNewFlowButton();
+            browser.wait(EC.visibilityOf(manageFlowPage.flowDialogBoxHeader("New Flow")));
+            await manageFlowPage.setFlowForm("name", "AdvantageFlow");
+            await manageFlowPage.clickFlowCancelSave("save");
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("AdvantageFlow")));
+            await expect(manageFlowPage.flowName("AdvantageFlow").getText()).toEqual("AdvantageFlow");
+        });
+
+        it('should create and run IngestAdvantage step', async function() {
+            await appPage.flowsTab.click();
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("AdvantageFlow")));
+            await manageFlowPage.clickFlowname("AdvantageFlow");
+            browser.sleep(5000);
+            browser.wait(EC.elementToBeClickable(editFlowPage.newStepButton));
+            await editFlowPage.clickNewStepButton();
+            browser.wait(EC.visibilityOf(stepsPage.stepDialogBoxHeader("New Step")));
+            await stepsPage.clickStepTypeDropDown();
+            browser.wait(EC.visibilityOf(stepsPage.stepTypeOptions("Ingestion")));
+            await stepsPage.clickStepTypeOption("Ingestion");
+            browser.wait(EC.visibilityOf(stepsPage.stepName));
+            await stepsPage.setStepName("IngestAdvantage");
+            await stepsPage.setStepDescription("Ingest Advantage docs");
+            await stepsPage.clickStepCancelSave("save");
+            browser.wait(EC.visibilityOf(stepsPage.stepDetailsName));
+            browser.sleep(3000);
+            await expect(stepsPage.stepDetailsName.getText()).toEqual("IngestAdvantage");
+            await ingestStepPage.setInputFilePath(qaProjectDir + "/input/advantage");
+            browser.sleep(3000);
+            await editFlowPage.clickRunFlowButton();
+            browser.wait(EC.visibilityOf(editFlowPage.runFlowHeader));
+            await editFlowPage.clickButtonRunCancel("flow");
+            browser.sleep(5000);
+            browser.wait(EC.visibilityOf(editFlowPage.finishedLatestJobStatus));
+            // Verify on Job Detail page
+            await editFlowPage.clickFinishedLatestJobStatus();
+            browser.sleep(5000);
+            browser.wait(EC.visibilityOf(jobDetailsPage.jobDetailsPageHeader));
+            browser.wait(EC.visibilityOf(jobDetailsPage.jobSummary));
+            browser.wait(EC.visibilityOf(jobDetailsPage.jobDetailsTable));
+            await expect(jobDetailsPage.jobSummaryFlowName.getText()).toEqual("AdvantageFlow");
+            await expect(jobDetailsPage.jobSummaryJobId.getText()).not.toBeNull;
+            await expect(jobDetailsPage.stepName("IngestAdvantage").getText()).toEqual("IngestAdvantage");
+            await expect(jobDetailsPage.stepStatus("IngestAdvantage").getText()).toEqual("Completed step 1");
+            await expect(jobDetailsPage.stepCommitted("IngestAdvantage").getText()).toEqual("1,002");   
+            await jobDetailsPage.clickStepCommitted("IngestAdvantage");
+            // Verify on Browse Data page
+            browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
+            browser.sleep(5000);
+            expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 1002');
+            await expect(browsePage.facetName("IngestAdvantage").getText()).toEqual("IngestAdvantage");
+            // Verify on Manage Flows page
+            await appPage.flowsTab.click()
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("AdvantageFlow")));
+            await expect(manageFlowPage.status("AdvantageFlow").getText()).toEqual("Finished");
+            await expect(manageFlowPage.docsCommitted("AdvantageFlow").getText()).toEqual("1,002");
+        });
+
+        it('should create and run MappingAdvantage step', async function() {
+            await appPage.flowsTab.click();
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("AdvantageFlow")));
+            await manageFlowPage.clickFlowname("AdvantageFlow");
+            browser.sleep(5000);
+            browser.wait(EC.elementToBeClickable(editFlowPage.newStepButton));
+            await editFlowPage.clickNewStepButton();
+            browser.wait(EC.visibilityOf(stepsPage.stepDialogBoxHeader("New Step")));
+            await stepsPage.clickStepTypeDropDown();
+            browser.wait(EC.visibilityOf(stepsPage.stepTypeOptions("Mapping")));
+            await stepsPage.clickStepTypeOption("Mapping");
+            browser.wait(EC.visibilityOf(stepsPage.stepName));
+            await stepsPage.setStepName("MappingAdvantage");
+            await stepsPage.setStepDescription("Mapping Advantage docs");
+            await stepsPage.clickSourceTypeRadioButton("collection");
+            browser.wait(EC.elementToBeClickable(stepsPage.stepSourceCollectionDropDown));
+            await stepsPage.clickStepSourceCollectionDropDown();
+            browser.wait(EC.elementToBeClickable(stepsPage.stepSourceCollectionOptions("IngestAdvantage")));
+            await stepsPage.clickStepSourceCollectionOption("IngestAdvantage");
+            await stepsPage.clickStepTargetEntityDropDown();
+            browser.wait(EC.elementToBeClickable(stepsPage.stepTargetEntityOptions("Customer")));
+            browser.sleep(5000);
+            await stepsPage.clickStepTargetEntityOption("Customer");
+            await stepsPage.clickStepCancelSave("save");
+            browser.wait(EC.visibilityOf(stepsPage.stepDetailsName));
+            browser.sleep(3000);
+            // Mapping the source to entity
+            // Map customerID to id
+            browser.wait(EC.visibilityOf(mappingStepPage.sourcePropertyContainer("id")));
+            await mappingStepPage.clickSourcePropertyContainer("id");
+            browser.wait(EC.visibilityOf(mappingStepPage.propertySelectMenu("id")));
+            await mappingStepPage.clickMapSourceProperty("customerID", "id");
+            // Map FirstName to firstname
+            browser.wait(EC.visibilityOf(mappingStepPage.sourcePropertyContainer("firstname")));
+            await mappingStepPage.clickSourcePropertyContainer("firstname");
+            browser.wait(EC.visibilityOf(mappingStepPage.propertySelectMenu("firstname")));
+            await mappingStepPage.clickMapSourceProperty("FirstName", "firstname");
+            // Map LastName to lastname
+            browser.wait(EC.visibilityOf(mappingStepPage.sourcePropertyContainer("lastname")));
+            await mappingStepPage.clickSourcePropertyContainer("lastname");
+            browser.wait(EC.visibilityOf(mappingStepPage.propertySelectMenu("lastname")));
+            await mappingStepPage.clickMapSourceProperty("LastName", "lastname");
+            // Map Email to email
+            browser.wait(EC.visibilityOf(mappingStepPage.sourcePropertyContainer("email")));
+            await mappingStepPage.clickSourcePropertyContainer("email");
+            browser.wait(EC.visibilityOf(mappingStepPage.propertySelectMenu("email")));
+            await mappingStepPage.clickMapSourceProperty("Email", "email");
+            // Map Postal to zip
+            browser.wait(EC.visibilityOf(mappingStepPage.sourcePropertyContainer("zip")));
+            await mappingStepPage.clickSourcePropertyContainer("zip");
+            browser.wait(EC.visibilityOf(mappingStepPage.propertySelectMenu("zip")));
+            await mappingStepPage.clickMapSourceProperty("Postal", "zip");
+            browser.sleep(10000);
+            // Redeploy
+            await appPage.flowsTab.click();
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("AdvantageFlow")));
+            await manageFlowPage.clickRedeployButton();
+            browser.wait(EC.visibilityOf(manageFlowPage.redeployDialog));
+            await manageFlowPage.clickRedeployConfirmationButton("YES");
+            browser.sleep(15000);
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("AdvantageFlow")));
+            await manageFlowPage.clickFlowname("AdvantageFlow");
+            browser.sleep(5000);
+            browser.wait(EC.elementToBeClickable(editFlowPage.newStepButton));
+            await editFlowPage.clickRunFlowButton();
+            browser.wait(EC.visibilityOf(editFlowPage.runFlowHeader));
+            // unselect run all
+            await editFlowPage.selectRunAll();
+            await editFlowPage.selectStepToRun("MappingAdvantage");
+            await editFlowPage.clickButtonRunCancel("flow");
+            browser.sleep(5000);
+            browser.wait(EC.visibilityOf(editFlowPage.finishedLatestJobStatus));
+            // Verify on Job Detail page
+            await editFlowPage.clickFinishedLatestJobStatus();
+            browser.sleep(5000);
+            browser.wait(EC.visibilityOf(jobDetailsPage.jobDetailsPageHeader));
+            browser.wait(EC.visibilityOf(jobDetailsPage.jobSummary));
+            browser.wait(EC.visibilityOf(jobDetailsPage.jobDetailsTable));
+            await expect(jobDetailsPage.jobSummaryFlowName.getText()).toEqual("AdvantageFlow");
+            await expect(jobDetailsPage.jobSummaryJobId.getText()).not.toBeNull;
+            await expect(jobDetailsPage.stepName("MappingAdvantage").getText()).toEqual("MappingAdvantage");
+            await expect(jobDetailsPage.stepStatus("MappingAdvantage").getText()).toEqual("Completed step 2");
+            await expect(jobDetailsPage.stepCommitted("MappingAdvantage").getText()).toEqual("1,002");   
+            await jobDetailsPage.clickStepCommitted("MappingAdvantage");
+            // Verify on Browse Data page
+            browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
+            browser.sleep(5000);
+            expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 1002');
+            await expect(browsePage.facetName("MappingAdvantage").getText()).toEqual("MappingAdvantage");
+            // Verify on Manage Flows page
+            await appPage.flowsTab.click();
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("AdvantageFlow")));
+            await expect(manageFlowPage.status("AdvantageFlow").getText()).toEqual("Finished");
+            await expect(manageFlowPage.docsCommitted("AdvantageFlow").getText()).toEqual("1,002");
+        });
+
+        it('should create Bedrock Flow', async function() {
+            await appPage.flowsTab.click();
+            await manageFlowPage.clickNewFlowButton();
+            browser.wait(EC.visibilityOf(manageFlowPage.flowDialogBoxHeader("New Flow")));
+            await manageFlowPage.setFlowForm("name", "BedrockFlow");
+            await manageFlowPage.clickFlowCancelSave("save");
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("BedrockFlow")));
+            await expect(manageFlowPage.flowName("BedrockFlow").getText()).toEqual("BedrockFlow");
+        });
+
+        it('should create and run IngestBedrock step', async function() {
+            await appPage.flowsTab.click();
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("BedrockFlow")));
+            await manageFlowPage.clickFlowname("BedrockFlow");
+            browser.sleep(5000);
+            browser.wait(EC.elementToBeClickable(editFlowPage.newStepButton));
+            await editFlowPage.clickNewStepButton();
+            browser.wait(EC.visibilityOf(stepsPage.stepDialogBoxHeader("New Step")));
+            await stepsPage.clickStepTypeDropDown();
+            browser.wait(EC.visibilityOf(stepsPage.stepTypeOptions("Ingestion")));
+            await stepsPage.clickStepTypeOption("Ingestion");
+            browser.wait(EC.visibilityOf(stepsPage.stepName));
+            await stepsPage.setStepName("IngestBedrock");
+            await stepsPage.setStepDescription("Ingest Bedrock docs");
+            await stepsPage.clickStepCancelSave("save");
+            browser.wait(EC.visibilityOf(stepsPage.stepDetailsName));
+            browser.sleep(3000);
+            await expect(stepsPage.stepDetailsName.getText()).toEqual("IngestBedrock");
+            await ingestStepPage.setInputFilePath(qaProjectDir + "/input/bedrock");
+            browser.sleep(3000);
+            await ingestStepPage.clickSourceFileTypeDropDown();
+            browser.wait(EC.elementToBeClickable(ingestStepPage.sourceFileTypeOptions("CSV")));
+            await ingestStepPage.clickSourceFileTypeOption("CSV");
+            await editFlowPage.clickRunFlowButton();
+            browser.wait(EC.visibilityOf(editFlowPage.runFlowHeader));
+            await editFlowPage.clickButtonRunCancel("flow");
+            browser.sleep(5000);
+            browser.wait(EC.visibilityOf(editFlowPage.finishedLatestJobStatus));
+            // Verify on Job Detail page
+            await editFlowPage.clickFinishedLatestJobStatus();
+            browser.sleep(5000);
+            browser.wait(EC.visibilityOf(jobDetailsPage.jobDetailsPageHeader));
+            browser.wait(EC.visibilityOf(jobDetailsPage.jobSummary));
+            browser.wait(EC.visibilityOf(jobDetailsPage.jobDetailsTable));
+            await expect(jobDetailsPage.jobSummaryFlowName.getText()).toEqual("BedrockFlow");
+            await expect(jobDetailsPage.jobSummaryJobId.getText()).not.toBeNull;
+            await expect(jobDetailsPage.stepName("IngestBedrock").getText()).toEqual("IngestBedrock");
+            await expect(jobDetailsPage.stepStatus("IngestBedrock").getText()).toEqual("Completed step 1");
+            await expect(jobDetailsPage.stepCommitted("IngestBedrock").getText()).toEqual("1,001");   
+            await jobDetailsPage.clickStepCommitted("IngestBedrock");
+            // Verify on Browse Data page
+            browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
+            browser.sleep(5000);
+            expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 1001');
+            await expect(browsePage.facetName("IngestBedrock").getText()).toEqual("IngestBedrock");
+            // Verify on Manage Flows page
+            await appPage.flowsTab.click()
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("BedrockFlow")));
+            await expect(manageFlowPage.status("BedrockFlow").getText()).toEqual("Finished");
+            await expect(manageFlowPage.docsCommitted("BedrockFlow").getText()).toEqual("1,001");
+        });
+
+        it('should create and run MappingBedrock step', async function() {
+            await appPage.flowsTab.click();
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("BedrockFlow")));
+            await manageFlowPage.clickFlowname("BedrockFlow");
+            browser.sleep(5000);
+            browser.wait(EC.elementToBeClickable(editFlowPage.newStepButton));
+            await editFlowPage.clickNewStepButton();
+            browser.wait(EC.visibilityOf(stepsPage.stepDialogBoxHeader("New Step")));
+            await stepsPage.clickStepTypeDropDown();
+            browser.wait(EC.visibilityOf(stepsPage.stepTypeOptions("Mapping")));
+            await stepsPage.clickStepTypeOption("Mapping");
+            browser.wait(EC.visibilityOf(stepsPage.stepName));
+            await stepsPage.setStepName("MappingBedrock");
+            await stepsPage.setStepDescription("Mapping Bedrock docs");
+            await stepsPage.clickSourceTypeRadioButton("collection");
+            browser.wait(EC.elementToBeClickable(stepsPage.stepSourceCollectionDropDown));
+            await stepsPage.clickStepSourceCollectionDropDown();
+            browser.wait(EC.elementToBeClickable(stepsPage.stepSourceCollectionOptions("IngestBedrock")));
+            await stepsPage.clickStepSourceCollectionOption("IngestBedrock");
+            await stepsPage.clickStepTargetEntityDropDown();
+            browser.wait(EC.elementToBeClickable(stepsPage.stepTargetEntityOptions("Customer")));
+            browser.sleep(5000);
+            await stepsPage.clickStepTargetEntityOption("Customer");
+            await stepsPage.clickStepCancelSave("save");
+            browser.wait(EC.visibilityOf(stepsPage.stepDetailsName));
+            browser.sleep(3000);
+            // Mapping the source to entity
+            // Map insurance_id to id
+            browser.wait(EC.visibilityOf(mappingStepPage.sourcePropertyContainer("id")));
+            await mappingStepPage.clickSourcePropertyContainer("id");
+            browser.wait(EC.visibilityOf(mappingStepPage.propertySelectMenu("id")));
+            await mappingStepPage.clickMapSourceProperty("insurance_id", "id");
+            // Map first_name to firstname
+            browser.wait(EC.visibilityOf(mappingStepPage.sourcePropertyContainer("firstname")));
+            await mappingStepPage.clickSourcePropertyContainer("firstname");
+            browser.wait(EC.visibilityOf(mappingStepPage.propertySelectMenu("firstname")));
+            await mappingStepPage.clickMapSourceProperty("first_name", "firstname");
+            // Map last_name to lastname
+            browser.wait(EC.visibilityOf(mappingStepPage.sourcePropertyContainer("lastname")));
+            await mappingStepPage.clickSourcePropertyContainer("lastname");
+            browser.wait(EC.visibilityOf(mappingStepPage.propertySelectMenu("lastname")));
+            await mappingStepPage.clickMapSourceProperty("last_name", "lastname");
+            // Map email to email
+            browser.wait(EC.visibilityOf(mappingStepPage.sourcePropertyContainer("email")));
+            await mappingStepPage.clickSourcePropertyContainer("email");
+            browser.wait(EC.visibilityOf(mappingStepPage.propertySelectMenu("email")));
+            await mappingStepPage.clickMapSourceProperty("email", "email");
+            // Map zip to zip
+            browser.wait(EC.visibilityOf(mappingStepPage.sourcePropertyContainer("zip")));
+            await mappingStepPage.clickSourcePropertyContainer("zip");
+            browser.wait(EC.visibilityOf(mappingStepPage.propertySelectMenu("zip")));
+            await mappingStepPage.clickMapSourceProperty("zip", "zip");
+            browser.sleep(10000);
+            // Redeploy
+            await appPage.flowsTab.click();
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("BedrockFlow")));
+            await manageFlowPage.clickRedeployButton();
+            browser.wait(EC.visibilityOf(manageFlowPage.redeployDialog));
+            await manageFlowPage.clickRedeployConfirmationButton("YES");
+            browser.sleep(15000);
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("BedrockFlow")));
+            await manageFlowPage.clickFlowname("BedrockFlow");
+            browser.sleep(5000);
+            browser.wait(EC.elementToBeClickable(editFlowPage.newStepButton));
+            await editFlowPage.clickRunFlowButton();
+            browser.wait(EC.visibilityOf(editFlowPage.runFlowHeader));
+            // unselect run all
+            await editFlowPage.selectRunAll();
+            await editFlowPage.selectStepToRun("MappingBedrock");
+            await editFlowPage.clickButtonRunCancel("flow");
+            browser.sleep(5000);
+            browser.wait(EC.visibilityOf(editFlowPage.finishedLatestJobStatus));
+            // Verify on Job Detail page
+            await editFlowPage.clickFinishedLatestJobStatus();
+            browser.sleep(5000);
+            browser.wait(EC.visibilityOf(jobDetailsPage.jobDetailsPageHeader));
+            browser.wait(EC.visibilityOf(jobDetailsPage.jobSummary));
+            browser.wait(EC.visibilityOf(jobDetailsPage.jobDetailsTable));
+            await expect(jobDetailsPage.jobSummaryFlowName.getText()).toEqual("BedrockFlow");
+            await expect(jobDetailsPage.jobSummaryJobId.getText()).not.toBeNull;
+            await expect(jobDetailsPage.stepName("MappingBedrock").getText()).toEqual("MappingBedrock");
+            await expect(jobDetailsPage.stepStatus("MappingBedrock").getText()).toEqual("Completed step 2");
+            await expect(jobDetailsPage.stepCommitted("MappingBedrock").getText()).toEqual("1,001");   
+            await jobDetailsPage.clickStepCommitted("MappingBedrock");
+            // Verify on Browse Data page
+            browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
+            browser.sleep(5000);
+            expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 1001');
+            await expect(browsePage.facetName("MappingBedrock").getText()).toEqual("MappingBedrock");
+            // Verify on Manage Flows page
+            await appPage.flowsTab.click();
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("BedrockFlow")));
+            await expect(manageFlowPage.status("BedrockFlow").getText()).toEqual("Finished");
+            await expect(manageFlowPage.docsCommitted("BedrockFlow").getText()).toEqual("1,001");
+        });     
+        
+        it('should create Mastering Flow', async function() {
+            await appPage.flowsTab.click();
+            await manageFlowPage.clickNewFlowButton();
+            browser.wait(EC.visibilityOf(manageFlowPage.flowDialogBoxHeader("New Flow")));
+            await manageFlowPage.setFlowForm("name", "MasteringFlow");
+            await manageFlowPage.clickFlowCancelSave("save");
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("MasteringFlow")));
+            await expect(manageFlowPage.flowName("MasteringFlow").getText()).toEqual("MasteringFlow");
+        });
+
+        it('should create and run MasteringCustomer step', async function() {
+            await appPage.flowsTab.click();
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("MasteringFlow")));
+            await manageFlowPage.clickFlowname("MasteringFlow");
+            browser.sleep(5000);
+            browser.wait(EC.elementToBeClickable(editFlowPage.newStepButton));
+            await editFlowPage.clickNewStepButton();
+            browser.wait(EC.visibilityOf(stepsPage.stepDialogBoxHeader("New Step")));
+            await stepsPage.clickStepTypeDropDown();
+            browser.wait(EC.visibilityOf(stepsPage.stepTypeOptions("Mastering")));
+            await stepsPage.clickStepTypeOption("Mastering");
+            browser.wait(EC.visibilityOf(stepsPage.stepName));
+            await stepsPage.setStepName("MasteringCustomer");
+            await stepsPage.setStepDescription("Mastering Customer docs");
+            await stepsPage.clickSourceTypeRadioButton("query");
+            browser.wait(EC.elementToBeClickable(stepsPage.stepSourceQuery));
+            await stepsPage.setStepSourceQuery(`cts.collectionQuery(["MappingAdvantage", "MappingBedrock"])`);
+            await stepsPage.clickStepTargetEntityDropDown();
+            browser.wait(EC.elementToBeClickable(stepsPage.stepTargetEntityOptions("Customer")));
+            browser.sleep(5000);
+            await stepsPage.clickStepTargetEntityOption("Customer");
+            await stepsPage.clickStepCancelSave("save");
+            browser.wait(EC.visibilityOf(stepsPage.stepDetailsName));
+            browser.sleep(3000);
+            await expect(stepsPage.stepDetailsName.getText()).toEqual("MasteringCustomer");
+            // Configure matching and merging
+            // Add matching option for firstname
+            await masteringStepPage.clickMatchOptionsAddButton();
+            browser.wait(EC.visibilityOf(masteringStepPage.matchOptionDialog));
+            await masteringStepPage.clickMatchOptionDialogPropertyMenu();
+            browser.wait(EC.elementToBeClickable(masteringStepPage.matchOptionDialogPropertyOptions("firstname")));
+            await masteringStepPage.clickMatchOptionDialogPropertyOption("firstname");
+            await masteringStepPage.setMatchOptionDialogWeight(5);
+            await masteringStepPage.clickMatchOptionCancelSave("save");
+            browser.sleep(3000);
+            // Add matching option for lastname
+            await masteringStepPage.clickMatchOptionsAddButton();
+            browser.wait(EC.visibilityOf(masteringStepPage.matchOptionDialog));
+            await masteringStepPage.clickMatchOptionDialogPropertyMenu();
+            browser.wait(EC.elementToBeClickable(masteringStepPage.matchOptionDialogPropertyOptions("lastname")));
+            await masteringStepPage.clickMatchOptionDialogPropertyOption("lastname");
+            await masteringStepPage.setMatchOptionDialogWeight(10);
+            await masteringStepPage.clickMatchOptionCancelSave("save");
+            browser.sleep(3000);
+            // Add matching option for email
+            await masteringStepPage.clickMatchOptionsAddButton();
+            browser.wait(EC.visibilityOf(masteringStepPage.matchOptionDialog));
+            await masteringStepPage.clickMatchOptionDialogPropertyMenu();
+            browser.wait(EC.elementToBeClickable(masteringStepPage.matchOptionDialogPropertyOptions("email")));
+            await masteringStepPage.clickMatchOptionDialogPropertyOption("email");
+            await masteringStepPage.setMatchOptionDialogWeight(20);
+            await masteringStepPage.clickMatchOptionCancelSave("save");
+            browser.sleep(3000);
+            // Add DefiniteMatch matching threshold
+            await masteringStepPage.clickMatchThresholdsAddButton();
+            browser.wait(EC.visibilityOf(masteringStepPage.matchThresholdDialog));
+            await masteringStepPage.setMatchThresholdDialogName("DefiniteMatch");
+            await masteringStepPage.setMatchThresholdDialogWeight(25);
+            await masteringStepPage.clickMatchThresholdDialogActionMenu();
+            browser.wait(EC.elementToBeClickable(masteringStepPage.matchThresholdDialogActionOptions("Merge")));
+            await masteringStepPage.clickMatchThresholdDialogActionOptions("Merge");
+            await masteringStepPage.clickMatchThresholdCancelSaveButton("save");
+            browser.wait(EC.visibilityOf(stepsPage.stepDetailsName));
+            browser.sleep(3000);
+            // Add MaybeMatch matching threshold
+            await masteringStepPage.clickMatchThresholdsAddButton();
+            browser.wait(EC.visibilityOf(masteringStepPage.matchThresholdDialog));
+            await masteringStepPage.setMatchThresholdDialogName("MaybeMatch");
+            await masteringStepPage.setMatchThresholdDialogWeight(15);
+            await masteringStepPage.clickMatchThresholdDialogActionMenu();
+            browser.wait(EC.elementToBeClickable(masteringStepPage.matchThresholdDialogActionOptions("Notify")));
+            await masteringStepPage.clickMatchThresholdDialogActionOptions("Notify");
+            await masteringStepPage.clickMatchThresholdCancelSaveButton("save");
+            browser.wait(EC.visibilityOf(stepsPage.stepDetailsName));
+            browser.sleep(3000);
+            // Add Merging Option for id
+            await masteringStepPage.clickMasteringTab("Merging");
+            browser.sleep(5000);
+            browser.wait(EC.elementToBeClickable(masteringStepPage.mergeOptionsAddButton));
+            await masteringStepPage.clickMergeOptionsAddButton();
+            browser.wait(EC.visibilityOf(masteringStepPage.mergeOptionDialog));
+            await masteringStepPage.clickMergeOptionDialogPropertyMenu();
+            browser.wait(EC.elementToBeClickable(masteringStepPage.mergeOptionDialogPropertyOptions("id")));
+            await masteringStepPage.clickMergeOptionDialogPropertyOption("id");
+            await masteringStepPage.setMergeOptionDialogMaxValues(1);
+            await masteringStepPage.clickMergeOptionCancelSave("save");
+            browser.wait(EC.visibilityOf(stepsPage.stepDetailsName));
+            browser.sleep(3000);
+            // Add onMerge Collection
+            await masteringStepPage.clickMergeCollectionsAddButton();
+            browser.wait(EC.visibilityOf(masteringStepPage.mergeCollectionDialog));
+            await masteringStepPage.setCollectionToSet(0, "customer-merge");
+            await masteringStepPage.clickMergeCollectionCancelSaveButton("save");
+            browser.wait(EC.visibilityOf(stepsPage.stepDetailsName));
+            browser.sleep(3000);
+            // Add onNotification Collection
+            await masteringStepPage.clickMergeCollectionsAddButton();
+            browser.wait(EC.visibilityOf(masteringStepPage.mergeCollectionDialog));
+            await masteringStepPage.clickMergeCollectionDialogEventMenu();
+            browser.wait(EC.elementToBeClickable(masteringStepPage.mergeCollectionDialogEventOptions("onNotification")));
+            await masteringStepPage.clickMergeCollectionDialogEventOptions("onNotification")
+            await masteringStepPage.setCollectionToSet(0, "customer-notify");
+            await masteringStepPage.clickMergeCollectionCancelSaveButton("save");
+            browser.wait(EC.visibilityOf(stepsPage.stepDetailsName));
+            browser.sleep(3000);
+            // Redeploy
+            await appPage.flowsTab.click();
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("MasteringFlow")));
+            await manageFlowPage.clickRedeployButton();
+            browser.wait(EC.visibilityOf(manageFlowPage.redeployDialog));
+            await manageFlowPage.clickRedeployConfirmationButton("YES");
+            browser.sleep(15000);
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("MasteringFlow")));
+            await manageFlowPage.clickFlowname("MasteringFlow");
+            browser.sleep(5000);
+            browser.wait(EC.elementToBeClickable(editFlowPage.newStepButton));
+            await editFlowPage.clickRunFlowButton();
+            browser.wait(EC.visibilityOf(editFlowPage.runFlowHeader));
+            // unselect run all
+            await editFlowPage.selectRunAll();
+            await editFlowPage.selectStepToRun("MasteringCustomer");
+            await editFlowPage.clickButtonRunCancel("flow");
+            browser.sleep(5000);
+            browser.wait(EC.visibilityOf(editFlowPage.finishedLatestJobStatus));
+            // Verify on Job Detail page
+            await editFlowPage.clickFinishedLatestJobStatus();
+            browser.sleep(5000);
+            browser.wait(EC.visibilityOf(jobDetailsPage.jobDetailsPageHeader));
+            browser.wait(EC.visibilityOf(jobDetailsPage.jobSummary));
+            browser.wait(EC.visibilityOf(jobDetailsPage.jobDetailsTable));
+            await expect(jobDetailsPage.jobSummaryFlowName.getText()).toEqual("MasteringFlow");
+            await expect(jobDetailsPage.jobSummaryJobId.getText()).not.toBeNull;
+            await expect(jobDetailsPage.stepName("MasteringCustomer").getText()).toEqual("MasteringCustomer");
+            await expect(jobDetailsPage.stepStatus("MasteringCustomer").getText()).toEqual("Completed step 1");
+            await expect(jobDetailsPage.stepCommitted("MasteringCustomer").getText()).toEqual("2,003");   
+            await jobDetailsPage.clickStepCommitted("MasteringCustomer");
+            // Verify on Browse Data page
+            browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
+            browser.sleep(5000);
+            expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 2006');
+            await expect(browsePage.facetName("MasteringCustomer").getText()).toEqual("MasteringCustomer");
+            await expect(browsePage.facetName("customer-merge").getText()).toEqual("customer-merge");
+            await expect(browsePage.facetCount("MasteringCustomer")).toEqual("2006");
+            await expect(browsePage.facetCount("customer-merge")).toEqual("1");
+            await expect(browsePage.facetCount("customer-notify")).toEqual("1");
+            // Verify on Manage Flows page
+            await appPage.flowsTab.click();
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("MasteringFlow")));
+            await expect(manageFlowPage.status("MasteringFlow").getText()).toEqual("Finished");
+            await expect(manageFlowPage.docsCommitted("MasteringFlow").getText()).toEqual("2,003");
+        });
+
+        it('should list AdvantageFlow jobs', async function() {
+            await appPage.jobsTab.click();
+            browser.wait(EC.visibilityOf(manageJobsPage.jobsPageHeader));
+            await manageJobsPage.clickFlowNameFilter();
+            browser.wait(EC.elementToBeClickable(manageJobsPage.flowNameFilterOptions("AdvantageFlow")));
+            await manageJobsPage.clickFlowNameFilterOptions("AdvantageFlow");
+            await manageJobsPage.getJobsCount("AdvantageFlow").then(function(jobs){expect(jobs >= 2)});
+        });
+
+        it('should search and list BedrockFlow jobs', async function() {
+            await appPage.jobsTab.click();
+            browser.wait(EC.visibilityOf(manageJobsPage.jobsPageHeader));
+            await manageJobsPage.setTextFilter("bedrock");
+            await manageJobsPage.getJobsCount("BedrockFlow").then(function(jobs){expect(jobs >= 2)});
+        });
+
+        it('should reset filter', async function() {
+            await appPage.jobsTab.click();
+            browser.wait(EC.visibilityOf(manageJobsPage.jobsPageHeader));
+            await manageJobsPage.clickResetFiltersButton();
+            await expect(manageJobsPage.jobPaginationRange.getText()).toEqual("1 - 5 of 5");
+        });
+
+        // Cleanup
+
+        it('should delete AdvantageFlow', async function() {
+            await appPage.flowsTab.click();
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("AdvantageFlow")));
+            await manageFlowPage.clickFlowMenu("AdvantageFlow");
+            browser.wait(EC.visibilityOf(manageFlowPage.flowMenuPanel));
+            browser.wait(EC.elementToBeClickable(manageFlowPage.flowMenuOptions("delete")));
+            await manageFlowPage.clickFlowMenuOption("delete");
+            browser.wait(EC.visibilityOf(manageFlowPage.deleteFlowHeader));
+            await manageFlowPage.clickDeleteConfirmationButton("YES");
+            browser.wait(EC.invisibilityOf(manageFlowPage.deleteFlowHeader));
+            browser.wait(EC.invisibilityOf(manageFlowPage.flowName("AdvantageFlow")));
+        });
+
+        it('should delete BedrockFlow', async function() {
+            await appPage.flowsTab.click();
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("BedrockFlow")));
+            await manageFlowPage.clickFlowMenu("BedrockFlow");
+            browser.wait(EC.visibilityOf(manageFlowPage.flowMenuPanel));
+            browser.wait(EC.elementToBeClickable(manageFlowPage.flowMenuOptions("delete")));
+            await manageFlowPage.clickFlowMenuOption("delete");
+            browser.wait(EC.visibilityOf(manageFlowPage.deleteFlowHeader));
+            await manageFlowPage.clickDeleteConfirmationButton("YES");
+            browser.wait(EC.invisibilityOf(manageFlowPage.deleteFlowHeader));
+            browser.wait(EC.invisibilityOf(manageFlowPage.flowName("BedrockFlow")));
+        });
+
+        it('should delete MasteringFlow', async function() {
+            await appPage.flowsTab.click();
+            browser.wait(EC.visibilityOf(manageFlowPage.flowName("MasteringFlow")));
+            await manageFlowPage.clickFlowMenu("MasteringFlow");
+            browser.wait(EC.visibilityOf(manageFlowPage.flowMenuPanel));
+            browser.wait(EC.elementToBeClickable(manageFlowPage.flowMenuOptions("delete")));
+            await manageFlowPage.clickFlowMenuOption("delete");
+            browser.wait(EC.visibilityOf(manageFlowPage.deleteFlowHeader));
+            await manageFlowPage.clickDeleteConfirmationButton("YES");
+            browser.wait(EC.invisibilityOf(manageFlowPage.deleteFlowHeader));
+            browser.wait(EC.invisibilityOf(manageFlowPage.flowName("MasteringFlow")));
+        });
+
+        it('should delete Customer entity', async function() {
+            await appPage.entitiesTab.click();
+            browser.wait(EC.visibilityOf(entityPage.toolsButton));
+            await entityPage.clickDeleteEntity('Customer');
+            browser.sleep(3000);
+            browser.wait(EC.elementToBeClickable(entityPage.confirmDialogYesButton));
+            await entityPage.confirmDialogYesButton.click();
+        });
+    });
+}


### PR DESCRIPTION
This PR:
- Add an E2E UI scenario from ingestion to mastering with CSV and JSON docs. This is similar to MLW demo with insurance customers. There is a test on docs merge notification
- Add test on manage jobs page to search specific jobs and undo filters
- Update and fix page objects to set/add/remove merge collections