### PR TITLE
Fix verification on merge collection facet

### DIFF
--- a/web/e2e/specs/scenarios/multiFlows.ts
+++ b/web/e2e/specs/scenarios/multiFlows.ts
@@ -482,7 +482,7 @@ export default function(qaProjectDir) {
             // Add onMerge Collection
             await masteringStepPage.clickMergeCollectionsAddButton();
             browser.wait(EC.visibilityOf(masteringStepPage.mergeCollectionDialog));
-            await masteringStepPage.setCollectionToSet(0, "customer-merge");
+            await masteringStepPage.setCollectionToSet(0, "CustomerMerge");
             await masteringStepPage.clickMergeCollectionCancelSaveButton("save");
             browser.wait(EC.visibilityOf(stepsPage.stepDetailsName));
             browser.sleep(3000);
@@ -529,12 +529,12 @@ export default function(qaProjectDir) {
             await jobDetailsPage.clickStepCommitted("MasteringCustomer");
             // Verify on Browse Data page
             browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
-            browser.sleep(5000);
+            browser.sleep(1000);
             expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 2006');
-            browser.wait(EC.elementToBeClickable(browsePage.facetName("customer-merge")));
+            browser.wait(EC.elementToBeClickable(browsePage.facetName("CustomerMerge")));
             await expect(browsePage.facetName("MasteringCustomer").getText()).toEqual("MasteringCustomer");
             await expect(browsePage.facetCount("MasteringCustomer")).toEqual("2006");
-            await expect(browsePage.facetCount("customer-merge")).toEqual("1");
+            await expect(browsePage.facetCount("CustomerMerge")).toEqual("1");
             await expect(browsePage.facetCount("customer-notify")).toEqual("1");
             // Verify on Manage Flows page
             await appPage.flowsTab.click();

--- a/web/e2e/specs/scenarios/multiFlows.ts
+++ b/web/e2e/specs/scenarios/multiFlows.ts
@@ -529,7 +529,7 @@ export default function(qaProjectDir) {
             await jobDetailsPage.clickStepCommitted("MasteringCustomer");
             // Verify on Browse Data page
             browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
-            browser.sleep(5000);
+            browser.sleep(10000);
             expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 2006');
             await expect(browsePage.facetName("MasteringCustomer").getText()).toEqual("MasteringCustomer");
             await expect(browsePage.facetName("customer-merge").getText()).toEqual("customer-merge");

--- a/web/e2e/specs/scenarios/multiFlows.ts
+++ b/web/e2e/specs/scenarios/multiFlows.ts
@@ -567,7 +567,6 @@ export default function(qaProjectDir) {
         });
 
         // Cleanup
-
         it('should delete AdvantageFlow', async function() {
             await appPage.flowsTab.click();
             browser.wait(EC.visibilityOf(manageFlowPage.flowName("AdvantageFlow")));

--- a/web/e2e/specs/scenarios/multiFlows.ts
+++ b/web/e2e/specs/scenarios/multiFlows.ts
@@ -482,8 +482,10 @@ export default function(qaProjectDir) {
             // Add onMerge Collection
             await masteringStepPage.clickMergeCollectionsAddButton();
             browser.wait(EC.visibilityOf(masteringStepPage.mergeCollectionDialog));
+            await masteringStepPage.clickMergeCollectionDialogEventMenu();
+            browser.wait(EC.elementToBeClickable(masteringStepPage.mergeCollectionDialogEventOptions("onMerge")));
+            await masteringStepPage.clickMergeCollectionDialogEventOptions("onMerge")
             await masteringStepPage.setCollectionToSet(0, "customer-merge");
-            browser.sleep(5000);
             await masteringStepPage.clickMergeCollectionCancelSaveButton("save");
             browser.wait(EC.visibilityOf(stepsPage.stepDetailsName));
             browser.sleep(3000);
@@ -530,7 +532,7 @@ export default function(qaProjectDir) {
             await jobDetailsPage.clickStepCommitted("MasteringCustomer");
             // Verify on Browse Data page
             browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
-            browser.sleep(1000);
+            browser.sleep(10000);
             expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 2006');
             await expect(browsePage.facetName("MasteringCustomer").getText()).toEqual("MasteringCustomer");
             await expect(browsePage.facetCount("MasteringCustomer")).toEqual("2006");

--- a/web/e2e/specs/scenarios/multiFlows.ts
+++ b/web/e2e/specs/scenarios/multiFlows.ts
@@ -482,7 +482,8 @@ export default function(qaProjectDir) {
             // Add onMerge Collection
             await masteringStepPage.clickMergeCollectionsAddButton();
             browser.wait(EC.visibilityOf(masteringStepPage.mergeCollectionDialog));
-            await masteringStepPage.setCollectionToSet(0, "CustomerMerge");
+            await masteringStepPage.setCollectionToSet(0, "customer-merge");
+            browser.sleep(5000);
             await masteringStepPage.clickMergeCollectionCancelSaveButton("save");
             browser.wait(EC.visibilityOf(stepsPage.stepDetailsName));
             browser.sleep(3000);
@@ -531,10 +532,9 @@ export default function(qaProjectDir) {
             browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
             browser.sleep(1000);
             expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 2006');
-            browser.wait(EC.elementToBeClickable(browsePage.facetName("CustomerMerge")));
             await expect(browsePage.facetName("MasteringCustomer").getText()).toEqual("MasteringCustomer");
             await expect(browsePage.facetCount("MasteringCustomer")).toEqual("2006");
-            await expect(browsePage.facetCount("CustomerMerge")).toEqual("1");
+            await expect(browsePage.facetCount("customer-merge")).toEqual("1");
             await expect(browsePage.facetCount("customer-notify")).toEqual("1");
             // Verify on Manage Flows page
             await appPage.flowsTab.click();

--- a/web/e2e/specs/scenarios/multiFlows.ts
+++ b/web/e2e/specs/scenarios/multiFlows.ts
@@ -529,8 +529,9 @@ export default function(qaProjectDir) {
             await jobDetailsPage.clickStepCommitted("MasteringCustomer");
             // Verify on Browse Data page
             browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
-            browser.sleep(50000);
+            browser.sleep(5000);
             expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 2006');
+            browser.wait(EC.elementToBeClickable(browsePage.facetName("customer-merge")));
             await expect(browsePage.facetName("MasteringCustomer").getText()).toEqual("MasteringCustomer");
             await expect(browsePage.facetCount("MasteringCustomer")).toEqual("2006");
             await expect(browsePage.facetCount("customer-merge")).toEqual("1");

--- a/web/e2e/specs/scenarios/multiFlows.ts
+++ b/web/e2e/specs/scenarios/multiFlows.ts
@@ -529,10 +529,9 @@ export default function(qaProjectDir) {
             await jobDetailsPage.clickStepCommitted("MasteringCustomer");
             // Verify on Browse Data page
             browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
-            browser.sleep(10000);
+            browser.sleep(50000);
             expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 2006');
             await expect(browsePage.facetName("MasteringCustomer").getText()).toEqual("MasteringCustomer");
-            await expect(browsePage.facetName("customer-merge").getText()).toEqual("customer-merge");
             await expect(browsePage.facetCount("MasteringCustomer")).toEqual("2006");
             await expect(browsePage.facetCount("customer-merge")).toEqual("1");
             await expect(browsePage.facetCount("customer-notify")).toEqual("1");


### PR DESCRIPTION
Fix some weird rendering issue. Sometimes the facet name "customer-merge" is displayed as "cus" or "custo" on jenkins run