### PR TITLE
Updates to run DHS test on 4.x

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     testCompile 'ch.qos.logback:logback-classic:1.1.11'
     testCompile 'org.slf4j:log4j-over-slf4j:1.7.13'
     testCompile("com.marklogic:mlcp-util:0.3.0")
-    testCompile("com.marklogic:mlcp:9.0.7") {
+    testCompile("com.marklogic:mlcp:9.0.8") {
       exclude group: 'org.apache.avro', module: 'avro-tools'
       exclude group: 'org.apache.commons', module: 'commons-csv'
     }

--- a/marklogic-data-hub/gradle-dhs.properties
+++ b/marklogic-data-hub/gradle-dhs.properties
@@ -14,22 +14,18 @@ mlFlowOperatorRole=flowOperator
 mlFlowOperatorUserName=flowop
 mlFlowOperatorPassword=SomePass#123
 
-mlFlowDeveloperRole=flow-developer-role
-mlFlowDeveloperUserName=flow-developer
-mlFlowDeveloperPassword=SomePass#123
-
 mlStagingAppserverName=data-hub-STAGING
-mlStagingPort=8006
+mlStagingPort=8010
 mlStagingDbName=data-hub-STAGING
 mlStagingForestsPerHost=1
 
-mlFinalAppserverName=data-hub-ADMIN
+mlFinalAppserverName=data-hub-FINAL
 mlFinalPort=8004
 mlFinalDbName=data-hub-FINAL
 mlFinalForestsPerHost=1
 
 mlJobAppserverName=data-hub-JOBS
-mlJobPort=8007
+mlJobPort=8013
 mlJobDbName=data-hub-JOBS
 mlJobForestsPerHost=1
 

--- a/ml-data-hub-plugin/gradle-dhs.properties
+++ b/ml-data-hub-plugin/gradle-dhs.properties
@@ -15,17 +15,17 @@ mlFlowOperatorUserName=flowop
 mlFlowOperatorPassword=SomePass#123
 
 mlStagingAppserverName=data-hub-STAGING
-mlStagingPort=8006
+mlStagingPort=8010
 mlStagingDbName=data-hub-STAGING
 mlStagingForestsPerHost=1
 
-mlFinalAppserverName=data-hub-ADMIN
+mlFinalAppserverName=data-hub-FINAL
 mlFinalPort=8004
 mlFinalDbName=data-hub-FINAL
 mlFinalForestsPerHost=1
 
 mlJobAppserverName=data-hub-JOBS
-mlJobPort=8007
+mlJobPort=8013
 mlJobDbName=data-hub-JOBS
 mlJobForestsPerHost=1
 


### PR DESCRIPTION
Made changes to ports to reflect latest changes in DHS.
Also updated the mlcp version to 9.0-8. This fixed all the failing mlcp tests in DHS.

Verified in a stack by running all the tests.