### PR TITLE
DHFPROD-2571: Updated dhf4-with-tests project for 4.3.1

### DIFF
--- a/examples/dhf4-with-tests/build.gradle
+++ b/examples/dhf4-with-tests/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "java"
     id 'net.saliman.properties' version '1.4.6'
-    id 'com.marklogic.ml-data-hub' version '4.1.0'
+    id 'com.marklogic.ml-data-hub' version '4.3.1'
 }
 
 repositories {

--- a/examples/dhf4-with-tests/src/main/hub-internal-config/servers/job-server.json
+++ b/examples/dhf4-with-tests/src/main/hub-internal-config/servers/job-server.json
@@ -9,6 +9,6 @@
   "authentication": "%%mlJobAuth%%",
   "default-error-format": "json",
   "error-handler": "/MarkLogic/rest-api/error-handler.xqy",
-  "url-rewriter": "/data-hub/5/tracing/tracing-rewriter.xml",
+  "url-rewriter": "/data-hub/4/tracing/tracing-rewriter.xml",
   "rewrite-resolves-globally": true
 }

--- a/examples/dhf4-with-tests/src/main/hub-internal-config/servers/staging-server.json
+++ b/examples/dhf4-with-tests/src/main/hub-internal-config/servers/staging-server.json
@@ -8,7 +8,7 @@
   "content-database": "%%mlStagingDbName%%",
   "authentication": "%%mlStagingAuth%%",
   "default-error-format": "json",
-  "error-handler": "/data-hub/5/rest-api/error-handler.xqy",
-  "url-rewriter": "/data-hub/5/rest-api/rewriter.xml",
+  "error-handler": "/data-hub/4/rest-api/error-handler.xqy",
+  "url-rewriter": "/data-hub/4/rest-api/rewriter.xml",
   "rewrite-resolves-globally": true
 }

--- a/examples/dhf4-with-tests/src/test/java/org/example/VerifyDeploymentTest.java
+++ b/examples/dhf4-with-tests/src/test/java/org/example/VerifyDeploymentTest.java
@@ -179,7 +179,7 @@ public class VerifyDeploymentTest extends AbstractDataHubTest {
 
         boolean wasInstalledViaQuickStart = wasInstalledViaQuickStart(databaseClient);
 
-        assertEquals(107, getModuleCountInDirectory("/data-hub/4/"), "DHF 4.1.0 has 107 modules in this directory");
+        assertEquals(109, getModuleCountInDirectory("/data-hub/4/"), "DHF 4.3.1 has 109 modules in this directory");
 
 
         if (wasInstalledViaQuickStart) {
@@ -215,9 +215,9 @@ public class VerifyDeploymentTest extends AbstractDataHubTest {
             "staging/default.xml; and staging/staging-entity-options.xml");
 
         if (wasInstalledViaQuickStart) {
-            assertEquals(153, getModuleCountInDirectory("/"));
+            assertEquals(155, getModuleCountInDirectory("/"));
         } else {
-            assertEquals(177, getModuleCountInDirectory("/"));
+            assertEquals(179, getModuleCountInDirectory("/"));
         }
     }
 


### PR DESCRIPTION
I figure this is worth doing, even though we're on 5, as anyone that's on 4 that can't yet go to 5 should still be able to go to 4.3.1. 

Had to add an empty settings.gradle file to make Gradle 5.x happy.