### PR TITLE
DHFPROD-2532: Add space for mapping menu

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/mapping-ui.component.scss
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/mapping-ui.component.scss
@@ -1,5 +1,5 @@
 .map-page {
-  padding: 20px 40px 150px 40px;
+  padding: 20px 40px 320px 40px;
 }
 
 .map-container {
@@ -194,6 +194,7 @@ p.item-identifying-info {
     padding: 0;
     cursor:pointer;
   }
+  width: 459px;
 }
 
 /* ENTITY INDEX ICONS */

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/mapping-ui.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/mapping-ui.component.ts
@@ -25,7 +25,7 @@ export class MappingUiComponent implements OnChanges {
   private uriOrig: string = '';
   private connsOrig: object = {};
 
-  public valMaxLen: number = 17;
+  public valMaxLen: number = 15;
 
   public filterFocus: object = {};
   public filterText: object = {};


### PR DESCRIPTION
Merge to bugfix branch develop, this bugfix has been already been reviewed and approved: https://github.com/marklogic/marklogic-data-hub/pull/2545

Add padding in mapping configuration container to account for mapping.
Also:
- Widen menu slightly to match filter container width.
- Decrease number of value characters shown to keep from crowding menu disclosure triangle.