### PR TITLE
DHFPROD-2554: Fields and field indexes are no longer dropped

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     compile('com.marklogic:ml-app-deployer:3.12.0'){
         exclude group: 'org.springframework', module: 'http'
     }
+    compile "org.jdom:jdom2:2.0.6"
 
     compile group: 'org.springframework.boot', name: 'spring-boot', version: '2.1.3.RELEASE'
     compile group: 'org.springframework.integration', name: 'spring-integration-http', version: '5.1.3.RELEASE'
@@ -54,7 +55,6 @@ dependencies {
     testRuntime "org.junit.platform:junit-platform-launcher:${junitPlatformVersion}"
 
     testCompile 'xmlunit:xmlunit:1.3'
-    testCompile 'org.jdom:jdom:2.0.2'
     testCompile 'org.skyscreamer:jsonassert:1.5.0'
     testCompile 'org.hamcrest:hamcrest-junit:2.0.0.0'
     testCompile 'org.easymock:easymock:3.4'

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/DeployDatabaseFieldCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/DeployDatabaseFieldCommand.java
@@ -19,18 +19,30 @@ package com.marklogic.hub.deploy.commands;
 import com.marklogic.appdeployer.command.CommandContext;
 import com.marklogic.appdeployer.command.SortOrderConstants;
 import com.marklogic.appdeployer.command.databases.DeployDatabaseCommand;
-import org.apache.commons.io.FileUtils;
+import com.marklogic.mgmt.resource.databases.DatabaseManager;
+import com.marklogic.rest.util.Fragment;
+import org.apache.commons.lang3.StringUtils;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.util.FileCopyUtils;
 
-import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Per DHFPROD-2554, this command ensures that when it adds DHF-specific fields and range field indexes to the
+ * staging, final, and jobs databases, it will not drop any existing fields or range field indexes.
+ * <p>
+ * The reason that these fields are applied via an XML file is to avoid a bug specific to JSON files and the Manage
+ * API that is not yet fixed in ML 9.0-9.
+ */
 public class DeployDatabaseFieldCommand extends DeployDatabaseCommand {
+
+    private final static Namespace MANAGE_NS = Namespace.getNamespace("http://marklogic.com/manage");
 
     public DeployDatabaseFieldCommand() {
         setExecuteSortOrder(SortOrderConstants.DEPLOY_CONTENT_DATABASES + 1);
@@ -38,42 +50,77 @@ public class DeployDatabaseFieldCommand extends DeployDatabaseCommand {
 
     @Override
     public void execute(CommandContext context) {
-        List<DeployDatabaseCommand> databaseCommandList = buildDatabaseCommands();
-        for (DeployDatabaseCommand deployDatabaseCommand : databaseCommandList) {
-            deployDatabaseCommand.execute(context);
+        DatabaseManager dbManager = new DatabaseManager(context.getManageClient());
+        for (Resource r : getDatabaseFieldFilesFromClasspath()) {
+            String payload;
+            try {
+                payload = new String(FileCopyUtils.copyToByteArray(r.getInputStream()));
+            } catch (IOException e) {
+                throw new RuntimeException("Unable to read database field file from classpath, cause: " + e.getMessage(), e);
+            }
+
+            payload = payloadTokenReplacer.replaceTokens(payload, context.getAppConfig(), false);
+            payload = addExistingFieldsAndRangeFieldIndexes(payload, dbManager);
+            dbManager.save(payload);
         }
     }
 
-    private List<DeployDatabaseCommand> buildDatabaseCommands() {
-        List<DeployDatabaseCommand> dbCommands = new ArrayList<>();
-
-        InputStream inputStream = null;
+    protected Resource[] getDatabaseFieldFilesFromClasspath() {
+        ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver(DeployDatabaseFieldCommand.class.getClassLoader());
         try {
-            ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver(DeployDatabaseFieldCommand.class.getClassLoader());
-            Resource[] resources = resolver.getResources("classpath*:/ml-database-field/*.xml");
-            for (Resource r : resources) {
-                inputStream = r.getInputStream();
-                File databaseFile = File.createTempFile("db-field-", ".xml");
-                databaseFile.deleteOnExit();
-                FileUtils.copyInputStreamToFile(inputStream, databaseFile);
+            return resolver.getResources("classpath*:/ml-database-field/*.xml");
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to find ml-database-field files on the classpath, cause: " + e.getMessage(), e);
+        }
+    }
 
-                logger.info("Will process file: " + databaseFile);
-                dbCommands.add(new DeployDatabaseCommand(databaseFile));
+    protected String addExistingFieldsAndRangeFieldIndexes(String payload, DatabaseManager dbManager) {
+        Fragment newProps = new Fragment(payload);
+        Fragment existingProps = dbManager.getPropertiesAsXml(newProps.getElementValue("/node()/m:database-name"));
+
+        addExistingFields(newProps, existingProps);
+        addExistingRangeFieldIndexes(newProps, existingProps);
+
+        return newProps.getPrettyXml();
+    }
+
+    protected void addExistingFields(Fragment newProps, Fragment existingProps) {
+        Element newFields = newProps.getInternalDoc().getRootElement().getChild("fields", MANAGE_NS);
+        if (newFields != null) {
+            List<String> newFieldNames = new ArrayList<>();
+            newProps.getElements("/m:database-properties/m:fields/m:field").forEach(field -> {
+                String name = field.getChildText("field-name", MANAGE_NS);
+                if (StringUtils.isNotBlank(name)) {
+                    newFieldNames.add(name);
+                }
+            });
+
+            for (Element field : existingProps.getElements("/m:database-properties/m:fields/m:field")) {
+                String name = field.getChildText("field-name", MANAGE_NS);
+                if (StringUtils.isNotBlank(name) && !newFieldNames.contains(name)) {
+                    newFields.addContent(field.detach());
+                }
             }
         }
-        catch (IOException e) {
-            e.printStackTrace();
-        }
-        finally {
-            if (inputStream != null) {
-                try {
-                    inputStream.close();
+    }
+
+    protected void addExistingRangeFieldIndexes(Fragment newProps, Fragment existingProps) {
+        Element newRangeFieldIndexes = newProps.getInternalDoc().getRootElement().getChild("range-field-indexes", MANAGE_NS);
+        if (newRangeFieldIndexes != null) {
+            List<String> newIndexFieldNames = new ArrayList<>();
+            newProps.getElements("/m:database-properties/m:range-field-indexes/m:range-field-index").forEach(index -> {
+                String name = index.getChildText("field-name", MANAGE_NS);
+                if (StringUtils.isNotBlank(name)) {
+                    newIndexFieldNames.add(name);
                 }
-                catch (IOException e) {
+            });
+
+            for (Element index : existingProps.getElements("/m:database-properties/m:range-field-indexes/m:range-field-index")) {
+                String name = index.getChildText("field-name", MANAGE_NS);
+                if (StringUtils.isNotBlank(name) && !newIndexFieldNames.contains(name)) {
+                    newRangeFieldIndexes.addContent(index.detach());
                 }
             }
         }
-
-        return dbCommands;
     }
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/DeployDatabaseFieldCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/DeployDatabaseFieldCommandTest.java
@@ -1,0 +1,136 @@
+package com.marklogic.hub.deploy.commands;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.appdeployer.command.CommandContext;
+import com.marklogic.hub.ApplicationConfig;
+import com.marklogic.hub.HubTestBase;
+import com.marklogic.mgmt.resource.databases.DatabaseManager;
+import com.marklogic.mgmt.util.ObjectMapperFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ApplicationConfig.class)
+public class DeployDatabaseFieldCommandTest extends HubTestBase {
+
+    @Test
+    public void test() {
+        givenTheFinalDatabaseHasACustomFieldAndIndex();
+        whenTheDatabaseFieldCommandIsExecuted();
+        thenTheCustomFieldAndIndexStillExist();
+    }
+
+    private void givenTheFinalDatabaseHasACustomFieldAndIndex() {
+        ObjectNode db = getFinalDatabaseProperties();
+
+        ObjectNode newNode = ObjectMapperFactory.getObjectMapper().createObjectNode();
+        newNode.put("database-name", "data-hub-FINAL");
+        newNode.set("field", db.get("field"));
+
+        ObjectNode newField = ((ArrayNode) newNode.get("field")).addObject();
+        newField.put("field-name", "myField");
+        ObjectNode fieldPath = newField.putObject("field-path");
+        fieldPath.put("path", "/myPath");
+        fieldPath.put("weight", 1);
+
+        ArrayNode indexes;
+        if (db.has("range-field-index")) {
+            indexes = (ArrayNode) db.get("range-field-index");
+            newNode.set("range-field-index", indexes);
+        } else {
+            indexes = newNode.putArray("range-field-index");
+        }
+        ObjectNode index = indexes.addObject();
+        index.put("scalar-type", "string");
+        index.put("field-name", "myField");
+        index.put("invalid-values", "reject");
+        index.put("range-value-positions", false);
+        index.put("collation", "http://marklogic.com/collation/");
+
+        new DatabaseManager(adminHubConfig.getManageClient()).save(newNode.toString());
+    }
+
+    private void whenTheDatabaseFieldCommandIsExecuted() {
+        CommandContext context = new CommandContext(adminHubConfig.getAppConfig(), adminHubConfig.getManageClient(),
+            adminHubConfig.getAdminManager());
+        new DeployDatabaseFieldCommand().execute(context);
+    }
+
+    private void thenTheCustomFieldAndIndexStillExist() {
+        ObjectNode db = getFinalDatabaseProperties();
+
+        ArrayNode fields = (ArrayNode) db.get("field");
+        // There could be other fields, so loop through the list to verify the custom one is there
+        JsonNode myField = null;
+        for (int i = 0; i < fields.size(); i++) {
+            JsonNode field = fields.get(i);
+            if ("myField".equals(field.get("field-name").asText())) {
+                myField = field;
+                break;
+            }
+        }
+        assertNotNull(myField, "Expected to find the myField custom field that was added before executing the command");
+
+        ArrayNode indexes = (ArrayNode) db.get("range-field-index");
+        JsonNode myIndex = null;
+        for (int i = 0; i < indexes.size(); i++) {
+            JsonNode field = indexes.get(i);
+            if ("myField".equals(field.get("field-name").asText())) {
+                myIndex = field;
+                break;
+            }
+        }
+        assertNotNull(myIndex, "Expected to find the myField range index that was added before executing the command");
+    }
+
+    private ObjectNode getFinalDatabaseProperties() {
+        DatabaseManager mgr = new DatabaseManager(adminHubConfig.getManageClient());
+        try {
+            return (ObjectNode) ObjectMapperFactory.getObjectMapper().readTree(mgr.getPropertiesAsJson("data-hub-FINAL"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * This ensures no residue is left behind on the final database.
+     */
+    @AfterEach
+    public void removeCustomFieldAndIndex() {
+        ObjectNode db = getFinalDatabaseProperties();
+
+        ArrayNode array = (ArrayNode) db.get("field");
+        for (int i = 0; i < array.size(); i++) {
+            JsonNode field = array.get(i);
+            if ("myField".equals(field.get("field-name").asText())) {
+                array.remove(i);
+                break;
+            }
+        }
+
+        array = (ArrayNode) db.get("range-field-index");
+        for (int i = 0; i < array.size(); i++) {
+            JsonNode field = array.get(i);
+            if ("myField".equals(field.get("field-name").asText())) {
+                array.remove(i);
+                break;
+            }
+        }
+
+        ObjectNode newNode = ObjectMapperFactory.getObjectMapper().createObjectNode();
+        newNode.set("database-name", db.get("database-name"));
+        newNode.set("field", db.get("field"));
+        newNode.set("range-field-index", db.get("range-field-index"));
+
+        new DatabaseManager(adminHubConfig.getManageClient()).save(newNode.toString());
+    }
+}


### PR DESCRIPTION
For reasons unknown to me, I had to make jdom a compile dependency, even though it should be coming over as a transitive dependency via ml-app-deployer.