### PR TITLE
DHFPROD-2341: Reset mapping config if source changes in step

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/mapping/mapping.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mapping/mapping.component.ts
@@ -253,6 +253,13 @@ export class MappingComponent implements OnInit {
     }
   }
 
+  // Parent component can trigger mapping reset if source changes
+  sourceChanged(): void {
+    this.sampleDocURI = '';
+    this.conns = {};
+    this.saveMap();
+  }
+
   /**
    * Interpret the datatype of a property value
    * Recognize all JSON types: array, object, number, boolean, null

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/mapping-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/mapping-ui.component.html
@@ -93,7 +93,7 @@
         </p>
       </div>
 
-      <div *ngIf="targetEntity?.definition.properties.length === 0">
+      <div *ngIf="targetEntity?.definition.properties.length === 0" class="no-properties">
         <em>{{ targetEntity?.info.title }} has no properties to map. Add them in the <a [routerLink]="['/entities']">Entities</a> view.</em>
       </div>
 

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/mapping-ui.component.scss
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/mapping-ui.component.scss
@@ -260,3 +260,7 @@ p.item-identifying-info {
 /deep/ .tooltip .tooltip-inner {
   max-width: 350px;
 }
+
+.no-properties {
+  padding: 10px 0 0 2px;
+}

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/edit-flow-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/edit-flow-ui.component.html
@@ -26,6 +26,7 @@
         [entities]="entities"
         [projectDirectory]="projectDirectory"
         [flowEnded]="flowEnded"
+        [sourceQuery]="step.options.sourceQuery"
         (updateStep)="updateStep($event)"
       ></app-step>
     </cdk-step>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/step.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/step.component.ts
@@ -19,6 +19,7 @@ export class StepComponent implements OnChanges {
   @Input() projectDirectory: any;
   @Input() selectedStepId: string;
   @Input() flowEnded: string;
+  @Input() sourceQuery: string;
   @Output() updateStep = new EventEmitter();
 
   @ViewChild(IngestComponent) ingestionStep: IngestComponent;
@@ -33,8 +34,8 @@ export class StepComponent implements OnChanges {
     public dialog: MatDialog
   ) {}
 
-  // workaround for: https://github.com/angular/material2/issues/7006
   ngOnChanges(changes: any) {
+    // workaround for: https://github.com/angular/material2/issues/7006
     if (changes &&
       changes.selectedStepId &&
       this.step.stepDefinitionType === this.stepType.MASTERING &&
@@ -47,6 +48,11 @@ export class StepComponent implements OnChanges {
       // reload mapping in case of new source docs
       if (this.mappingStep)
         this.mappingStep.loadMap();
+    }
+    if (changes.sourceQuery) {
+      // reset source doc URI on source change
+      if (this.mappingStep)
+        this.mappingStep.sourceChanged();
     }
   }
 


### PR DESCRIPTION
Resets mapping config when there are changes to the source collection setting or source query setting.

Looks for changes to source in step component. If found, calls a reset method (sourceChanged()) in mapping component.

Also CSS update to no-properties messaging to make consistent with other messaging styles.
