### PR TITLE
DHFPROD-2343: Remove the entity definition from database on deletion from UI

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/DataHub.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/DataHub.java
@@ -63,6 +63,13 @@ public interface DataHub {
     void clearUserModules();
 
     /**
+     * Deletes document based on supplied doc uri in supplied database
+     * @param uri - document uri
+     * @param databaseKind - database type
+     */
+    void deleteDocument(String uri, DatabaseKind databaseKind);
+
+    /**
      * Runs the pre-install check for the datahub populating the object
      * with variables necessary to perform the install.
      * This is used for running install.

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -396,6 +396,7 @@ public class DataHubImpl implements DataHub {
 
     public void deleteDocument(String uri, DatabaseKind databaseKind) {
         String query = "xdmp:document-delete(\"" + uri + "\")";
+        logger.info("Deleting URI " + uri + " from " + databaseKind + " database.");
         runInDatabase(query, hubConfig.getDbName(databaseKind));
     }
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -394,6 +394,11 @@ public class DataHubImpl implements DataHub {
         }
     }
 
+    public void deleteDocument(String uri, DatabaseKind databaseKind) {
+        String query = "xdmp:document-delete(\"" + uri + "\")";
+        runInDatabase(query, hubConfig.getDbName(databaseKind));
+    }
+
     public List<Command> buildListOfCommands() {
         Map<String, List<Command>> commandMap = buildCommandMap();
         List<Command> commands = new ArrayList<>();

--- a/web/src/main/java/com/marklogic/hub/web/service/DataHubService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/DataHubService.java
@@ -19,6 +19,7 @@ package com.marklogic.hub.web.service;
 import com.marklogic.appdeployer.command.Command;
 import com.marklogic.appdeployer.impl.SimpleAppDeployer;
 import com.marklogic.hub.DataHub;
+import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.deploy.commands.LoadHubArtifactsCommand;
 import com.marklogic.hub.deploy.commands.LoadUserArtifactsCommand;
@@ -123,6 +124,11 @@ public class DataHubService {
         }
         PerformanceLogger.logTimeInsideMethod(startTime, "DataHubService.reinstallUserModules");
 
+    }
+
+    @Async
+    public void deleteDocument(String uri, DatabaseKind databaseKind) {
+        dataHub.deleteDocument(uri, databaseKind);
     }
 
     @Async

--- a/web/src/main/java/com/marklogic/hub/web/service/EntityManagerService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/EntityManagerService.java
@@ -143,11 +143,12 @@ public class EntityManagerService {
     }
 
     public void deleteEntity(String entity) throws IOException {
-        File entitiesFile = hubConfig.getHubEntitiesDir().resolve(entity + ENTITY_FILE_EXTENSION).toFile();
+        String entityFileName = entity + ENTITY_FILE_EXTENSION;
+        File entitiesFile = hubConfig.getHubEntitiesDir().resolve(entityFileName).toFile();
         if (entitiesFile.exists()) {
             em.deleteEntity(entity);
-            dataHubService.deleteDocument("/entities/" + entity + ENTITY_FILE_EXTENSION, DatabaseKind.STAGING);
-            dataHubService.deleteDocument("/entities/" + entity + ENTITY_FILE_EXTENSION, DatabaseKind.FINAL);
+            dataHubService.deleteDocument("/entities/" + entityFileName, DatabaseKind.STAGING);
+            dataHubService.deleteDocument("/entities/" + entityFileName, DatabaseKind.FINAL);
         }
     }
 

--- a/web/src/main/java/com/marklogic/hub/web/service/EntityManagerService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/EntityManagerService.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.EntityManager;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.entity.HubEntity;
@@ -145,6 +146,8 @@ public class EntityManagerService {
         File entitiesFile = hubConfig.getHubEntitiesDir().resolve(entity + ENTITY_FILE_EXTENSION).toFile();
         if (entitiesFile.exists()) {
             em.deleteEntity(entity);
+            dataHubService.deleteDocument("/entities/" + entity + ENTITY_FILE_EXTENSION, DatabaseKind.STAGING);
+            dataHubService.deleteDocument("/entities/" + entity + ENTITY_FILE_EXTENSION, DatabaseKind.FINAL);
         }
     }
 

--- a/web/src/test/java/com/marklogic/hub/web/service/EntityManagerServiceTest.java
+++ b/web/src/test/java/com/marklogic/hub/web/service/EntityManagerServiceTest.java
@@ -19,12 +19,13 @@ package com.marklogic.hub.web.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marklogic.client.document.DocumentPage;
 import com.marklogic.hub.ApplicationConfig;
 import com.marklogic.hub.error.DataHubProjectException;
+import com.marklogic.hub.impl.HubConfigImpl;
 import com.marklogic.hub.legacy.flow.CodeFormat;
 import com.marklogic.hub.legacy.flow.DataFormat;
 import com.marklogic.hub.legacy.flow.FlowType;
-import com.marklogic.hub.impl.HubConfigImpl;
 import com.marklogic.hub.scaffold.Scaffolding;
 import com.marklogic.hub.util.FileUtil;
 import com.marklogic.hub.web.WebApplication;
@@ -47,8 +48,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(SpringExtension.class)
@@ -149,6 +149,22 @@ public class EntityManagerServiceTest extends AbstractServiceTest {
         List<String> expected = Arrays.asList(ENTITY, ENTITY2);
         List<String> actual = Arrays.asList(entities.get(0).getName(), entities.get(1).getName());
         assertTrue(expected.containsAll(actual));
+    }
+
+    @Test
+    public void deleteEntity() throws IOException {
+        List<EntityModel> entities = entityMgrService.getEntities();
+        assertEquals(1, entities.size());
+
+        entityMgrService.deleteEntity(ENTITY);
+
+        entities = entityMgrService.getEntities();
+        assertEquals(0, entities.size());
+
+        DocumentPage doc = finalDocMgr.read("/entities/" + ENTITY + ".entity.json");
+        assertFalse(doc.hasNext());
+        doc = stagingDocMgr.read("/entities/" + ENTITY + ".entity.json");
+        assertFalse(doc.hasNext());
     }
 
     @Test


### PR DESCRIPTION
Things to consider:
1. Security concerns for adding 
`void deleteDocument(String uri, DatabaseKind databaseKind);`
2. With this PR, we are moving away from the trend of clearing all modules and then reinstalling all of them. Instead, we are specifically removing a document if the user removes the entity from UI. This causes an issue if a user removes the entity from the filesystem and then expects it to be removed from the server on redeploy using UI.