### PR TITLE
DHFPROD-1878: Long facet text

### DIFF
--- a/web/src/main/ui/app/components/facets/facets.component.html
+++ b/web/src/main/ui/app/components/facets/facets.component.html
@@ -5,7 +5,7 @@
         mdl-colored="primary" mdl-button mdl-button-type="raised"
         *ngFor="let value of facet.values"
         (click)="toggle(facet.__key, value)">
-        <span class="chiclet-name" title="{{ value }}">{{ facet.__key }}: {{ value | truncate : 20 }}</span>
+        <span class="chiclet-name ellipsis" title="{{ value }}">{{ facet.__key }}: {{ value }}</span>
         <span class="fa fa-remove"></span>
       </button>
     </div>
@@ -16,9 +16,9 @@
       <ng-template [ngIf]="!isToggleCollapsed(facet.__key)">
         <div *ngFor="let value of facet.facetValues" class="facet-value" (click)="toggle(facet.__key, value.name)">
           <i class="fa fa-plus-circle facet-right-padding facet-add-pos"></i>
-          <span *ngIf="!!value.name" title="{{ value.name }}" [ngClass]='{"facet-small-name": value.name.length > 17}'>{{ value.name | truncate : 30 }}</span>
+          <span *ngIf="!!value.name" title="{{ value.name }}" class="facet-name-list ellipsis">{{ value.name }}</span>
           <em *ngIf="!value.name">blank</em>
-          <span class="badge" [mdl-badge]="value.count">.</span>
+          <span class="facet-count">{{ value.count }}</span>
           <i class="fa fa-ban facet-add-neg" *ngIf="shouldNegate" (click)="negate({facet: facet.__key, value: value.name})" title="{{ value.name }}"></i>
         </div>
         <div *ngIf="shouldShowMore &amp;&amp; !facet.displayingAll">

--- a/web/src/main/ui/app/components/facets/facets.component.scss
+++ b/web/src/main/ui/app/components/facets/facets.component.scss
@@ -28,21 +28,40 @@ $bg-color: unquote("rgb(#{$palette-datahub-500})");
     padding: 2px;
     padding-top: 10px;
     cursor: pointer;
+    position: relative;
 
     .fa {
       color: $bg-color;
       font-size: 11px;
     }
 
-    .facet-small-name {
-      font-size: .59vw;
+    .facet-add-pos {
+      float: left;
+      margin-top: 5px;
     }
 
-    .mdl-badge {
-      &:after {
-        width: 48px;
-        border-radius: 10%;
-      }
+    .ellipsis {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .facet-name-list {
+      width: 82%;
+      font-size: 0.84em;
+      display: inline-block;
+    }
+
+    .facet-count {
+      position: absolute;
+      right: 3px;
+      top: 9px;
+      min-width: 10%;
+      padding: 0 3px;
+      border-radius: 10%;
+      background: $bg-color;
+      color: white;
+      text-align: center;
     }
   }
 
@@ -51,22 +70,32 @@ $bg-color: unquote("rgb(#{$palette-datahub-500})");
   }
 }
 
-/deep/ span.badge.mdl-badge[data-badge] {
-  float: right;
-  &:after {
-    top: -5px;
-    background: $bg-color;
-  }
-}
-
 .chiclets {
   button {
     font-size: 10px;
     margin-bottom: 5px;
+    display: inline-block;
+    width: 100%;
 
     .chiclet-name {
-        font-size: .54vw;
+        font-size: 1em;
+        display: inline-block;
+        width: 90%;
+        text-transform: none;
     }
+
+    .ellipsis {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .fa-remove {
+      position: absolute;
+      margin: 12px 0 0 0;
+      right: 16px;
+    }
+
   }
 
   margin-bottom: 10px;

--- a/web/src/main/ui/app/components/jobs/ui/jobs-ui.component.scss
+++ b/web/src/main/ui/app/components/jobs/ui/jobs-ui.component.scss
@@ -55,7 +55,7 @@ input[type="search"] {
 }
 
 .results {
-  width: 90%;
+  width: 95%;
 }
 
 .mdl-data-table {

--- a/web/src/main/ui/app/components/search/ui/search-ui.component.html
+++ b/web/src/main/ui/app/components/search/ui/search-ui.component.html
@@ -30,13 +30,13 @@
       (pageChanged)="pageChanged.emit($event)"></app-pagination>
     <div *ngIf="!loadingTraces && (!searchResponse || searchResponse.total === 0)">No Data</div>
     <div class="mdl-grid results">
-      <div class="mdl-cell mdl-cell--2-col">
+      <div class="mdl-cell mdl-cell--3-col">
         <app-facets
           [facets]="searchResponse.facets"
           [(activeFacets)]="activeFacets"
           (activeFacetsChange)="onActiveFacetsChange.emit($event)"></app-facets>
       </div>
-      <div class="mdl-cell mdl-cell--10-col">
+      <div class="mdl-cell mdl-cell--9-col">
         <div *ngIf="searchResponse && searchResponse.total > 0">
           <div *ngFor="let result of searchResponse.results" class="result">
             <div class="link">

--- a/web/src/main/ui/app/components/search/ui/search-ui.component.scss
+++ b/web/src/main/ui/app/components/search/ui/search-ui.component.scss
@@ -34,7 +34,7 @@ input[type="search"] {
 }
 
 .results {
-  width: 90%;
+  width: 95%;
 }
 
 .mdl-data-table {

--- a/web/src/main/ui/app/components/traces/ui/traces-ui.component.scss
+++ b/web/src/main/ui/app/components/traces/ui/traces-ui.component.scss
@@ -33,7 +33,7 @@ input[type="search"] {
 }
 
 .results {
-  width: 90%;
+  width: 95%;
 }
 
 .mdi-alert {


### PR DESCRIPTION
The following is the proposed change to the UI to not only fix the described bug with the text bumping down the chicklets but also the general size and "..." truncation of longer names.

What changed?

- The facets column became one column wider, while the results became one smaller. There is no negative impact on the results, as far as I can tell.
- As the browser shrinks or on smaller screen sizes, there was previously code that made the text bump down in size, making it unreadable. I've removed that and stayed at a fixed, readable size.
- We're now using CSS to handle the ellipsis, rathar than truncating by # of characters. This makes our truncation be more accurate.
- The chiclet size is much less wide with less padding, leaving more room for the collection name.

Old Behavior:
https://drive.google.com/file/d/1wFhbM1C1xMkW1wJkeDd35mI6NByhQjbO/view

New Behavior:
https://drive.google.com/file/d/1XvGI6TkRNWlZ9_h2DCZBo1Na-P400TwB/view