### PR TITLE
DHFPROD-2572: Save options when editing flow settings

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/edit-flow-ui.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/edit-flow-ui.component.ts
@@ -123,6 +123,7 @@ export class EditFlowUiComponent implements OnChanges {
         this.flow.description = response.description;
         this.flow.batchSize = response.batchSize;
         this.flow.threadCount = response.threadCount;
+        this.flow.options = response.options;
         this.saveFlow.emit(this.flow);
       }
     });


### PR DESCRIPTION
To test:

- Create a flow.
- Edit the flow settings on the Edit Flow page.
- Add a key/value option and save.

Option should now persist.