### PR TITLE
DHFPROD-2607: Fix uber-model generation on ML nightly

### DIFF
--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-admin-role.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-admin-role.json
@@ -36,6 +36,11 @@
       "kind": "execute"
     },
     {
+      "privilege-name": "xdmp:xslt-invoke",
+      "action": "http://marklogic.com/xdmp/privileges/xslt-invoke",
+      "kind": "execute"
+    },
+    {
       "privilege-name": "xdmp:invoke",
       "action": "http://marklogic.com/xdmp/privileges/xdmp-invoke",
       "kind": "execute"

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/flow-developer-role.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/flow-developer-role.json
@@ -36,6 +36,11 @@
       "kind": "execute"
     },
     {
+      "privilege-name": "xdmp:xslt-invoke",
+      "action": "http://marklogic.com/xdmp/privileges/xslt-invoke",
+      "kind": "execute"
+    },
+    {
       "privilege-name": "xdmp:invoke",
       "action": "http://marklogic.com/xdmp/privileges/xdmp-invoke",
       "kind": "execute"

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/flow-operator-role.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/flow-operator-role.json
@@ -38,6 +38,11 @@
       "kind": "execute"
     },
     {
+      "privilege-name": "xdmp:xslt-invoke",
+      "action": "http://marklogic.com/xdmp/privileges/xslt-invoke",
+      "kind": "execute"
+    },
+    {
       "privilege-name": "xdmp:invoke",
       "action": "http://marklogic.com/xdmp/privileges/xdmp-invoke",
       "kind": "execute"


### PR DESCRIPTION
Entity services has a fix for bugtrack 52006, which requires DHF to have xdmp:xslt-invoke privilege to our roles.