### PR TITLE
DHFPROD-2611: Using ml-gradle 3.15.0 for deploying DHF bootstrap project

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'java'
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.7.2'
-    id 'com.marklogic.ml-gradle' version '3.12.0'
+    id 'com.marklogic.ml-gradle' version '3.15.0'
     id 'com.moowork.node' version '1.1.1'
     id 'org.springframework.boot' version '2.1.3.RELEASE'
     id "io.spring.dependency-management" version "1.0.7.RELEASE"
@@ -68,7 +68,7 @@ dependencies {
 
     // Provides support for invoking marklogic-unit-test tests via JUnit
     testCompile "com.marklogic:marklogic-junit:1.0.beta"
-    mlRestApi "com.marklogic:marklogic-unit-test-modules:1.0.beta"
+    mlBundle "com.marklogic:marklogic-unit-test-modules:1.0.beta"
 }
 
 import com.marklogic.mgmt.ManageClient

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/LoadTestModules.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/LoadTestModules.java
@@ -32,11 +32,11 @@ public class LoadTestModules {
          * because that will overwrite some collections and tokens set by the Installer program.
          */
         config.getModulePaths().clear();
-        config.getModulePaths().add("marklogic-data-hub/build/mlRestApi/marklogic-unit-test-modules/ml-modules");
+        config.getModulePaths().add("marklogic-data-hub/build/mlBundle/marklogic-unit-test-modules/ml-modules");
         config.getModulePaths().add("marklogic-data-hub/src/test/ml-modules");
-        config.getModulePaths().add("build/mlRestApi/marklogic-unit-test-modules/ml-modules");
+        config.getModulePaths().add("build/mlBundle/marklogic-unit-test-modules/ml-modules");
         config.getModulePaths().add("src/test/ml-modules");
-        config.getModulePaths().add("../build/mlRestApi/marklogic-unit-test-modules/ml-modules");
+        config.getModulePaths().add("../build/mlBundle/marklogic-unit-test-modules/ml-modules");
         config.getModulePaths().add("../src/test/ml-modules");
 
         new SimpleAppDeployer(new LoadModulesCommand()).deploy(config);


### PR DESCRIPTION
This is the project that's used for running DHF tests.