### PR TITLE
DHFPROD-2634: Disabling CMA for users

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'java'
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.7.2'
-    id 'com.marklogic.ml-gradle' version '3.15.0'
+    id 'com.marklogic.ml-gradle' version '3.15.1'
     id 'com.moowork.node' version '1.1.1'
     id 'org.springframework.boot' version '2.1.3.RELEASE'
     id "io.spring.dependency-management" version "1.0.7.RELEASE"
@@ -377,7 +377,7 @@ task setupSSL{
     }
 }
 
-bootstrap.finalizedBy mlPrepareRestApiDependencies // ensures that marklogic-unit-test is downloaded
+bootstrap.finalizedBy mlPrepareBundles // ensures that marklogic-unit-test is downloaded
 
 setupSSL.dependsOn(testClasses)
 bootstrap.dependsOn(setupSSL)

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -528,9 +528,19 @@ public class DataHubImpl implements DataHub {
             }
         }
 
+        /**
+         * Starting in 5.0.1, with ml-app-deployer 3.15.0, CMA usage is enabled by default. But a bug in ML 9.0-7
+         * and 9.0-8 prevents user deployment from working correctly. So have to disable user deployment via CMA to
+         * be compatible with 9.0-7, which also means disabling combined requests (as the first combined request
+         * involves deploying users and several other security resources).
+         */
+        AppConfig appConfig = hubConfig.getAppConfig();
+        appConfig.getCmaConfig().setCombineRequests(false);
+        appConfig.getCmaConfig().setDeployUsers(false);
+
         HubAppDeployer finalDeployer = new HubAppDeployer(getManageClient(), getAdminManager(), listener, hubConfig.newStagingClient());
         finalDeployer.setCommands(buildListOfCommands());
-        finalDeployer.deploy(hubConfig.getAppConfig());
+        finalDeployer.deploy(appConfig);
     }
 
     /**

--- a/ml-data-hub-plugin/build.gradle
+++ b/ml-data-hub-plugin/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     compile (project(':marklogic-data-hub')) {
         exclude group: 'ch.qos.logback'
     }
-    compile ('com.marklogic:ml-gradle:3.15.0') {
+    compile ('com.marklogic:ml-gradle:3.15.1') {
         exclude group: 'ch.qos.logback'
     }
     compile group: 'org.jdom', name: 'jdom2', version: '2.0.6'

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -225,6 +225,15 @@ class DataHubPlugin implements Plugin<Project> {
             hubConfig.setManageConfig(extensions.getByName("mlManageConfig"))
             hubConfig.setManageClient(extensions.getByName("mlManageClient"))
 
+            /**
+             * Starting in 5.0.1, with ml-app-deployer 3.15.0, CMA usage is enabled by default. But a bug in ML 9.0-7
+             * and 9.0-8 prevents user deployment from working correctly. So have to disable user deployment via CMA to
+             * be compatible with 9.0-7, which also means disabling combined requests (as the first combined request
+             * involves deploying users and several other security resources).
+             */
+            hubConfig.getAppConfig().getCmaConfig().setCombineRequests(false);
+            hubConfig.getAppConfig().getCmaConfig().setDeployUsers(false);
+
             project.extensions.add("hubConfig", hubConfig)
             project.extensions.add("hubProject", hubProject)
             project.extensions.add("dataHub", dataHub)


### PR DESCRIPTION
CMA for users doesn't work in ML 9.0-7, and DHF must be compatible with 9.0-7.