### PR TITLE
DHFPROD-2634: Turning off CMA for databases and roles

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -542,14 +542,11 @@ public class DataHubImpl implements DataHub {
 
         logger.warn("Installing the Data Hub into MarkLogic");
 
-        /**
-         * Starting in 5.0.1, with ml-app-deployer 3.15.0, CMA usage is enabled by default. But a bug in ML 9.0-7
-         * and 9.0-8 prevents user deployment from working correctly. So have to disable user deployment via CMA to
-         * be compatible with 9.0-7, which also means disabling combined requests (as the first combined request
-         * involves deploying users and several other security resources).
-         */
+        // Turning off CMA for resources that have bugs in ML 9.0-7/8
         AppConfig appConfig = hubConfig.getAppConfig();
         appConfig.getCmaConfig().setCombineRequests(false);
+        appConfig.getCmaConfig().setDeployDatabases(false);
+        appConfig.getCmaConfig().setDeployRoles(false);
         appConfig.getCmaConfig().setDeployUsers(false);
 
         // in AWS setting this fails...

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -421,8 +421,10 @@ public class HubTestBase {
         adminHubConfig.setMlUsername(user);
         adminHubConfig.setMlPassword(password);
 
-        // Turning off CMA for users as it has bugs in ML 9.0-7/8
+        // Turning off CMA for resources that have bugs in ML 9.0-7/8
         adminHubConfig.getAppConfig().getCmaConfig().setCombineRequests(false);
+        adminHubConfig.getAppConfig().getCmaConfig().setDeployDatabases(false);
+        adminHubConfig.getAppConfig().getCmaConfig().setDeployRoles(false);
         adminHubConfig.getAppConfig().getCmaConfig().setDeployUsers(false);
 
         wireClients();

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -225,13 +225,10 @@ class DataHubPlugin implements Plugin<Project> {
             hubConfig.setManageConfig(extensions.getByName("mlManageConfig"))
             hubConfig.setManageClient(extensions.getByName("mlManageClient"))
 
-            /**
-             * Starting in 5.0.1, with ml-app-deployer 3.15.0, CMA usage is enabled by default. But a bug in ML 9.0-7
-             * and 9.0-8 prevents user deployment from working correctly. So have to disable user deployment via CMA to
-             * be compatible with 9.0-7, which also means disabling combined requests (as the first combined request
-             * involves deploying users and several other security resources).
-             */
+            // Turning off CMA for resources that have bugs in ML 9.0-7/8
             hubConfig.getAppConfig().getCmaConfig().setCombineRequests(false);
+            hubConfig.getAppConfig().getCmaConfig().setDeployDatabases(false);
+            hubConfig.getAppConfig().getCmaConfig().setDeployRoles(false);
             hubConfig.getAppConfig().getCmaConfig().setDeployUsers(false);
 
             project.extensions.add("hubConfig", hubConfig)


### PR DESCRIPTION
Doing this because when I ran the latest ml-app-deployer 3.15.0 tests on ML 9.0-7, several tests failed pertaining to databases and roles. The tests all pass in 9.0-9. So thinking better safe than sorry for now with DHF.