### PR TITLE
DHFPROD-2383: Matching tooltip edits

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.html
@@ -51,7 +51,7 @@
     [matTooltip]="selectedType === 'reduce' ? tooltips.weightReduce : tooltips.weightOption"
     matTooltipPosition="left"
     matTooltipShowDelay="500"
-    matTooltipHideDelay="500000"
+    matTooltipHideDelay="500"
     matTooltipClass="weight-tooltip"
     *ngIf="selectedType !== 'zip'" layout-fill>
     <mat-label>Weight</mat-label>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.html
@@ -20,7 +20,11 @@
   </mat-form-field>
 
   <div *ngIf="selectedType === 'reduce'" id="properties-reduce">
-    <mat-label>
+    <mat-label
+      [matTooltip]="tooltips.propsReduce"
+      matTooltipPosition="left"
+      matTooltipShowDelay="500"
+      matTooltipHideDelay="500">
       Properties to Match
     </mat-label>
     <button class="add-property-btn" mat-icon-button (click)="onAddProp()">
@@ -31,11 +35,7 @@
       formArrayName="propertiesReduce"
       *ngFor="let prop of this.propertiesReduce.controls; let i = index;">
       <div [formGroupName]="i" class="prop-group">
-        <mat-form-field
-          [matTooltip]="tooltips.propsReduce"
-          matTooltipPosition="left"
-          matTooltipShowDelay="500"
-          matTooltipHideDelay="500" layout-fill>
+        <mat-form-field layout-fill>
           <mat-select class="match-option-property-reduce" required placeholder="Property Name" formControlName="name">
             <mat-option class="type-option" *ngFor="let prop of data.entityProps" [value]="prop.name">{{prop.name}}</mat-option>
           </mat-select>
@@ -51,10 +51,11 @@
     [matTooltip]="selectedType === 'reduce' ? tooltips.weightReduce : tooltips.weightOption"
     matTooltipPosition="left"
     matTooltipShowDelay="500"
-    matTooltipHideDelay="500"
+    matTooltipHideDelay="500000"
+    matTooltipClass="weight-tooltip"
     *ngIf="selectedType !== 'zip'" layout-fill>
     <mat-label>Weight</mat-label>
-    <input id="match-option-weight" matInput formControlName="weight" required title=" "/>
+    <input id="match-option-weight" matInput formControlName="weight" required title=""/>
     <mat-error id="match-option-weight-error" *ngIf="form.get('weight').invalid">A number is required</mat-error>
   </mat-form-field>
 
@@ -110,7 +111,7 @@
       matTooltipShowDelay="500"
       matTooltipHideDelay="500" layout-fill>
       <mat-label>5-Matches-9 Boost</mat-label>
-      <input id="match-option-zip-zip5match9" matInput formControlName="zip5match9" required title=" "/>
+      <input id="match-option-zip-zip5match9" matInput formControlName="zip5match9" required title=""/>
       <mat-error id="match-option-zip-zip5match9-error" *ngIf="form.get('zip5match9').invalid">A number is required</mat-error>
     </mat-form-field>
     <mat-form-field
@@ -119,7 +120,7 @@
       matTooltipShowDelay="500"
       matTooltipHideDelay="500" layout-fill>
       <mat-label>9-Matches-5 Weight</mat-label>
-      <input id="match-option-zip-zip9match5" matInput formControlName="zip9match5" required title=" "/>
+      <input id="match-option-zip-zip9match5" matInput formControlName="zip9match5" required title=""/>
       <mat-error id="match-option-zip-zip9match5-error" *ngIf="form.get('zip9match5').invalid">A number is required</mat-error>
     </mat-form-field>
   </div>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.scss
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.scss
@@ -31,6 +31,9 @@ div.prop-group input {
 /deep/ .mat-tooltip {
   white-space: pre-line !important;
   position: relative;
-  left: 427px;
+  left: 448px;
   top: -8px;
+}
+/deep/ .mat-tooltip.weight-tooltip {
+  max-width: 260px !important;
 }

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-threshold-dialog.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-threshold-dialog.component.html
@@ -10,10 +10,14 @@
     matTooltipShowDelay="500"
     matTooltipHideDelay="500" layout-fill>
     <mat-label>Weight</mat-label>
-    <input id="match-threshold-weight" matInput formControlName="above" required title=" " />
+    <input id="match-threshold-weight" matInput formControlName="above" required title="" />
     <mat-error id="match-threshold-weight-error" *ngIf="form.get('above').invalid">A number is required</mat-error>
   </mat-form-field>
-  <mat-form-field layout-fill>
+  <mat-form-field
+    [matTooltip]="tooltips.actionThreshold"
+    matTooltipPosition="left"
+    matTooltipShowDelay="500"
+    matTooltipHideDelay="500"  layout-fill>
     <mat-select id="match-threshold-action" placeholder="Action" formControlName="action" [(value)]="selectedAction" required>
       <mat-option value="merge">Merge</mat-option>
       <mat-option value="notify">Notify</mat-option>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-threshold-dialog.component.scss
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-threshold-dialog.component.scss
@@ -10,6 +10,6 @@
 /deep/ .mat-tooltip {
   white-space: pre-line !important;
   position: relative;
-  left: 427px;
+  left: 440px;
   top: -8px;
 }

--- a/web/src/main/ui/app/components/flows-new/tooltips/flows.tooltips.ts
+++ b/web/src/main/ui/app/components/flows-new/tooltips/flows.tooltips.ts
@@ -32,20 +32,21 @@ export class FlowsTooltips {
     targetDatabase: 'The database where to store the processed data. For mastering, choose the FINAL database where you want to store mastered data. Default is data-hub-FINAL. IMPORTANT: For mastering, the source database and the target database must be the same. If you want the target database to be different, create a custom step with a custom module to override the default.',
 
     matching: {
-        weightOption: 'A factor that signifies the relative importance of the rule.',
-        thesaurusURI: 'The path to a thesaurus that is stored in a MarkLogic Server database and used to determine synonyms.',
-        filter: 'A node in the thesaurus to use as a filter. For example, <thsr:qualifier>birds</thsr:qualifier>.',
-        dictionaryURI: 'The path to a phonetic dictionary that is stored in a database and used when comparing words phonetically. ',
-        distanceThresh: 'The threshold below which the phonetic difference (distance) between two strings is considered insignificant; i.e., the strings are similar to each other.',
-        collation: 'The URI to the collation to use. A collation specifies the order for sorting strings.',
-        zip5matches9: 'The weight to use if, given one 9-digit zip code and one 5-digit zip code, the first five digits of the zip codes match.',
-        zip9matches5: 'The weight to use if, given two 9-digit zip codes, the first five digits match and the last four do not. To add a weight when all nine digits match, use the Exact matching type to compare the zip codes as strings.',
-        propsReduce: 'One or more properties whose values to compare.',
-        weightReduce: 'A positive integer that denotes how much to reduce the weight of a match.',
+        weightOption: 'A factor signifying the relative importance of the rule.',
+        thesaurusURI: 'The path to the thesaurus used to determine synonyms.',
+        filter: 'A node in the thesaurus to use as a filter. Example: <thsr:qualifier>birds</thsr:qualifier>',
+        dictionaryURI: 'The path to the dictionary used to compare words phonetically.',
+        distanceThresh: 'The phonetic distance below which two strings are considered similar.',
+        collation: 'The URI for a collation, which specifies the order for sorting strings.',
+        zip5matches9: 'The weight to add to the exact match weight when a 5-digit zip code matches the first five digits of a 9-digit zip code.',
+        zip9matches5: 'The weight to apply when the first five digits of a 9-digit zip code match a 5-digit zip code.',
+        propsReduce: 'One or more properties to compare.',
+        weightReduce: 'How much to reduce the weight when all compared properties match.',
         customURI: 'The path to the custom module.',
         customFunc: 'The name of the custom function within the custom module.',
-        customNS: 'The namespace of the library module where the custom function is. Blank, if the custom function is JavaScript code.',
-        weightThreshold: 'The threshold with which to compare the total weight of the matches.'
+        customNS: 'The namespace of the custom module. Leave blank if the custom module is JavaScript.',
+        weightThreshold: 'The threshold the sum of match weights must meet for documents to be considered a match.',
+        actionThreshold: 'The action to take when the threshold is met.'
     },
 
     merging: {


### PR DESCRIPTION
- Move Reduce Properties tooltip up to section label.
- Make title attributes empty (no space) strings.
- Nudge the tooltip containers to the right and widen container for match weight tooltip (keep to one line).
- Add tooltip for Action in Match Thresholds dialog.
- Edit tooltip content, mostly for length.