### PR TITLE
DHFPROD-2656: Added unit tests for building invoke options

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -145,6 +145,7 @@ processResources {
 if (!(
     gradle.startParameter.taskNames*.toLowerCase().contains("bootrun") ||
         gradle.startParameter.taskNames*.toLowerCase().contains("test") ||
+        gradle.startParameter.taskNames*.toLowerCase().contains("testunit") ||
         gradle.startParameter.taskNames*.toLowerCase().contains("publishplugins") ||
         gradle.startParameter.taskNames*.toLowerCase().contains("publishtomavenlocal") ||
         gradle.startParameter.taskNames*.toLowerCase().contains("bintrayupload") ||
@@ -327,6 +328,13 @@ task testIntegration(type: Test) {
 task testBootstrap(type: Test) {
     useJUnitPlatform  {
         include 'com/marklogic/bootstrap/**'
+    }
+}
+
+task testUnit(type: Test) {
+    description = "Run the marklogic-unit-test tests, which also forces those modules to be loaded"
+    useJUnitPlatform {
+        include 'com/marklogic/hub_unit_test/RunMarkLogicUnitTestsTest*'
     }
 }
 

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils.sjs
@@ -113,19 +113,26 @@ class HubUtils {
   }
 
   invoke(moduleUri, parameters, user = null, database) {
+    let options = buildInvokeOptions(user, database);
+    xdmp.invoke(moduleUri, parameters, options)
+  }
+
+  buildInvokeOptions(user = null, database) {
     let options = {
       ignoreAmps: true
     };
 
-    if(user && user !== xdmp.getCurrentUser()) {
+    if (user && user !== xdmp.getCurrentUser()) {
       options.userId = xdmp.user(user);
     }
-    
-    if(database) {
-      options.database = database ? xdmp.database(database): xdmp.database();
+
+    if (database) {
+      options.database = xdmp.database(database);
     }
-    xdmp.invoke(moduleUri, parameters, options)
+
+    return options;
   }
+
   /**
   * Generate and return a UUID
   */

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub_unit_test/RunMarkLogicUnitTestsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub_unit_test/RunMarkLogicUnitTestsTest.java
@@ -1,5 +1,6 @@
-package com.marklogic.hub;
+package com.marklogic.hub_unit_test;
 
+import com.marklogic.hub_unit_test.TestConfig;
 import com.marklogic.junit5.MarkLogicUnitTestArgumentsProvider;
 import com.marklogic.junit5.spring.AbstractSpringMarkLogicTest;
 import com.marklogic.test.unit.TestModule;

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub_unit_test/TestConfig.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub_unit_test/TestConfig.java
@@ -1,8 +1,9 @@
-package com.marklogic.hub;
+package com.marklogic.hub_unit_test;
 
 import com.marklogic.client.ext.DatabaseClientConfig;
 import com.marklogic.client.ext.helper.DatabaseClientProvider;
 import com.marklogic.client.ext.spring.SimpleDatabaseClientProvider;
+import com.marklogic.hub.LoadTestModules;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,6 +14,9 @@ import javax.annotation.PostConstruct;
 
 /**
  * Spring configuration class that defines a connection to the final REST server in the test project.
+ *
+ * This isn't in the "com.marklogic.hub" package so that it's not picked up by Spring ComponentScan annotations that
+ * scan that package.
  */
 @Configuration
 @PropertySource(

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/buildInvokeHookOptions.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/buildInvokeHookOptions.sjs
@@ -1,0 +1,29 @@
+const HubUtils = require("/data-hub/5/impl/hub-utils.sjs")
+const test = require("/test/test-helper.xqy");
+const results = [];
+
+const hubUtils = new HubUtils();
+
+var options = hubUtils.buildInvokeOptions("nobody", "data-hub-FINAL");
+results.push(
+  test.assertEqual(true, options.ignoreAmps),
+  test.assertEqual(xdmp.user("nobody"), options.userId),
+  test.assertEqual(xdmp.database("data-hub-FINAL"), options.database)
+);
+
+options = hubUtils.buildInvokeOptions(null, null);
+results.push(
+  test.assertEqual(true, options.ignoreAmps),
+  test.assertNotExists(options.userId),
+  test.assertNotExists(options.database)
+);
+
+options = hubUtils.buildInvokeOptions(xdmp.getCurrentUser(), null);
+results.push(
+  test.assertEqual(true, options.ignoreAmps),
+  // userId shouldn't be set when the user passed in is the current user
+  test.assertNotExists(options.userId),
+  test.assertNotExists(options.database)
+);
+
+results


### PR DESCRIPTION
Added "testUnit" task as well so it's easy to run marklogic-unit-test tests. 

This also fixes an issue where TestConfig was being mistakenly picked up by the web tests. 

