### PR TITLE
DHFPROD-2658: Revert "Add filename to header and metadata properties when ingesting csv docs"

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
@@ -539,15 +539,6 @@ public class WriteStepRunner implements StepRunner {
             while(itr.hasNext()) {
                 try {
                     File file = new File((String) itr.next());
-                    if("csv".equalsIgnoreCase(inputFileType)) {
-                        //Add "file" to options so that it gets added to header in enode code
-                        options.put("file", file.getAbsolutePath());
-                        optionString = jsonToString(options);
-                        serverTransform.remove("options");
-                        serverTransform.addParameter("options", optionString);
-                        //Add additional document metadata
-                        metadataValues.add("datahubCreatedUsingFile" , file.getAbsolutePath());
-                    }
                     addToBatcher(file, fileFormat);
                 }
                 catch (Exception e) {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow-utils.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow-utils.sjs
@@ -505,9 +505,6 @@ class FlowUtils {
     for (let key in options.headers) {
       headers[key] = this.evalSubstituteVal(options.headers[key]);
     }
-    if(options.file) {
-      headers["createdUsingFile"] = options.file;
-    }
     return headers;
   }
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunnerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunnerTest.java
@@ -19,7 +19,6 @@ package com.marklogic.hub.flow;
 import com.marklogic.bootstrap.Installer;
 import com.marklogic.client.eval.EvalResult;
 import com.marklogic.client.eval.EvalResultIterator;
-import com.marklogic.client.io.StringHandle;
 import com.marklogic.hub.ApplicationConfig;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.HubTestBase;
@@ -105,13 +104,6 @@ public class FlowRunnerTest extends HubTestBase {
         RunStepResponse stepResp = resp.getStepResponses().get("1");
         Assertions.assertNotNull(stepResp.getStepStartTime());
         Assertions.assertNotNull(stepResp.getStepEndTime());
-        EvalResultIterator itr = runInDatabase("fn:collection(\"csv-coll\")[1]/envelope/headers/createdUsingFile", HubConfig.DEFAULT_STAGING_NAME);
-        EvalResult res = itr.next();
-        StringHandle sh = new StringHandle();
-        res.get(sh);
-        String file = sh.get();
-        Assertions.assertNotNull(file);
-        Assertions.assertTrue(file.contains("ye-olde-project/input/ingest.csv"));
     }
 
     @Test

--- a/marklogic-data-hub/src/test/resources/flow-runner-test/flows/testFlow.flow.json
+++ b/marklogic-data-hub/src/test/resources/flow-runner-test/flows/testFlow.flow.json
@@ -42,13 +42,6 @@
         "outputURIReplacement": ".*/input,''"
       },
       "options": {
-        "headers" : {
-          "sources" : [ {
-            "name" : "testFlow"
-          } ],
-          "createdOn" : "currentDateTime",
-          "createdBy" : "currentUser"
-        },
         "outputFormat": "json",
         "collections": ["csv-coll"]
       }


### PR DESCRIPTION
Revert "Add filename to header and metadata properties when ingesting csv docs"
This reverts commit 0c3795d4 
The original solution to the issue has bugs, so reverting it. The new fix will go in 5.0.2

