### PR TITLE
DHFPROD-2587: Reduce latency of getFlows API call on the backend server

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -44,9 +44,12 @@ dependencies {
     compile 'com.marklogic:marklogic-data-movement-components:1.0'
     compile 'commons-io:commons-io:2.4'
     compile 'org.apache.commons:commons-text:1.1'
-
+    
     // For installer program
     implementation "com.beust:jcommander:1.72"
+    //https://github.com/jaegertracing/jaeger-client-java/tree/master/jaeger-core
+    compile("io.jaegertracing:jaeger-core:0.35.4")
+    compile("io.jaegertracing:jaeger-thrift:0.35.4")
 
     // JUnit Jupiter API and TestEngine implementation
     testCompile "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/util/metrics/tracer/JaegerConfig.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/util/metrics/tracer/JaegerConfig.java
@@ -1,0 +1,119 @@
+package com.marklogic.hub.util.metrics.tracer;
+
+import io.jaegertracing.Configuration;
+import io.jaegertracing.Configuration.ReporterConfiguration;
+import io.jaegertracing.Configuration.SamplerConfiguration;
+import io.jaegertracing.internal.samplers.ConstSampler;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.Tracer.SpanBuilder;
+import io.opentracing.util.GlobalTracer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JaegerConfig {
+    private static final Logger logger = LoggerFactory.getLogger(JaegerConfig.class);
+
+    /**
+     * Returns the currently configured tracer
+     * @return a tracer
+     */
+    public static Tracer getTracer() {
+        return GlobalTracer.get();
+    }
+
+    /**
+     * Returns true when tracing is configured
+     * to report spans vs just producing a noop.
+     * @return tracer is registered or not
+     */
+    public static boolean enabled() {
+        return GlobalTracer.isRegistered();
+    }
+
+    /**
+     * Make a {@link Span} instance active for the current context (usually a thread).
+     * This is a shorthand for {@code Tracer.scopeManager().activate(span)}.
+     * @param span the built span
+     * @return a {@link Scope} instance to control the end of the active period for the {@link Span}.
+     */
+    public static Scope activate(Span span) {
+        return getTracer().activateSpan(span);
+    }
+
+    /**
+     * @return the active {@link Span}. This is a shorthand for {@code Tracer.scopeManager().activeSpan()}
+     */
+    public static Span activeSpan() {
+        return getTracer().scopeManager().activeSpan();
+    }
+
+    /**
+     * Builds a child span with the current class and method name
+     * @param enclosed a type created in the current method scope
+     * @param parentSpan parent span of the built span
+     * @return a span builder
+     */
+    public static SpanBuilder buildSpanFromMethod(Object enclosed, Span parentSpan) {
+        return buildSpanFromMethod(enclosed).asChildOf(parentSpan);
+    }
+
+    /**
+     * Builds a span with the operation name
+     * @param operationName span operation name
+     * @return a span builder
+     */
+    public static SpanBuilder buildSpan(String operationName) {
+        return getTracer().buildSpan(operationName);
+    }
+
+    /**
+     * Builds a span with the current class as the operation name.
+     * Usage: {@code JaegerConfig.buildFromMethod(new Object(){})}
+     * @param spanClass used to set the operation name.
+     * @return a span builder
+     */
+    public static SpanBuilder buildSpan(Class spanClass) {
+        return buildSpan(spanClass.getSimpleName());
+    }
+
+    /**
+     * Builds a span with the current class and method name.
+     * Usage: {@code JaegerConfig.buildFromMethod(new Object(){})}
+     * @param enclosed a type created in the current method scope
+     * @return a span builder
+     */
+    public static SpanBuilder buildSpanFromMethod(Object enclosed) {
+        if (enclosed != null) {
+            String className = enclosed.getClass().getEnclosingClass().getSimpleName();
+            String methodName = enclosed.getClass().getEnclosingMethod() != null ? enclosed.getClass().getEnclosingMethod().getName() : "";
+            return getTracer().buildSpan(String.format("%s.%s", className, methodName));
+        } else {
+            return getTracer().buildSpan("JaegerConfig.buildFromMethod");
+        }
+    }
+
+    /**
+     * Initialize a tracer
+     * @param service a service name
+     * @return a tracer
+     */
+    public static Tracer init(String service) {
+        if (!GlobalTracer.isRegistered()) {
+            SamplerConfiguration samplerConfig = SamplerConfiguration.fromEnv()
+                .withType(ConstSampler.TYPE)
+                .withParam(1);
+
+            ReporterConfiguration reporterConfig = ReporterConfiguration.fromEnv()
+                .withLogSpans(true);
+
+            Configuration config = new Configuration(service)
+                .withSampler(samplerConfig)
+                .withReporter(reporterConfig);
+            GlobalTracer.registerIfAbsent(config.getTracer());
+        }
+        return getTracer();
+    }
+}
+

--- a/marklogic-data-hub/src/main/resources/dhf-defaults.properties
+++ b/marklogic-data-hub/src/main/resources/dhf-defaults.properties
@@ -67,3 +67,7 @@ mlHubLogLevel=default
 # Default module permissions which allow flow-operator-role to execute flows
 mlModulePermissions=rest-reader,read,rest-writer,insert,rest-writer,update,rest-extension-user,execute
 mlIsProvisionedEnvironment=false
+
+#Turn on/off Jaeger trace. It can be set as an arbitrary name (e.g: data-hub). 
+#If the value is empty, it is off, otherwise it is on.
+JaegerServiceName=

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/extensions/jobs.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/extensions/jobs.sjs
@@ -21,18 +21,22 @@ function get(context, params) {
   let jobId = params["jobid"];
   let status = params["status"];
   let flow = params["flow-name"];
+  let flowNames = params["flowNames"];
   let latest = params["latest"];
 
   let resp = null;
 
   if(fn.exists(jobId) && fn.exists(status)) {
-      fn.error(null,"RESTAPI-SRVEXERR",  Sequence.from([400, "Bad Request", "Invalid request"]));
+    fn.error(null,"RESTAPI-SRVEXERR",  Sequence.from([400, "Bad Request", "Invalid request"]));
   }
   else if(fn.exists(jobId)) {
     resp = datahub.jobs.getJobDocWithId(jobId);
   }
   else if(fn.exists(status)) {
     resp = datahub.jobs.getJobDocs(status);
+  }
+  else if (fn.exists(flowNames)) {
+    resp = datahub.jobs.getJobDocsForFlows(flowNames);
   }
   else if (fn.exists(flow)) {
     resp = datahub.jobs.getJobDocsByFlow(flow);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/jobs.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/jobs.sjs
@@ -1,18 +1,15 @@
 /**
-  Copyright 2012-2019 MarkLogic Corporation
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-*/
+ Copyright 2012-2019 MarkLogic Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
 'use strict';
 // Batch documents can be cached because they should never be altered across transactions
 const cachedBatchDocuments = {};
@@ -36,20 +33,20 @@ class Jobs {
   createJob(flowName, id = null ) {
     let job = null;
     if(!id) {
-     id = this.hubutils.uuid();
+      id = this.hubutils.uuid();
     }
     job = {
-     job: {
-       jobId: id,
-       flow: flowName,
-       user: xdmp.getCurrentUser(),
-       lastAttemptedStep: 0,
-       lastCompletedStep: 0 ,
-       jobStatus: "started" ,
-       timeStarted:  fn.currentDateTime(),
-       timeEnded: "N/A",
-       stepResponses :{}
-     }
+      job: {
+        jobId: id,
+        flow: flowName,
+        user: xdmp.getCurrentUser(),
+        lastAttemptedStep: 0,
+        lastCompletedStep: 0 ,
+        jobStatus: "started" ,
+        timeStarted:  fn.currentDateTime(),
+        timeEnded: "N/A",
+        stepResponses :{}
+      }
     };
 
     this.hubutils.writeDocument("/jobs/"+job.job.jobId+".json", job, this.jobsPermissions,  ['Jobs','Job'], this.config.JOBDATABASE);
@@ -69,19 +66,19 @@ class Jobs {
 
   getJobDocWithUri(jobUri) {
     return fn.head(this.hubutils.queryLatest(function() {
-        if (xdmp.documentGetCollections(jobUri).includes("Job")) {
-          return cts.doc(jobUri).toObject();
-        }
-      }, this.config.JOBDATABASE));
+      if (xdmp.documentGetCollections(jobUri).includes("Job")) {
+        return cts.doc(jobUri).toObject();
+      }
+    }, this.config.JOBDATABASE));
   }
 
   deleteJob(jobId) {
     let uris = cts.uris("", null ,cts.andQuery([cts.orQuery([cts.directoryQuery("/jobs/"),cts.directoryQuery("/jobs/batches/")]),
-    cts.jsonPropertyValueQuery("jobId", jobId)]));
+      cts.jsonPropertyValueQuery("jobId", jobId)]));
     for (let doc of uris) {
-     if (fn.docAvailable(doc)){
-       this.hubutils.deleteDocument(doc, this.config.JOBDATABASE);
-     }
+      if (fn.docAvailable(doc)){
+        this.hubutils.deleteDocument(doc, this.config.JOBDATABASE);
+      }
     }
   }
 
@@ -142,9 +139,77 @@ class Jobs {
       }
       let results = cts.search(cts.orQuery(timeQuery));
       if(results) {
-       return results.toArray();
+        return results.toArray();
       }
     }, this.config.JOBDATABASE);
+  }
+
+  getJobDocsForFlows(flowNames) {
+    // Grab all the timeStarted values for each flow
+    const tuples = cts.valueTuples(
+      [
+        cts.jsonPropertyReference("flow"),
+        cts.jsonPropertyReference("timeStarted")
+      ], [],
+      cts.andQuery([
+        cts.collectionQuery("Job"),
+        cts.jsonPropertyRangeQuery("flow", "=", flowNames)
+      ])
+    );
+
+    // Build a map of flowName to latestTime
+    const timeMap = {};
+    tuples.toArray().forEach(values => {
+      const name = values[0];
+      if (timeMap[name] == undefined) {
+        timeMap[name] = values[1];
+      }
+      else {
+        let latestTime = xs.dateTime(timeMap[name]);
+        if (xs.dateTime(values[1]) > latestTime) {
+          timeMap[name] = values[1];
+        }
+      }
+    });
+
+    // Build an array of queries for the latest job for each flow
+    const queryArray = Object.keys(timeMap).map(flowName => {
+      return cts.andQuery([
+        cts.jsonPropertyRangeQuery("flow", "=", flowName),
+        cts.jsonPropertyRangeQuery("timeStarted", "=", xs.dateTime(timeMap[flowName]))
+      ])
+    });
+
+    // Find the latest jobs
+    const latestJobs = cts.search(cts.andQuery([
+      cts.collectionQuery("Job"),
+      cts.orQuery(queryArray)
+    ]));
+
+    // Build a map of flow name to latest job for quick lookup
+    const latestJobMap = {};
+    latestJobs.toArray().forEach(job => {
+      var obj = job.toObject();
+      latestJobMap[obj.job.flow] = obj;
+    });
+
+    // Grab all the job IDs for the flow names
+    // Could get these during the valueTuples call as well, but this is nice because it returns the values in a map
+    const jobIdMap = cts.elementValueCoOccurrences(xs.QName("flow"), xs.QName("jobId"), ["map"], cts.andQuery([
+      cts.collectionQuery("Job"),
+      cts.jsonPropertyRangeQuery("flow", "=", flowNames)
+    ]));
+
+    // For each flow name, return its job IDs and latest job
+    const response = {};
+    flowNames.forEach(flowName => {
+      response[flowName] = {
+        jobIds: jobIdMap[flowName],
+        latestJob: latestJobMap[flowName]
+      }
+    });
+
+    return response;
   }
 
   getJobDocsByFlow(flowName) {
@@ -198,11 +263,11 @@ class Jobs {
   }
 
   getBatchDocWithUri(batchUri) {
-     return fn.head(this.hubutils.queryLatest(function() {
-       if (xdmp.documentGetCollections(batchUri).includes("Batch")) {
-         return cts.doc(batchUri).toObject();
-       }
-     }, this.config.JOBDATABASE));
+    return fn.head(this.hubutils.queryLatest(function() {
+      if (xdmp.documentGetCollections(batchUri).includes("Batch")) {
+        return cts.doc(batchUri).toObject();
+      }
+    }, this.config.JOBDATABASE));
   }
 
   updateBatch(jobId, batchId, batchStatus, uris, writeTransactionInfo, error) {
@@ -221,7 +286,7 @@ class Jobs {
         let stackTraceObj = error.stackFrames[0];
         docObj.batch.fileName = stackTraceObj.uri;
         docObj.batch.lineNumber = stackTraceObj.line;
-      // If we don't get stackFrames, see if we can get the stack
+        // If we don't get stackFrames, see if we can get the stack
       } else if (error.stack) {
         docObj.batch.errorStack = error.stack;
       }

--- a/web/src/main/java/com/marklogic/hub/web/model/FlowJobModel.java
+++ b/web/src/main/java/com/marklogic/hub/web/model/FlowJobModel.java
@@ -1,11 +1,11 @@
 package com.marklogic.hub.web.model;
 
+import static java.util.Optional.ofNullable;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import static java.util.Optional.ofNullable;
 
 public class FlowJobModel {
     public static class LatestJob {
@@ -22,7 +22,7 @@ public class FlowJobModel {
 
         public String toString() {
             List<String> lstOutput = new ArrayList<>();
-            if (output != null && !output.get("output").isNull() && output.get("output").isArray()) {
+            if (output != null && output.get("output") != null && output.get("output").isArray()) {
                 output.get("output").forEach(e -> lstOutput.add(e.asText()));
             }
             return String.format("{jobId: %s, stepId: %s, status: %s, startTime: %s, endTime: %s, " +

--- a/web/src/main/java/com/marklogic/hub/web/model/FlowStepModel.java
+++ b/web/src/main/java/com/marklogic/hub/web/model/FlowStepModel.java
@@ -183,7 +183,7 @@ public class FlowStepModel {
     }
 
     public void setJobs(FlowJobs flowJobs, boolean fromRunFlow) {
-        if(flowJobs != null) {
+        if (flowJobs != null) {
             this.jobIds = flowJobs.jobIds;
             if (fromRunFlow) {
                 //reset the latestJob info until the running flow starts with a new jobId

--- a/web/src/main/java/com/marklogic/hub/web/service/AsyncFlowService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/AsyncFlowService.java
@@ -41,9 +41,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Service;
 
 @Service
+@PropertySource({"classpath:dhf-defaults.properties"})
 public class AsyncFlowService {
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -65,13 +68,16 @@ public class AsyncFlowService {
 
     ExecutorService executor;
 
+    @Value("${JaegerServiceName}")
+    private String jaegerServiceName;
+
     @PostConstruct
     public void init(){
         //we could turn on/off jaeger to trace performance of any call stacks by
         //injecting customized span code along with tags, e.g. try (Scope scope = JaegerConfig.activate(span))
-        //default tracing is off, in order to turn on, just add a VM option -DJaegerServiceName=data-hub
+        //default tracing is off. In order to turn it on, set JaegerServiceName with a value defined in the dhf-defaults.properties file
+        //or just add a VM option -DJaegerServiceName=data-hub as a system parameter
         //also see: https://www.jaegertracing.io/docs/1.12/getting-started/
-        String jaegerServiceName = System.getProperty("JaegerServiceName");
         if (StringUtils.isNotEmpty(jaegerServiceName)) {
             JaegerConfig.init(jaegerServiceName);
         }

--- a/web/src/main/java/com/marklogic/hub/web/service/AsyncFlowService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/AsyncFlowService.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2012-2019 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.marklogic.hub.web.service;
+
+import com.marklogic.hub.FlowManager;
+import com.marklogic.hub.flow.Flow;
+import com.marklogic.hub.flow.impl.FlowRunnerImpl;
+import com.marklogic.hub.job.JobStatus;
+import com.marklogic.hub.util.metrics.tracer.JaegerConfig;
+import com.marklogic.hub.web.exception.DataHubException;
+import com.marklogic.hub.web.model.FlowJobModel.FlowJobs;
+import com.marklogic.hub.web.model.FlowStepModel;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AsyncFlowService {
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    //core/maximum pool size, can be configurable if required
+    private static final int NTHREADS = 6;
+
+    //a thread processes 10 flows, can be configurable if required
+    //if the flow number is not more than 10, we do not use any thread in the pool
+    private static final int FLOW_COUNT_PER_THREAD = 10;
+
+    @Autowired
+    private FlowManager flowManager;
+
+    @Autowired
+    private FlowRunnerImpl flowRunner;
+
+    @Autowired
+    private FlowJobService flowJobService;
+
+    ExecutorService executor;
+
+    @PostConstruct
+    public void init(){
+        //we could turn on/off jaeger to trace performance of any call stacks by
+        //injecting customized span code along with tags, e.g. try (Scope scope = JaegerConfig.activate(span))
+        //default tracing is off, in order to turn on, just add a VM option -DJaegerServiceName=data-hub
+        //also see: https://www.jaegertracing.io/docs/1.12/getting-started/
+        String jaegerServiceName = System.getProperty("JaegerServiceName");
+        if (StringUtils.isNotEmpty(jaegerServiceName)) {
+            JaegerConfig.init(jaegerServiceName);
+        }
+
+        executor = Executors.newFixedThreadPool(NTHREADS);
+        logger.info(String.format("Initialized a fixed thread pool with pool size: %d", NTHREADS));
+    }
+
+    @PreDestroy
+    public void destroy() {
+        executor.shutdown();
+        try {
+            executor.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
+        } catch (Exception e) {
+            logger.error(e.getMessage());
+        }
+        logger.info("shutdown the thread pool");
+    }
+
+    class FlowStepsWithThreadInfo {
+        int groupId;
+        long threadId;
+
+        List<FlowStepModel> flowSteps;
+
+        public FlowStepsWithThreadInfo(List<FlowStepModel> flowSteps, int groupId, long threadId) {
+            this.flowSteps = flowSteps;
+            this.groupId = groupId;
+            this.threadId = threadId;
+        }
+    }
+
+    class FlowStepsCallable implements Callable<FlowStepsWithThreadInfo> {
+        List<Flow> flows;
+        int start;
+        Span parentSpan;
+        public FlowStepsCallable(List<Flow> flows, int start, Span parentSpan) {
+            this.flows = flows;
+            this.start = start;
+            this.parentSpan = parentSpan;
+        }
+
+        @Override
+        public FlowStepsWithThreadInfo call()  {
+            FlowStepsWithThreadInfo flowStepsWithThreadInfo;
+            Span span = JaegerConfig.buildSpanFromMethod(new Object() {}, parentSpan)
+                .withTag("currThread", Thread.currentThread().getId()).start();
+
+            try (Scope ignored = JaegerConfig.activate(span)) {
+                List<FlowStepModel> flowSteps = new ArrayList<>();
+                int startIdx = start * FLOW_COUNT_PER_THREAD;
+                IntStream.range(startIdx, Math.min(flows.size(), startIdx + FLOW_COUNT_PER_THREAD))
+                    .forEach(i -> {
+                        logger.debug(String
+                            .format("thread id: %d, flowName: %s", Thread.currentThread().getId(),
+                                flows.get(i).getName()));
+                        FlowStepModel fsm = getFlowStepModel(flows.get(i),false, span);
+                        flowSteps.add(fsm);
+                    });
+                flowStepsWithThreadInfo = new FlowStepsWithThreadInfo(flowSteps, start, Thread.currentThread().getId());
+            } finally {
+                span.finish();
+            }
+            return flowStepsWithThreadInfo;
+        }
+    }
+
+    public List<FlowStepModel> getFlows(boolean useThread) {
+        FlowRunnerChecker.getInstance(flowRunner);
+        List<Flow> flows = flowManager.getFlows();
+        List<FlowStepModel> flowSteps = new ArrayList<>();
+        if (flows.isEmpty()) {
+            return flowSteps;
+        }
+        int threadCnt = flows.size() / FLOW_COUNT_PER_THREAD;
+
+        Span span = JaegerConfig.buildSpanFromMethod(new Object() {})
+            .withTag("mainThread", Thread.currentThread().getId()).start();
+
+        try (Scope ignored = JaegerConfig.activate(span)) {
+            if (useThread && threadCnt > 0) {
+                asyncGetFlowSteps(flows, threadCnt, flowSteps);
+            } else {
+                for (Flow flow : flows) {
+                    FlowStepModel fsm = getFlowStepModel(flow,false, span);
+                    flowSteps.add(fsm);
+                }
+            }
+        } finally {
+            span.finish();
+        }
+
+        return flowSteps;
+    }
+
+    private void asyncGetFlowSteps(List<Flow> flows, int threadCnt, List<FlowStepModel> flowSteps) {
+        if (flows.size() % FLOW_COUNT_PER_THREAD != 0) {
+            threadCnt++;
+        }
+
+        ExecutorCompletionService<FlowStepsWithThreadInfo> ecs = new ExecutorCompletionService(executor);
+        Future[] futures = IntStream.range(0, threadCnt)
+            .mapToObj(i -> ecs.submit(new FlowStepsCallable(flows, i, JaegerConfig.activeSpan())))
+            .toArray(Future[]::new);
+
+        IntStream.range(0, threadCnt).mapToObj(i -> JaegerConfig.buildSpanFromMethod(new Object() {
+        }, JaegerConfig.activeSpan())
+            .withTag("threadCnt", i).start()).forEach(span -> {
+            try (Scope ignored = JaegerConfig.activate(span)) {
+                final Future<FlowStepsWithThreadInfo> future = ecs.take();
+
+                FlowStepsWithThreadInfo flowStepsWithThreadInfo = future.get();
+                span.setTag("threadId", flowStepsWithThreadInfo.threadId);
+                span.setTag("groupId", flowStepsWithThreadInfo.groupId);
+
+                flowSteps.addAll(flowStepsWithThreadInfo.flowSteps);
+            } catch (ExecutionException e) {
+                logger.error("Failed to get data: ", e.getCause());
+                throw new DataHubException("Failed to get data: " + e.getMessage());
+            } catch (InterruptedException e) {
+                logger.error("Interrupted exception: ", e.getCause());
+                throw new DataHubException("Interrupted exception: " + e.getMessage());
+            } finally {
+                span.finish();
+            }
+        });
+    }
+
+    public FlowStepModel getFlowStepModel(Flow flow, boolean fromRunFlow, Span parentSpan) {
+        FlowStepModel fsm = FlowStepModel.transformFromFlow(flow);
+        if (fromRunFlow) {
+            FlowRunnerChecker.getInstance(flowRunner).resetLatestJob(flow);
+        }
+        FlowJobs flowJobs;
+        if (flowRunner.getRunningFlow() != null && flow.getName().equalsIgnoreCase(flowRunner.getRunningFlow().getName())) {
+            fsm.setLatestJob(FlowRunnerChecker.getInstance(flowRunner).getLatestJob(flow));
+        }
+        if (fsm.latestJob != null  && (JobStatus.isJobDone(fsm.latestJob.status) || JobStatus.isStepDone(fsm.latestJob.status))) {
+            flowJobs = flowJobService.getJobs(flow,true, parentSpan);
+        } else {
+            flowJobs = flowJobService.getJobs(flow,false, parentSpan);
+        }
+        fsm.setJobs(flowJobs, fromRunFlow);
+        return fsm;
+    }
+}

--- a/web/src/main/java/com/marklogic/hub/web/service/FlowJobService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/FlowJobService.java
@@ -1,4 +1,21 @@
+/*
+ * Copyright 2012-2019 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.marklogic.hub.web.service;
+
+import static com.marklogic.hub.job.JobStatus.RUNNING_PREFIX;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.cache.Cache;
@@ -11,20 +28,23 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.util.RequestParameters;
-import com.marklogic.hub.FlowManager;
 import com.marklogic.hub.flow.Flow;
 import com.marklogic.hub.flow.impl.FlowRunnerImpl;
 import com.marklogic.hub.impl.HubConfigImpl;
 import com.marklogic.hub.job.JobStatus;
 import com.marklogic.hub.step.impl.Step;
 import com.marklogic.hub.util.json.JSONObject;
+import com.marklogic.hub.util.metrics.tracer.JaegerConfig;
 import com.marklogic.hub.web.model.FlowJobModel.FlowJobs;
 import com.marklogic.hub.web.model.FlowJobModel.LatestJob;
+import io.opentracing.Scope;
+import io.opentracing.Span;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.PreDestroy;
 import javax.xml.bind.DatatypeConverter;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -32,16 +52,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import static com.marklogic.hub.job.JobStatus.RUNNING_PREFIX;
-
 @Service
 public class FlowJobService extends ResourceManager {
     private static final String ML_JOBS_NAME = "ml:jobs";
 
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
-
-    @Autowired
-    private FlowManager flowManager;
 
     @Autowired
     private FlowRunnerImpl flowRunner;
@@ -64,47 +79,101 @@ public class FlowJobService extends ResourceManager {
 
     private void setupClient() {
         client = hubConfig.newJobDbClient();
+        client.init(ML_JOBS_NAME, this);
     }
 
-    public FlowJobs getJobs(String flowName, boolean forceRefresh) {
+    @PreDestroy
+    public void destroy() {
+        logger.info("release the job database client.");
+        this.release();
+    }
+
+    public FlowJobs getJobs(Flow flow, boolean forceRefresh, Span parentSpan) {
+        String flowName = flow.getName();
         if (forceRefresh) {
-            FlowJobs flowJobs = retrieveJobsByFlowName(flowName);
+            FlowJobs flowJobs = retrieveJobsByFlowName(flow, parentSpan);
             cachedJobsByFlowName.put(flowName, flowJobs);
             return flowJobs;
         }
-        try {
-            return cachedJobsByFlowName.get(flowName, () -> retrieveJobsByFlowName(flowName));
+
+        Span span = JaegerConfig.buildSpanFromMethod(new Object() {}, parentSpan)
+            .withTag("flowName", flowName)
+            .start();
+
+        try (Scope ignored = JaegerConfig.activate(span)) {
+            return cachedJobsByFlowName.get(flowName, () -> retrieveJobsByFlowName(flow, span));
         } catch (Exception e) {
             logger.error(e.getMessage());
         } finally {
             if (cachedJobsByFlowName.getIfPresent(flowName) == null) {
                 cachedJobsByFlowName.invalidate(flowName);
             }
+            span.finish();
         }
 
         return cachedJobsByFlowName.getIfPresent(flowName);
     }
 
-    private FlowJobs retrieveJobsByFlowName(String flowName) {
-        if (client == null) {
-            setupClient();
+    private FlowJobs retrieveJobsByFlowName(Flow flow, Span parentSpan) {
+        String flowName = flow.getName();
+        Span span = JaegerConfig.buildSpanFromMethod(new Object() {
+        }, parentSpan)
+            .withTag("flowName", flowName)
+            .start();
+
+        JsonNode jsonNode;
+        try (Scope ignored = JaegerConfig.activate(span)) {
+            span.setTag("setupClient", true);
+            span.setTag("beforeInitialClient",
+                client == null ? "client is null" : "client is not null");
+            if (client == null) {
+                setupClient();
+            }
+            span.setTag("AfterInitialClient", client.getClientImplementation().toString());
+        } catch (Exception e) {
+            logger.error("Failed to init client!!!");
+        } finally {
+            span.finish();
         }
-        client.init(ML_JOBS_NAME, this);
-        RequestParameters params = new RequestParameters();
-        if (StringUtils.isNotEmpty(flowName)) {
-            params.add("flow-name", flowName);
+        Span span2 = JaegerConfig.buildSpanFromMethod(new Object() {
+        }, parentSpan)
+            .withTag("flowName", flowName)
+            .start();
+
+        ServiceResultIterator resultItr;
+        try (Scope ignored = JaegerConfig.activate(span2)) {
+            span2.setTag("getJobCall", true);
+            RequestParameters params = new RequestParameters();
+            if (StringUtils.isNotEmpty(flowName)) {
+                params.add("flow-name", flowName);
+            }
+
+            resultItr = this.getServices().get(params);
+            if (resultItr == null || !resultItr.hasNext()) {
+                throw new RuntimeException("No jobs found for flow with name: " + flowName);
+            }
+        } finally {
+            span2.finish();
         }
 
-        ServiceResultIterator resultItr = this.getServices().get(params);
-        if (resultItr == null || !resultItr.hasNext()) {
-            throw new RuntimeException("No jobs found for flow with name: " + flowName);
-        }
-        ServiceResult res = resultItr.next();
-        JsonNode jsonNode = res.getContent(new JacksonHandle()).get();
+        Span span3 = JaegerConfig.buildSpanFromMethod(new Object() {
+        }, parentSpan)
+            .withTag("flowName", flowName)
+            .start();
 
-        Flow flow = flowManager.getFlow(flowName);
+        try (Scope ignored = JaegerConfig.activate(span3)) {
+            span3.setTag("getContent", true);
+            ServiceResult res = resultItr.next();
+            jsonNode = res.getContent(new JacksonHandle()).get();
+        } finally {
+            span3.finish();
+        }
+
+        return retrieveJobsByFlowName(flow, jsonNode);
+    }
+
+    private FlowJobs retrieveJobsByFlowName(Flow flow, JsonNode jsonNode) {
         Map<String, Step> steps = flow.getSteps();
-
         List<String> jobs = new ArrayList<>();
         LatestJob latestJob = new LatestJob();
         FlowJobs flowJobs = new FlowJobs(jobs, latestJob);
@@ -193,7 +262,6 @@ public class FlowJobService extends ResourceManager {
             updateJobStaleStates(staleStateJobIds);
         }
 
-        this.release();
         return flowJobs;
     }
 

--- a/web/src/main/java/com/marklogic/hub/web/service/FlowJobService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/FlowJobService.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2012-2019 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.marklogic.hub.web.service;
 
 import static com.marklogic.hub.job.JobStatus.RUNNING_PREFIX;
@@ -28,6 +13,7 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.util.RequestParameters;
+import com.marklogic.hub.FlowManager;
 import com.marklogic.hub.flow.Flow;
 import com.marklogic.hub.flow.impl.FlowRunnerImpl;
 import com.marklogic.hub.impl.HubConfigImpl;
@@ -40,6 +26,8 @@ import com.marklogic.hub.web.model.FlowJobModel.LatestJob;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -59,12 +47,17 @@ public class FlowJobService extends ResourceManager {
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Autowired
+    private FlowManager flowManager;
+
+    @Autowired
     private FlowRunnerImpl flowRunner;
 
     @Autowired
     private HubConfigImpl hubConfig;
 
     private DatabaseClient client;
+
+    protected static boolean firstTimeRun = true;
 
     //use a cache with ttl 5 minutes to reduce frequency for fetching data from DB
     public final Cache<String, FlowJobs> cachedJobsByFlowName = CacheBuilder.newBuilder().expireAfterWrite(
@@ -88,40 +81,15 @@ public class FlowJobService extends ResourceManager {
         this.release();
     }
 
-    public FlowJobs getJobs(Flow flow, boolean forceRefresh, Span parentSpan) {
-        String flowName = flow.getName();
-        if (forceRefresh) {
-            FlowJobs flowJobs = retrieveJobsByFlowName(flow, parentSpan);
-            cachedJobsByFlowName.put(flowName, flowJobs);
-            return flowJobs;
-        }
-
+    /**
+     * Get all the jobs for a list of flows
+     * @param flows a list of flows
+     * @param parentSpan parent span
+     * @return a map (k,v) => (flowname, flowjobs)
+     */
+    public Map<String, FlowJobs> getFlowJobs(List<Flow> flows, Span parentSpan) {
         Span span = JaegerConfig.buildSpanFromMethod(new Object() {}, parentSpan)
-            .withTag("flowName", flowName)
             .start();
-
-        try (Scope ignored = JaegerConfig.activate(span)) {
-            return cachedJobsByFlowName.get(flowName, () -> retrieveJobsByFlowName(flow, span));
-        } catch (Exception e) {
-            logger.error(e.getMessage());
-        } finally {
-            if (cachedJobsByFlowName.getIfPresent(flowName) == null) {
-                cachedJobsByFlowName.invalidate(flowName);
-            }
-            span.finish();
-        }
-
-        return cachedJobsByFlowName.getIfPresent(flowName);
-    }
-
-    private FlowJobs retrieveJobsByFlowName(Flow flow, Span parentSpan) {
-        String flowName = flow.getName();
-        Span span = JaegerConfig.buildSpanFromMethod(new Object() {
-        }, parentSpan)
-            .withTag("flowName", flowName)
-            .start();
-
-        JsonNode jsonNode;
         try (Scope ignored = JaegerConfig.activate(span)) {
             span.setTag("setupClient", true);
             span.setTag("beforeInitialClient",
@@ -135,52 +103,194 @@ public class FlowJobService extends ResourceManager {
         } finally {
             span.finish();
         }
-        Span span2 = JaegerConfig.buildSpanFromMethod(new Object() {
-        }, parentSpan)
-            .withTag("flowName", flowName)
+
+        Map<String, Flow> flowMap = new HashMap<>();
+        flows.forEach(flow -> flowMap.put(flow.getName(), flow));
+
+        JsonNode jsonNode;
+        Span span2 = JaegerConfig.buildSpanFromMethod(new Object() {}, parentSpan)
+            .withTag("getAllJobsCall", true)
             .start();
-
-        ServiceResultIterator resultItr;
         try (Scope ignored = JaegerConfig.activate(span2)) {
-            span2.setTag("getJobCall", true);
             RequestParameters params = new RequestParameters();
-            if (StringUtils.isNotEmpty(flowName)) {
-                params.add("flow-name", flowName);
+            List<String> names = new ArrayList<>();
+            for (Flow flow : flows) {
+                names.add(flow.getName());
+            }
+            params.put("flowNames", names.toArray(new String[]{}));
+            ServiceResultIterator resultItr = this.getServices().get(params);
+            if (resultItr == null || !resultItr.hasNext()) {
+                throw new RuntimeException("Failed to get jobs for flows!");
             }
 
-            resultItr = this.getServices().get(params);
-            if (resultItr == null || !resultItr.hasNext()) {
-                throw new RuntimeException("No jobs found for flow with name: " + flowName);
-            }
+            ServiceResult res = resultItr.next();
+            jsonNode = res.getContent(new JacksonHandle()).get();
+
         } finally {
             span2.finish();
         }
 
-        Span span3 = JaegerConfig.buildSpanFromMethod(new Object() {
-        }, parentSpan)
+        Map<String, FlowJobs> mapJobsByFlow = new HashMap<>();
+        Iterator<String> fields = jsonNode.fieldNames();
+        List<String> staleStateJobIds = new ArrayList<>();
+        while (fields.hasNext()) {
+            String flowName = fields.next();
+            JsonNode flowData =jsonNode.get(flowName);
+            List<String> jobIds = new ArrayList<>();
+            if (flowData.get("jobIds") != null && flowData.get("jobIds").isArray()) {
+                flowData.get("jobIds").forEach(id -> jobIds.add(id.asText()));
+            }
+
+            LatestJob latestJob = new LatestJob();
+            if (flowData.get("latestJob") != null && flowData.get("latestJob").has("job")) {
+                convertJsonToLatestJob(latestJob, flowData.get("latestJob").get("job"), flowMap.get(flowName), staleStateJobIds);
+            }
+
+            mapJobsByFlow.put(flowName, new FlowJobs(jobIds, latestJob));
+        }
+        if (!staleStateJobIds.isEmpty()) {
+            updateJobStaleStates(staleStateJobIds);
+        }
+        return mapJobsByFlow;
+    }
+
+    /**
+     * Get jobs for one flow
+     * @param flow a flow
+     * @param forceRefresh if refresh or not
+     * @return FlowJobs for the flow
+     */
+    public FlowJobs getJobsByFlow(Flow flow, boolean forceRefresh) {
+        String flowName = flow.getName();
+        if (forceRefresh) {
+            FlowJobs flowJobs = retrieveJobsByFlowName(flow);
+            cachedJobsByFlowName.put(flowName, flowJobs);
+            return flowJobs;
+        }
+
+        Span span = JaegerConfig.buildSpanFromMethod(new Object() {})
             .withTag("flowName", flowName)
             .start();
 
-        try (Scope ignored = JaegerConfig.activate(span3)) {
-            span3.setTag("getContent", true);
-            ServiceResult res = resultItr.next();
-            jsonNode = res.getContent(new JacksonHandle()).get();
+        try (Scope ignored = JaegerConfig.activate(span)) {
+            return cachedJobsByFlowName.get(flowName, () -> retrieveJobsByFlowName(flow));
+        } catch (Exception e) {
+            logger.error(e.getMessage());
         } finally {
-            span3.finish();
+            if (cachedJobsByFlowName.getIfPresent(flowName) == null) {
+                cachedJobsByFlowName.invalidate(flowName);
+            }
+            span.finish();
         }
+
+        return cachedJobsByFlowName.getIfPresent(flowName);
+    }
+
+    private void convertJsonToLatestJob(LatestJob latestJob, JsonNode node, Flow flow, List<String> staleStateJobIds) {
+        JSONObject jobJson = new JSONObject(node);
+
+        String jobId = jobJson.getString("jobId");
+        String jobStatus = jobJson.getString("jobStatus");
+        latestJob.id = jobId;
+        latestJob.startTime = jobJson.getString("timeStarted", "");
+        latestJob.endTime = jobJson.getString("timeEnded", "");
+        if ("N/A".equals(latestJob.endTime)) {
+            latestJob.endTime = "";
+        }
+
+        boolean setJobStatus = true;
+        if (firstTimeRun && flowRunner.getRunningFlow() == null) {
+            if (StringUtils.isNotEmpty(jobStatus) && jobStatus.startsWith(RUNNING_PREFIX)) {
+                //invalid state on the job database that may be caused by unexpected server shutdown or crashed
+                staleStateJobIds.add(jobId);
+                latestJob.status = JobStatus.FAILED.toString();
+                setJobStatus = false;
+            }
+        }
+        if (setJobStatus) {
+            latestJob.status = jobJson.getString("jobStatus");
+        }
+        setLastestJob(latestJob, flow, jobJson);
+    }
+
+    private void setLastestJob(LatestJob latestJob, Flow flow, JSONObject jobJson) {
+        Map<String, Step> steps = flow.getSteps();
+
+        latestJob.id = jobJson.getString("jobId");
+        latestJob.startTime = jobJson.getString("timeStarted", "");
+        latestJob.endTime = jobJson.getString("timeEnded", "");
+        if ("N/A".equals(latestJob.endTime)) {
+            latestJob.endTime = "";
+        }
+
+        latestJob.status = jobJson.getString("jobStatus");
+        String completedKey = jobJson.getString("lastCompletedStep", "0");
+        String attemptedKey = jobJson.getString("lastAttemptedStep", "0");
+        String stepKey = Integer.compare(Integer.valueOf(completedKey), Integer.valueOf(attemptedKey)) < 0 ? attemptedKey : completedKey;
+        Optional.ofNullable(steps.get(stepKey)).ifPresent(s -> {
+            latestJob.stepName = s.getName();
+            latestJob.stepId = s.getName() + "-" + s.getStepDefinitionType();
+        });
+
+        JsonNode stepRes = jobJson.getNode("stepResponses");
+
+        if (stepRes != null) {
+            stepRes.forEach(s -> {
+                latestJob.successfulEvents += s.get("successfulEvents") != null ? s.get("successfulEvents").asLong() : 0;
+                latestJob.failedEvents += s.get("failedEvents") != null ? s.get("failedEvents").asLong() : 0;
+                latestJob.output = s.get("stepOutput"); //last step output ?
+            });
+        }
+    }
+
+    /**
+     * Set the jobStatus as Failed and timeEnded due to server failure during flow running
+     * @param staleStateJobIds a list of staleJobIds
+     */
+    private void updateJobStaleStates(List<String> staleStateJobIds) {
+        logger.warn("UPDATING JOB STALE STATES!!!");
+        RequestParameters params = new RequestParameters();
+        for (String jobId : staleStateJobIds) {
+            params.add("jobid", jobId);
+            params.add("status", JobStatus.FAILED.toString());
+
+            try {
+                this.getServices().post(params, new StringHandle("{}").withFormat(Format.JSON));
+            } catch (Exception e) {
+                logger.error(jobId + ":" + e.getMessage());
+            }
+        }
+    }
+
+    private FlowJobs retrieveJobsByFlowName(Flow flow) {
+        String flowName = flow.getName();
+        if (client == null) {
+            setupClient();
+        }
+
+        RequestParameters params = new RequestParameters();
+        if (StringUtils.isNotEmpty(flowName)) {
+            params.add("flow-name", flowName);
+        }
+
+        ServiceResultIterator resultItr = this.getServices().get(params);
+        if (resultItr == null || !resultItr.hasNext()) {
+            throw new RuntimeException("Failed to get jobs for one flow: " + flowName);
+        }
+
+        ServiceResult res = resultItr.next();
+        JsonNode jsonNode = res.getContent(new JacksonHandle()).get();
 
         return retrieveJobsByFlowName(flow, jsonNode);
     }
 
     private FlowJobs retrieveJobsByFlowName(Flow flow, JsonNode jsonNode) {
-        Map<String, Step> steps = flow.getSteps();
-        List<String> jobs = new ArrayList<>();
         LatestJob latestJob = new LatestJob();
+        List<String> jobs = new ArrayList<>();
         FlowJobs flowJobs = new FlowJobs(jobs, latestJob);
 
         final JsonNode[] lastJob = {null};
         final String[] lastTime = {null, null}; //store last start and end time
-        List<String> staleStateJobIds = new ArrayList<>();
         if (jsonNode.isArray()) {
             jsonNode.forEach(job -> {
                 JSONObject jobJson = new JSONObject(job.get("job"));
@@ -189,14 +299,6 @@ public class FlowJobService extends ResourceManager {
                 jobs.add(jobId);
                 String currStartTime = jobJson.getString("timeStarted", "");
                 String currEndTime = jobJson.getString("timeEnded", "");
-
-                if (cachedJobsByFlowName.size() == 0 && flowRunner.getRunningFlow() == null) {
-                    if (StringUtils.isNotEmpty(jobStatus) && jobStatus.startsWith(RUNNING_PREFIX)) {
-                        //invalid state on the job database that may be caused by unexpected server shutdown or crashed
-                        staleStateJobIds.add(jobId);
-                        latestJob.status = JobStatus.FAILED.toString();
-                    }
-                }
 
                 if (StringUtils.isEmpty(lastTime[0])) {
                     lastTime[0] = currStartTime;
@@ -227,71 +329,19 @@ public class FlowJobService extends ResourceManager {
         if (jobs.isEmpty() || lastJob[0] == null) {
             return flowJobs;
         }
+
         JSONObject jobJson = new JSONObject(lastJob[0]);
-
-        latestJob.id = jobJson.getString("jobId");
-        latestJob.startTime = jobJson.getString("timeStarted", "");
-        latestJob.endTime = jobJson.getString("timeEnded", "");
-        if ("N/A".equals(latestJob.endTime)) {
-            latestJob.endTime = "";
-        }
-
-        if (!staleStateJobIds.contains(latestJob.id)) {
-            latestJob.status = jobJson.getString("jobStatus");
-        }
-
-        String completedKey = jobJson.getString("lastCompletedStep", "0");
-        String attemptedKey = jobJson.getString("lastAttemptedStep", "0");
-        String stepKey = Integer.compare(Integer.valueOf(completedKey), Integer.valueOf(attemptedKey)) < 0 ? attemptedKey : completedKey;
-        Optional.ofNullable(steps.get(stepKey)).ifPresent(s -> {
-            latestJob.stepName = s.getName();
-            latestJob.stepId = s.getName() + "-" + s.getStepDefinitionType();
-        });
-
-        JsonNode stepRes = jobJson.getNode("stepResponses");
-
-        if (stepRes != null) {
-            stepRes.forEach(s -> {
-                latestJob.successfulEvents += s.get("successfulEvents") != null ? s.get("successfulEvents").asLong() : 0;
-                latestJob.failedEvents += s.get("failedEvents") != null ? s.get("failedEvents").asLong() : 0;
-                latestJob.output = s.get("stepOutput"); //last step output ?
-            });
-        }
-
-        if (!staleStateJobIds.isEmpty()) {
-            updateJobStaleStates(staleStateJobIds);
-        }
-
+        setLastestJob(latestJob, flow, jobJson);
         return flowJobs;
-    }
-
-    /**
-     * Set the jobStatus as Failed and timeEnded due to server failure during flow running
-     * @param staleStateJobIds
-     */
-    private void updateJobStaleStates(List<String> staleStateJobIds) {
-        RequestParameters params = new RequestParameters();
-        for (String jobId : staleStateJobIds) {
-            params.add("jobid", jobId);
-            params.add("status", JobStatus.FAILED.toString());
-
-            try {
-                this.getServices().post(params, new StringHandle("{}").withFormat(Format.JSON));
-            } catch (Exception e) {
-                logger.error(jobId + ":" + e.getMessage());
-            }
-        }
     }
 
     private void release() {
         if (client != null) {
             try {
                 client.release();
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 logger.error(e.getMessage());
-            }
-            finally {
+            } finally {
                 client = null;
             }
         }

--- a/web/src/main/java/com/marklogic/hub/web/web/FlowController.java
+++ b/web/src/main/java/com/marklogic/hub/web/web/FlowController.java
@@ -47,7 +47,7 @@ public class FlowController {
 
     @RequestMapping(method = RequestMethod.GET)
     @ResponseBody
-    public Callable<ResponseEntity<?>>  getFlows() {
+    public Callable<ResponseEntity<?>> getFlows() {
         List<FlowStepModel> flowSteps;
         Span span = JaegerConfig.buildSpan("getFlows").start();
         try (Scope scope = JaegerConfig.activate(span)) {

--- a/web/src/main/java/com/marklogic/hub/web/web/FlowController.java
+++ b/web/src/main/java/com/marklogic/hub/web/web/FlowController.java
@@ -16,34 +16,49 @@
 package com.marklogic.hub.web.web;
 
 import com.marklogic.hub.error.DataHubProjectException;
+import com.marklogic.hub.util.metrics.tracer.JaegerConfig;
 import com.marklogic.hub.web.exception.DataHubException;
 import com.marklogic.hub.web.model.FlowStepModel;
 import com.marklogic.hub.web.model.StepModel;
 import com.marklogic.hub.web.service.FlowManagerService;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping("/api/flows")
+@EnableAsync
 public class FlowController {
     @Autowired
     private FlowManagerService flowManagerService;
 
     @RequestMapping(method = RequestMethod.GET)
     @ResponseBody
-    public ResponseEntity<?> getFlows() {
+    public Callable<ResponseEntity<?>>  getFlows() {
         List<FlowStepModel> flowSteps;
-        try {
+        Span span = JaegerConfig.buildSpan("getFlows").start();
+        try (Scope scope = JaegerConfig.activate(span)) {
             flowSteps = flowManagerService.getFlows();
+            Collections.sort(flowSteps, (a, b) -> a.getName().compareTo(b.getName()));
         } catch (Exception ex) {
             throw new DataHubException(ex.getMessage(), ex);
+        } finally {
+            span.finish();
         }
-        return new ResponseEntity<>(flowSteps, HttpStatus.OK);
+        return () -> ResponseEntity.ok(flowSteps);
     }
 
     @RequestMapping(method = RequestMethod.POST)

--- a/web/src/main/java/com/marklogic/hub/web/web/NewJobController.java
+++ b/web/src/main/java/com/marklogic/hub/web/web/NewJobController.java
@@ -1,15 +1,22 @@
 package com.marklogic.hub.web.web;
 
+import com.marklogic.hub.util.metrics.tracer.JaegerConfig;
 import com.marklogic.hub.web.exception.DataHubException;
 import com.marklogic.hub.web.model.JobModel;
 import com.marklogic.hub.web.service.NewJobService;
+import io.opentracing.Scope;
+import io.opentracing.Span;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping(value="/api/jobs")
@@ -22,12 +29,16 @@ public class NewJobController {
     @ResponseBody
     public ResponseEntity<?> getJobs(@RequestParam(value = "flowName", required = false) String flowName) throws IOException {
         List<JobModel> jobModels;
-        try {
+        Span span = JaegerConfig.buildSpan("getJobs").start();
+        try (Scope ignored = JaegerConfig.activate(span)) {
             jobService.setupClient();
             jobModels = jobService.getJobs(flowName);
+            span.setTag("flowName", flowName != null ? flowName : "");
             jobService.release();
         } catch (Exception ex) {
             throw new DataHubException(ex.getMessage(), ex);
+        } finally {
+            span.finish();
         }
         return new ResponseEntity<>(jobModels, HttpStatus.OK);
     }


### PR DESCRIPTION
https://project.marklogic.com/jira/browse/DHFPROD-2587

1. Introduce Jaeger for performance tracing;
2. Use Asyn callable/thread pool to improve the performance of getFlows api call;
3. Reduce getFlow call with disk access;
4. Sorte by flow name as default for getFlows response
5. Refractor code