### PR TITLE
DHFPROD-2714: Metadata datahubCreatedByStep has a value of currentStep and all prev step names

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow-utils.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow-utils.sjs
@@ -518,7 +518,7 @@ class FlowUtils {
     metaData[this.consts.CREATED_ON] = fn.string(this.evalSubstituteVal(this.consts.CREATED_ON));
     metaData[this.consts.CREATED_BY] = fn.string(this.evalSubstituteVal(this.consts.CREATED_BY));
     metaData[this.consts.CREATED_IN_FLOW] = flowName;
-    metaData[this.consts.CREATED_BY_STEP] = fn.stringJoin(fn.distinctValues(Sequence.from([fn.tokenize(metaData[this.consts.CREATED_BY_STEP],"\\s+"),stepName])), " ");
+    metaData[this.consts.CREATED_BY_STEP] = stepName;
     metaData[this.consts.CREATED_BY_JOB] = fn.stringJoin(fn.distinctValues(Sequence.from([fn.tokenize(metaData[this.consts.CREATED_BY_JOB],"\\s+"),jobId])), " ");
 
     return metaData;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/flow-utils/getMetadata.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/flow-utils/getMetadata.sjs
@@ -1,0 +1,46 @@
+const test = require("/test/test-helper.xqy");
+
+const FlowUtils = require("/data-hub/5/impl/flow-utils.sjs");
+const flowUtils = new FlowUtils();
+
+const results = [];
+const metadata = [];
+
+let jobId = "alpha-num3r1c-j06-1d";
+let flowDoc = {
+                "name": "testFlow",
+                "description": "This is the flow doc to test metadata values",
+                "steps": {
+                  "1": {
+                    "name": "ingestion",
+                    "description": "This is the custom ingestion step",
+                    "stepDefinitionName": "ingestion",
+                    "stepDefinitionType": "INGESTION"
+                  },
+                  "2": {
+                    "name": "mapping",
+                    "description": "This is the custom mapping step",
+                    "stepDefinitionName": "mapping",
+                    "stepDefinitionType": "MAPPING"
+                  },
+                  "3": {
+                     "name": "mastering",
+                     "description": "This is the custom mapping step",
+                     "stepDefinitionName": "mastering",
+                     "stepDefinitionType": "MASTERING"
+                  }
+                }
+              };
+
+//metadata is set in processResults method of flow.sjs as below and it gets called for every step in the flowDoc
+//this is to verify that stepDefName corresponding to the stepNumber is the value of metadata datahubCreatedByStep
+for (const stepNum in flowDoc.steps) {
+  metadata.push(flowUtils.createMetadata(metadata ? metadata : {}, flowDoc.name, flowDoc.steps[stepNum].stepDefinitionName, jobId).datahubCreatedByStep)
+}
+
+
+results.push(
+  test.assertEqual("ingestion,mapping,mastering", metadata.toString())
+);
+
+results;


### PR DESCRIPTION
Issue: Metadata for documents from step1 has step1 name. Metadata for documents from step2 has step1 + step2 name and so on

Fix and test in this PR.