### PR TITLE
DHFPROD-2655: fixed unsavable state in Ingestion step dialog.

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog-ui.component.html
@@ -52,8 +52,10 @@
       matTooltipShowDelay="500"
       matTooltipHideDelay="500">
       <mat-select id="step-target-entity" placeholder="Target Entity" formControlName="targetEntity" [required]="entityRequired">
+        <mat-option *ngIf="isCustom">None</mat-option>
         <mat-option *ngFor="let entity of entities" [value]="entity.name">{{entity.name}}</mat-option>
       </mat-select>
+      <mat-error id="step-entity-error" *ngIf="newStepForm.get('targetEntity').invalid">Target Entity is required.</mat-error>
     </mat-form-field>
 
     <mat-accordion>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog-ui.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog-ui.component.ts
@@ -1,5 +1,5 @@
 import {Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
-import { FormBuilder, FormGroup, Validators, FormArray, FormControl } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators, FormArray, FormControl, AbstractControl } from '@angular/forms';
 import { Step, StepType } from '../../models/step.model';
 import {NewStepDialogValidator} from '../../validators/new-step-dialog.validator';
 import {FlowsTooltips} from "../../tooltips/flows.tooltips";

--- a/web/src/main/ui/app/components/flows-new/validators/new-step-dialog.validator.ts
+++ b/web/src/main/ui/app/components/flows-new/validators/new-step-dialog.validator.ts
@@ -6,6 +6,10 @@ export function NewStepDialogValidator(group: FormGroup) {
   let errors = {};
 
   switch (group.value.stepDefinitionType) {
+    case StepType.CUSTOM:
+    case StepType.INGESTION:
+      group.controls['targetEntity'].setErrors(null);
+      break;
     case StepType.MAPPING:
     case StepType.MASTERING:
       if (!group.value.targetEntity) {


### PR DESCRIPTION
- Save now works when validly filling out Ingestion step, switching to a different step type, and then returning to Ingestion.
- Added option to choose "None" in optional Target Entity dropdown for Custom step dialog.
- Added error message for required Target Entity field.
