### PR TITLE
DHFPROD-2560: Copying query options and loading staging triggers

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/AbstractVerifyCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/AbstractVerifyCommand.java
@@ -117,9 +117,11 @@ public abstract class AbstractVerifyCommand extends AbstractInstallerCommand {
     }
 
     protected void verifyTriggers() {
-        ResourcesFragment triggers = new TriggerManager(hubConfig.getManageClient(), hubConfig.getAppConfig().getTriggersDatabaseName()).getAsXml();
-        for (String trigger : new String[]{"ml-dh-entity-create", "ml-dh-entity-delete", "ml-dh-entity-modify"}) {
-            verify(triggers.resourceExists(trigger), "Trigger was not created: " + trigger);
+        for (String triggersDatabaseName : new String[]{"data-hub-final-TRIGGERS", "data-hub-staging-TRIGGERS"}) {
+            ResourcesFragment triggers = new TriggerManager(hubConfig.getManageClient(), triggersDatabaseName).getAsXml();
+            for (String trigger : new String[]{"ml-dh-entity-create", "ml-dh-entity-delete", "ml-dh-entity-modify"}) {
+                verify(triggers.resourceExists(trigger), "Trigger was not created: " + trigger);
+            }
         }
     }
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/VerifyDhfInDhsCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/VerifyDhfInDhsCommand.java
@@ -102,15 +102,18 @@ public class VerifyDhfInDhsCommand extends AbstractVerifyCommand {
                 "/Evaluator/data-hub-JOBS/rest-api/options/jobs.xml",
                 "/Evaluator/data-hub-JOBS/rest-api/options/traces.xml",
                 "/Evaluator/data-hub-STAGING/rest-api/options/default.xml",
-                "/Evaluator/data-hub-FINAL/rest-api/options/default.xml"
+                "/Evaluator/data-hub-FINAL/rest-api/options/default.xml",
+                "/Curator/data-hub-FINAL/rest-api/options/default.xml",
+                "/Curator/data-hub-JOBS/rest-api/options/jobs.xml",
+                "/Curator/data-hub-JOBS/rest-api/options/traces.xml",
+                "/Curator/data-hub-STAGING/rest-api/options/default.xml",
+                "/Analyzer/data-hub-ANALYTICS/rest-api/options/default.xml",
+                "/Analyzer/data-hub-ANALYTICS-REST/rest-api/options/default.xml",
+                "/Operator/data-hub-OPERATION/rest-api/options/default.xml",
+                "/Operator/data-hub-OPERATION-REST/rest-api/options/default.xml",
+                "/Evaluator/data-hub-ANALYTICS/rest-api/options/default.xml",
+                "/Evaluator/data-hub-OPERATION/rest-api/options/default.xml"
             );
-
-            // Not verifying these for now as the current DHS setup doesn't install them
-//            verifyOptionsExist(documentManager,
-//                "/Curator/data-hub-JOBS/rest-api/options/jobs.xml",
-//                "/Curator/data-hub-JOBS/rest-api/options/traces.xml",
-//                "/Curator/data-hub-STAGING/rest-api/options/default.xml"
-//            );
         } finally {
             hubConfig.setPort(DatabaseKind.FINAL, finalPort);
             client.release();

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/deploy/CopyQueryOptionsCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/deploy/CopyQueryOptionsCommand.java
@@ -1,0 +1,54 @@
+package com.marklogic.hub.cli.deploy;
+
+import com.marklogic.appdeployer.command.AbstractCommand;
+import com.marklogic.appdeployer.command.CommandContext;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.hub.HubConfig;
+import com.marklogic.hub.deploy.commands.LoadUserModulesCommand;
+
+public class CopyQueryOptionsCommand extends AbstractCommand {
+
+    private HubConfig hubConfig;
+
+    public CopyQueryOptionsCommand(HubConfig hubConfig) {
+        this.hubConfig = hubConfig;
+
+        // Need to run this after the contents of ml-modules-final is loaded
+        setExecuteSortOrder(new LoadUserModulesCommand().getExecuteSortOrder() + 1);
+    }
+
+    @Override
+    public void execute(CommandContext context) {
+        String script = "declareUpdate();\n" +
+            "[\n" +
+            "  '/Evaluator/data-hub-JOBS/rest-api/options/jobs.xml',\n" +
+            "  '/Evaluator/data-hub-JOBS/rest-api/options/traces.xml',\n" +
+            "  '/Evaluator/data-hub-STAGING/rest-api/options/default.xml',\n" +
+            "  '/Evaluator/data-hub-FINAL/rest-api/options/default.xml'\n" +
+            "].forEach(uri => {\n" +
+            "  xdmp.documentInsert(uri.replace('Evaluator', 'Curator'), cts.doc(uri), \n" +
+            "    xdmp.documentGetPermissions(uri), xdmp.documentGetCollections(uri));\n" +
+            "});\n" +
+            "\n" +
+            "const finalUri = '/Evaluator/data-hub-FINAL/rest-api/options/default.xml';\n" +
+            "[\n" +
+            "  '/Analyzer/data-hub-ANALYTICS/rest-api/options/default.xml',\n" +
+            "  '/Analyzer/data-hub-ANALYTICS-REST/rest-api/options/default.xml',\n" +
+            "  '/Operator/data-hub-OPERATION/rest-api/options/default.xml',\n" +
+            "  '/Operator/data-hub-OPERATION-REST/rest-api/options/default.xml',\n" +
+            "  '/Evaluator/data-hub-ANALYTICS/rest-api/options/default.xml',\n" +
+            "  '/Evaluator/data-hub-OPERATION/rest-api/options/default.xml'\n" +
+            "].forEach(uri => {\n" +
+            "  xdmp.documentInsert(uri, cts.doc(finalUri), xdmp.documentGetPermissions(finalUri), \n" +
+            "    xdmp.documentGetCollections(finalUri));\n" +
+            "})";
+
+        DatabaseClient client = hubConfig.newModulesDbClient();
+        try {
+            client.newServerEval().javascript(script).eval();
+        } finally {
+            client.release();
+        }
+
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/command/InstallIntoDhsCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/command/InstallIntoDhsCommandTest.java
@@ -8,17 +8,17 @@ import com.marklogic.appdeployer.command.security.DeployPrivilegesCommand;
 import com.marklogic.appdeployer.command.triggers.DeployTriggersCommand;
 import com.marklogic.hub.ApplicationConfig;
 import com.marklogic.hub.HubTestBase;
+import com.marklogic.hub.cli.deploy.CopyQueryOptionsCommand;
 import com.marklogic.hub.cli.deploy.DhsDeployServersCommand;
-import com.marklogic.hub.deploy.commands.DeployDatabaseFieldCommand;
-import com.marklogic.hub.deploy.commands.LoadHubArtifactsCommand;
-import com.marklogic.hub.deploy.commands.LoadHubModulesCommand;
-import com.marklogic.hub.deploy.commands.LoadUserModulesCommand;
+import com.marklogic.hub.deploy.commands.*;
 import com.marklogic.hub.impl.HubConfigImpl;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Properties;
 
@@ -63,15 +63,19 @@ public class InstallIntoDhsCommandTest extends HubTestBase {
         command.dataHub = super.dataHub;
 
         List<Command> commands = command.buildCommandsForDhs();
-        assertEquals(9, commands.size());
+        assertEquals(11, commands.size());
+        Collections.sort(commands, (c1, c2) -> c1.getExecuteSortOrder().compareTo(c2.getExecuteSortOrder()));
+
         assertTrue(commands.get(0) instanceof DeployPrivilegesCommand);
-        assertTrue(commands.get(1) instanceof DeployAmpsCommand);
-        assertTrue(commands.get(2) instanceof DeployOtherDatabasesCommand);
+        assertTrue(commands.get(1) instanceof DeployOtherDatabasesCommand);
+        assertTrue(commands.get(2) instanceof DeployDatabaseFieldCommand);
         assertTrue(commands.get(3) instanceof DhsDeployServersCommand);
-        assertTrue(commands.get(4) instanceof DeployTriggersCommand);
-        assertTrue(commands.get(5) instanceof DeployDatabaseFieldCommand);
-        assertTrue(commands.get(6) instanceof LoadHubModulesCommand);
-        assertTrue(commands.get(7) instanceof LoadUserModulesCommand);
-        assertTrue(commands.get(8) instanceof LoadHubArtifactsCommand);
+        assertTrue(commands.get(4) instanceof LoadHubModulesCommand);
+        assertTrue(commands.get(5) instanceof DeployAmpsCommand);
+        assertTrue(commands.get(6) instanceof LoadUserModulesCommand);
+        assertTrue(commands.get(7) instanceof CopyQueryOptionsCommand);
+        assertTrue(commands.get(8) instanceof DeployTriggersCommand);
+        assertTrue(commands.get(9) instanceof DeployHubTriggersCommand);
+        assertTrue(commands.get(10) instanceof LoadHubArtifactsCommand);
     }
 }


### PR DESCRIPTION
Triggers weren't getting loaded into the staging triggers database, but now they are.

Query options are now being copied to all of the URIs necessary for them to work via each of the 4 DHS groups.