### PR TITLE
Handle Sequence payloads in cleanData()

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow-utils.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow-utils.sjs
@@ -227,35 +227,43 @@ class FlowUtils {
     if (resp instanceof BinaryNode) {
       return xs.hexBinary(resp);
     }
-      let kind = resp ? xdmp.nodeKind(resp) : null;
-      let isXml = (kind === 'element');
-      if (!isXml && resp) {
-        // object with $type key is ES response type
-        if (resp instanceof Object && resp.hasOwnProperty('$type')) {
-          return resp;
-        } else if (dataFormat === this.consts.XML) {
-          return json.transformFromJson(resp, json.config("custom"));
-        } else {
-          return resp;
-        }
-      } else if (isXml && resp) {
-        if ((resp instanceof ArrayNode || resp instanceof Array) && dataFormat === this.consts.XML) {
-          return json.arrayValues(resp);
-        } else {
-          return resp;
-        }
+
+    if (resp instanceof Sequence) {
+      var cleanResp = [];
+      for (const respPart of resp) {
+        cleanResp.push(this.cleanData(respPart, destination, dataFormat));
       }
-    else if (!resp) {
-        if (destination === "headers" && dataFormat === this.consts.JSON) {
-          return {};
-        }
-        else if (destination === "triples" && dataFormat === this.consts.JSON) {
-          return [];
-        }
-        else {
-          return resp;
-        }
+      return Sequence.from(cleanResp);
+    }
+
+    let kind = resp ? xdmp.nodeKind(resp) : null;
+    let isXml = (kind === 'element');
+    if (!isXml && resp) {
+      // object with $type key is ES response type
+      if (resp instanceof Object && resp.hasOwnProperty('$type')) {
+        return resp;
+      } else if (dataFormat === this.consts.XML) {
+        return json.transformFromJson(resp, json.config("custom"));
+      } else {
+        return resp;
       }
+    } else if (isXml && resp) {
+      if ((resp instanceof ArrayNode || resp instanceof Array) && dataFormat === this.consts.XML) {
+        return json.arrayValues(resp);
+      } else {
+        return resp;
+      }
+    } else if (!resp) {
+      if (destination === "headers" && dataFormat === this.consts.JSON) {
+        return {};
+      }
+      else if (destination === "triples" && dataFormat === this.consts.JSON) {
+        return [];
+      }
+      else {
+        return resp;
+      }
+    }
 
     if (dataFormat === this.consts.JSON &&
       destination === "triples") {


### PR DESCRIPTION
This handles `Sequence` instances agnostically. It fixes my proximate problem with #2736, though it could probably be improved.

Includes whitespace changes as the previous indenting obscured the logic.