### PR TITLE
Latest mastering changes with performance tracing and enhancements

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/algorithms/standard-reduction.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/algorithms/standard-reduction.xqy
@@ -4,6 +4,8 @@ module namespace algorithms = "http://marklogic.com/smart-mastering/algorithms";
 
 import module namespace const = "http://marklogic.com/smart-mastering/constants"
   at "/com.marklogic.smart-mastering/constants.xqy";
+import module namespace helper-impl = "http://marklogic.com/smart-mastering/helper-impl"
+  at "/com.marklogic.smart-mastering/matcher-impl/helper-impl.xqy";
 
 declare option xdmp:mapping "false";
 
@@ -20,28 +22,12 @@ declare function algorithms:standard-reduction-query(
       else
         0
     return
-      let $property-def := $options-xml/*:property-defs/*:property[@name = $property-name]
-      where fn:exists($property-def)
+      let $base-query := helper-impl:property-name-to-query($options-xml, $property-name)
+      where fn:exists($base-query)
       return
-        let $qname := fn:QName($property-def/@namespace, $property-def/@localname)
+        let $qname := helper-impl:property-name-to-qname($options-xml, $property-name)
         let $value := $document//*[fn:node-name(.) eq $qname]
         return
-            if ($options-xml/*:data-format = $const:FORMAT-JSON) then
-              cts:json-property-value-query(
-                fn:string($qname),
-                $value,
-                "case-insensitive",
-                $weight
-              )
-            else if ($options-xml/*:data-format = $const:FORMAT-XML) then
-              cts:element-value-query(
-                $qname,
-                $value,
-                "case-insensitive",
-                $weight
-              )
-            else
-              fn:error(xs:QName("SM-INVALID-FORMAT"), "invalid format in match options")
-
+            helper-impl:property-name-to-query($options-xml, $property-name)($value, $weight)
   ))
 };

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/algorithms/thesaurus.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/algorithms/thesaurus.xqy
@@ -4,6 +4,8 @@ module namespace algorithms = "http://marklogic.com/smart-mastering/algorithms";
 
 import module namespace const = "http://marklogic.com/smart-mastering/constants"
   at "/com.marklogic.smart-mastering/constants.xqy";
+import module namespace helper-impl = "http://marklogic.com/smart-mastering/helper-impl"
+  at "/com.marklogic.smart-mastering/matcher-impl/helper-impl.xqy";
 import module namespace thsr = "http://marklogic.com/xdmp/thesaurus"
   at "/MarkLogic/thesaurus.xqy";
 
@@ -27,8 +29,6 @@ declare function algorithms:thesaurus(
 )
 {
   let $property-name := $expand-xml/@property-name
-  let $property-def := $options-xml/*:property-defs/*:property[@name = $property-name]
-  let $qname := fn:QName($property-def/@namespace, $property-def/@localname)
   let $thesaurus := $expand-xml/*:thesaurus
   where fn:exists($thesaurus)
   return
@@ -37,20 +37,7 @@ declare function algorithms:thesaurus(
     where fn:exists($entries)
     return
       thsr:expand(
-        if ($options-xml/match:data-format = $const:FORMAT-JSON) then
-          cts:json-property-value-query(
-            fn:string($qname),
-            fn:lower-case($value),
-            "case-insensitive",
-            $expand-xml/@weight
-          )
-        else
-          cts:element-value-query(
-            $qname,
-            fn:lower-case($value),
-            "case-insensitive",
-            $expand-xml/@weight
-          ),
+        helper-impl:property-name-to-query($options-xml, $property-name)($value, $expand-xml/@weight),
         $entries,
         $expand-xml/@weight,
         (),

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/algorithms/zip.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/algorithms/zip.xqy
@@ -5,6 +5,9 @@ xquery version "1.0-ml";
  :)
 module namespace algorithms = "http://marklogic.com/smart-mastering/algorithms";
 
+import module namespace helper-impl = "http://marklogic.com/smart-mastering/helper-impl"
+  at "/com.marklogic.smart-mastering/matcher-impl/helper-impl.xqy";
+
 declare namespace matcher = "http://marklogic.com/smart-mastering/matcher";
 
 declare option xdmp:mapping "false";
@@ -27,15 +30,13 @@ declare function algorithms:zip-match(
   as cts:query*
 {
   let $property-name := $expand-xml/@property-name
-  let $property-def := $options-xml/matcher:property-defs/matcher:property[@name = $property-name]
-  let $qname := fn:QName($property-def/@namespace, $property-def/@localname)
   let $sep := "-"
   let $origin-5-weight := $expand-xml/matcher:zip[@origin = "5"]/@weight/fn:data()
   let $origin-9-weight := $expand-xml/matcher:zip[@origin = "9"]/@weight/fn:data()
   for $value in $expand-values
   return
     if (fn:string-length($value) = 5) then
-      cts:element-value-query($qname, $value || $sep || "*", (), $origin-5-weight)
+      helper-impl:property-name-to-query($options-xml, $property-name)($value || $sep || "*", $origin-5-weight)
     else
-      cts:element-value-query($qname, fn:substring($value, 1, 5), (), $origin-9-weight)
+      helper-impl:property-name-to-query($options-xml, $property-name)(fn:substring($value, 1, 5), $origin-9-weight)
 };

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/auditing/base.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/auditing/base.xqy
@@ -250,6 +250,7 @@ declare function auditing:audit-trace-rollback($prov-xml)
     fn:string(
       $entity/*:label
     )
+  where fn:not($merged-uri = $orig-uri)
   return
     auditing:audit-trace(
       $auditing:ROLLBACK-ACTION,

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/constants.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/constants.xqy
@@ -52,6 +52,7 @@ declare variable $FORMAT-XML  as xs:string := "xml";
 (: Trace Events :)
 declare variable $TRACE-MATCH-RESULTS := "SM-MATCH";
 declare variable $TRACE-MERGE-RESULTS := "SM-MERGE";
+declare variable $TRACE-PERFORMANCE := "SM-PERFORMANCE";
 
 (: ERRORS :)
 declare variable $NO-MERGE-OPTIONS-ERROR := xs:QName("SM-NO-MERGING-OPTIONS");

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/impl/collections.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/impl/collections.xqy
@@ -11,7 +11,7 @@ declare namespace merging = "http://marklogic.com/smart-mastering/merging";
 declare function coll:get-collections($spec as element()*, $default as xs:string?)
   as xs:string*
 {
-  let $coll-names := $spec/fn:string()
+  let $coll-names := $spec ! fn:string()[. ne '']
   return
     if (fn:exists($spec/@none)) then
       ()
@@ -21,10 +21,10 @@ declare function coll:get-collections($spec as element()*, $default as xs:string
       $default
 };
 
-declare function coll:content-collections($options as element(matcher:options)?)
+declare function coll:content-collections($options as element()?)
   as xs:string*
 {
-  coll:get-collections($options/matcher:collections/matcher:content, $const:CONTENT-COLL)
+  coll:get-collections($options/*:collections/*:content, $const:CONTENT-COLL)
 };
 
 declare function coll:merged-collections($options as element(merging:options)?)

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/impl/sm-es-impl.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/impl/sm-es-impl.xqy
@@ -30,20 +30,18 @@ declare variable $_entity-descriptors as array-node() := array-node {
     let $entity-version := map:get($entity, "entityVersion")
     let $entity-title := map:get($entity, "entityTitle")
     let $nc-name := xdmp:encode-for-NCName($entity-title)
-    let $namespace-uri := fn:string(
-        fn:head(
+    let $raw-def :=
           fn:collection("http://marklogic.com/entity-services/models")
             /(object-node()|es:model)[(es:info/es:version|info/version) = $entity-version]
             /(es:definitions|definitions)/*[fn:string(fn:node-name(.)) eq $nc-name]
-            /(es:namespace-uri|namespaceUri)
-        )
-      )
+    let $namespace-uri := fn:string(fn:head($raw-def/(es:namespace-uri|namespaceUri)))
+    let $primary-key := fn:head((map:get($entity, "primaryKey"), $raw-def/(es:primary-key|primaryKey) ! fn:string(.),null-node{}))
     return object-node {
       "entityIRI": map:get($entity, "entityIRI"),
       "entityTitle": $entity-title,
       "entityVersion": $entity-version,
       "namespaceUri": $namespace-uri,
-      "primaryKey": fn:head((map:get($entity, "primaryKey"),null-node{})),
+      "primaryKey": $primary-key,
       "properties": array-node {
         let $properties :=
           sem:sparql("SELECT ?propertyIRI ?primaryKey ?ref ?datatype ?collation ?items ?title ?itemsDatatype ?itemsRef

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/matcher-impl/helper-impl.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/matcher-impl/helper-impl.xqy
@@ -1,0 +1,143 @@
+xquery version "1.0-ml";
+
+(:
+ : This is an implementation library, not an interface to the Smart Mastering functionality.
+ :
+ : This module contains helper functions for generating queries for properties.
+ :)
+
+module namespace helper-impl = "http://marklogic.com/smart-mastering/helper-impl";
+
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/com.marklogic.smart-mastering/constants.xqy";
+import module namespace es-helper = "http://marklogic.com/smart-mastering/entity-services"
+  at "/com.marklogic.smart-mastering/sm-entity-services.xqy";
+
+declare namespace matcher = "http://marklogic.com/smart-mastering/matcher";
+declare namespace sm = "http://marklogic.com/smart-mastering";
+declare namespace es = "http://marklogic.com/entity-services";
+
+declare variable $_cached-property-name-to-queries as map:map := map:map();
+
+declare function helper-impl:property-name-to-query($options as element(), $full-property-name as xs:string)
+{
+  let $key := fn:generate-id($options)|| "|" || $full-property-name
+  return
+    if (map:contains($_cached-property-name-to-queries, $key)) then
+      map:get($_cached-property-name-to-queries, $key)
+    else
+      let $is-json := $options/matcher:data-format = $const:FORMAT-JSON
+      let $target-entity-def := es-helper:get-entity-def($options/matcher:target-entity)
+      let $qname := helper-impl:property-name-to-qname($options, $full-property-name)
+      let $property-name :=
+        if (fn:contains($full-property-name, ".")) then
+          fn:substring-after($full-property-name, ".")
+        else
+          $full-property-name
+      let $property-details :=
+        if (fn:exists($target-entity-def)) then
+          let $prop-entity-def :=
+            if (fn:contains($full-property-name, ".")) then
+              es-helper:get-entity-def(fn:substring-before($full-property-name, "."))
+            else
+              $target-entity-def
+          return
+            es-helper:get-entity-def-property(
+              $prop-entity-def,
+              $property-name
+            )
+        else ()
+      let $prop-entity-def := $property-details/../..
+      let $property-entity-qname := $prop-entity-def ! fn:QName(./namespaceUri, xdmp:encode-for-NCName(./entityTitle))
+      let $scope-query :=
+        if (fn:exists($property-entity-qname)) then
+          if ($is-json) then
+            cts:json-property-scope-query(fn:string($property-entity-qname), ?)
+          else
+            cts:element-query($property-entity-qname, ?)
+        else
+          function($val) {
+            $val
+          }
+      let $property-def := $options/matcher:property-defs/matcher:property[@name = $full-property-name]
+      let $index-reference-xml := $property-def/(cts:json-property-reference|cts:element-reference|cts:path-reference|cts:field-reference)
+      let $helper-query :=
+        if (fn:exists($property-def) or fn:exists($property-details)) then
+          if (fn:exists($index-reference-xml)) then
+            let $references := $index-reference-xml ! cts:reference-parse(.)
+            let $scalar-type := cts:reference-scalar-type(fn:head($references))
+            return function($val, $weight) {
+              let $cast-values := $val ! fn:data(element val { attribute xsi:type {"xs:"||$scalar-type}, fn:string(.)})
+              return
+                $scope-query(cts:range-query($references, "=", $cast-values, (), $weight))
+            }
+          else if ($is-json) then
+              function($val, $weight) {
+                $scope-query(cts:json-property-value-query(
+                  fn:string($qname),
+                  (
+                    $val,
+                    $val ! fn:number(.)[fn:string(.) ne "NaN"],
+                    $val[. castable as xs:boolean] ! xs:boolean(.)
+                  ),
+                  ("case-insensitive"),
+                  $weight
+                ))
+              }
+            else
+              function($val, $weight) {
+                $scope-query(cts:element-value-query(
+                  $qname,
+                  $val,
+                  ("case-insensitive"),
+                  $weight
+                ))
+              }
+        else ()
+      return (
+        map:put($_cached-property-name-to-queries, $key, $helper-query),
+        $helper-query
+      )
+};
+
+declare variable $_cached-property-name-to-qnames as map:map := map:map();
+
+declare function helper-impl:property-name-to-qname($options as element(), $full-property-name as xs:string)
+{
+  let $key := fn:generate-id($options)|| "|" || $full-property-name
+  return
+    if (map:contains($_cached-property-name-to-qnames, $key)) then
+      map:get($_cached-property-name-to-qnames, $key)
+    else
+      let $target-entity-def := es-helper:get-entity-def($options/matcher:target-entity)
+      let $property-name :=
+        if (fn:contains($full-property-name, ".")) then
+          fn:substring-after($full-property-name, ".")
+        else
+          $full-property-name
+      let $property-details :=
+        if (fn:exists($target-entity-def)) then
+          let $prop-entity-def :=
+            if (fn:contains($full-property-name, ".")) then
+              es-helper:get-entity-def(fn:substring-before($full-property-name, "."))
+            else
+              $target-entity-def
+          return
+            es-helper:get-entity-def-property(
+              $prop-entity-def,
+              $property-name
+            )
+        else ()
+      let $prop-entity-def := $property-details/../..
+      let $property-entity-qname := $prop-entity-def ! fn:QName(./namespaceUri, xdmp:encode-for-NCName(./entityTitle))
+      let $property-def := $options/matcher:property-defs/matcher:property[@name = $full-property-name]
+      let $qname :=
+          if (fn:exists($property-def)) then
+            fn:QName($property-def/@namespace, $property-def/@localname)
+          else
+            fn:QName($prop-entity-def/namespaceUri, xdmp:encode-for-NCName($property-name))
+      return (
+        map:put($_cached-property-name-to-qnames, $key, $qname),
+        $qname
+      )
+};

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/matcher-impl/options-impl.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/matcher-impl/options-impl.xqy
@@ -135,18 +135,91 @@ declare function opt-impl:save-options(
 (: Convert JSON match options to XML :)
 declare function opt-impl:options-from-json($options-json)
 {
-  (: TODO consider more explicit translation, like merge options :)
-  let $xml := json:transform-from-json($options-json, $opt-impl:options-json-config)
+  let $options-root := $options-json/options
   return
-    if (fn:exists($options-json/options/collections/content[. instance of null-node()])) then
-      element matcher:options {
-        $xml/* except $xml/matcher:collections,
-        element matcher:collections {
+    element matcher:options {
+      if (fn:exists($options-root/targetEntity)) then
+        element matcher:target-entity {fn:string($options-root/targetEntity)}
+      else (),
+      if (fn:exists($options-root/dataFormat)) then
+        element matcher:data-format {fn:string($options-root/dataFormat)}
+      else (),
+      element matcher:property-defs {
+        for $property in $options-root/propertyDefs/(properties|property)
+        return
+          element matcher:property {
+            attribute namespace {fn:string($property/namespace)},
+            attribute localname {fn:string($property/localname)},
+            attribute name {fn:string($property/name)},
+            $property/indexReferences ! cts:reference-parse(.)
+          }
+      },
+      element matcher:collections {
+        if (fn:exists($options-root/collections/content[. instance of null-node()])) then
           element matcher:content {attribute none {"true"}}
+        else
+          for $content in $options-root/collections/content
+          return
+            element matcher:content {fn:string($content)}
+      },
+      element matcher:algorithms {
+        for $algorithm in $options-root/(array-node("algorithms")/object-node()|algorithms/algorithm)
+        return
+          element matcher:algorithm {
+            attribute name { fn:string($algorithm/name) },
+            if (fn:exists($algorithm/function)) then
+              attribute function {fn:string($algorithm/function) }
+            else (),
+            if (fn:exists($algorithm/namespace)) then
+              attribute namespace { fn:string($algorithm/namespace) }
+            else (),
+            if (fn:exists($algorithm/at)) then
+              attribute at { fn:string($algorithm/at) }
+            else ()
+          }
+      },
+      element matcher:scoring {
+        json:transform-from-json(object-node { "scoring": $options-root/scoring }, $opt-impl:options-json-config)/*
+      },
+      element matcher:actions {
+        for $action in $options-root/(array-node("actions")/object-node()|actions/action)
+        return
+          element matcher:action {
+            attribute name { fn:string($action/name) },
+            if (fn:exists($action/function)) then
+              attribute function {fn:string($action/function) }
+            else (),
+            if (fn:exists($action/namespace)) then
+              attribute namespace { fn:string($action/namespace) }
+            else (),
+            if (fn:exists($action/at)) then
+              attribute at { fn:string($action/at) }
+            else (),
+            for $node in ($action/* except $action/(name|function|namespace|at))
+            return
+              json:transform-from-json(object-node { fn:node-name($node): $node }, $opt-impl:options-json-config)
+          }
+      },
+      element matcher:thresholds {
+        for $threshold in $options-root/(array-node("thresholds")/object-node()|thresholds/threshold)
+        return
+          element matcher:threshold {
+            attribute label { fn:string($threshold/label) },
+            attribute above {fn:string($threshold/above) },
+            if (fn:exists($threshold/action)) then
+              attribute action { fn:string($threshold/action) }
+            else (),
+            for $node in ($threshold/* except $threshold/(label|above|action))
+            return
+              json:transform-from-json(object-node { fn:node-name($node): $node }, $opt-impl:options-json-config)
+          }
+      },
+      if (fn:exists($options-root/tuning/maxScan)) then
+        element matcher:tuning {
+          element matcher:max-scan {fn:string($options-root/tuning/maxScan)}
         }
-      }
-    else
-      $xml
+      else ()
+    }
 };
 
 declare function opt-impl:options-to-json($options-xml as element(matcher:options)?)
@@ -154,7 +227,97 @@ declare function opt-impl:options-to-json($options-xml as element(matcher:option
 {
   if (fn:exists($options-xml)) then
     xdmp:to-json(
-      json:transform-to-json-object($options-xml, $opt-impl:options-json-config)
+      map:entry(
+      "options", map:new((
+        if (fn:exists($options-xml/matcher:target-entity)) then
+          map:entry("targetEntity", fn:string($options-xml/matcher:target-entity))
+        else (),
+        if (fn:exists($options-xml/matcher:data-format)) then
+          map:entry("dataFormat", fn:string($options-xml/matcher:data-format))
+        else (),
+        map:entry(
+          "propertyDefs",
+          map:entry("properties",
+            array-node {
+              for $property in $options-xml/matcher:property-defs/matcher:property
+              return
+                xdmp:to-json(map:new((
+                  map:entry("namespace", fn:string($property/@namespace)),
+                  map:entry("localname", fn:string($property/@localname)),
+                  map:entry("name", fn:string($property/@name)),
+                  if (fn:exists($property/(cts:json-property-reference|cts:element-reference|cts:path-reference|cts:field-reference))) then
+                    map:entry("indexReferences",
+                      array-node {
+                        $property/(cts:json-property-reference|cts:element-reference|cts:path-reference|cts:field-reference) ! cts:reference-parse(.)
+                      }
+                    )
+                  else ()
+                )))/object-node()
+            }
+          )
+        ),
+        map:entry("algorithms",
+          array-node {
+            for $algorithm in $options-xml/matcher:algorithms/matcher:algorithm
+            return
+              xdmp:to-json(map:new((
+                map:entry("name", fn:string($algorithm/@name)),
+                if (fn:exists($algorithm/@function)) then
+                  map:entry("function", fn:string($algorithm/@function))
+                else (),
+                if (fn:exists($algorithm/@namespace)) then
+                  map:entry("namespace", fn:string($algorithm/@namespace))
+                else (),
+                if (fn:exists($algorithm/@at)) then
+                  map:entry("at", fn:string($algorithm/@at))
+                else ()
+              )))/object-node()
+          }
+        ),
+        if (fn:exists($options-xml/matcher:collections/matcher:content)) then
+          map:entry("collections",
+            map:entry("content",
+              if ($options-xml/matcher:collections/matcher:content/@none = "true") then
+                null-node {}
+              else
+                array-node {
+                  $options-xml/matcher:collections/matcher:content ! fn:string(.)
+                }
+            )
+          )
+        else (),
+        map:entry("scoring",
+          xdmp:to-json(
+              json:transform-to-json-object($options-xml/matcher:scoring, $opt-impl:options-json-config)
+          )/scoring
+        ),
+        map:entry("actions",
+          array-node {
+            if (fn:exists($options-xml/matcher:actions)) then
+              xdmp:to-json(
+                json:transform-to-json-object($options-xml/matcher:actions, $opt-impl:options-json-config)
+              )/actions/action
+            else ()
+          }
+        ),
+        map:entry("thresholds",
+          array-node {
+            if (fn:exists($options-xml/matcher:thresholds)) then
+              xdmp:to-json(
+                json:transform-to-json-object($options-xml/matcher:thresholds, $opt-impl:options-json-config)
+              )/thresholds/threshold
+            else ()
+          }
+        ),
+        if (fn:exists($options-xml/matcher:tuning)) then
+          map:entry("tuning",
+            xdmp:to-json(
+                json:transform-to-json-object($options-xml/matcher:tuning, $opt-impl:options-json-config)
+            )/tuning
+          )
+        else ()
+      ))
+      )
     )/object-node()
   else ()
 };

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/matcher.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/matcher.xqy
@@ -149,7 +149,7 @@ declare function matcher:find-document-matches-by-options(
     $options,
     $start,
     $page-length,
-    fn:min($options//*:thresholds/*:threshold/(@above|above) ! fn:number(.)),
+    fn:min($options//(array-node("thresholds")/object-node()|*:thresholds/*:threshold)/(@above|above) ! fn:number(.)),
     fn:false(),
     $include-matches,
     $filter-query

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/merging.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/merging.xqy
@@ -26,7 +26,8 @@ xquery version "1.0-ml";
 module namespace merging = "http://marklogic.com/smart-mastering/merging";
 
 import module namespace impl = "http://marklogic.com/smart-mastering/survivorship/merging"
-  at "/com.marklogic.smart-mastering/survivorship/merging/base.xqy";
+  at "/com.marklogic.smart-mastering/survivorship/merging/base.xqy",
+    "/com.marklogic.smart-mastering/survivorship/merging/options.xqy";
 import module namespace const = "http://marklogic.com/smart-mastering/constants"
   at "/com.marklogic.smart-mastering/constants.xqy";
 

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
@@ -21,10 +21,6 @@ xquery version "1.0-ml";
  : but nothing prevents an algorithm from combining or otherwise modifying
  : source document values. (Value source tracking might be a little more
  : complex.)
- :
- : Merge options can be sent to Smart Mastering Core as XML or JSON, but they
- : are stored and worked with as XML. This library has functions to convert
- : from JSON to XML.
  :)
 module namespace merge-impl = "http://marklogic.com/smart-mastering/survivorship/merging";
 
@@ -39,7 +35,8 @@ import module namespace history = "http://marklogic.com/smart-mastering/auditing
 import module namespace json="http://marklogic.com/xdmp/json"
   at "/MarkLogic/json/json.xqy";
 import module namespace merge-impl = "http://marklogic.com/smart-mastering/survivorship/merging"
-  at  "standard.xqy";
+  at  "standard.xqy",
+      "options.xqy";
 import module namespace const = "http://marklogic.com/smart-mastering/constants"
   at "/com.marklogic.smart-mastering/constants.xqy";
 import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
@@ -62,11 +59,6 @@ declare namespace host = "http://marklogic.com/xdmp/status/host";
 declare namespace xsl = "http://www.w3.org/1999/XSL/Transform";
 
 declare option xdmp:mapping "false";
-
-(:
- : Directory in which merging options are stored.
- :)
-declare variable $MERGING-OPTIONS-DIR := "/com.marklogic.smart-mastering/options/merging/";
 
 (:
  : Directory in which merged documents are created.
@@ -361,7 +353,7 @@ declare function merge-impl:generate-provenance-details(
  :)
 declare function merge-impl:rollback-merge(
   $merged-doc-uri as xs:string
-) as empty-sequence()
+) as xs:string*
 {
   merge-impl:rollback-merge($merged-doc-uri, fn:true(), fn:true())
 };
@@ -405,6 +397,7 @@ declare function merge-impl:rollback-merge(
       $latest-auditing-receipt-for-doc/auditing:previous-uri ! fn:string(.)
     else
       $all-contributing-uris[(@last-merge|../last-merge) = $last-merge-dateTime] ! fn:string(.)
+  let $merge-doc-in-previous := $previous-uris = $merged-doc-uri
   where fn:exists($latest-auditing-receipt-for-doc)
   return (
     let $prevent-auto-match :=
@@ -416,15 +409,33 @@ declare function merge-impl:rollback-merge(
     let $new-collections := coll-impl:on-merge(
             map:entry($previous-doc-uri, xdmp:document-get-collections($previous-doc-uri)[fn:not(. = $const:ARCHIVED-COLL)])
           ,$on-merge-options)
-    where fn:not(merge-impl:source-of-other-merged-doc($previous-doc-uri, $merged-doc-uri))
+    where fn:not($previous-doc-uri = $merged-doc-uri or merge-impl:source-of-other-merged-doc($previous-doc-uri, $merged-doc-uri))
     return (
       xdmp:document-set-collections($previous-doc-uri, $new-collections)
     ),
+    if ($merge-doc-in-previous) then
+      let $merge-options-ref := $merge-doc-headers/*:merge-options/*:value ! fn:string(.)
+      let $castable-as-hex := $merge-options-ref castable as xs:hexBinary
+      let $doc-available := fn:doc-available($merge-options-ref)
+      where $castable-as-hex or $doc-available
+      return
+        merge-impl:save-merge-models-by-uri(
+          $all-contributing-uris[fn:not(. = $previous-uris)],
+          if ($castable-as-hex) then
+            xdmp:zip-get(binary { $merge-options-ref }, "merge-options.xml")/*
+          else
+            fn:doc($merge-options-ref)/*
+        )
+    else (
+      if ($retain-rollback-info) then (
+        merge-impl:archive-document($merged-doc-uri, $merge-options)
+      ) else (
+        xdmp:document-delete($merged-doc-uri)
+      )
+    ),
     if ($retain-rollback-info) then (
-      merge-impl:archive-document($merged-doc-uri, $merge-options),
       $latest-auditing-receipt-for-doc ! auditing:audit-trace-rollback(.)
     ) else (
-      xdmp:document-delete($merged-doc-uri),
       $latest-auditing-receipt-for-doc ! xdmp:document-delete(xdmp:node-uri(.))
     )
   )
@@ -2190,10 +2201,56 @@ declare function merge-impl:execute-algorithm(
   if (fn:ends-with(xdmp:function-module($algorithm), "sjs")) then
     let $properties := json:to-array($properties)
     let $property-spec := merge-impl:propertyspec-to-json($property-spec)
+    let $results := xdmp:apply($algorithm, $property-name, $properties, $property-spec)
     return
-      xdmp:apply($algorithm, $property-name, $properties, $property-spec)
+      merge-impl:normalize-javascript-results(
+        $results
+      )
   else
     xdmp:apply($algorithm, $property-name, $properties, $property-spec)
+};
+
+(:
+ : Normalize the results of JavaScript merge function.
+ : @param $results  output of a merge JavaScript function
+ :)
+declare function merge-impl:normalize-javascript-results(
+  $results as item()*
+) {
+  let $results-sequence :=
+    if ($results instance of json:array) then
+      json:array-values($results)
+    else
+      $results
+  for $result in $results-sequence
+  let $values := map:get($result, "values")
+  return
+    if (fn:exists($values[fn:not(. instance of node())])) then
+      map:new((
+        $result,
+        map:entry("values", merge-impl:normalize-json-to-nodes(map:get($result, "name"), $values))
+      ))
+    else
+      $result
+
+};
+
+(:
+ : Normalize the values to nodes of JavaScript merge function.
+ : @param $results  output of a merge JavaScript function
+ :)
+declare function merge-impl:normalize-json-to-nodes(
+  $prop-name as xs:QName,
+  $values as item()*
+) {
+  for $value in $values
+  return
+    if ($value instance of node()) then
+      $value
+    else if ($value instance of json:array or $value instance of json:object) then
+      xdmp:to-json($value)/node()
+    else
+      object-node { $prop-name: $value }/node()
 };
 
 declare variable $documents-archived-in-transaction := map:map();
@@ -2216,535 +2273,6 @@ declare function merge-impl:archive-document($uri as xs:string, $merge-options a
         fn:true()
       )
     )
-};
-
-(:~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- : Functions related to merge options.
- :~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~:)
-
-declare function merge-impl:get-options($format as xs:string)
-{
-  let $options :=
-    cts:search(fn:collection(), cts:and-query((
-        cts:collection-query($const:OPTIONS-COLL),
-        (: In future version, remove mdm-merge collection from query
-          Currently part of the query to avoid breaking changes.
-        :)
-        cts:collection-query(('mdm-merge',$const:MERGE-OPTIONS-COLL))
-    )))/merging:options
-  return
-    if ($format eq $const:FORMAT-XML) then
-      $options
-    else if ($format eq $const:FORMAT-JSON) then
-      array-node { $options ! merge-impl:options-to-json(.) }
-    else
-      fn:error(xs:QName("SM-INVALID-FORMAT"), "matcher:get-option-names called with invalid format " || $format)
-};
-
-declare function merge-impl:get-options($options-name, $format as xs:string)
-{
-  let $options := fn:doc($MERGING-OPTIONS-DIR||$options-name||".xml")/merging:options
-  return
-    if ($format eq $const:FORMAT-XML) then
-      $options
-    else if ($format eq $const:FORMAT-JSON) then
-      merge-impl:options-to-json($options)
-    else
-      fn:error(xs:QName("SM-INVALID-FORMAT"), "merge-impl:get-options called with invalid format " || $format)
-};
-
-declare function merge-impl:save-options(
-  $name as xs:string,
-  $options as node()
-) as empty-sequence()
-{
-  let $options :=
-    if ($options instance of document-node()) then
-      $options/node()
-    else
-      $options
-  let $options :=
-    if ($options instance of object-node()) then
-      merge-impl:options-from-json($options)
-    else
-      $options
-  return
-    xdmp:document-insert(
-      $MERGING-OPTIONS-DIR||$name||".xml",
-      $options,
-      xdmp:default-permissions(),
-      ($const:OPTIONS-COLL, $const:MERGE-OPTIONS-COLL)
-    )
-};
-
-declare variable $options-json-config := merge-impl:_options-json-config();
-
-(: Removes whitespace nodes to keep the output json from options-to-json clean :)
-declare function merge-impl:remove-whitespace($xml)
-{
-  for $x in $xml
-  return
-    typeswitch($x)
-      case element() return
-        element { fn:node-name($x) } {
-          merge-impl:remove-whitespace(($x/@*, $x/node()))
-        }
-      case text() return
-        if (fn:string-length(fn:normalize-space($x)) > 0) then
-          $x
-        else ()
-      default return $x
-};
-
-(:
- : Convert merge options from XML to JSON.
- :)
-declare function merge-impl:options-to-json($options-xml as element(merging:options))
-{
-  if (fn:exists($options-xml)) then
-    xdmp:to-json(
-      map:entry(
-        "options",
-        map:new((
-          if (fn:exists($options-xml/merging:target-entity)) then
-            map:entry("targetEntity", $options-xml/merging:target-entity/fn:string())
-          else (),
-          map:entry("matchOptions", $options-xml/merging:match-options/fn:string()),
-          map:entry(
-            "propertyDefs",
-            map:new((
-              map:entry(
-                "properties",
-                array-node {
-                  for $prop in $options-xml/merging:property-defs/merging:property
-                  return
-                    if (fn:exists($prop/@path)) then
-                      object-node {
-                        "path": $prop/@path/fn:string(),
-                        "name": $prop/@name/fn:string()
-                      }
-                    else
-                      object-node {
-                        "namespace": $prop/@namespace/fn:string(),
-                        "localname": $prop/@localname/fn:string(),
-                        "name": $prop/@name/fn:string()
-                      }
-                }
-              ),
-              if (fn:exists($options-xml/merging:property-defs/merging:property/@path)) then
-                map:entry("namespaces", merge-impl:build-namespace-map($options-xml/merging:property-defs))
-              else ()
-            ))
-          ),
-          if ($options-xml/merging:collections) then
-            map:entry("collections",
-              map:new((
-                for $collection-type in fn:distinct-values($options-xml/merging:collections/* ! fn:node-name(.))
-                let $collection-type-values := $options-xml/merging:collections/*[fn:node-name(.) eq $collection-type]
-                return map:entry(
-                    fn:local-name-from-QName($collection-type),
-                    if (fn:exists($collection-type-values/@none)) then
-                      null-node {}
-                    else
-                      array-node {
-                        $collection-type-values ! fn:string(.)
-                      }
-                  )
-              ))
-            )
-          else (),
-          if (fn:exists($options-xml/merging:algorithms)) then
-            map:entry(
-              "algorithms",
-              map:new((
-                map:entry(
-                  "custom", array-node {
-                    for $alg in $options-xml/merging:algorithms/merging:algorithm
-                    return
-                      object-node {
-                        "name": $alg/@name/fn:string(),
-                        "function": $alg/@function/fn:string(),
-                        "at": let $at := $alg/@at/fn:string() return if (fn:exists($at)) then $at else ""
-                      }
-                  }),
-                if (fn:exists($options-xml/merging:algorithms/merging:std-algorithm)) then
-                  map:entry(
-                    "stdAlgorithm", object-node {
-                      "namespaces":
-                        merge-impl:build-namespace-map($options-xml/merging:algorithms/merging:std-algorithm),
-                      "timestamp": object-node {
-                        "path":
-                          let $path :=
-                            fn:head($options-xml/merging:algorithms/merging:std-algorithm/merging:timestamp/@path/fn:string()[. ne ''])
-                          return
-                            if (fn:exists($path)) then $path
-                            else null-node {}
-                      }
-                    }
-                  )
-                else (),
-                if (fn:exists($options-xml/merging:algorithms/merging:collections)) then
-                  map:entry(
-                    "collections",
-                    map:new(
-                      for $event in $options-xml/merging:algorithms/merging:collections/*
-                      let $json := merge-impl:collection-event-to-json($event)
-                      return
-                        map:entry(fn:string(fn:node-name($json)), $json)
-                    )
-                  )
-                else ()
-              ))
-            )
-          else (),
-          if (fn:exists($options-xml/merging:merging/merging:merge-strategy)) then
-            map:entry(
-              "mergeStrategies",
-              array-node {
-                for $merge in $options-xml/merging:merging/merging:merge-strategy
-                return
-                  merge-impl:propertyspec-to-json($merge)
-              }
-            )
-          else (),
-          if (fn:exists($options-xml/merging:merging/merging:merge)) then
-            map:entry(
-              "merging",
-              array-node {
-                for $merge in $options-xml/merging:merging/merging:merge
-                return
-                  merge-impl:propertyspec-to-json($merge)
-              }
-            )
-          else (),
-          if (fn:exists($options-xml/merging:triple-merge)) then
-            map:entry(
-              "tripleMerge",
-              let $config := json:config("custom")
-                => map:with("camel-case", fn:true())
-                => map:with("whitespace", "ignore")
-                => map:with("ignore-element-names", xs:QName("merging:merge"))
-              return
-                json:transform-to-json($options-xml/merging:triple-merge, $config)/*
-            )
-          else ()
-        ))
-      )
-    )/node()
-  else ()
-};
-
-declare variable $collection-event-json-config := json:config("custom")
-                          => map:with("camel-case", fn:true())
-                          => map:with("whitespace", "ignore")
-                          => map:with("attribute-names", ("namespace", "at", "function"));
-
-declare function merge-impl:collection-event-to-json($event as element())
-{
-  let $config := $collection-event-json-config => map:with("array-element-names", if (fn:empty($event/merging:function)) then xs:QName("merging:collection") else ())
-  return
-    json:transform-to-json($event, $config)/*
-};
-
-
-(:
- : Given an element, return a map entry with the key "namespaces" that holds
- : a map from namespace prefixes -> namespace URIs
- : @param $source  the element from which to draw the namespaces
- :)
-declare function merge-impl:build-namespace-map($source as element()?)
-{
-  let $obj := json:object()
-  let $populate :=
-    if (fn:exists($source)) then
-      for $prefix in fn:in-scope-prefixes($source)
-      (: xml prefix is predefined (see https://www.w3.org/XML/1998/namespace) :)
-      where fn:not($prefix = ("", "xml"))
-      return map:put($obj, $prefix, fn:namespace-uri-for-prefix($prefix, $source))
-    else ()
-  return $obj
-};
-
-(:
- : Convert merge options from JSON to XML.
- :)
-declare function merge-impl:options-from-json($options-json as object-node())
-  as element(merging:options)
-{
-  <options xmlns="http://marklogic.com/smart-mastering/merging">
-    {
-      if (fn:exists($options-json/*:options/*:targetEntity)) then
-        element merging:target-entity {
-          $options-json/*:options/*:targetEntity
-        }
-      else (),
-      element merging:match-options {
-        $options-json/*:options/*:matchOptions
-      },
-      merge-impl:construct-property-defs-element($options-json),
-      merge-impl:construct-algorithms-element($options-json),
-      merge-impl:construct-collections-element($options-json),
-      merge-impl:construct-merging-element($options-json),
-      merge-impl:construct-triple-merge-element($options-json)
-    }
-  </options>
-};
-
-declare private function merge-impl:construct-property-defs-element($options-json as object-node())
-  as element()
-{
-  element merging:property-defs {
-    attribute xmlns { "http://marklogic.com/smart-mastering/merging" },
-    for $ns in <r>{fn:data($options-json/*:options/*:propertyDefs/*:namespaces)}</r>/json:object/json:entry
-    return
-      attribute { xs:QName("xmlns:" || $ns/@key) } { $ns/json:value/fn:string() },
-    for $prop in $options-json/*:options/*:propertyDefs/*:properties
-    return
-      element merging:property {
-        attribute name { $prop/*:name },
-        if (fn:exists($prop/*:namespace)) then attribute namespace { $prop/*:namespace } else (),
-        if (fn:exists($prop/*:localname)) then attribute localname { $prop/*:localname } else (),
-        if (fn:exists($prop/*:path)) then attribute path { $prop/*:path} else ()
-      }
-  }
-};
-
-declare private function merge-impl:construct-algorithms-element($options-json as object-node())
-{
-  if (fn:exists($options-json/*:options/*:algorithms)) then
-    element merging:algorithms {
-      attribute xmlns { "http://marklogic.com/smart-mastering/merging" },
-      for $alg in $options-json/*:options/*:algorithms/*:custom
-      return
-        element merging:algorithm {
-          attribute xmlns { "http://marklogic.com/smart-mastering/merging" },
-          attribute name { $alg/*:name },
-          attribute function { $alg/*:function },
-          if (fn:exists($alg/*:namespace)) then attribute namespace { $alg/*:namespace } else (),
-          if (fn:exists($alg/*:at)) then attribute at { $alg/*:at } else ()
-        },
-      if (fn:exists($options-json/*:options/*:algorithms/*:stdAlgorithm)) then
-        element merging:std-algorithm {
-          if (fn:exists($options-json/*:options/*:algorithms/*:stdAlgorithm/*:timestamp)) then (
-            for $ns in <r>{fn:data($options-json/*:options/*:algorithms/*:stdAlgorithm/*:namespaces)}</r>/json:object/json:entry
-            return
-              attribute { xs:QName("xmlns:" || $ns/@key) } { $ns/json:value/fn:string() },
-            element merging:timestamp {
-              attribute path {
-                $options-json/*:options/*:algorithms/*:stdAlgorithm/*:timestamp/*:path/fn:string()
-              }
-            }
-          )
-          else ()
-        }
-      else (),
-      if (fn:exists($options-json/*:options/*:algorithms/*:collections)) then
-        element merging:collections {
-          let $config := json:config("custom")
-                          => map:with("element-namespace", "http://marklogic.com/smart-mastering/merging")
-                          => map:with("camel-case", fn:true())
-                          => map:with("whitespace", "ignore")
-                          => map:with("attribute-names", ("namespace", "at", "function"))
-          for $event in $options-json/*:options/*:algorithms/*:collections/*
-          let $qn := fn:node-name($event)
-          let $config := map:new($config) => map:with("array-element-names", if (fn:empty($event/*:function)) then "collection" else ())
-          return
-            json:transform-from-json(object-node{ $qn: $event}, $config)
-        }
-      else ()
-    }
-  else ()
-};
-
-declare private function merge-impl:construct-collections-element($options-json as object-node())
-{
-  if (fn:exists($options-json/*:options/*:collections)) then
-    element merging:collections {
-      attribute xmlns { "http://marklogic.com/smart-mastering/merging" },
-      for $collection-type in $options-json/*:options/*:collections/*
-      let $element-name := fn:string(fn:node-name($collection-type))
-      return
-        if ($collection-type instance of null-node()) then
-          element {fn:QName("http://marklogic.com/smart-mastering/merging",$element-name)} { attribute none {"true"}}
-        else
-          element {fn:QName("http://marklogic.com/smart-mastering/merging",$element-name)} { fn:string($collection-type) }
-    }
-  else ()
-};
-
-declare private function merge-impl:construct-merging-element($options-json as object-node())
-{
-  element merging:merging {
-    attribute xmlns { "http://marklogic.com/smart-mastering/merging" },
-    let $all-merge-options := $options-json/*:options/*:merging
-    let $all-merge-strategy-options := $options-json/*:options/*:mergeStrategies
-    let $array-element-names :=
-      fn:distinct-values(
-        ($all-merge-options,$all-merge-strategy-options)//array-node() !
-          xs:QName("merging:"||fn:lower-case(fn:replace(fn:string(fn:node-name(.)), "([a-z])([A-Z])", "$1-$2")))
-      )
-    let $config := json:config("custom")
-      => map:with("element-namespace", "http://marklogic.com/smart-mastering/merging")
-      => map:with("camel-case", fn:true())
-      => map:with("whitespace", "ignore")
-      => map:with("array-element-names", $array-element-names)
-      => map:with("attribute-names", ("default", "name", "weight", "strategy", "propertyName", "algorithmRef", "maxValues", "maxSources", "documentUri"))
-    let $all-xml := (
-      for $merge in $options-json/*:options/*:merging
-      return
-        element merging:merge {
-          json:transform-from-json($merge, $config)
-        },
-      for $merge-strategy in $all-merge-strategy-options
-      return
-        element merging:merge-strategy {
-          json:transform-from-json($merge-strategy, $config)
-        }
-      )
-    for $xml in $all-xml
-    let $array-elements := $xml//*[fn:node-name(.) = $array-element-names]
-    return
-      if (fn:exists($array-elements)) then
-        mem:execute(
-          mem:transform(
-            mem:copy($xml),
-            $array-elements,
-            function($node) {
-              let $qn := fn:node-name($node)
-              where fn:empty($node/preceding-sibling::*[fn:node-name(.) = $qn])
-              return element {$qn} {
-                $node/*,
-                $node/following-sibling::*[fn:node-name(.) = $qn]/*
-              }
-            }
-          )
-        )
-      else
-        $xml
-  }
-};
-
-declare private function merge-impl:construct-triple-merge-element($options-json as object-node())
-{
-  let $triple-merge := $options-json/*:options/*:tripleMerge
-  return
-    if (fn:exists($triple-merge)) then
-      element merging:triple-merge {
-        attribute xmlns { "http://marklogic.com/smart-mastering/merging" },
-        attribute namespace { $triple-merge/*:namespace },
-        attribute function { $triple-merge/*:function },
-        attribute at { $triple-merge/*:at },
-
-        let $config := json:config("custom")
-          => map:with("camel-case", fn:true())
-          => map:with("whitespace", "ignore")
-          => map:with("ignore-element-names", ("namespace","function","at"))
-        for $merge in $triple-merge
-        return
-          json:transform-from-json($merge, $config)
-      }
-    else ()
-};
-
-declare function merge-impl:_options-json-config()
-{
-  let $config := json:config("custom")
-  return (
-    map:put($config, "array-element-names", ("algorithm","threshold","scoring","property", "reduce", "add", "expand", "merging", "merge-strategy", "mergeStrategy")),
-    map:put($config, "element-namespace", "http://marklogic.com/smart-mastering/merging"),
-    map:put($config, "element-namespace-prefix", "merging"),
-    map:put($config, "attribute-names",
-      ("name","localname", "namespace", "function",
-        "at", "property-name", "propertyName", "weight", "above", "label","algorithm-ref", "algorithmRef", "strategy", "default")
-    ),
-    map:put($config, "camel-case", fn:true()),
-    map:put($config, "whitespace", "ignore"),
-    $config
-  )
-};
-
-declare function merge-impl:get-option-names($format as xs:string)
-{
-  if ($format eq $const:FORMAT-XML) then
-    let $options := cts:uris('', (), cts:and-query((
-        cts:collection-query($const:OPTIONS-COLL),
-        (: In future version, remove mdm-merge collection from query
-          Currently part of the query to avoid breaking changes.
-        :)
-        cts:collection-query(('mdm-merge',$const:MERGE-OPTIONS-COLL))
-      )))
-    let $option-names := $options ! fn:replace(
-      fn:replace(., $MERGING-OPTIONS-DIR, ""),
-      "\.xml$", ""
-    )
-    return
-      element merging:options {
-        for $name in $option-names
-        return
-          element merging:option { $name }
-      }
-  else if ($format eq $const:FORMAT-JSON) then
-    merge-impl:option-names-to-json(merge-impl:get-option-names($const:FORMAT-XML))
-  else
-    fn:error(xs:QName("SM-INVALID-FORMAT"), "Attempted to call merge-impl:get-option-names with invalid format: " || $format)
-};
-
-declare variable $option-names-json-config := merge-impl:_option-names-json-config();
-
-declare function merge-impl:_option-names-json-config()
-{
-  json:config("custom")
-    => map:with("array-element-names", xs:QName("merging:option"))
-};
-
-declare function merge-impl:option-names-to-json($options-xml)
-  as array-node()
-{
-  array-node {
-    xdmp:to-json(
-      json:transform-to-json-object(
-        $options-xml,
-        merge-impl:_option-names-json-config()
-      )
-    )/options/option
-  }
-};
-
-declare function merge-impl:propertyspec-to-json($property-spec as element()) as object-node()
-{
-  let $array-element-names := fn:distinct-values((
-      xs:QName("merging:source-weights"),
-      for $child-element in $property-spec//*
-      let $current-qn := fn:node-name($child-element)
-      let $siblings-with-same-name := $child-element/(preceding-sibling::*|following-sibling::*)[fn:node-name(.) eq $current-qn]
-      where $current-qn ne xs:QName("merging:source") and fn:exists($siblings-with-same-name)
-      return $current-qn
-    ))
-  let $source-weights-to-transform := $property-spec//merging:source-weights
-  let $transformed-xml :=
-    if (fn:exists($source-weights-to-transform)) then
-      mem:execute(mem:transform(
-        mem:copy($property-spec),
-        $source-weights-to-transform,
-        function($node) {
-          let $node-name := fn:node-name($node)
-          for $child in $node/*
-          return
-            element {$node-name} {
-              $node/@*,
-              $child
-            }
-        }
-      ))
-    else
-      $property-spec
-  let $config := json:config("custom")
-    => map:with("camel-case", fn:true())
-    => map:with("whitespace", "ignore")
-    => map:with("array-element-names", $array-element-names)
-    => map:with("ignore-element-names", xs:QName("merging:merge"))
-  return
-    json:transform-to-json($transformed-xml, $config)/*
 };
 
 declare function merge-impl:NCName-compatible($value as xs:string)

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/options.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/options.xqy
@@ -1,0 +1,564 @@
+xquery version "1.0-ml";
+
+(:~
+ : Merge options can be sent to Smart Mastering Core as XML or JSON, but they
+ : are stored and worked with as XML. This library has functions to convert
+ : from JSON to XML.
+ :)
+module namespace merge-impl = "http://marklogic.com/smart-mastering/survivorship/merging";
+
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/com.marklogic.smart-mastering/constants.xqy";
+import module namespace json="http://marklogic.com/xdmp/json"
+  at "/MarkLogic/json/json.xqy";
+import module namespace mem = "http://maxdewpoint.blogspot.com/memory-operations/functional"
+  at "/mlpm_modules/XQuery-XML-Memory-Operations/memory-operations-functional.xqy";
+
+declare namespace merging = "http://marklogic.com/smart-mastering/merging";
+
+declare option xdmp:mapping "false";
+
+(:
+ : Directory in which merging options are stored.
+ :)
+declare variable $MERGING-OPTIONS-DIR := "/com.marklogic.smart-mastering/options/merging/";
+
+declare variable $event-names-json as xs:QName+ := (xs:QName("onMerge"),xs:QName("onArchive"),xs:QName("onNoMatch"),xs:QName("onNotification"));
+declare variable $event-names-xml as xs:QName+ := (xs:QName("merging:on-merge"),xs:QName("merging:on-archive"),xs:QName("merging:on-no-match"),xs:QName("merging:on-notification"));
+
+(:~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ : Functions related to merge options.
+ :~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~:)
+
+declare function merge-impl:get-options($format as xs:string)
+{
+  let $options :=
+    cts:search(fn:collection(), cts:and-query((
+        cts:collection-query($const:OPTIONS-COLL),
+        (: In future version, remove mdm-merge collection from query
+          Currently part of the query to avoid breaking changes.
+        :)
+        cts:collection-query(('mdm-merge',$const:MERGE-OPTIONS-COLL))
+    )))/merging:options
+  return
+    if ($format eq $const:FORMAT-XML) then
+      $options
+    else if ($format eq $const:FORMAT-JSON) then
+      array-node { $options ! merge-impl:options-to-json(.) }
+    else
+      fn:error(xs:QName("SM-INVALID-FORMAT"), "matcher:get-option-names called with invalid format " || $format)
+};
+
+declare function merge-impl:get-options($options-name, $format as xs:string)
+{
+  let $options := fn:doc($MERGING-OPTIONS-DIR||$options-name||".xml")/merging:options
+  return
+    if ($format eq $const:FORMAT-XML) then
+      $options
+    else if ($format eq $const:FORMAT-JSON) then
+      merge-impl:options-to-json($options)
+    else
+      fn:error(xs:QName("SM-INVALID-FORMAT"), "merge-impl:get-options called with invalid format " || $format)
+};
+
+declare function merge-impl:save-options(
+  $name as xs:string,
+  $options as node()
+) as empty-sequence()
+{
+  let $options :=
+    if ($options instance of document-node()) then
+      $options/node()
+    else
+      $options
+  let $options :=
+    if ($options instance of object-node()) then
+      merge-impl:options-from-json($options)
+    else
+      $options
+  return
+    xdmp:document-insert(
+      $MERGING-OPTIONS-DIR||$name||".xml",
+      $options,
+      xdmp:default-permissions(),
+      ($const:OPTIONS-COLL, $const:MERGE-OPTIONS-COLL)
+    )
+};
+
+declare variable $options-json-config := merge-impl:_options-json-config();
+
+(: Removes whitespace nodes to keep the output json from options-to-json clean :)
+declare function merge-impl:remove-whitespace($xml)
+{
+  for $x in $xml
+  return
+    typeswitch($x)
+      case element() return
+        element { fn:node-name($x) } {
+          merge-impl:remove-whitespace(($x/@*, $x/node()))
+        }
+      case text() return
+        if (fn:string-length(fn:normalize-space($x)) > 0) then
+          $x
+        else ()
+      default return $x
+};
+
+(:
+ : Convert merge options from XML to JSON.
+ :)
+declare function merge-impl:options-to-json($options-xml as element(merging:options))
+{
+  if (fn:exists($options-xml)) then
+    xdmp:to-json(
+      map:entry(
+        "options",
+        map:new((
+          if (fn:exists($options-xml/merging:target-entity)) then
+            map:entry("targetEntity", $options-xml/merging:target-entity/fn:string())
+          else (),
+          map:entry("matchOptions", $options-xml/merging:match-options/fn:string()),
+          map:entry(
+            "propertyDefs",
+            map:new((
+              map:entry(
+                "properties",
+                array-node {
+                  for $prop in $options-xml/merging:property-defs/merging:property
+                  return
+                    if (fn:exists($prop/@path)) then
+                      object-node {
+                        "path": $prop/@path/fn:string(),
+                        "name": $prop/@name/fn:string()
+                      }
+                    else
+                      object-node {
+                        "namespace": $prop/@namespace/fn:string(),
+                        "localname": $prop/@localname/fn:string(),
+                        "name": $prop/@name/fn:string()
+                      }
+                }
+              ),
+              if (fn:exists($options-xml/merging:property-defs/merging:property/@path)) then
+                map:entry("namespaces", merge-impl:build-namespace-map($options-xml/merging:property-defs))
+              else ()
+            ))
+          ),
+          if ($options-xml/merging:collections) then
+            map:entry("collections",
+              map:new((
+                for $collection-type in fn:distinct-values($options-xml/merging:collections/* ! fn:node-name(.))
+                let $collection-type-values := $options-xml/merging:collections/*[fn:node-name(.) eq $collection-type]
+                return map:entry(
+                    fn:local-name-from-QName($collection-type),
+                    if (fn:exists($collection-type-values/@none)) then
+                      null-node {}
+                    else
+                      array-node {
+                        $collection-type-values ! fn:string(.)
+                      }
+                  )
+              ))
+            )
+          else (),
+          if (fn:exists($options-xml/merging:algorithms)) then
+            map:entry(
+              "algorithms",
+              map:new((
+                map:entry(
+                  "custom", array-node {
+                    for $alg in $options-xml/merging:algorithms/merging:algorithm
+                    return
+                      object-node {
+                        "name": $alg/@name/fn:string(),
+                        "function": $alg/@function/fn:string(),
+                        "at": let $at := $alg/@at/fn:string() return if (fn:exists($at)) then $at else ""
+                      }
+                  }),
+                if (fn:exists($options-xml/merging:algorithms/merging:std-algorithm)) then
+                  map:entry(
+                    "stdAlgorithm", object-node {
+                      "namespaces":
+                        merge-impl:build-namespace-map($options-xml/merging:algorithms/merging:std-algorithm),
+                      "timestamp": object-node {
+                        "path":
+                          let $path :=
+                            fn:head($options-xml/merging:algorithms/merging:std-algorithm/merging:timestamp/@path/fn:string()[. ne ''])
+                          return
+                            if (fn:exists($path)) then $path
+                            else null-node {}
+                      }
+                    }
+                  )
+                else (),
+                map:entry(
+                  "collections",
+                  map:new(
+                    for $qn in $event-names-xml
+                    let $event := $options-xml/merging:algorithms/merging:collections/*[fn:node-name(.) eq $qn]
+                    let $json := merge-impl:collection-event-to-json(
+                          if (fn:exists($event)) then
+                            $event
+                          else
+                            element {$qn} {()}
+                        )
+                    return
+                      map:entry(fn:string(fn:node-name($json)), $json)
+                  )
+                )
+              ))
+            )
+          else (),
+          if (fn:exists($options-xml/merging:merging/merging:merge-strategy)) then
+            map:entry(
+              "mergeStrategies",
+              array-node {
+                for $merge in $options-xml/merging:merging/merging:merge-strategy
+                return
+                  merge-impl:propertyspec-to-json($merge)
+              }
+            )
+          else (),
+          if (fn:exists($options-xml/merging:merging/merging:merge)) then
+            map:entry(
+              "merging",
+              array-node {
+                for $merge in $options-xml/merging:merging/merging:merge
+                return
+                  merge-impl:propertyspec-to-json($merge)
+              }
+            )
+          else (),
+          if (fn:exists($options-xml/merging:triple-merge)) then
+            map:entry(
+              "tripleMerge",
+              let $config := json:config("custom")
+                => map:with("camel-case", fn:true())
+                => map:with("whitespace", "ignore")
+                => map:with("ignore-element-names", xs:QName("merging:merge"))
+              return
+                json:transform-to-json($options-xml/merging:triple-merge, $config)/*
+            )
+          else ()
+        ))
+      )
+    )/node()
+  else ()
+};
+
+declare variable $collection-event-json-config := json:config("custom")
+                          => map:with("camel-case", fn:true())
+                          => map:with("whitespace", "ignore")
+                          => map:with("attribute-names", ("namespace", "at", "function"));
+
+declare function merge-impl:collection-event-to-json($event as element())
+{
+  let $config := $collection-event-json-config => map:with("array-element-names", if (fn:empty($event/merging:function)) then xs:QName("merging:collection") else ())
+  return
+    json:transform-to-json($event, $config)/*
+};
+
+
+(:
+ : Given an element, return a map entry with the key "namespaces" that holds
+ : a map from namespace prefixes -> namespace URIs
+ : @param $source  the element from which to draw the namespaces
+ :)
+declare function merge-impl:build-namespace-map($source as element()?)
+{
+  let $obj := json:object()
+  let $populate :=
+    if (fn:exists($source)) then
+      for $prefix in fn:in-scope-prefixes($source)
+      (: xml prefix is predefined (see https://www.w3.org/XML/1998/namespace) :)
+      where fn:not($prefix = ("", "xml"))
+      return map:put($obj, $prefix, fn:namespace-uri-for-prefix($prefix, $source))
+    else ()
+  return $obj
+};
+
+(:
+ : Convert merge options from JSON to XML.
+ :)
+declare function merge-impl:options-from-json($options-json as object-node())
+  as element(merging:options)
+{
+  <options xmlns="http://marklogic.com/smart-mastering/merging">
+    {
+      if (fn:exists($options-json/*:options/*:targetEntity)) then
+        element merging:target-entity {
+          $options-json/*:options/*:targetEntity
+        }
+      else (),
+      element merging:match-options {
+        $options-json/*:options/*:matchOptions
+      },
+      merge-impl:construct-property-defs-element($options-json),
+      merge-impl:construct-algorithms-element($options-json),
+      merge-impl:construct-collections-element($options-json),
+      merge-impl:construct-merging-element($options-json),
+      merge-impl:construct-triple-merge-element($options-json)
+    }
+  </options>
+};
+
+declare private function merge-impl:construct-property-defs-element($options-json as object-node())
+  as element()
+{
+  element merging:property-defs {
+    attribute xmlns { "http://marklogic.com/smart-mastering/merging" },
+    for $ns in <r>{fn:data($options-json/*:options/*:propertyDefs/*:namespaces)}</r>/json:object/json:entry
+    return
+      attribute { xs:QName("xmlns:" || $ns/@key) } { $ns/json:value/fn:string() },
+    for $prop in $options-json/*:options/*:propertyDefs/*:properties
+    return
+      element merging:property {
+        attribute name { $prop/*:name },
+        if (fn:exists($prop/*:namespace)) then attribute namespace { $prop/*:namespace } else (),
+        if (fn:exists($prop/*:localname)) then attribute localname { $prop/*:localname } else (),
+        if (fn:exists($prop/*:path)) then attribute path { $prop/*:path} else ()
+      }
+  }
+};
+
+declare private function merge-impl:construct-algorithms-element($options-json as object-node())
+{
+  if (fn:exists($options-json/*:options/*:algorithms)) then
+    element merging:algorithms {
+      attribute xmlns { "http://marklogic.com/smart-mastering/merging" },
+      for $alg in $options-json/*:options/*:algorithms/*:custom
+      return
+        element merging:algorithm {
+          attribute xmlns { "http://marklogic.com/smart-mastering/merging" },
+          attribute name { $alg/*:name },
+          attribute function { $alg/*:function },
+          if (fn:exists($alg/*:namespace)) then attribute namespace { $alg/*:namespace } else (),
+          if (fn:exists($alg/*:at)) then attribute at { $alg/*:at } else ()
+        },
+      if (fn:exists($options-json/*:options/*:algorithms/*:stdAlgorithm)) then
+        element merging:std-algorithm {
+          if (fn:exists($options-json/*:options/*:algorithms/*:stdAlgorithm/*:timestamp)) then (
+            for $ns in <r>{fn:data($options-json/*:options/*:algorithms/*:stdAlgorithm/*:namespaces)}</r>/json:object/json:entry
+            return
+              attribute { xs:QName("xmlns:" || $ns/@key) } { $ns/json:value/fn:string() },
+            element merging:timestamp {
+              attribute path {
+                $options-json/*:options/*:algorithms/*:stdAlgorithm/*:timestamp/*:path/fn:string()
+              }
+            }
+          )
+          else ()
+        }
+      else (),
+      element merging:collections {
+        let $empty-object := object-node {}
+        let $config := json:config("custom")
+                        => map:with("element-namespace", "http://marklogic.com/smart-mastering/merging")
+                        => map:with("camel-case", fn:true())
+                        => map:with("whitespace", "ignore")
+                        => map:with("attribute-names", ("namespace", "at", "function"))
+        for $qn in $event-names-json
+        let $event :=
+            fn:head((
+              $options-json/*:options/*:algorithms/*:collections/*[fn:node-name(.) eq $qn],
+              $empty-object
+            ))
+        let $config := map:new($config) => map:with("array-element-names", if (fn:empty($event/*:function)) then "collection" else ())
+        return
+          json:transform-from-json(object-node{ $qn: $event}, $config)
+      }
+    }
+  else ()
+};
+
+declare private function merge-impl:construct-collections-element($options-json as object-node())
+{
+  if (fn:exists($options-json/*:options/*:collections)) then
+    element merging:collections {
+      attribute xmlns { "http://marklogic.com/smart-mastering/merging" },
+      for $collection-type in $options-json/*:options/*:collections/*
+      let $element-name := fn:string(fn:node-name($collection-type))
+      return
+        if ($collection-type instance of null-node()) then
+          element {fn:QName("http://marklogic.com/smart-mastering/merging",$element-name)} { attribute none {"true"}}
+        else
+          element {fn:QName("http://marklogic.com/smart-mastering/merging",$element-name)} { fn:string($collection-type) }
+    }
+  else ()
+};
+
+declare private function merge-impl:construct-merging-element($options-json as object-node())
+{
+  element merging:merging {
+    attribute xmlns { "http://marklogic.com/smart-mastering/merging" },
+    let $all-merge-options := $options-json/*:options/*:merging
+    let $all-merge-strategy-options := $options-json/*:options/*:mergeStrategies
+    let $array-element-names :=
+      fn:distinct-values(
+        ($all-merge-options,$all-merge-strategy-options)//array-node() !
+          xs:QName("merging:"||fn:lower-case(fn:replace(fn:string(fn:node-name(.)), "([a-z])([A-Z])", "$1-$2")))
+      )
+    let $config := json:config("custom")
+      => map:with("element-namespace", "http://marklogic.com/smart-mastering/merging")
+      => map:with("camel-case", fn:true())
+      => map:with("whitespace", "ignore")
+      => map:with("array-element-names", $array-element-names)
+      => map:with("attribute-names", ("default", "name", "weight", "strategy", "propertyName", "algorithmRef", "maxValues", "maxSources", "documentUri"))
+    let $all-xml := (
+      for $merge in $options-json/*:options/*:merging
+      return
+        element merging:merge {
+          json:transform-from-json($merge, $config)
+        },
+      for $merge-strategy in $all-merge-strategy-options
+      return
+        element merging:merge-strategy {
+          json:transform-from-json($merge-strategy, $config)
+        }
+      )
+    for $xml in $all-xml
+    let $array-elements := $xml//*[fn:node-name(.) = $array-element-names]
+    return
+      if (fn:exists($array-elements)) then
+        mem:execute(
+          mem:transform(
+            mem:copy($xml),
+            $array-elements,
+            function($node) {
+              let $qn := fn:node-name($node)
+              where fn:empty($node/preceding-sibling::*[fn:node-name(.) = $qn])
+              return element {$qn} {
+                $node/*,
+                $node/following-sibling::*[fn:node-name(.) = $qn]/*
+              }
+            }
+          )
+        )
+      else
+        $xml
+  }
+};
+
+declare private function merge-impl:construct-triple-merge-element($options-json as object-node())
+{
+  let $triple-merge := $options-json/*:options/*:tripleMerge
+  return
+    if (fn:exists($triple-merge)) then
+      element merging:triple-merge {
+        attribute xmlns { "http://marklogic.com/smart-mastering/merging" },
+        attribute namespace { $triple-merge/*:namespace },
+        attribute function { $triple-merge/*:function },
+        attribute at { $triple-merge/*:at },
+
+        let $config := json:config("custom")
+          => map:with("camel-case", fn:true())
+          => map:with("whitespace", "ignore")
+          => map:with("ignore-element-names", ("namespace","function","at"))
+        for $merge in $triple-merge
+        return
+          json:transform-from-json($merge, $config)
+      }
+    else ()
+};
+
+declare function merge-impl:_options-json-config()
+{
+  let $config := json:config("custom")
+  return (
+    map:put($config, "array-element-names", ("algorithm","threshold","scoring","property", "reduce", "add", "expand", "merging", "merge-strategy", "mergeStrategy")),
+    map:put($config, "element-namespace", "http://marklogic.com/smart-mastering/merging"),
+    map:put($config, "element-namespace-prefix", "merging"),
+    map:put($config, "attribute-names",
+      ("name","localname", "namespace", "function",
+        "at", "property-name", "propertyName", "weight", "above", "label","algorithm-ref", "algorithmRef", "strategy", "default")
+    ),
+    map:put($config, "camel-case", fn:true()),
+    map:put($config, "whitespace", "ignore"),
+    $config
+  )
+};
+
+declare function merge-impl:get-option-names($format as xs:string)
+{
+  if ($format eq $const:FORMAT-XML) then
+    let $options := cts:uris('', (), cts:and-query((
+        cts:collection-query($const:OPTIONS-COLL),
+        (: In future version, remove mdm-merge collection from query
+          Currently part of the query to avoid breaking changes.
+        :)
+        cts:collection-query(('mdm-merge',$const:MERGE-OPTIONS-COLL))
+      )))
+    let $option-names := $options ! fn:replace(
+      fn:replace(., $MERGING-OPTIONS-DIR, ""),
+      "\.xml$", ""
+    )
+    return
+      element merging:options {
+        for $name in $option-names
+        return
+          element merging:option { $name }
+      }
+  else if ($format eq $const:FORMAT-JSON) then
+    merge-impl:option-names-to-json(merge-impl:get-option-names($const:FORMAT-XML))
+  else
+    fn:error(xs:QName("SM-INVALID-FORMAT"), "Attempted to call merge-impl:get-option-names with invalid format: " || $format)
+};
+
+declare variable $option-names-json-config := merge-impl:_option-names-json-config();
+
+declare function merge-impl:_option-names-json-config()
+{
+  json:config("custom")
+    => map:with("array-element-names", xs:QName("merging:option"))
+};
+
+declare function merge-impl:option-names-to-json($options-xml)
+  as array-node()
+{
+  array-node {
+    xdmp:to-json(
+      json:transform-to-json-object(
+        $options-xml,
+        merge-impl:_option-names-json-config()
+      )
+    )/options/option
+  }
+};
+
+declare function merge-impl:propertyspec-to-json($property-spec as element()) as object-node()
+{
+  let $array-element-names := fn:distinct-values((
+      xs:QName("merging:source-weights"),
+      for $child-element in $property-spec//*
+      let $current-qn := fn:node-name($child-element)
+      let $siblings-with-same-name := $child-element/(preceding-sibling::*|following-sibling::*)[fn:node-name(.) eq $current-qn]
+      where $current-qn ne xs:QName("merging:source") and fn:exists($siblings-with-same-name)
+      return $current-qn
+    ))
+  let $source-weights-to-transform := $property-spec//merging:source-weights
+  let $transformed-xml :=
+    if (fn:exists($source-weights-to-transform)) then
+      mem:execute(mem:transform(
+        mem:copy($property-spec),
+        $source-weights-to-transform,
+        function($node) {
+          let $node-name := fn:node-name($node)
+          for $child in $node/*
+          return
+            element {$node-name} {
+              $node/@*,
+              $child
+            }
+        }
+      ))
+    else
+      $property-spec
+  let $config := json:config("custom")
+    => map:with("camel-case", fn:true())
+    => map:with("whitespace", "ignore")
+    => map:with("array-element-names", $array-element-names)
+    => map:with("ignore-element-names", xs:QName("merging:merge"))
+  return
+    json:transform-to-json($transformed-xml, $config)/*
+};
+

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/standard.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/standard.xqy
@@ -114,7 +114,7 @@ declare function merging:standard(
         ))
       let $weight := fn:max(($length-score, $source-score))
       where fn:exists($sources[fn:exists(. intersect $selected-sources)])
-      stable order by $weight descending, $source-dateTime descending
+      stable order by $weight descending, $source-score descending, $source-dateTime descending
       return
         $property
     ),

--- a/marklogic-data-hub/src/test/resources/master-test/step-definitions/mastering/mastering/mastering.step.json
+++ b/marklogic-data-hub/src/test/resources/master-test/step-definitions/mastering/mastering/mastering.step.json
@@ -17,6 +17,11 @@
         "properties": [
           {
             "namespace": "",
+            "localname": "id",
+            "name": "id"
+          },
+          {
+            "namespace": "",
             "localname": "firstName",
             "name": "firstName"
           },
@@ -43,12 +48,12 @@
         {
           "default": "true",
           "maxSources": "1",
-          "sourceWeights": {
+          "sourceWeights": [{
             "source": {
               "name": "A",
               "weight": "10"
             }
-          }
+          }]
         }
       ]
     },


### PR DESCRIPTION
Items addressed:

- Adds SM-PERFORMANCE trace to better track where time is spent
- Minor performance enhancements in reducing the number of searches
- Moves merge options code into a separate library module at /com.marklogic.smart-mastering/survivorship/merging/options.xqy to reduce /com.marklogic.smart-mastering/survivorship/merging/base.xqy size
- Adds a helper function for building queries to reduce the duplicate code to determine whether json-property, element-value, or range queries should be used in the match algorithms
- Normalizes the output from a merge JavaScript function for the user, so the user can output array instead of sequence and JSON values will be converted to nodes for the user.

These changes current exist in the develop branch of smart-mastering-core (https://github.com/marklogic-community/smart-mastering-core/tree/develop) with all unit test passing.