### PR TITLE
DHFPROD-2674: Fixes for deploying user files to DHS

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommand.java
@@ -76,17 +76,20 @@ public class LoadUserArtifactsCommand extends AbstractCommand {
         String timestampFile = hubConfig.getHubProject().getUserModulesDeployTimestampFile();
         PropertiesModuleManager pmm = new PropertiesModuleManager(timestampFile);
 
-        // Need to delete ml-javaclient-utils timestamp file as well as modules present in the standard gradle locations are now
-        // loaded by the modules loader in the parent class which adds these entries to the ml-javaclient-utils timestamp file
-        String filePath = hubConfig.getAppConfig().getModuleTimestampsPath();
-        File defaultTimestampFile = new File(filePath);
-
         if (forceLoad) {
             pmm.deletePropertiesFile();
-            if (defaultTimestampFile.exists()) {
-                defaultTimestampFile.delete();
+
+            // Need to delete ml-javaclient-utils timestamp file as well as modules present in the standard gradle locations are now
+            // loaded by the modules loader in the parent class which adds these entries to the ml-javaclient-utils timestamp file
+            String filePath = hubConfig.getAppConfig().getModuleTimestampsPath();
+            if (filePath != null) {
+                File defaultTimestampFile = new File(filePath);
+                if (defaultTimestampFile.exists()) {
+                    defaultTimestampFile.delete();
+                }
             }
         }
+
         return pmm;
     }
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserModulesCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserModulesCommand.java
@@ -84,17 +84,20 @@ public class LoadUserModulesCommand extends LoadModulesCommand {
         String timestampFile = hubConfig.getHubProject().getUserModulesDeployTimestampFile();
         PropertiesModuleManager pmm = new PropertiesModuleManager(timestampFile);
 
-        // Need to delete ml-javaclient-utils timestamp file as well as modules present in the standard gradle locations are now
-        // loaded by the modules loader in the parent class which adds these entries to the ml-javaclient-utils timestamp file
-        String filePath = hubConfig.getAppConfig().getModuleTimestampsPath();
-        File defaultTimestampFile = new File(filePath);
-
         if (forceLoad) {
             pmm.deletePropertiesFile();
-            if (defaultTimestampFile.exists()){
-                defaultTimestampFile.delete();
+
+            // Need to delete ml-javaclient-utils timestamp file as well as modules present in the standard gradle locations are now
+            // loaded by the modules loader in the parent class which adds these entries to the ml-javaclient-utils timestamp file
+            String filePath = hubConfig.getAppConfig().getModuleTimestampsPath();
+            if (filePath != null) {
+                File defaultTimestampFile = new File(filePath);
+                if (defaultTimestampFile.exists()) {
+                    defaultTimestampFile.delete();
+                }
             }
         }
+
         return pmm;
     }
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -577,17 +577,23 @@ public class DataHubImpl implements DataHub {
     }
 
     public void dhsInstall(HubDeployStatusListener listener) {
-        prepareAppConfigForInstallingIntoDhs(hubConfig.getAppConfig());
+        prepareAppConfigForInstallingIntoDhs(hubConfig);
 
         HubAppDeployer dhsDeployer = new HubAppDeployer(getManageClient(), getAdminManager(), listener, hubConfig.newStagingClient());
         dhsDeployer.setCommands(buildCommandListForInstallingIntoDhs());
         dhsDeployer.deploy(hubConfig.getAppConfig());
     }
 
-    protected void prepareAppConfigForInstallingIntoDhs(AppConfig appConfig) {
+    protected void prepareAppConfigForInstallingIntoDhs(HubConfig hubConfig) {
+        AppConfig appConfig = hubConfig.getAppConfig();
+
+        appConfig.setModuleTimestampsPath(null);
         appConfig.setCreateForests(false);
         appConfig.setResourceFilenamesIncludePattern(buildPatternForDatabasesToUpdateIndexesFor());
         disableSomeCmaUsage(appConfig);
+
+        // 8000 is not available in DHS
+        appConfig.setAppServicesPort(hubConfig.getPort(DatabaseKind.FINAL));
     }
 
     protected List<Command> buildCommandListForInstallingIntoDhs() {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -593,7 +593,7 @@ public class DataHubImpl implements DataHub {
         disableSomeCmaUsage(appConfig);
 
         // 8000 is not available in DHS
-        appConfig.setAppServicesPort(hubConfig.getPort(DatabaseKind.FINAL));
+        appConfig.setAppServicesPort(hubConfig.getPort(DatabaseKind.STAGING));
     }
 
     protected List<Command> buildCommandListForInstallingIntoDhs() {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/DhsInstallTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/DhsInstallTest.java
@@ -46,8 +46,8 @@ public class DhsInstallTest extends HubTestBase {
 
         new DataHubImpl().prepareAppConfigForInstallingIntoDhs(adminHubConfig);
 
-        assertEquals(adminHubConfig.getPort(DatabaseKind.FINAL), appConfig.getAppServicesPort(),
-            "DHS does not allow access to the default App-Services port - 8000 - so it's set to the final port instead so " +
+        assertEquals(adminHubConfig.getPort(DatabaseKind.STAGING), appConfig.getAppServicesPort(),
+            "DHS does not allow access to the default App-Services port - 8000 - so it's set to the staging port instead so " +
                 "that user modules can be loaded into the DHF modules database");
         
         assertFalse(appConfig.isCreateForests(), "DHS handles forest creation");


### PR DESCRIPTION
8000 isn't available, so defaulting appServicesPort to finalPort.

Also, was running into some issues where timestamps files were preventing modules from being loaded. When running dhsDeploy, we rarely will have a desire to not load all the modules, so the module timestamps path is set to null.