### PR TITLE
DHFPROD-2773: E2E UI tests for target URI replace and preview

### DIFF
--- a/web/e2e/page-objects/steps/ingestStep.ts
+++ b/web/e2e/page-objects/steps/ingestStep.ts
@@ -88,6 +88,14 @@ export class IngestStep extends AppPage {
     await inputField.clear();
     return await inputField.sendKeys(uriReplace);  
   }
+
+  get targetUriPreview() {
+    return element(by.id("uri-preview"));  
+  }
+
+  get mlcpCommand() {
+    return element(by.css(".mlcp-cmd p"));  
+  }
 }
 
 let ingestStepPage = new IngestStep();

--- a/web/e2e/page-objects/steps/ingestStep.ts
+++ b/web/e2e/page-objects/steps/ingestStep.ts
@@ -76,7 +76,8 @@ export class IngestStep extends AppPage {
   async setTargetPermissions(permissions: string) {
     let inputField = this.targetPermissions;
     await inputField.clear();
-    return await inputField.sendKeys(permissions);  
+    await inputField.sendKeys(permissions);
+    await inputField.sendKeys(protractor.Key.ENTER);  
   }
   
   get targetUriReplace() {
@@ -86,7 +87,8 @@ export class IngestStep extends AppPage {
   async setTargetUriReplace(uriReplace: string) {
     let inputField = this.targetUriReplace;
     await inputField.clear();
-    return await inputField.sendKeys(uriReplace);  
+    await inputField.sendKeys(uriReplace);
+    await inputField.sendKeys(protractor.Key.ENTER);  
   }
 
   get targetUriPreview() {

--- a/web/e2e/specs/scenarios/multiFlows.ts
+++ b/web/e2e/specs/scenarios/multiFlows.ts
@@ -80,29 +80,34 @@ export default function(qaProjectDir) {
 
         it('should create and run IngestAdvantage step', async function() {
             await appPage.flowsTab.click();
-            browser.wait(EC.visibilityOf(manageFlowPage.flowName("AdvantageFlow")));
+            await browser.wait(EC.visibilityOf(manageFlowPage.flowName("AdvantageFlow")));
             await manageFlowPage.clickFlowname("AdvantageFlow");
-            browser.sleep(5000);
-            browser.wait(EC.elementToBeClickable(editFlowPage.newStepButton));
+            await browser.sleep(5000);
+            await browser.wait(EC.elementToBeClickable(editFlowPage.newStepButton));
             await editFlowPage.clickNewStepButton();
-            browser.wait(EC.visibilityOf(stepsPage.stepDialogBoxHeader("New Step")));
+            await browser.wait(EC.visibilityOf(stepsPage.stepDialogBoxHeader("New Step")));
             await stepsPage.clickStepTypeDropDown();
-            browser.wait(EC.visibilityOf(stepsPage.stepTypeOptions("Ingestion")));
+            await browser.wait(EC.visibilityOf(stepsPage.stepTypeOptions("Ingestion")));
             await stepsPage.clickStepTypeOption("Ingestion");
-            browser.wait(EC.visibilityOf(stepsPage.stepName));
+            await browser.wait(EC.visibilityOf(stepsPage.stepName));
             await stepsPage.setStepName("IngestAdvantage");
             await stepsPage.setStepDescription("Ingest Advantage docs");
             await stepsPage.clickAdvSettingsExpandCollapse();
             await browser.wait(EC.visibilityOf(stepsPage.additionalCollectionToAdd(0)));
             await stepsPage.setAdditionalCollection(0, "LoadAdvantage");
             await stepsPage.clickStepCancelSave("save");
-            browser.wait(EC.visibilityOf(stepsPage.stepDetailsName));
-            browser.sleep(3000);
+            await browser.wait(EC.visibilityOf(stepsPage.stepDetailsName));
+            await browser.sleep(3000);
             await expect(stepsPage.stepDetailsName.getText()).toEqual("IngestAdvantage");
             await ingestStepPage.setInputFilePath(qaProjectDir + "/input/advantage");
-            browser.sleep(3000);
+            await browser.sleep(3000);
+            // Verify target URI replacement and preview
+            await ingestStepPage.setTargetUriReplace(qaProjectDir + "/input/advantage" + ", " + "\'\/advantage\'");
+            await browser.sleep(3000);
+            await browser.wait(EC.visibilityOf(ingestStepPage.targetUriPreview));
+            await expect(ingestStepPage.targetUriPreview.getText()).toEqual("/advantage/example.json");
             await editFlowPage.clickRunFlowButton();
-            browser.wait(EC.visibilityOf(editFlowPage.runFlowHeader));
+            await browser.wait(EC.visibilityOf(editFlowPage.runFlowHeader));
             await editFlowPage.clickButtonRunCancel("flow");
             await browser.sleep(5000);
             await browser.wait(EC.elementToBeClickable(editFlowPage.finishedLatestJobStatus));
@@ -121,14 +126,14 @@ export default function(qaProjectDir) {
             await expect(jobDetailsPage.stepCommitted("IngestAdvantage").getText()).toEqual("1,003");   
             await jobDetailsPage.clickStepCommitted("IngestAdvantage");
             // Verify on Browse Data page
-            browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
-            browser.sleep(5000);
-            expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 1003');
+            await browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
+            await browser.sleep(5000);
+            await expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 1003');
             await expect(browsePage.facetName("IngestAdvantage").getText()).toEqual("IngestAdvantage");
             await expect(browsePage.facetName("LoadAdvantage").getText()).toEqual("LoadAdvantage");
             // Verify on Manage Flows page
             await appPage.flowsTab.click()
-            browser.wait(EC.visibilityOf(manageFlowPage.flowName("AdvantageFlow")));
+            await browser.wait(EC.visibilityOf(manageFlowPage.flowName("AdvantageFlow")));
             await expect(manageFlowPage.status("AdvantageFlow").getText()).toEqual("Finished");
             await expect(manageFlowPage.docsCommitted("AdvantageFlow").getText()).toEqual("1,003");
         });

--- a/web/e2e/specs/scenarios/multiFlows.ts
+++ b/web/e2e/specs/scenarios/multiFlows.ts
@@ -105,7 +105,6 @@ export default function(qaProjectDir) {
             await ingestStepPage.setTargetUriReplace(qaProjectDir + "/input/advantage" + ", " + "\'\/advantage\'");
             await browser.sleep(3000);
             await browser.wait(EC.visibilityOf(ingestStepPage.targetUriPreview));
-            await expect(ingestStepPage.targetUriPreview.getText()).toEqual("/advantage/example.json");
             await editFlowPage.clickRunFlowButton();
             await browser.wait(EC.visibilityOf(editFlowPage.runFlowHeader));
             await editFlowPage.clickButtonRunCancel("flow");

--- a/web/e2e/specs/scenarios/multiFlows.ts
+++ b/web/e2e/specs/scenarios/multiFlows.ts
@@ -130,6 +130,10 @@ export default function(qaProjectDir) {
             await expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 1003');
             await expect(browsePage.facetName("IngestAdvantage").getText()).toEqual("IngestAdvantage");
             await expect(browsePage.facetName("LoadAdvantage").getText()).toEqual("LoadAdvantage");
+            // Verify target URI replacement
+            await browsePage.searchKeyword("dray");
+            await browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
+            await expect(browsePage.resultsUri().getText()).toEqual("/advantage/cust1001.json");
             // Verify on Manage Flows page
             await appPage.flowsTab.click()
             await browser.wait(EC.visibilityOf(manageFlowPage.flowName("AdvantageFlow")));


### PR DESCRIPTION
Add tests on setting target URI replace and verify it on browse page

We will add the verification on target URI preview once DHFPROD-2776 is fixed (right now, the UI element doesn't show the text value)