### PR TITLE
DHFPROD-2801: Upgrading to ml-gradle 3.15.2 and ml-app-deployer 3.15.1

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'java'
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.7.2'
-    id 'com.marklogic.ml-gradle' version '3.15.1'
+    id 'com.marklogic.ml-gradle' version '3.15.2'
     id 'com.moowork.node' version '1.1.1'
     id 'org.springframework.boot' version '2.1.3.RELEASE'
     id "io.spring.dependency-management" version "1.0.7.RELEASE"
@@ -31,15 +31,15 @@ ext.junitJupiterVersion  = '5.3.1'
 
 dependencies {
     compile 'com.marklogic:marklogic-client-api:4.2.0'
-    compile('com.marklogic:ml-app-deployer:3.15.0'){
+    compile('com.marklogic:ml-app-deployer:3.15.1'){
         exclude group: 'org.springframework', module: 'http'
     }
-    compile "org.jdom:jdom2:2.0.6"
 
     compile group: 'org.springframework.boot', name: 'spring-boot', version: '2.1.3.RELEASE'
     compile group: 'org.springframework.integration', name: 'spring-integration-http', version: '5.1.3.RELEASE'
     compile group: 'org.springframework.boot', name: 'spring-boot-autoconfigure', version: '2.1.3.RELEASE'
     testCompile group: 'org.springframework', name: 'spring-test', version: '5.1.5.RELEASE'
+
     compile 'com.marklogic:mlcp-util:0.9.0'
     compile 'com.marklogic:marklogic-data-movement-components:1.0'
     compile 'commons-io:commons-io:2.4'

--- a/ml-data-hub-plugin/build.gradle
+++ b/ml-data-hub-plugin/build.gradle
@@ -56,10 +56,10 @@ dependencies {
     compile (project(':marklogic-data-hub')) {
         exclude group: 'ch.qos.logback'
     }
-    compile ('com.marklogic:ml-gradle:3.15.1') {
+    compile ('com.marklogic:ml-gradle:3.15.2') {
         exclude group: 'ch.qos.logback'
     }
-    compile group: 'org.jdom', name: 'jdom2', version: '2.0.6'
+
     testCompile localGroovy()
     testCompile gradleTestKit()
     testCompile 'xmlunit:xmlunit:1.3'


### PR DESCRIPTION
Now that the Gradle configurations are up-to-date for these libraries, we no longer need to explicitly depend on jdom2, as it is now properly depended on via the use of the "api" configuration in ml-app-deployer.

Releases notes for ml-gradle 3.15.2 are at https://github.com/marklogic-community/ml-gradle/releases/tag/3.15.2