### PR TITLE
DHFPROD-2798: Generate function metadata and OOTB date, dateTime functions

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateFunctionMetadataCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateFunctionMetadataCommand.java
@@ -1,0 +1,75 @@
+package com.marklogic.hub.deploy.commands;
+
+import com.marklogic.appdeployer.command.AbstractCommand;
+import com.marklogic.appdeployer.command.CommandContext;
+import com.marklogic.appdeployer.command.SortOrderConstants;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.datamovement.ApplyTransformListener;
+import com.marklogic.client.datamovement.DataMovementManager;
+import com.marklogic.client.datamovement.QueryBatcher;
+import com.marklogic.client.document.ServerTransform;
+import com.marklogic.client.query.StructuredQueryBuilder;
+import com.marklogic.hub.DatabaseKind;
+import com.marklogic.hub.HubConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class GenerateFunctionMetadataCommand extends AbstractCommand {
+    @Autowired
+    private HubConfig hubConfig;
+    private Throwable caughtException;
+
+    public GenerateFunctionMetadataCommand() {
+        super();
+        // This command has to be executed after modules are loaded
+        setExecuteSortOrder(SortOrderConstants.LOAD_MODULES + 1);
+    }
+
+    @Override
+    public void execute(CommandContext context) {
+        DatabaseClient databaseClient = hubConfig.newStagingClient(hubConfig.getDbName(DatabaseKind.MODULES));
+        DataMovementManager dataMovementManager = databaseClient.newDataMovementManager();
+
+        StructuredQueryBuilder sb = databaseClient.newQueryManager().newStructuredQueryBuilder();
+
+
+        ServerTransform serverTransform = new ServerTransform("ml:generateFunctionMetadata");
+
+        ApplyTransformListener transformListener = new ApplyTransformListener()
+            .withTransform(serverTransform)
+            .withApplyResult(ApplyTransformListener.ApplyResult.IGNORE)
+            .onBatchFailure((batch, throwable) -> {
+                logger.error(throwable.getMessage());
+                // throw the first exception
+                if (caughtException == null) {
+                    caughtException = throwable;
+                }
+            });
+
+        /*
+        Query for uris "/data-hub/5/mapping-functions/" and "/custom-modules/mapping-functions/" which are reserved for mapping functions
+         */
+        QueryBatcher queryBatcher = dataMovementManager.newQueryBatcher(
+            new StructuredQueryBuilder().or(sb.directory(true, "/data-hub/5/mapping-functions/"),sb.directory(true, "/custom-modules/mapping-functions/")))
+            .withBatchSize(1)
+            .withThreadCount(4)
+            .onUrisReady(transformListener);
+
+        dataMovementManager.startJob(queryBatcher);
+        //Stop batcher if transform takes more than 2 minutes.
+        try {
+            queryBatcher.awaitCompletion(2L, TimeUnit.MINUTES);
+        } catch (InterruptedException e) {
+            logger.error("Loading function metadata timed out, took longer than 2 minutes");
+        }
+        dataMovementManager.stopJob(queryBatcher);
+
+        if (caughtException != null) {
+            throw new RuntimeException(caughtException);
+        }
+
+    }
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -95,6 +95,9 @@ public class DataHubImpl implements DataHub {
 
     @Autowired
     private LoadHubArtifactsCommand loadHubArtifactsCommand;
+
+    @Autowired
+    private GenerateFunctionMetadataCommand generateFunctionMetadataCommand;
     
     @Autowired
     private Versions versions;
@@ -781,6 +784,7 @@ public class DataHubImpl implements DataHub {
         commands.add(loadUserModulesCommand);
         commands.add(loadUserArtifactsCommand);
         commands.add(loadHubArtifactsCommand);
+        commands.add(generateFunctionMetadataCommand);
 
         for (Command c : commandsMap.get("mlModuleCommands")) {
             if (c instanceof LoadModulesCommand) {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/mapping-functions/parseDate.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/mapping-functions/parseDate.sjs
@@ -1,0 +1,70 @@
+/*
+  Copyright 2012-2019 MarkLogic Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+function parseDate(picture, value) {
+    let standardFormats = ["MM/DD/YYYY", "DD/MM/YYYY", "MM-DD-YYYY", "MM.DD.YYYY", "DD.MM.YYYY", "YYYYMMDD", "YYYY/MM/DD"];
+    let nonStandardFormats = ["Mon DD, YYYY", "DD Mon YYYY", "DD-Mon-YYYY" ];
+    let response;
+    if(standardFormats.includes(picture.trim())){
+        try{
+            let standardizedDate = xdmp.parseYymmdd(picture.replace("YYYY", "yyyy").replace("DD","dd"), value).toString().split("T")[0];
+            response = xs.date(standardizedDate);
+        }
+        catch (ex) {
+            fn.error(null, "Given value doesn't match with the specified pattern (" + picture + "," + value + ") for parsing date string.");
+        }
+    }
+    else if (nonStandardFormats.includes(picture.trim())) {
+        picture = picture.trim();
+        let pattern;
+        if(picture === nonStandardFormats[0]) {
+            pattern = "^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ([0-9]|[0-2][0-9]|[3][0-1])\, ([0-9]{4})$";
+        }
+        else if(picture === nonStandardFormats[1]) {
+            pattern = "^([0-9]|[0-2][0-9]|[3][0-1]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ([0-9]{4})$";
+        }
+        else {
+            pattern = "^([0-9]|[0-2][0-9]|[3][0-1])\-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\-([0-9]{4})$";
+        }
+        let match = new RegExp(pattern, 'i').exec(value);
+        if (match === null) {
+            fn.error(null, "Given value doesn't match with the specified pattern (" + picture + "," + value + ") for parsing date string.");
+        }
+        else {
+            let date = new Date(value);
+            let day = date.getDate();
+            let month = date.getMonth() + 1;
+            if(isNaN(date) || isNaN(day) || isNaN(month)) {
+                fn.error(null, "Given value (" + value + ") for date string is invalid.");
+            }
+            else {
+                let year = date.getFullYear();
+                day = day < 10 ? "0".concat(day) : day;
+                month = month < 10 ? "0".concat(month) : month;
+                response = xs.date(year + "-" + month + "-" + day);
+            }
+        }
+    }
+    else {
+        fn.error(null, "The given date pattern (" + picture + ") is not supported.");
+    }
+    return response;
+}
+
+module.exports = {
+  parseDate: parseDate
+};
+

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/mapping-functions/parseDateTime.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/mapping-functions/parseDateTime.sjs
@@ -1,0 +1,36 @@
+/*
+  Copyright 2012-2019 MarkLogic Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+function parseDateTime(picture, value) {
+    let supportedFormats = ["YYYYMMDDThhmmss", "DD/MM/YYYY-hh:mm:ss", "DD/MM/YYYY hh:mm:ss", "YYYY/MM/DD-hh:mm:ss" , "YYYY/MM/DD hh:mm:ss"];
+    let response;
+    if(supportedFormats.includes(picture.trim())){
+        try {
+            response = xdmp.parseYymmdd(picture.replace("YYYY","yyyy").replace("DD","dd"), value);
+        }
+        catch(ex){
+            fn.error(null, ex.message);
+        }
+    }
+    else{
+        fn.error(null, "The given dateTime pattern (" + picture + ") is not supported.");
+    }
+    return response;
+}
+
+module.exports = {
+  parseDateTime: parseDateTime
+};

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/rest-api/lib/extensions-util.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/rest-api/lib/extensions-util.xqy
@@ -37,7 +37,8 @@ declare private variable $system-transforms-40 := map:map()
 
 declare private variable $system-transforms-50 := map:map()
     =>map:with("ml:runFlow",              "run-flow")
-    =>map:with("ml:runIngest",            "dmsdk-ingest");
+    =>map:with("ml:runIngest",            "dmsdk-ingest")
+    =>map:with("ml:generateFunctionMetadata", "generate-function-metadata");
 
 declare private variable $system-resource-extensions-40 := map:map()
     =>map:with("ml:dbConfigs",              "db-configs")

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/transforms/generate-function-metadata.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/transforms/generate-function-metadata.sjs
@@ -1,0 +1,20 @@
+'use strict';
+const es = require('/MarkLogic/entity-services/entity-services');
+const DataHubSingleton = require("/data-hub/5/datahub-singleton.sjs");
+const datahub = DataHubSingleton.instance();
+
+function transform(context, params, content) {
+  let uri = context.uri;
+  let pattern = '^(.*)\.(sjs|mjs|xqy)$';
+  let match = new RegExp(pattern).exec(uri);
+  if (match !== null) {
+    let uriVal = match[1];
+    let metaDataXml = es.functionMetadataValidate(es.functionMetadataGenerate(uri));
+    let collection = 'http://marklogic.com/entity-services/function-metadata';
+    datahub.hubUtils.writeDocument(uriVal+ ".xml", metaDataXml, 'xdmp.defaultPermissions()',  [collection], datahub.config.MODULESDATABASE);
+    es.functionMetadataPut(uriVal+ ".xml")
+  }
+  return content;
+}
+
+exports.transform = transform;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/transforms/generate-function-metadata.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/transforms/generate-function-metadata.xqy
@@ -1,0 +1,61 @@
+(:
+  Copyright 2012-2019 MarkLogic Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+:)
+xquery version "1.0-ml";
+module namespace generate-function-metadata = "http://marklogic.com/rest-api/transform/generate-function-metadata";
+
+import module namespace extut = "http://marklogic.com/rest-api/lib/extensions-util"
+at "/MarkLogic/rest-api/lib/extensions-util.xqy";
+
+declare default function namespace "http://www.w3.org/2005/xpath-functions";
+declare option xdmp:mapping "false";
+
+declare private variable $extName := "generate-function-metadata";
+declare private variable $modPath := "/data-hub/5/transforms/generate-function-metadata.sjs";
+declare private variable $caller  := xdmp:function(
+  xs:QName("applyOnce"), "/MarkLogic/rest-api/lib/extensions-util.sjs"
+);
+
+(:  For ApplyTransformListener to work for the datahub OOTB transforms, this method has to return a string that is not "javascript".
+    ApplyTransformListener uses /v1/internal/apply-transform end point and if this method returns a string that is not "javascript",
+    generate-function-metadata:transform will be the entry point of the transform execution which is what we want.
+:)
+declare function generate-function-metadata:source-format() as xs:string {
+  "xquery"
+};
+declare function generate-function-metadata:get(
+  $context as map:map, $params as map:map
+) as map:map {
+  xdmp:apply($caller,$extName,$modPath,"GET",$context,$params)
+};
+declare function generate-function-metadata:delete(
+  $context as map:map, $params as map:map
+) as map:map {
+  xdmp:apply($caller,$extName,$modPath,"DELETE",$context,$params)
+};
+declare function generate-function-metadata:post(
+  $context as map:map, $params as map:map, $input as document-node()*
+) as map:map {
+  xdmp:apply($caller,$extName,$modPath,"POST",$context,$params,$input)
+};
+declare function generate-function-metadata:put($context as map:map, $params as map:map, $input as document-node()*
+) as map:map {
+  xdmp:apply($caller,$extName,$modPath,"PUT",$context,$params,$input)
+};
+declare function generate-function-metadata:transform(
+  $context as map:map, $params as map:map, $input as document-node()?
+) as map:map {
+  xdmp:apply($caller,$extName,$modPath,"transform",$context,$params,$input)
+};

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/GenerateFunctionMetadataCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/GenerateFunctionMetadataCommandTest.java
@@ -1,0 +1,74 @@
+package com.marklogic.hub.deploy.commands;
+
+
+import com.marklogic.appdeployer.command.CommandContext;
+import com.marklogic.bootstrap.Installer;
+import com.marklogic.client.document.DocumentWriteSet;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.hub.ApplicationConfig;
+import com.marklogic.hub.HubTestBase;
+import com.marklogic.hub.impl.HubConfigImpl;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.IOException;
+
+import static com.marklogic.client.io.DocumentMetadataHandle.Capability.READ;
+import static com.marklogic.client.io.DocumentMetadataHandle.Capability.UPDATE;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ApplicationConfig.class)
+public class GenerateFunctionMetadataCommandTest extends HubTestBase {
+
+    @Autowired
+    private HubConfigImpl hubConfig;
+
+    @Autowired
+    private GenerateFunctionMetadataCommand generateFunctionMetadataCommand;
+
+    @BeforeAll
+    public static void setup() {
+        XMLUnit.setIgnoreWhitespace(true);
+        new Installer().deleteProjectDir();
+    }
+
+    @BeforeEach
+    public void setupEach() throws IOException {
+        basicSetup();
+        getDataHubAdminConfig();
+        DocumentWriteSet writeSet = modMgr.newWriteSet();
+        StringHandle handle = new StringHandle("'use strict';\n" +
+            "\n" +
+            "function testModule(picture, value) {\n" +
+            "  return xdmp.parseDateTime(picture, value);\n" +
+            "}\n" +
+            "\n" +
+            "module.exports = {\n" +
+            "  testModule: testModule\n" +
+            "};");
+        handle.setFormat(Format.TEXT);
+        DocumentMetadataHandle permissions = new DocumentMetadataHandle()
+            .withPermission(getDataHubAdminConfig().getFlowDeveloperRoleName(), DocumentMetadataHandle.Capability.EXECUTE, UPDATE, READ);
+        writeSet.add("/custom-modules/mapping-functions/testModule.sjs", permissions, handle);
+        modMgr.write(writeSet);
+    }
+
+    @AfterAll
+    public static void cleanUp() {
+        new Installer().deleteProjectDir();
+    }
+
+    @Test
+    public void testMetaDataGeneration() {
+        CommandContext context = new CommandContext(hubConfig.getAppConfig(), hubConfig.getManageClient(), hubConfig.getAdminManager());
+        generateFunctionMetadataCommand.execute(context);
+        Assertions.assertFalse(getModulesFile("/custom-modules/mapping-functions/testModule.xml.xslt").isEmpty());
+    }
+}
+

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping-functions/testDateTimeFunctions.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping-functions/testDateTimeFunctions.sjs
@@ -1,0 +1,26 @@
+const dt = require('/data-hub/5/mapping-functions/parseDateTime.sjs');
+const d = require('/data-hub/5/mapping-functions/parseDate.sjs');
+const test = require("/test/test-helper.xqy");
+
+function testParseDateTime() {
+return [
+    test.assertTrue(xs.dateTime("2014-01-06T18:13:50-07:00").eq(dt.parseDateTime("DD/MM/YYYY-hh:mm:ss","06/01/2014-18:13:50"))),
+    test.assertTrue(xs.dateTime("2014-01-06T18:13:50-07:00").eq(dt.parseDateTime("DD/MM/YYYY hh:mm:ss","06/01/2014 18:13:50"))),
+    test.assertTrue(xs.dateTime("2014-01-06T18:13:50-07:00").eq(dt.parseDateTime("YYYYMMDDThhmmss","20140106T181350"))),
+    test.assertTrue(xs.dateTime("2014-01-06T18:13:50-07:00").eq(dt.parseDateTime("YYYY/MM/DD-hh:mm:ss","2014/01/06-18:13:50"))),
+    test.assertTrue(xs.dateTime("2014-01-06T18:13:50-07:00").eq(dt.parseDateTime("YYYY/MM/DD hh:mm:ss","2014/01/06 18:13:50"))),
+    test.assertThrowsError(xdmp.function(xs.QName("dt.parseDateTime")), "YYYY/MM/DDThh:mm:ss","2014/01/06T18:13:50", null)
+  ];
+}
+
+function testParseDate() {
+return [
+    test.assertTrue(xs.date("2014-01-06").eq(d.parseDate("MM/DD/YYYY","01/06/2014"))),
+    test.assertTrue(xs.date("2014-01-06").eq(d.parseDate("DD/MM/YYYY","06/01/2014"))),
+    test.assertTrue(xs.date("2014-01-06").eq(d.parseDate("MM.DD.YYYY","01.06.2014"))),
+    test.assertTrue(xs.date("2014-01-06").eq(d.parseDate("DD.MM.YYYY","06.01.2014"))),
+    test.assertTrue(xs.date("2014-01-06").eq(d.parseDate("YYYYMMDD","20140106"))),
+    test.assertTrue(xs.date("2014-01-06").eq(d.parseDate("Mon DD, YYYY","Jan 06, 2014")))
+  ];
+}
+[].concat(testParseDateTime()).concat(testParseDate())


### PR DESCRIPTION
1. This PR implements  DHFPROD-2798, DHFPROD-2576, DHFPROD-2157 as they are all related.
2. The function metadata generated in the today's 9.0-nightly and 10.0-nightly server would be incorrect. The issue will be fixed in tomorrow's nightly server (or the latest jenkins server)