### PR TITLE
DHFPROD-2844: Property name is not populated when editing a match option in mastering step

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.ts
@@ -36,7 +36,7 @@ export class AddMatchOptionDialogComponent {
   ngOnInit() {
     this.tooltips = FlowsTooltips.mastering.matching;
     this.form = this.fb.group({
-      propertyName: [this.data.option ? this.data.option.propertyName[0] : ''],
+      propertyName: [this.data.option ? this.data.option.propertyName : ''],
       matchType: [this.data.option ? this.data.option.matchType : 'exact'],
       weight: [this.data.option ? this.data.option.weight : ''],
       thesaurus: [this.data.option ? this.data.option.thesaurus : ''],
@@ -83,9 +83,7 @@ export class AddMatchOptionDialogComponent {
       return this.fb.array([this.createProp('')]);
     }
     const result = [];
-    this.data.option.propertyName.forEach(name => {
-      result.push(this.createProp(name))
-    })
+    result.push(this.createProp(this.data.option.propertyName));
     return this.fb.array(result);
   }
 

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/matching/ui/add-match-option-dialog.component.ts
@@ -83,7 +83,14 @@ export class AddMatchOptionDialogComponent {
       return this.fb.array([this.createProp('')]);
     }
     const result = [];
-    result.push(this.createProp(this.data.option.propertyName));
+    if(typeof this.data.option.propertyName === 'string'){
+      result.push(this.createProp(this.data.option.propertyName))
+    }
+    else{
+      this.data.option.propertyName.forEach(name => {
+        result.push(this.createProp(name))
+      })
+    }
     return this.fb.array(result);
   }
 


### PR DESCRIPTION
Fixed the issue. The property to match should now pre-populate in the edit-setting dialogue box for any match-option.