### PR TITLE
DHFPROD-2875: Defaulting to TLSv1.2 via ml-javaclient-util 3.13.2

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     compile('com.marklogic:ml-app-deployer:3.15.1'){
         exclude group: 'org.springframework', module: 'http'
     }
+    // Temporarily forcing a dependency on this version until a new version of ml-app-deployer depends on this as well
+    compile("com.marklogic:ml-javaclient-util:3.13.2")
 
     compile group: 'org.springframework.boot', name: 'spring-boot', version: '2.1.3.RELEASE'
     compile group: 'org.springframework.integration', name: 'spring-integration-http', version: '5.1.3.RELEASE'
@@ -44,7 +46,7 @@ dependencies {
     compile 'com.marklogic:marklogic-data-movement-components:1.0'
     compile 'commons-io:commons-io:2.4'
     compile 'org.apache.commons:commons-text:1.1'
-    
+
     // For installer program
     implementation "com.beust:jcommander:1.72"
     //https://github.com/jaegertracing/jaeger-client-java/tree/master/jaeger-core
@@ -167,7 +169,7 @@ if (!(
 
 tasks.clean.dependsOn cleanUI
 
-jar{ 
+jar{
     enabled = true
 }
 


### PR DESCRIPTION
@bsrikan You can test this out via the same tests you were running yesterday for deploying into DHS - both via the installer and via dhsDeploy. 