### PR TITLE
DHFPROD-2848: Enabling verification after mastering fix

### DIFF
--- a/web/e2e/specs/scenarios/multiFlows.ts
+++ b/web/e2e/specs/scenarios/multiFlows.ts
@@ -743,13 +743,9 @@ export default function(qaProjectDir) {
             await expect(jobDetailsPage.stepCommitted("MasteringCustomer").getText()).toEqual("2,505");   
             await jobDetailsPage.clickStepCommitted("MasteringCustomer");
             // Verify on Browse Data page
-            /*await browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
+            await browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
             await browser.sleep(10000);
-            await expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 10 of 2512');
-            await expect(browsePage.facetName("MasteringCustomer").getText()).toEqual("MasteringCustomer");
-            await expect(browsePage.facetCount("MasteringCustomer").getText()).toEqual("2512");
             await expect(browsePage.facetCount("customer-merge").getText()).toEqual("3");
-            await expect(browsePage.facetCount("customer-notify").getText()).toEqual("1");
             // Verify the merge results
             await browsePage.clickFacetName("customer-merge");
             await browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
@@ -765,7 +761,7 @@ export default function(qaProjectDir) {
             // Verify the merge doc from xml mapping
             await browsePage.searchKeyword("gardner");
             await browser.wait(EC.visibilityOf(browsePage.resultsPagination()));
-            await expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 1 of 1');*/
+            await expect(browsePage.resultsPagination().getText()).toContain('Showing Results 1 to 1 of 1');
             // Verify on Manage Flows page
             await appPage.flowsTab.click();
             await browser.wait(EC.visibilityOf(manageFlowPage.flowName("MasteringFlow")));


### PR DESCRIPTION
Enabling the mastering merge verification after the bug is fixed. The merge count is correct now.

Still excluding the notify and total doc count due to a new bug: DHFPROD-2895.