### PR TITLE
DHFPROD-2910: validation of entity dialog fields test fix.

### DIFF
--- a/web/e2e/page-objects/entities/entities.ts
+++ b/web/e2e/page-objects/entities/entities.ts
@@ -1,4 +1,4 @@
-import { browser, element, by, ElementFinder, Key } from 'protractor'
+import {browser, element, by, ElementFinder, Key, ExpectedConditions as EC} from 'protractor'
 import { AppPage } from '../appPage';
 import { pages } from '../page';
 
@@ -23,6 +23,12 @@ export class EntityPage extends AppPage {
 
   get newEntityButton() {
     return element(by.css('#new-entity'));
+  }
+
+  async clickNewEntityButton() {
+    await browser.wait(EC.visibilityOf(this.newEntityButton));
+    await this.newEntityButton.click();
+    await browser.wait(EC.visibilityOf(entityPage.entityHeader));
   }
 
   get entityEditor() {

--- a/web/e2e/page-objects/flows/editFlow.ts
+++ b/web/e2e/page-objects/flows/editFlow.ts
@@ -217,7 +217,9 @@ export class EditFlow extends AppPage {
       await stepsPage.clickStepCancelSave("save");
       await browser.wait(EC.visibilityOf(stepsPage.stepDetailsName));
       await browser.sleep(5000);
-      await stepsPage.stepSelectContainer(step.stepName).click();
+      await browser.wait(EC.elementToBeClickable(stepsPage.stepSelectContainer(step.stepName)), 5000);
+      await browser.executeScript("arguments[0].click();", stepsPage.stepSelectContainer(step.stepName));
+      //await stepsPage.stepSelectContainer(step.stepName).click();
       await expect(stepsPage.stepDetailsName.getText()).toEqual(step.stepName);
     }
   }

--- a/web/e2e/page-objects/flows/manageFlows.ts
+++ b/web/e2e/page-objects/flows/manageFlows.ts
@@ -1,6 +1,6 @@
 import appPage, { AppPage } from "../appPage";
 import { pages } from '../page';
-import { browser, by, ExpectedConditions as EC, element, $$ } from "protractor";
+import {browser, by, ExpectedConditions as EC, element, $$, $} from "protractor";
 
 export class ManageFlows extends AppPage {
 
@@ -131,7 +131,15 @@ export class ManageFlows extends AppPage {
    */
   async clickFlowCancelSave(option: string) {
     let button = this.flowCancelSaveButton(option);
-    return await button.click();
+    await browser.wait(EC.elementToBeClickable(button), 5000);
+    await button.click();
+    await browser.sleep(1000);
+    // this.flowDialogBox.isPresent().then(function(result) {
+    //   if(result) {
+    //     button.click();
+    //     browser.sleep(1000);
+    //   }
+    // });
   }
 
   get redeployButton() {

--- a/web/e2e/specs/scenarios/simpleJson.ts
+++ b/web/e2e/specs/scenarios/simpleJson.ts
@@ -76,7 +76,7 @@ export default function (qaProjectDir) {
     });
 
     it('validate new entity dialog fields', async function () {
-      await entityPage.newEntityButton.click();
+      await entityPage.clickNewEntityButton();
       await expect(entityPage.entityHeader.isDisplayed()).toBe(true);
       await expect(entityPage.entityHeader.getText()).toBe("New Entity");
       await expect(entityPage.entityTitle.isDisplayed()).toBe(true);


### PR DESCRIPTION
Added Protractor's browser.wait() method to ensure the cancel/ok button is clickable on new flow popup window dialog. 