### PR TITLE
DHFPROD-2928: No longer throwing an error when flows directory is mis…

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/FlowManagerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/FlowManagerImpl.java
@@ -114,7 +114,12 @@ public class FlowManagerImpl extends LoggingObject implements FlowManager {
     @Override
     public List<String> getFlowNames() {
         // Get all the files with flow.json extension from flows dir
-        List<File> files = (List<File>) FileUtils.listFiles(hubConfig.getFlowsDir().toFile(), new String[]{"flow.json"}, false);
+        File flowsDir = hubConfig.getFlowsDir().toFile();
+        if (flowsDir == null || !flowsDir.exists()) {
+            return new ArrayList<>();
+        }
+
+        List<File> files = (List<File>) FileUtils.listFiles(flowsDir, new String[]{"flow.json"}, false);
         List<String> flowNames = files.stream()
             .map(f -> f.getName().replaceAll("(.+)\\.flow\\.json", "$1"))
             .collect(Collectors.toList());

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowManagerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowManagerTest.java
@@ -69,6 +69,15 @@ class FlowManagerTest extends HubTestBase {
     }
 
     @Test
+    void missingFlowsDirectory() {
+        runAfterAll();
+
+        List<String> names = fm.getFlowNames();
+        Assertions.assertEquals(0, names.size(), "When the flows directory doesn't exist (in this case, the entire " +
+            "project directory is missing), an error shouldn't be thrown - should just get back an empty list");
+    }
+
+    @Test
     void getFlow() {
         Flow flow = fm.getFlow("test-flow");
         Assertions.assertNotNull(flow);


### PR DESCRIPTION
…sing

This would occur in QS in a new project. If the flows directory hadn't been created yet, the "Flows" link would throw an error and the spinner would just keep spinning.