### PR TITLE
Forbid matches on declared-unique properties

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/matcher-impl/matcher-impl.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/matcher-impl/matcher-impl.xqy
@@ -270,7 +270,7 @@ declare function match-impl:find-document-matches-by-options(
     )
     let $exclusion-query :=
       if ($excluded-docs-query or $excluded-matches-query) then
-        cts:or-query($excluded-docs-query, $excluded-matches-query)
+        cts:or-query(($excluded-docs-query, $excluded-matches-query))
       else ()
     let $match-base-query := cts:and-query((
           $compiled-options => map:get("collectionQuery"),


### PR DESCRIPTION
Implements solution 1 from #2811. Forbids merging of items with declared-unique properites.

Probably could be optimized, but it works.