### PR TITLE
DHFPROD-2875: Defaulting to TLSv1.2 via ml-javaclient-util 3.13.2

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     compile('com.marklogic:ml-app-deployer:3.15.1'){
         exclude group: 'org.springframework', module: 'http'
     }
+    // Temporarily forcing a dependency on this version until a new version of ml-app-deployer depends on this as well
+    compile("com.marklogic:ml-javaclient-util:3.13.2")
 
     compile group: 'org.springframework.boot', name: 'spring-boot', version: '2.1.3.RELEASE'
     compile group: 'org.springframework.integration', name: 'spring-integration-http', version: '5.1.3.RELEASE'


### PR DESCRIPTION
Created this for the 5.0.3 branch