### PR TITLE
DHFPROD-3035: Custom ingestion step no longer has a default separator…

### DIFF
--- a/web/src/main/ui/app/components/flows-new/models/step.model.ts
+++ b/web/src/main/ui/app/components/flows-new/models/step.model.ts
@@ -36,7 +36,7 @@ export class Step {
       inputFilePath: filePath,
       inputFileType: 'json',
       outputURIReplacement: '',
-      separator: ',',
+      separator: ''
     };
     step.fileLocations = fileLocations;
     step.options = new IngestionOptions();


### PR DESCRIPTION
… value

I couldn't remove "separator" because then I got a compilation error based on "separator" being required. So it at least doesn't have a default value anymore. I verified that if I switch the source format to "Delimited", then "Field Separator" appears with a default value of ",".