### PR TITLE
DHFPROD-3041: New step definitions no longer have a null description

### DIFF
--- a/examples/dh-5-example/build.gradle
+++ b/examples/dh-5-example/build.gradle
@@ -8,9 +8,9 @@ buildscript {
     dependencies {
         classpath "net.saliman:gradle-properties-plugin:1.5.1"
         if (project.hasProperty("testing")) {
-            classpath "com.marklogic:ml-data-hub:5.0-SNAPSHOT"
+            classpath "com.marklogic:ml-data-hub:5.1-SNAPSHOT"
         } else {
-            classpath "gradle.plugin.com.marklogic:ml-data-hub:5.0.1"
+            classpath "gradle.plugin.com.marklogic:ml-data-hub:5.0.2"
         }
     }
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/AbstractStepDefinition.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/AbstractStepDefinition.java
@@ -44,6 +44,7 @@ public abstract class AbstractStepDefinition implements StepDefinition {
 
     protected AbstractStepDefinition() {
         language = "zxx";
+        description = "";
         version = 1;
 
         options = new HashMap<>();

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/IngestionStepDefinitionImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/IngestionStepDefinitionImpl.java
@@ -42,6 +42,7 @@ public class IngestionStepDefinitionImpl extends AbstractStepDefinition {
         setFileLocations(this.fileLocations);
 
         Map<String, Object> options = getOptions();
+        options.put("sourceQuery", "cts.collectionQuery([])");
         options.put("outputFormat", "json");
 
         List<String> collectionName = new ArrayList<>();

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/util/json/JSONObject.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/util/json/JSONObject.java
@@ -1,9 +1,11 @@
 package com.marklogic.hub.util.json;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.NullNode;
@@ -19,6 +21,7 @@ import java.util.*;
 
 public class JSONObject {
     private static Logger logger = LoggerFactory.getLogger(JSONObject.class);
+
     ObjectMapper mapper;
     JsonNode json;
 
@@ -120,6 +123,13 @@ public class JSONObject {
      */
     public static String writeValueAsString(Object obj, boolean hasPrettyPrint) throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
+
+        // Adding this so that the ObjectMapper in this class can be JsonIgnore'd.
+        // Otherwise, serializing instances of this class can fail with the following error:
+        // "No serializer found for class com.marklogic.hub.util.json.JSONObject and no properties discovered to create
+        // BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)"
+        mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+
         if (hasPrettyPrint) {
             return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
         }
@@ -138,6 +148,7 @@ public class JSONObject {
      * Returns the mapper
      * @return an object mapper
      */
+    @JsonIgnore
     public ObjectMapper getMapper() {
         return mapper;
     }

--- a/marklogic-data-hub/src/main/resources/scaffolding/defaultFlow.flow.json
+++ b/marklogic-data-hub/src/main/resources/scaffolding/defaultFlow.flow.json
@@ -20,7 +20,7 @@
       },
       "options": {
         "targetDatabase": "%%mlStagingDbName%%",
-        "sourceQuery": null,
+        "sourceQuery": "cts.collectionQuery([])",
         "outputFormat": "json",
         "collections": [
           "default-ingestion"

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/step/CreateStepDefinitionTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/step/CreateStepDefinitionTest.java
@@ -1,0 +1,55 @@
+package com.marklogic.hub.step;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.hub.util.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CreateStepDefinitionTest {
+
+    @Test
+    public void customStep() {
+        JsonNode node = createStep(StepDefinition.StepDefinitionType.CUSTOM);
+        verifyCommonFieldsOnStep(node);
+    }
+
+    @Test
+    public void ingestionStep() {
+        JsonNode node = createStep(StepDefinition.StepDefinitionType.INGESTION);
+        verifyCommonFieldsOnStep(node);
+    }
+
+    @Test
+    public void mappingStep() {
+        JsonNode node = createStep(StepDefinition.StepDefinitionType.MAPPING);
+        verifyCommonFieldsOnStep(node);
+    }
+
+    @Test
+    public void masteringStep() {
+        JsonNode node = createStep(StepDefinition.StepDefinitionType.MASTERING);
+
+        verifyCommonFieldsOnStep(node);
+
+        JsonNode mergeOptions = node.get("options").get("mergeOptions");
+        assertNotNull(mergeOptions);
+        assertFalse(mergeOptions.has("mapper"),
+            "Verifying that the ObjectMapper is written out as a JSON field");
+    }
+
+    private void verifyCommonFieldsOnStep(JsonNode node) {
+        assertEquals("", node.get("description").asText(),
+            "Description should default to an empty string instead of null so that 'null' doesn't appear in a client interface");
+    }
+
+    private JsonNode createStep(StepDefinition.StepDefinitionType type) {
+        StepDefinition step = StepDefinition.create("my-step", type);
+        try {
+            String json = JSONObject.writeValueAsString(step);
+            return new JSONObject(json).jsonNode();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/step/CreateStepDefinitionTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/step/CreateStepDefinitionTest.java
@@ -18,6 +18,9 @@ public class CreateStepDefinitionTest {
     public void ingestionStep() {
         JsonNode node = createStep(StepDefinition.StepDefinitionType.INGESTION);
         verifyCommonFieldsOnStep(node);
+
+        assertEquals("cts.collectionQuery([])", node.get("options").get("sourceQuery").asText(),
+            "Per DHFPROD-3056, sourceQuery now gets a default value to match QuickStart");
     }
 
     @Test


### PR DESCRIPTION
The string "null" was showing up in QS. In addition, I fixed a problem where "mapper" was appearing under matchOptions and mergeOptions - that was due to Jackson serializing the ObjectMapper instance on JSONObject. That no longer occurs. 

Also addresses:

DHFPROD-3056: Custom ingestion step now has a default sourceQuery