### PR TITLE
DHFPROD-2755: Initial manual merge work

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     testCompile 'ch.qos.logback:logback-classic:1.1.11'
     testCompile 'org.slf4j:log4j-over-slf4j:1.7.13'
     testCompile("com.marklogic:mlcp-util:0.3.0")
-    testCompile("com.marklogic:mlcp:9.0.7") {
+    testCompile("com.marklogic:mlcp:10.0.1") {
       exclude group: 'org.apache.avro', module: 'avro-tools'
       exclude group: 'org.apache.commons', module: 'commons-csv'
     }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/MasteringManager.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/MasteringManager.java
@@ -15,7 +15,10 @@
  */
 package com.marklogic.hub;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import java.util.List;
+import java.util.Map;
 
 /**
  * Handles the calls to the Mastering endpoints.
@@ -32,6 +35,17 @@ public interface MasteringManager {
     public UnmergeResponse unmerge(String mergeURI, Boolean retainAuditTrail, Boolean blockFutureMerges);
 
     /**
+     * Manually merges a set of documents
+     * @param mergeURIs - URIs of the documents to merge
+     * @param flowName - The name of the flow that has the mastering settings
+     * @param stepNumber - The number of the mastering step with settings
+     * @param preview - determines if the changes should be written to the database
+     * @param options - Overrides any options for the step
+     * @return - a MergeResponse
+     */
+    public MergeResponse merge(List<String> mergeURIs, String flowName, String stepNumber, Boolean preview, JsonNode options);
+
+    /**
      * Holds the response information from an unmerge request
      */
     class UnmergeResponse {
@@ -41,6 +55,19 @@ public interface MasteringManager {
 
         public String toString() {
             return String.format("{success: %b, mergeURIs: %s, restoredURIs: %s}", success, mergeURIs, restoredURIs);
+        }
+    }
+
+    /**
+     * Holds the response information from an manual merge request
+     */
+    class MergeResponse {
+        public List<String> mergedURIs;
+        public boolean success;
+        public Map<String,Object> mergedDocument;
+
+        public String toString() {
+            return String.format("{success: %b, mergedURIs: %s, mergeDocument: %s}", success, mergedURIs, mergedDocument);
         }
     }
 }

--- a/marklogic-data-hub/src/main/resources/hub-internal-artifacts/flows/manual-merge-mastering.flow.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-artifacts/flows/manual-merge-mastering.flow.json
@@ -1,0 +1,17 @@
+{
+  "name": "manual-merge-mastering",
+  "description": "This is the merge flow for manually merging documents",
+  "options": {
+    "sourceQuery": "cts.collectionQuery('mdm-content')"
+  },
+  "steps": {
+    "1": {
+      "stepDefinitionType": "mastering",
+      "stepDefinitionName": "manual-merge-mastering",
+      "retryLimit": 0,
+      "options": {
+        "outputFormat": "json"
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-artifacts/step-definitions/mastering/marklogic/manual-merge-mastering.step.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-artifacts/step-definitions/mastering/marklogic/manual-merge-mastering.step.json
@@ -1,0 +1,15 @@
+{
+  "language": "zxx",
+  "name": "manual-merge-mastering",
+  "type": "mastering",
+  "version": 1,
+  "modulePath": "/data-hub/5/builtins/steps/mastering/default/manual-merge.sjs",
+  "retryLimit" : 0,
+  "batchSize" : 100,
+  "threadCount" : 4,
+  "options": {
+    "stepUpdate": true,
+    "sourceDatabase": "data-hub-FINAL",
+    "targetDatabase": "data-hub-FINAL"
+  }
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/amps/dhf-amp-69.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/amps/dhf-amp-69.json
@@ -1,0 +1,7 @@
+{
+  "namespace" : "http://marklogic.com/smart-mastering/survivorship/merging",
+  "local-name" : "locked-uris",
+  "document-uri" : "/com.marklogic.smart-mastering/survivorship/merging/base.xqy",
+  "modules-database" : "%%mlModulesDbName%%",
+  "role" : [ "rest-reader-internal" ]
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/collections.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/collections.xqy
@@ -86,7 +86,7 @@ declare function collection-impl:build-collection-algorithm-map(
 declare function collection-impl:execute-algorithm(
   $event-name as xs:string,
   $collections-by-uri as map:map,
-  $event-options as element()?
+  $event-options as node()?
 )
 {
   let $algorithm-map :=
@@ -115,7 +115,7 @@ declare function collection-impl:execute-algorithm(
       xdmp:apply($algorithm, $event-name, $collections-by-uri, $event-options)
 };
 
-declare function collection-impl:on-merge($collections-by-uri as map:map, $event-options as element()?) {
+declare function collection-impl:on-merge($collections-by-uri as map:map, $event-options as node()?) {
   collection-impl:execute-algorithm(
     "on-merge",
     $collections-by-uri,
@@ -123,7 +123,7 @@ declare function collection-impl:on-merge($collections-by-uri as map:map, $event
   )
 };
 
-declare function collection-impl:on-archive($collections-by-uri as map:map, $event-options as element()?) {
+declare function collection-impl:on-archive($collections-by-uri as map:map, $event-options as node()?) {
   collection-impl:execute-algorithm(
     "on-archive",
     $collections-by-uri,
@@ -131,7 +131,7 @@ declare function collection-impl:on-archive($collections-by-uri as map:map, $eve
   )
 };
 
-declare function collection-impl:on-no-match($collections-by-uri as map:map, $event-options as element()?) {
+declare function collection-impl:on-no-match($collections-by-uri as map:map, $event-options as node()?) {
   collection-impl:execute-algorithm(
     "on-no-match",
     $collections-by-uri,
@@ -139,7 +139,7 @@ declare function collection-impl:on-no-match($collections-by-uri as map:map, $ev
   )
 };
 
-declare function collection-impl:on-notification($collections-by-uri as map:map, $event-options as element()?) {
+declare function collection-impl:on-notification($collections-by-uri as map:map, $event-options as node()?) {
   collection-impl:execute-algorithm(
     "on-notification",
     $collections-by-uri,
@@ -150,13 +150,13 @@ declare function collection-impl:on-notification($collections-by-uri as map:map,
 declare function collection-impl:default-collection-handler(
   $event-name as xs:string,
   $collections-by-uri as map:map,
-  $event-options as element()?
+  $event-options as node()?
 ) {
-  if (fn:exists($event-options/merging:set/merging:collection[. ne ''])) then
-    $event-options/merging:set/merging:collection ! fn:string(.)
+  if (fn:exists($event-options/*:set/*:collection[. ne ''])) then
+    $event-options/*:set/*:collection ! fn:string(.)
   else (
     let $merge-options := collection-impl:get-options-root($event-options)
-    let $match-options := matcher:get-options($merge-options/merging:match-options, $const:FORMAT-XML)
+    let $match-options := matcher:get-options($merge-options/(merging:match-options|matchOptions), $const:FORMAT-XML)
     let $content-collection-options := fn:head(($match-options,$merge-options))
     let $all-collections := fn:distinct-values((
           map:keys(-$collections-by-uri),
@@ -173,7 +173,7 @@ declare function collection-impl:default-collection-handler(
               ()
         ))
     let $remove-collections := fn:distinct-values((
-        $event-options/merging:remove/merging:collection ! fn:string(.),
+        $event-options/*:remove/*:collection ! fn:string(.),
         switch ($event-name)
           case $const:ON-ARCHIVE-EVENT return
             coll:content-collections($content-collection-options)
@@ -183,7 +183,7 @@ declare function collection-impl:default-collection-handler(
     return
       (
         $all-collections[fn:not(. = $remove-collections)],
-        $event-options/merging:add/merging:collection ! fn:string(.)
+        $event-options/*:add/*:collection ! fn:string(.)
       )[. ne '']
   )
 };
@@ -192,7 +192,7 @@ declare function collection-impl:get-options-root(
   $event-options as element()?
 ) as element(merging:options)? {
   if (fn:exists($event-options)) then
-    fn:root($event-options)/(self::merging:options|merging:options)
+    fn:root($event-options)/(self::*:options|*:options)
   else
     ()
 };

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mastering/default/manual-merge.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mastering/default/manual-merge.sjs
@@ -1,0 +1,28 @@
+const merging = require('/com.marklogic.smart-mastering/merging.xqy');
+const masteringMain = require('/data-hub/5/builtins/steps/mastering/default/main.sjs');
+const collImpl = require('/com.marklogic.smart-mastering/survivorship/merging/collections.xqy');
+
+function main(content, options) {
+  masteringMain.checkOptions(content, options);
+  let uris = [];
+  let mergeOptions = new NodeBuilder().addNode({ options: options.mergeOptions }).toNode();
+  for (const item of content) {
+    uris.push(item.uri);
+    item.context.collections = collImpl.onArchive({ [item.uri]: item.context.originalCollections }, mergeOptions.xpath('options/algorithms/collections/onArchive'));
+  }
+  let mergedDocument = fn.head(merging.buildMergeModelsByUri(uris, mergeOptions));
+  let contentArray = content.toArray();
+  mergedDocument.context = mergedDocument.context || {
+    permissions: Sequence.from(contentArray.map((item) => item.context.permissions))
+  };
+  mergedDocument.context.collections = collImpl.onMerge(contentArray.reduce((prev, item) => {
+    prev[item.uri] = Sequence.from(item.context.originalCollections);
+    return prev;
+  },{}), mergeOptions.xpath('options/algorithms/collections/onMerge'));
+  let filteredContent = contentArray.filter((item) => item.uri !== mergedDocument.uri);
+  return Sequence.from(filteredContent.concat([mergedDocument]));
+}
+
+module.exports = {
+  main: main
+};

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/match-and-merge/all-merged.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/match-and-merge/all-merged.xqy
@@ -7,10 +7,10 @@ import module namespace test = "http://marklogic.com/test" at "/test/test-helper
 
 declare option xdmp:mapping "false";
 
-xdmp:lock-for-update("/uri1"),
-xdmp:lock-for-update("/uri2"),
-xdmp:lock-for-update("/uri3"),
-xdmp:lock-for-update("/uri4"),
+merge-impl:lock-for-update("/uri1"),
+merge-impl:lock-for-update("/uri2"),
+merge-impl:lock-for-update("/uri3"),
+merge-impl:lock-for-update("/uri4"),
 
 test:assert-true(merge-impl:all-merged(("/uri1"))),
 test:assert-true(merge-impl:all-merged(("/uri1", "/uri2"))),

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -109,10 +109,17 @@ class DataHubPlugin implements Plugin<Project> {
 
         // Hub Mastering tasks
         String masteringGroup = "MarkLogic Data Hub Mastering Tasks"
-        project.task("hubUnmergeDocs", group: masteringGroup, type: UnmergeDocs,
-            description: "Reverses the last set of merges made into the given -PmergeURI=URI. " +
-                "-PretainAuditTrail (default true) determines if provenance for the merge/unmerge is kept. " +
-                "-PblockFutureMerges (default true) ensures that the documents won't be merged together in the next mastering run.")
+        project.task("hubUnmergeEntities", group: masteringGroup, type: UnmergeEntitiesTask,
+            description: "Reverses the last set of merges made into the given merge URI.\n -PmergeURI=URI. \n" +
+                "-PretainAuditTrail=<true|false> (default true) determines if provenance for the merge/unmerge is kept. \n" +
+                "-PblockFutureMerges=<true|false> (default true) ensures that the documents won't be merged together in the next mastering run.")
+
+        project.task("hubMergeEntities", group: masteringGroup, type: MergeEntitiesTask,
+            description: "Manually merge documents together given a set of options.\n -PmergeURIs=<URI1>,...,<URIn> –  the URIs of the documents to merge, separated by commas.\n" +
+                "-PflowName=<true|false> – optional; if true, the merged document will be moved to an archive collection; if false, the merged document will be deleted. Defaults to true.\n" +
+                "-Pstep=<masteringStepNumber> – optional; The number of the mastering step with settings. Defaults to 1.\n" +
+                "-Ppreview=<true|false> – optional; if true, the merge doc is returned in the response body and not committed to the database; if false, the merged document will be saved. Defaults to false.\n" +
+                "-Poptions=<stepOptionOverrides> – optional; Any overrides to the mastering step options. Defaults to {}.")
 
         /**
          * In order to guarantee that Gradle and the QS app perform this function in the same way, this task is being

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/MergeDocs.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/MergeDocs.groovy
@@ -1,0 +1,32 @@
+package com.marklogic.gradle.task
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.TaskAction
+
+class MergeDocs extends HubTask  {
+    @TaskAction
+    void mergeDocs() {
+        def propName = "mergeURIs"
+        def mergeURIs = project.hasProperty(propName) ? project.property(propName).toString() : null
+        if (mergeURIs == null) {
+            throw new GradleException("mergeURIs is a required parameter. Supply the parameter with -PmergeURIs=URI1,URI2,...n")
+        }
+        def flowName = project.hasProperty('flowName') ? project.property('flowName').toString() : null
+        if (flowName == null) {
+            throw new GradleException("flowName is a required parameter. Supply the parameter with -PflowName=myFlow")
+        }
+        def stepNumber = project.hasProperty('stepNumber') ? project.property('stepNumber').toString() : '1'
+        def preview = project.hasProperty('preview') ? project.property('preview').asBoolean() : Boolean.FALSE
+        def options = (JsonNode) (project.hasProperty('options') ? new ObjectMapper().readTree(project.property('options').toString()) : new ObjectMapper().readTree('{}'))
+        println "mergeURIs: " + mergeURIs
+        println "flowName: " + flowName
+        println "stepNumber: " + preview
+        println "preview: " + preview
+        println "options: " + options
+
+        def mergeResponse = getMasteringManager().merge(Arrays.asList(mergeURIs.split(',')), flowName, stepNumber, preview, options);
+        println mergeResponse.toString()
+    }
+}

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/MergeEntitiesTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/MergeEntitiesTask.groovy
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
 
-class MergeDocs extends HubTask  {
+class MergeEntitiesTask extends HubTask  {
     @TaskAction
     void mergeDocs() {
         def propName = "mergeURIs"

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/UnmergeEntitiesTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/UnmergeEntitiesTask.groovy
@@ -4,7 +4,7 @@ package com.marklogic.gradle.task
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
 
-class UnmergeDocs extends HubTask  {
+class UnmergeEntitiesTask extends HubTask  {
     @TaskAction
     void unmergeDocs() {
         def propName = "mergeURI"

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/DeployHubArtifactTaskTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/DeployHubArtifactTaskTest.groovy
@@ -42,9 +42,9 @@ class DeployHubArtifactTaskTest extends BaseTest {
         result.task(":hubDeployArtifacts").outcome == SUCCESS
 
         // Steps ingest, mapping, and master
-        getStagingDocCount("http://marklogic.com/data-hub/step-definition") == 4
+        getStagingDocCount("http://marklogic.com/data-hub/step-definition") == 5
         // Flows ingest, mapping, mastering, map-and-master
-        getStagingDocCount("http://marklogic.com/data-hub/flow") == 5
+        getStagingDocCount("http://marklogic.com/data-hub/flow") == 6
         getModulesDocCount() == modCount
     }
 


### PR DESCRIPTION
Merge Documents
Manually merge documents together given a set of options.

REST API
POST /v1/resources/ml:smMerge

parameters

- rs:uri=\<URIn> – the URIs of the documents to merge. It is a repeating parameter for each document to merge together. 
- rs:flowName=\<nameOfFlowWithMastering> – The name of the flow that has the mastering settings.
- rs:step=\<masteringStepNumber> – optional; The number of the mastering step with settings. Defaults to 1.
- rs:preview=\<true|false> – optional; if true, the merge doc is returned in the response body and not committed to the database; if false, the merged document will be saved. Defaults to false.
- request body

JSON object with any step options to override.

Gradle task
./gradlew hubMergeEntities

parameters

- -PmergeURIs=\<URI1>,...,\<URIn> –  the URIs of the documents to merge, separated by commas.
- -PflowName=\<true|false> – optional; if true, the merged document will be moved to an archive collection; if false, the merged document will be deleted. Defaults to true.
- -Pstep=\<masteringStepNumber> – optional; The number of the mastering step with settings. Defaults to 1.
- -Ppreview=\<true|false> – optional; if true, the merge doc is returned in the response body and not committed to the database; if false, the merged document will be saved. Defaults to false.
- -Poptions=\<stepOptionOverrides> – optional; Any overrides to the mastering step options. Defaults to {}.