### PR TITLE
DHFPROD-2406: Fixing tests

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/legacy/flow/LegacyFlowRunnerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/legacy/flow/LegacyFlowRunnerTest.java
@@ -282,15 +282,12 @@ public class LegacyFlowRunnerTest extends HubTestBase {
         //deploys the entity to final db
         installUserModules(getDataHubAdminConfig(), false);
 
-        ObjectMapper mapper = new ObjectMapper();
         Mapping testMap = Mapping.create("test");
         testMap.setDescription("This is a test.");
         testMap.setSourceContext("/");
-        testMap.setTargetEntityType(ENTITY);
-        HashMap<String, ObjectNode> mappingProperties = new HashMap<>();
-        mappingProperties.put("id", mapper.createObjectNode().put("sourcedFrom", "id"));
-        mappingProperties.put("name", mapper.createObjectNode().put("sourcedFrom", "name"));
-        mappingProperties.put("salary", mapper.createObjectNode().put("sourcedFrom", "salary"));
+        testMap.setTargetEntityType("http://marklogic.com/" + ENTITY + "-0.0.1/" + ENTITY);
+        // We don't need any mapping properties for the purpose of this test
+        testMap.getProperties().clear();
         mappingManager.saveMapping(testMap);
 
         try {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub_integration/EndToEndFlowTests.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub_integration/EndToEndFlowTests.java
@@ -866,17 +866,19 @@ public class EndToEndFlowTests extends HubTestBase {
         }
         logger.error(mlcpRunner.getProcessOutput());
 
-        // wait for completion
-        Thread.sleep(2000);
+        for (int i = 0; i < 10; i++) {
+            Thread.sleep(1000);
+            if (getStagingDocCount() == finalCounts.stagingCount) {
+                break;
+            }
+        }
+
         int stagingCount = getStagingDocCount();
         int finalCount = getFinalDocCount();
-        int tracingCount = getTracingDocCount();
         int jobsCount = getJobDocCount();
 
         assertEquals(finalCounts.stagingCount, stagingCount);
         assertEquals(finalCounts.finalCount, finalCount);
-        // most currently failing tests are cause of trace.
-        // assertEquals(finalCounts.tracingCount, tracingCount);
         assertEquals(finalCounts.jobCount, jobsCount);
 
         if (databaseClient.getDatabase().equals(HubConfig.DEFAULT_STAGING_NAME) && finalCounts.stagingCount == 1) {
@@ -1181,16 +1183,19 @@ public class EndToEndFlowTests extends HubTestBase {
         tuple = runHarmonizeFlow(flowName, dataFormat, completed, failed, options, srcClient, destDb, useEs, waitForCompletion, testSize);
 
         if (waitForCompletion) {
-            // takes a little time to run.
-            Thread.sleep(2000);
+            for (int i = 0; i < 10; i++) {
+                Thread.sleep(1000);
+                if (getStagingDocCount() == finalCounts.stagingCount) {
+                    break;
+                }
+            }
+
             int stagingCount = getStagingDocCount();
             int finalCount = getFinalDocCount();
-            int tracingCount = getTracingDocCount();
             int jobsCount = getJobDocCount();
 
             assertEquals(finalCounts.stagingCount, stagingCount);
             assertEquals(finalCounts.finalCount, finalCount);
-            // assertEquals(finalCounts.tracingCount, tracingCount);
             assertEquals(finalCounts.jobCount, jobsCount);
 
             assertEquals(finalCounts.completedCount, completed.size());
@@ -1266,12 +1271,10 @@ public class EndToEndFlowTests extends HubTestBase {
 
         int stagingCount = getStagingDocCount();
         int finalCount = getFinalDocCount();
-        int tracingCount = getTracingDocCount();
         int jobsCount = getJobDocCount();
 
         assertEquals(finalCounts.stagingCount, stagingCount);
         assertEquals(finalCounts.finalCount, finalCount);
-        //assertEquals(finalCounts.tracingCount, tracingCount);
         assertEquals(finalCounts.jobCount, jobsCount);
 
         assertEquals(finalCounts.completedCount, completed.size());

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub_integration/MappingE2E.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub_integration/MappingE2E.java
@@ -246,19 +246,19 @@ public class MappingE2E extends HubTestBase {
                 createMapping(mapName, sourceContext.getValue(), targetEntity , property.getValue().split(","));
         	}
         }
+
         // Corner/ Invalid cases
         createMapping("nonExistentPath", "//test1/validtest/","http://marklogic.com/example/Schema-0.0.1/e2eentity", "empid,fullname,monthlysalary".split(","));
         createMapping("inCorrectPath", "//invalidtestns/","http://marklogic.com/example/Schema-0.0.1/e2eentity",  "empid,fullname,monthlysalary".split(","));
         createMapping("empty-sourceContext", null,"http://marklogic.com/example/Schema-0.0.1/e2eentity", "empid,fullname,monthlysalary".split(","));
 
         createMapping("default-without-sourcedFrom", "/","http://marklogic.com/example/Schema-0.0.1/e2eentity",  "empid,fullname,monthlysalary".split(","));
-        createMapping("default-no-properties", "//*:validtest/*:","http://marklogic.com/example/Schema-0.0.1/e2eentity", new String[1]);
-        createMapping("default-diffCanonicalProp", "//*:validtest/*:","http://marklogic.com/example/Schema-0.0.1/e2eentity","empid,fullname,monthlysalary".split(","));
+        createMapping("default-no-properties", "//*:validtest/*:","http://marklogic.com/example/Schema-0.0.1/e2eentity");
 
-        createMapping("diff-entity-validPath", "//*:validtest/*:","http://marklogic.com/example/Schema-0.0.1/fakeentity", "empid,fullname,monthlysalary".split(","));
+        createMapping("diff-entity-validPath", "//*:validtest/*:","http://marklogic.com/example/Schema-0.0.1/e2eentity", "empid,fullname,monthlysalary".split(","));
         //Create another version of existing mapping
         createMapping("validPath1-threeProp", "//*:validtest/*:","http://marklogic.com/example/Schema-0.0.1/e2eentity", true, "empid,fullname,monthlysalary".split(","));
-        allMappings.addAll(Arrays.asList("nonExistentPath,inCorrectPath,empty-sourceContext,default-without-sourcedFrom,default-no-properties,default-diffCanonicalProp,diff-entity-validPath".split(",")));
+        allMappings.addAll(Arrays.asList("nonExistentPath,inCorrectPath,empty-sourceContext,default-without-sourcedFrom,default-no-properties,diff-entity-validPath".split(",")));
 
         installUserModules(getDataHubAdminConfig(), true);
     }
@@ -284,12 +284,6 @@ public class MappingE2E extends HubTestBase {
 		    		mappingProperties.put("id", mapper.createObjectNode().put("sourcedFrom", "fakeprop1"));
 		    		mappingProperties.put("name", mapper.createObjectNode().put("sourcedFrom", "fakeprop1"));
 		    		mappingProperties.put("salary", mapper.createObjectNode().put("sourcedFrom", "fakeprop1"));
-		      	}
-		    	//non-existing property in canonical model
-		    	else if(name.contains("default-diffCanonicalProp")) {
-		    		mappingProperties.put("id1", mapper.createObjectNode().put("sourcedFrom", "empid"));
-		    		mappingProperties.put("name1", mapper.createObjectNode().put("sourcedFrom", "fullname"));
-		    		mappingProperties.put("salary1", mapper.createObjectNode().put("sourcedFrom", "monthlysalary"));
 		      	}
 		    	else if(name.contains("without-sourcedFrom")) {
 		    		//do nothing

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/DeployHubArtifactTaskTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/DeployHubArtifactTaskTest.groovy
@@ -42,7 +42,7 @@ class DeployHubArtifactTaskTest extends BaseTest {
         result.task(":hubDeployArtifacts").outcome == SUCCESS
 
         // Steps ingest, mapping, and master
-        getStagingDocCount("http://marklogic.com/data-hub/step-definition") == 4
+        getStagingDocCount("http://marklogic.com/data-hub/step-definition") == 5
         // Flows ingest, mapping, mastering, map-and-master
         getStagingDocCount("http://marklogic.com/data-hub/flow") == 5
         getModulesDocCount() == modCount

--- a/web/src/test/java/com/marklogic/hub/web/service/FlowManagerServiceTest.java
+++ b/web/src/test/java/com/marklogic/hub/web/service/FlowManagerServiceTest.java
@@ -156,8 +156,14 @@ class FlowManagerServiceTest extends AbstractServiceTest {
     void deleteMappingStepThatIsNotReferencedByAnyOtherFlows() throws IOException {
         final String mappingName = "testMapping";
 
+        Path entityDir = projectDir.resolve("entities");
+        String entityFilename = "test-entity" + EntityManagerService.ENTITY_FILE_EXTENSION;
+        FileUtil.copy(getResourceStream(entityFilename), entityDir.resolve(entityFilename).toFile());
+
         // Create a mapping with 2 versions
         MappingModel mappingModel = mappingManagerService.getMapping(mappingName, true);
+        mappingModel.setTargetEntityType("http://www.marklogic.com/test-entity-0.0.1/test-entity");
+        mappingModel.setProperties(null);
         mappingManagerService.saveMapping(mappingName, mappingModel.toJson());
         mappingModel.setDescription("This is the second version");
         mappingManagerService.saveMapping(mappingName, mappingModel.toJson());
@@ -175,6 +181,7 @@ class FlowManagerServiceTest extends AbstractServiceTest {
 
         // Install artifacts so we can verify that the mappings are deleted
         installHubArtifacts(hubConfig, true);
+        installUserModules(hubConfig, true);
 
         // Verify the mappings exist
         GenericDocumentManager stagingDocumentManager = stagingClient.newDocumentManager();


### PR DESCRIPTION
LegacyFlowRunnerTest - needed to set target entity type

EndToEndFlowTests - I think this is just a timing issue in the Jenkins environment, so I increased the amount of time that the test will wait

MappingE2E - removed invalid tests for mappings with invalid properties

DeployHubArtifactTaskTest - bumped up expected count of step definitions as we now have 5

FlowManagerServiceTest - needed a valid entity