### PR TITLE
DHFPROD-2406: Assigning default permissions to debug/trace modules

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/impl/debug-lib.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/impl/debug-lib.xqy
@@ -17,9 +17,6 @@ xquery version "1.0-ml";
 
 module namespace debug = "http://marklogic.com/data-hub/debug";
 
-import module namespace hul = "http://marklogic.com/data-hub/hub-utils-lib"
-  at "/data-hub/4/impl/hub-utils-lib.xqy";
-
 declare option xdmp:mapping "false";
 
 declare function debug:enable($enabled as xs:boolean)
@@ -28,11 +25,10 @@ declare function debug:enable($enabled as xs:boolean)
   then
       xdmp:eval('
         declare namespace debug = "http://marklogic.com/data-hub/debug";
-
         xdmp:document-insert(
           "/com.marklogic.hub/settings/__debug_enabled__.xml",
           element debug:is-debugging-enabled { 1 },
-          xdmp:default-permissions(),
+          (xdmp:permission("rest-reader", "read"), xdmp:permission("rest-writer", "update")),
           "hub-core-module")
         ',
         (),

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/impl/trace-lib.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/impl/trace-lib.xqy
@@ -20,9 +20,6 @@ module namespace trace = "http://marklogic.com/data-hub/trace";
 import module namespace config = "http://marklogic.com/data-hub/config"
   at "/com.marklogic.hub/config.xqy";
 
-import module namespace consts = "http://marklogic.com/data-hub/consts"
-  at "/data-hub/4/impl/consts.xqy";
-
 import module namespace err = "http://marklogic.com/data-hub/err"
   at "/data-hub/4/impl/error-lib.xqy";
 
@@ -57,7 +54,7 @@ declare function trace:enable-tracing($enabled as xs:boolean)
     xdmp:document-insert(
       "/com.marklogic.hub/settings/__tracing_enabled__.xml",
       element trace:is-tracing-enabled { 1 },
-      xdmp:default-permissions(),
+      (xdmp:permission("rest-reader", "read"), xdmp:permission("rest-writer", "update")),
       "hub-core-module")
     ', (), map:new((map:entry("database", xdmp:modules-database()), map:entry("ignoreAmps", fn:true())))
   )


### PR DESCRIPTION
Not sure why this is breaking on this branch and not on develop, but this fixes the problem - which was a couple failing tests in InstalledTests