### PR TITLE
DHFPROD-2406: Function metadata is now generated before unit tests ar…

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateFunctionMetadataCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateFunctionMetadataCommand.java
@@ -18,9 +18,11 @@ import java.util.concurrent.TimeUnit;
 
 @Component
 public class GenerateFunctionMetadataCommand extends AbstractCommand {
+
     @Autowired
     private HubConfig hubConfig;
     private Throwable caughtException;
+    private DatabaseClient modulesClient;
 
     public GenerateFunctionMetadataCommand() {
         super();
@@ -28,12 +30,20 @@ public class GenerateFunctionMetadataCommand extends AbstractCommand {
         setExecuteSortOrder(SortOrderConstants.LOAD_MODULES + 1);
     }
 
+    public GenerateFunctionMetadataCommand(DatabaseClient modulesClient) {
+        this();
+        this.modulesClient = modulesClient;
+    }
+
     @Override
     public void execute(CommandContext context) {
-        DatabaseClient databaseClient = hubConfig.newStagingClient(hubConfig.getDbName(DatabaseKind.MODULES));
-        DataMovementManager dataMovementManager = databaseClient.newDataMovementManager();
+        if (modulesClient == null) {
+            modulesClient = hubConfig.newStagingClient(hubConfig.getDbName(DatabaseKind.MODULES));
+        }
 
-        StructuredQueryBuilder sb = databaseClient.newQueryManager().newStructuredQueryBuilder();
+        DataMovementManager dataMovementManager = modulesClient.newDataMovementManager();
+
+        StructuredQueryBuilder sb = modulesClient.newQueryManager().newStructuredQueryBuilder();
 
 
         ServerTransform serverTransform = new ServerTransform("ml:generateFunctionMetadata");

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/LoadTestModules.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/LoadTestModules.java
@@ -4,6 +4,7 @@ import com.marklogic.appdeployer.AppConfig;
 import com.marklogic.appdeployer.DefaultAppConfigFactory;
 import com.marklogic.appdeployer.command.modules.LoadModulesCommand;
 import com.marklogic.appdeployer.impl.SimpleAppDeployer;
+import com.marklogic.hub.deploy.commands.GenerateFunctionMetadataCommand;
 import com.marklogic.mgmt.util.SimplePropertySource;
 
 import java.util.Properties;
@@ -25,6 +26,7 @@ public class LoadTestModules {
         AppConfig config = new DefaultAppConfigFactory(new SimplePropertySource(props)).newAppConfig();
         config.setModuleTimestampsPath(null);
         config.setModulesDatabaseName(modulesDatabaseName);
+        config.setAppServicesPort(8010);
 
         /**
          * Setting this to a small number to fix some issues on Jenkins where jobs are picking up test modules
@@ -46,6 +48,9 @@ public class LoadTestModules {
         config.getModulePaths().add("../build/mlBundle/marklogic-unit-test-modules/ml-modules");
         config.getModulePaths().add("../src/test/ml-modules");
 
-        new SimpleAppDeployer(new LoadModulesCommand()).deploy(config);
+        new SimpleAppDeployer(
+            new LoadModulesCommand(),
+            new GenerateFunctionMetadataCommand(config.newAppServicesDatabaseClient("data-hub-MODULES"))
+        ).deploy(config);
     }
 }


### PR DESCRIPTION
…e run

This fixes a couple unit tests that were failing because the function metadata didn't exist