### PR TITLE
DHFPROD-2897: ml-gradle database names are now set to DHS values

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -633,6 +633,11 @@ public class DataHubImpl implements DataHub {
 
         AppConfig appConfig = hubConfig.getAppConfig();
         if (appConfig != null) {
+            appConfig.setContentDatabaseName(hubConfig.getDbName(DatabaseKind.FINAL));
+            appConfig.setTriggersDatabaseName(hubConfig.getDbName(DatabaseKind.FINAL_TRIGGERS));
+            appConfig.setSchemasDatabaseName(hubConfig.getDbName(DatabaseKind.FINAL_SCHEMAS));
+            appConfig.setModulesDatabaseName(hubConfig.getDbName(DatabaseKind.MODULES));
+
             Map<String, String> customTokens = appConfig.getCustomTokens();
             customTokens.put("%%mlStagingDbName%%", hubConfig.getDbName(DatabaseKind.STAGING));
             customTokens.put("%%mlFinalDbName%%", hubConfig.getDbName(DatabaseKind.FINAL));

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/DhsInstallTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/DhsInstallTest.java
@@ -92,6 +92,11 @@ public class DhsInstallTest extends HubTestBase {
         hubConfig.modifyCustomTokensMap(appConfig);
         assertEquals("my-staging-db", appConfig.getCustomTokens().get("%%mlStagingDbName%%"));
 
+        appConfig.setContentDatabaseName("my-final-db");
+        appConfig.setTriggersDatabaseName("my-final-triggers");
+        appConfig.setSchemasDatabaseName("my-final-schemas");
+        appConfig.setModulesDatabaseName("my-modules");
+
         new DataHubImpl().setKnownValuesForDhsInstall(hubConfig);
 
         assertEquals(HubConfig.DEFAULT_STAGING_NAME, hubConfig.getHttpName(DatabaseKind.STAGING));
@@ -119,6 +124,12 @@ public class DhsInstallTest extends HubTestBase {
         assertEquals(HubConfig.DEFAULT_STAGING_SCHEMAS_DB_NAME, tokens.get("%%mlStagingSchemasDbName%%"));
         assertEquals(HubConfig.DEFAULT_FINAL_TRIGGERS_DB_NAME, tokens.get("%%mlFinalTriggersDbName%%"));
         assertEquals(HubConfig.DEFAULT_FINAL_SCHEMAS_DB_NAME, tokens.get("%%mlFinalSchemasDbName%%"));
+
+        // Verify that ml-gradle's "default" database properties are set to the expected default values as well
+        assertEquals(HubConfig.DEFAULT_FINAL_NAME, appConfig.getContentDatabaseName());
+        assertEquals(HubConfig.DEFAULT_FINAL_TRIGGERS_DB_NAME, appConfig.getTriggersDatabaseName());
+        assertEquals(HubConfig.DEFAULT_FINAL_SCHEMAS_DB_NAME, appConfig.getSchemasDatabaseName());
+        assertEquals(HubConfig.DEFAULT_MODULES_DB_NAME, appConfig.getModulesDatabaseName());
     }
 
     @Test


### PR DESCRIPTION
These properties are used by some ml-gradle features that DHF makes use of, and thus they need to be forced to the DHS default values in addition to the DHS-specific properties.