### PR TITLE
DHFPROD-3068: Populate 'serverVersion' if it is null

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -969,6 +969,9 @@ public class DataHubImpl implements DataHub {
 
     @Override
     public String getServerVersion() {
+        if(serverVersion == null) {
+            serverVersion = versions.getMarkLogicVersion();
+        }
         return serverVersion;
     }
 


### PR DESCRIPTION
'serverVersion' gets populated only if dataHub.preInstallCheck() is called. bootstrap task doesn't call it. so adding a null check. This should fix the incorrect version in server rewriter 