### PR TITLE
DHFPROD-3162: Added command line option to not use SSL

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/Options.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/Options.java
@@ -38,6 +38,12 @@ public class Options {
     )
     private String password;
 
+    @Parameter(
+        names = {"--disableSsl"},
+        description = "Set to true to disable SSL usage when connecting to MarkLogic"
+    )
+    private boolean disableSsl;
+
     @DynamicParameter(
         names = "-P",
         description = "Use this argument to include any property supported by DHF; e.g. -PmlHost=somehost"
@@ -82,5 +88,13 @@ public class Options {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public boolean isDisableSsl() {
+        return disableSsl;
+    }
+
+    public void setDisableSsl(boolean disableSsl) {
+        this.disableSsl = disableSsl;
     }
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/VerifyDhfInDhsCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/VerifyDhfInDhsCommand.java
@@ -24,7 +24,7 @@ public class VerifyDhfInDhsCommand extends AbstractVerifyCommand {
     @Override
     public void run(ApplicationContext context, Options options) {
         // TODO This is hacky, need a better mechanism for building these properties post 5.0.2
-        Properties props = new InstallIntoDhsCommand().buildDefaultProjectProperties();
+        Properties props = new InstallIntoDhsCommand().buildDefaultProjectProperties(options);
         initializeProject(context, options, props);
 
         long start = System.currentTimeMillis();

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/deploy/CopyQueryOptionsCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/deploy/CopyQueryOptionsCommand.java
@@ -26,8 +26,8 @@ public class CopyQueryOptionsCommand extends AbstractCommand {
             "  '/Evaluator/data-hub-STAGING/rest-api/options/default.xml',\n" +
             "  '/Evaluator/data-hub-FINAL/rest-api/options/default.xml'\n" +
             "].forEach(uri => {\n" +
-            "  xdmp.documentInsert(uri.replace('Evaluator', 'Curator'), cts.doc(uri), \n" +
-            "    xdmp.documentGetPermissions(uri), xdmp.documentGetCollections(uri));\n" +
+            "  if (fn.docAvailable(uri)) { xdmp.documentInsert(uri.replace('Evaluator', 'Curator'), cts.doc(uri), \n" +
+            "    xdmp.documentGetPermissions(uri), xdmp.documentGetCollections(uri));}\n" +
             "});\n" +
             "\n" +
             "const finalUri = '/Evaluator/data-hub-FINAL/rest-api/options/default.xml';\n" +
@@ -39,8 +39,8 @@ public class CopyQueryOptionsCommand extends AbstractCommand {
             "  '/Evaluator/data-hub-ANALYTICS/rest-api/options/default.xml',\n" +
             "  '/Evaluator/data-hub-OPERATION/rest-api/options/default.xml'\n" +
             "].forEach(uri => {\n" +
-            "  xdmp.documentInsert(uri, cts.doc(finalUri), xdmp.documentGetPermissions(finalUri), \n" +
-            "    xdmp.documentGetCollections(finalUri));\n" +
+            "  if (fn.docAvailable(finalUri)) {xdmp.documentInsert(uri, cts.doc(finalUri), xdmp.documentGetPermissions(finalUri), \n" +
+            "    xdmp.documentGetCollections(finalUri));}\n" +
             "})";
 
         DatabaseClient client = hubConfig.newModulesDbClient();


### PR DESCRIPTION
Can include --disableSsl=true

Also modifying CopyQueryOptionsCommand to not fail if a particular URI is not found