### PR TITLE
DHFPROD-3223: mlServerVersion is now set correctly by the server

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/AbstractInstallerCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/AbstractInstallerCommand.java
@@ -74,4 +74,15 @@ public abstract class AbstractInstallerCommand extends LoggingObject implements 
         }
     }
 
+    // TODO Some duplication between this and the logic in DeployHubOtherServersCommand
+    protected String getServerMajorVersion() {
+        try {
+            String serverVersion = this.dataHub.getServerVersion();
+            return serverVersion != null ? serverVersion.replaceAll("([^.]+)\\..*", "$1") : "9";
+        } catch (Exception ex) {
+            logger.warn("Unable to determine the server version; cause: " + ex.getMessage());
+            logger.warn("Will use 9 as a fallback");
+            return "9";
+        }
+    }
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/AbstractVerifyCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/AbstractVerifyCommand.java
@@ -34,17 +34,18 @@ public abstract class AbstractVerifyCommand extends AbstractInstallerCommand {
     }
 
     protected void verifyAmps() {
-        // For amps - there are 66 of them, will just verify that the first and last ones exist
+        // For amps - just spot-checking a couple of them
         AmpManager ampManager = new AmpManager(hubConfig.getManageClient());
         Amp firstAmp = new Amp();
-        firstAmp.setLocalName("addResponseHeader");
+        firstAmp.setLocalName("map-to-xml");
         firstAmp.setModulesDatabase(hubConfig.getAppConfig().getModulesDatabaseName());
-        firstAmp.setDocumentUri("/data-hub/5/rest-api/lib/endpoint-util.sjs");
+        firstAmp.setDocumentUri("/com.marklogic.smart-mastering/survivorship/merging/base.xqy");
+        firstAmp.setNamespace("http://marklogic.com/smart-mastering/survivorship/merging");
         Amp lastAmp = new Amp();
-        lastAmp.setLocalName("invoke-service");
-        lastAmp.setDocumentUri("/data-hub/5/rest-api/lib/extensions-util.xqy");
+        lastAmp.setLocalName("construct-type");
+        lastAmp.setDocumentUri("/com.marklogic.smart-mastering/survivorship/merging/base.xqy");
         lastAmp.setModulesDatabase(hubConfig.getAppConfig().getModulesDatabaseName());
-        lastAmp.setNamespace("http://marklogic.com/rest-api/lib/extensions-util");
+        lastAmp.setNamespace("http://marklogic.com/smart-mastering/survivorship/merging");
         for (Amp amp : new Amp[]{firstAmp, lastAmp}) {
             verify(ampManager.ampExists(amp.getJson()), "Expected amp to have been created: " + amp.getJson());
         }
@@ -127,9 +128,10 @@ public abstract class AbstractVerifyCommand extends AbstractInstallerCommand {
     }
 
     protected void verifyStagingServer(String groupName) {
+        final String version = getServerMajorVersion();
         verifyRewriterAndErrorHandler(new ServerManager(hubConfig.getManageClient(), groupName).getPropertiesAsXml("data-hub-STAGING"),
-            "/data-hub/5/rest-api/rewriter.xml",
-            "/data-hub/5/rest-api/error-handler.xqy"
+            format("/data-hub/5/rest-api/rewriter/%s-rewriter.xml", version),
+            "/MarkLogic/rest-api/error-handler.xqy"
         );
     }
 
@@ -141,8 +143,9 @@ public abstract class AbstractVerifyCommand extends AbstractInstallerCommand {
     }
 
     protected void verifyJobServer(String groupName) {
+        final String version = getServerMajorVersion();
         verifyRewriterAndErrorHandler(new ServerManager(hubConfig.getManageClient(), groupName).getPropertiesAsXml("data-hub-JOBS"),
-            "/data-hub/5/tracing/tracing-rewriter.xml",
+            format("/data-hub/5/tracing/%s-tracing-rewriter.xml", version),
             "/MarkLogic/rest-api/error-handler.xqy"
         );
     }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/InstallIntoDhsCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/InstallIntoDhsCommand.java
@@ -5,6 +5,7 @@ import com.marklogic.appdeployer.command.Command;
 import com.marklogic.appdeployer.command.databases.DeployOtherDatabasesCommand;
 import com.marklogic.appdeployer.command.security.DeployAmpsCommand;
 import com.marklogic.appdeployer.command.security.DeployPrivilegesCommand;
+import com.marklogic.hub.DataHub;
 import com.marklogic.hub.cli.Options;
 import com.marklogic.hub.cli.deploy.CopyQueryOptionsCommand;
 import com.marklogic.hub.cli.deploy.DhsDeployServersCommand;
@@ -34,7 +35,7 @@ public class InstallIntoDhsCommand extends AbstractInstallerCommand {
         // Update the servers in the Curator group
         groupName = "Curator";
         modifyHubConfigForDhs(groupName);
-        deployer.setCommands(Arrays.asList(new DhsDeployServersCommand()));
+        deployer.setCommands(Arrays.asList(new DhsDeployServersCommand(dataHub)));
         deployer.deploy(hubConfig.getAppConfig());
     }
 
@@ -50,7 +51,7 @@ public class InstallIntoDhsCommand extends AbstractInstallerCommand {
         commands.add(new DeployPrivilegesCommand());
         commands.add(new DeployAmpsCommand());
         commands.add(dbCommand);
-        commands.add(new DhsDeployServersCommand());
+        commands.add(new DhsDeployServersCommand(dataHub));
         commands.add(new DeployDatabaseFieldCommand());
 
         Map<String, List<Command>> commandMap = dataHub.buildCommandMap();

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/deploy/DhsDeployServersCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/deploy/DhsDeployServersCommand.java
@@ -1,6 +1,7 @@
 package com.marklogic.hub.cli.deploy;
 
 import com.marklogic.appdeployer.command.CommandContext;
+import com.marklogic.hub.DataHub;
 import com.marklogic.hub.deploy.commands.DeployHubOtherServersCommand;
 
 import java.io.File;
@@ -11,8 +12,8 @@ import java.io.File;
  */
 public class DhsDeployServersCommand extends DeployHubOtherServersCommand {
 
-    public DhsDeployServersCommand() {
-        super(null);
+    public DhsDeployServersCommand(DataHub dataHub) {
+        super(dataHub);
     }
 
     @Override

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/DeployHubOtherServersCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/DeployHubOtherServersCommand.java
@@ -45,8 +45,15 @@ public class DeployHubOtherServersCommand extends DeployOtherServersCommand {
             AppConfig appConfig = context.getAppConfig();
             Map<String, String> customTokens = appConfig.getCustomTokens();
             //set the server version for the rewriter
-            String serverVersion = this.dataHub.getServerVersion();
-            customTokens.put("%%mlServerVersion%%", serverVersion != null ? serverVersion.replaceAll("([^.]+)\\..*", "$1") : "9");
+            final String token = "%%mlServerVersion%%";
+            try {
+                String serverVersion = this.dataHub.getServerVersion();
+                customTokens.put(token, serverVersion != null ? serverVersion.replaceAll("([^.]+)\\..*", "$1") : "9");
+            } catch (Exception ex) {
+                logger.warn("Unable to determine the server version; cause: " + ex.getMessage());
+                logger.warn("Will set mlServerVersion to 9 as a fallback");
+                customTokens.put(token, "9");
+            }
             appConfig.setCustomTokens(customTokens);
             Map<String, Object> contextMap = context.getContextMap();
             contextMap.put("AppConfig", appConfig);

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/deploy/DhsDeployServersCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/deploy/DhsDeployServersCommandTest.java
@@ -26,7 +26,7 @@ public class DhsDeployServersCommandTest {
         server.setPort(8123);
         server.setAuthentication("digestbasic");
 
-        final String payload = new DhsDeployServersCommand().adjustPayloadBeforeSavingResource(context, null, server.getJson());
+        final String payload = new DhsDeployServersCommand(null).adjustPayloadBeforeSavingResource(context, null, server.getJson());
         JsonNode node = ObjectMapperFactory.getObjectMapper().readTree(payload);
         assertEquals("some-server", node.get("server-name").asText());
         assertEquals("some-rewriter", node.get("url-rewriter").asText());


### PR DESCRIPTION
This does depend on DHS no longer defaulting servers to DHF 4-specific rewriters, as those no longer exists.