### PR TITLE
DHFPROD-3193: Ensuring language is not submitted in a database payload

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/DeployHubDatabaseCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/DeployHubDatabaseCommand.java
@@ -26,6 +26,7 @@ import com.marklogic.rest.util.JsonNodeUtil;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Iterator;
 
 /**
  * Extends ml-app-deployer's standard command for deploying a single database and adds DHF-specific functionality.
@@ -78,6 +79,11 @@ public class DeployHubDatabaseCommand extends DeployDatabaseCommand {
                 ObjectNode payloadNode = (ObjectNode) ObjectMapperFactory.getObjectMapper().readTree(payload);
                 payloadNode = mergePayloadWithEntityConfigFileIfItExists(payloadNode);
                 removeSchemaAndTriggersDatabaseSettingsInAProvisionedEnvironment(payloadNode);
+
+                // language is somehow being added in a test; not sure how, but strip it out if it exists
+                if (payloadNode.has("language")) {
+                    payloadNode.remove("language");
+                }
                 return payloadNode.toString();
             } catch (IOException e) {
                 throw new DataHubConfigurationException(e);


### PR DESCRIPTION
This fixes the error in UpdateIndexesTaskTest, but the test still fails for me locally for what seems like the following reason - the number of path range indexes isn't increased because hubSaveIndexes is called before the count of current indexes is retrieved. 

I don't think this test is really testing much that isn't covered elsewhere, and for that reason, I think it would suffice for the test to just verify that no errors occur.