### PR TITLE
DHFPROD-3010: Fixing unit tests for mapping functions

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/Versions.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/Versions.java
@@ -189,8 +189,9 @@ public class Versions extends ResourceManager {
 
     }
 
-    public boolean isVersionCompatibleWithES(){
-        return  isVersionCompatibleWithESNightly(getMLVersion()) || isVersionCompatibleWithESServer(getMLVersion());
+    public boolean isVersionCompatibleWithES() {
+        final MarkLogicVersion mlVersion = getMLVersion();
+        return isVersionCompatibleWithESNightly(mlVersion) || isVersionCompatibleWithESServer(mlVersion);
     }
 
     private boolean isVersionCompatibleWithESNightly(Versions.MarkLogicVersion serverVersion) {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/LoadTestModules.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/LoadTestModules.java
@@ -4,6 +4,8 @@ import com.marklogic.appdeployer.AppConfig;
 import com.marklogic.appdeployer.DefaultAppConfigFactory;
 import com.marklogic.appdeployer.command.modules.LoadModulesCommand;
 import com.marklogic.appdeployer.impl.SimpleAppDeployer;
+import com.marklogic.hub.deploy.commands.GenerateFunctionMetadataCommand;
+import com.marklogic.hub.impl.Versions;
 import com.marklogic.mgmt.util.SimplePropertySource;
 
 import java.util.Properties;
@@ -47,10 +49,11 @@ public class LoadTestModules {
         config.getModulePaths().add("../build/mlBundle/marklogic-unit-test-modules/ml-modules");
         config.getModulePaths().add("../src/test/ml-modules");
 
-        // Removing GenerateFunctionMetaDataCommand as the command has spring related dependencies (hubConfig, versions
-        // objects have to be created
+        // Need to run GenerateFunctionMetadataCommand as well so that function metadata is generated both for
+        // core mapping functions and custom functions under src/test/ml-modules/root/custom-modules.
         new SimpleAppDeployer(
-            new LoadModulesCommand()
+            new LoadModulesCommand(),
+            new GenerateFunctionMetadataCommand(config.newAppServicesDatabaseClient("data-hub-MODULES"), new Versions(config))
         ).deploy(config);
     }
 }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping-functions/getMappingFunctions.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping-functions/getMappingFunctions.sjs
@@ -1,11 +1,10 @@
 const mappingFunctions = require('/marklogic.rest.resource/mlMappingFunctions/assets/resource.sjs');
 const test = require("/test/test-helper.xqy");
 
-function testMappingFunctions() {
-return [
-    test.assertEqual(129, Object.keys(mappingFunctions.getXpathFunctions()).length, "As of 10.0-2 server, there are 129 xpath functions"),
-    test.assertEqual(4, Object.keys(mappingFunctions.getMarkLogicFunctions()).length, "There are 4 OOTB mapping functions that are being shipped with DHF")
-  ];
-}
-
-[].concat(testMappingFunctions());
+[
+  test.assertTrue(Object.keys(mappingFunctions.getXpathFunctions()).length >= 129,
+    "As of 10.0-2 server, there are 129 xpath functions; there may be more in a future version, but we expect at least that many to exist"),
+  
+  test.assertTrue(Object.keys(mappingFunctions.getMarkLogicFunctions()).length >= 4,
+    "There are 4 OOTB mapping functions that are being shipped with DHF; there may be more from other tests in the suite, but we expect at least those 4 to exist")
+];


### PR DESCRIPTION
GenerateFunctionMetadataCommand can now be run again as part of the unit test suite