### PR TITLE
DHFPROD-3277: Unit test suite now loads hub artifacts

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub_unit_test/RunMarkLogicUnitTestsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub_unit_test/RunMarkLogicUnitTestsTest.java
@@ -1,12 +1,20 @@
 package com.marklogic.hub_unit_test;
 
-import com.marklogic.hub_unit_test.TestConfig;
+import com.marklogic.appdeployer.impl.SimpleAppDeployer;
+import com.marklogic.hub.ApplicationConfig;
+import com.marklogic.hub.HubTestBase;
 import com.marklogic.junit5.MarkLogicUnitTestArgumentsProvider;
-import com.marklogic.junit5.spring.AbstractSpringMarkLogicTest;
+import com.marklogic.test.unit.TestManager;
 import com.marklogic.test.unit.TestModule;
+import com.marklogic.test.unit.TestResult;
+import com.marklogic.test.unit.TestSuiteResult;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Runs all marklogic-unit-test tests located under src/test/ml-modules/root/test.
@@ -20,12 +28,35 @@ import org.springframework.test.context.ContextConfiguration;
  * <p>
  * After running this, you can also access the marklogic-unit-test runner at host:8011/test/default.xqy.
  */
-@ContextConfiguration(classes = {TestConfig.class})
-public class RunMarkLogicUnitTestsTest extends AbstractSpringMarkLogicTest {
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {ApplicationConfig.class, TestConfig.class})
+public class RunMarkLogicUnitTestsTest extends HubTestBase {
 
+    private static boolean loadedHubArtifacts = false;
+    private static boolean initialized = false;
+
+    /**
+     * Some tests clear out the final database, so we have to ensure that hub artifacts are still present. Only need to
+     * do this once though. It does create a need to extend HubTestBase though
+     */
+    @BeforeEach
+    public void setup() {
+        if (!loadedHubArtifacts) {
+            new SimpleAppDeployer(loadHubArtifactsCommand).deploy(adminHubConfig.getAppConfig());
+            loadedHubArtifacts = true;
+        }
+    }
+
+    /**
+     * This is overridden so that the test class is only initialized once, which is sufficient. Otherwise, it's invoked
+     * for every unit test module, which is unnecessary.
+     */
     @Override
-    public void deleteDocumentsBeforeTestRuns() {
-        // No need for this yet
+    protected void init() {
+        if (!initialized) {
+            super.init();
+            initialized = true;
+        }
     }
 
     /**
@@ -36,7 +67,13 @@ public class RunMarkLogicUnitTestsTest extends AbstractSpringMarkLogicTest {
     @ParameterizedTest
     @ArgumentsSource(MarkLogicUnitTestArgumentsProvider.class)
     public void test(TestModule testModule) {
-        runMarkLogicUnitTests(testModule);
+        TestSuiteResult result = new TestManager(adminHubConfig.newFinalClient()).run(testModule);
+        for (TestResult testResult : result.getTestResults()) {
+            String failureXml = testResult.getFailureXml();
+            if (failureXml != null) {
+                Assertions.fail(String.format("Test %s in suite %s failed, cause: %s", testResult.getName(), testModule.getSuite(), failureXml));
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Some tests prior to RunMarkLogicUnitTestsTest are clearing the final database which causes some of the unit tests to break.