### PR TITLE
DHFPROD-3146: Function metadata now generated when loading modules

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateFunctionMetadataCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateFunctionMetadataCommand.java
@@ -2,7 +2,6 @@ package com.marklogic.hub.deploy.commands;
 
 import com.marklogic.appdeployer.command.AbstractCommand;
 import com.marklogic.appdeployer.command.CommandContext;
-import com.marklogic.appdeployer.command.SortOrderConstants;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.datamovement.ApplyTransformListener;
 import com.marklogic.client.datamovement.DataMovementManager;
@@ -29,8 +28,10 @@ public class GenerateFunctionMetadataCommand extends AbstractCommand {
 
     public GenerateFunctionMetadataCommand() {
         super();
-        // This command has to be executed after modules are loaded
-        setExecuteSortOrder(SortOrderConstants.LOAD_MODULES + 1);
+
+        // Per DHFPROD-3146, need this to run after modules are loaded. LoadUserModulesCommand is configured
+        // to run after amps are deployed, so need this to run after user modules are loaded.
+        setExecuteSortOrder(new LoadUserModulesCommand().getExecuteSortOrder() + 1);
     }
 
     public GenerateFunctionMetadataCommand(DatabaseClient modulesClient, Versions versions) {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserModulesCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserModulesCommand.java
@@ -176,7 +176,6 @@ public class LoadUserModulesCommand extends LoadModulesCommand {
         Path userModulesPath = hubConfig.getHubPluginsDir();
         String baseDir = userModulesPath.normalize().toAbsolutePath().toString();
         Path startPath = userModulesPath.resolve("entities");
-        Path mappingPath = userModulesPath.resolve("mappings");
 
         // load any user files under plugins/* int the modules database.
         // this will ignore REST folders under entities
@@ -212,7 +211,7 @@ public class LoadUserModulesCommand extends LoadModulesCommand {
                 //first let's do the entities and flows + extensions
                 Files.walkFileTree(startPath, new SimpleFileVisitor<Path>() {
                     @Override
-                    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
                         String currentDir = dir.normalize().toAbsolutePath().toString();
 
                         // for REST dirs we need to deploy all the REST stuff (transforms, options, services, etc)
@@ -231,9 +230,7 @@ public class LoadUserModulesCommand extends LoadModulesCommand {
                     }
 
                     @Override
-                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                        throws IOException
-                    {
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                         if (isFlowPropertiesFile(file) && modulesManager.hasFileBeenModifiedSinceLastLoaded(file.toFile())) {
                             LegacyFlow flow = flowManager.getFlowFromProperties(file);
                             StringHandle handle = new StringHandle(flow.serialize());

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/util/ModuleWatchingConsumer.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/util/ModuleWatchingConsumer.java
@@ -1,0 +1,54 @@
+package com.marklogic.hub.deploy.util;
+
+import com.marklogic.appdeployer.command.Command;
+import com.marklogic.appdeployer.command.CommandContext;
+import com.marklogic.client.ext.helper.LoggingObject;
+import org.springframework.core.io.Resource;
+
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * Consumer implementation to be used with mlWatch. Expected to be invoked after one or more new/modified modules have
+ * been detected and loaded.
+ */
+public class ModuleWatchingConsumer extends LoggingObject implements Consumer<Set<Resource>> {
+
+    private CommandContext commandContext;
+    private Command generateFunctionMetadataCommand;
+
+    public ModuleWatchingConsumer(CommandContext commandContext, Command generateFunctionMetadataCommand) {
+        this.commandContext = commandContext;
+        this.generateFunctionMetadataCommand = generateFunctionMetadataCommand;
+    }
+
+    @Override
+    public void accept(Set<Resource> resources) {
+        if (generateFunctionMetadataCommand != null && commandContext != null && shouldFunctionMetadataBeGenerated(resources)) {
+            try {
+                logger.info("Generating function metadata for modules containing mapping functions");
+                generateFunctionMetadataCommand.execute(commandContext);
+            } catch (Exception ex) {
+                logger.error("Unable to generate function metadata, cause: " + ex.getMessage());
+            }
+        }
+    }
+
+    protected boolean shouldFunctionMetadataBeGenerated(Set<Resource> resources) {
+        if (resources != null && !resources.isEmpty()) {
+            for (Resource r : resources) {
+                try {
+                    if (r.getFile().getAbsolutePath().contains("mapping-functions")) {
+                        return true;
+                    }
+                } catch (Exception ex) {
+                    // This is not expected to ever happen, and it shouldn't cause a failure, but a log message is
+                    // still warranted in case there's a real problem, as it may result in function metadata never being
+                    // generated while mlWatch is running
+                    logger.warn("Unable to read resource: " + r + "; cause: " + ex.getMessage());
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/GenerateFunctionMetadataCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/GenerateFunctionMetadataCommandTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 
 import static com.marklogic.client.io.DocumentMetadataHandle.Capability.READ;
 import static com.marklogic.client.io.DocumentMetadataHandle.Capability.UPDATE;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = ApplicationConfig.class)
@@ -66,6 +67,14 @@ public class GenerateFunctionMetadataCommandTest extends HubTestBase {
     @AfterAll
     public static void cleanUp() {
         new Installer().deleteProjectDir();
+    }
+
+    @Test
+    public void sortOrder() {
+        int metadataOrder = generateFunctionMetadataCommand.getExecuteSortOrder();
+        int userModulesOrder = loadUserModulesCommand.getExecuteSortOrder();
+        assertTrue(metadataOrder > userModulesOrder,
+            "Function metadata should be generated after user modules are loaded");
     }
 
     @Test

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/util/ModuleWatchingConsumerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/util/ModuleWatchingConsumerTest.java
@@ -1,0 +1,61 @@
+package com.marklogic.hub.deploy.util;
+
+import com.marklogic.appdeployer.command.Command;
+import com.marklogic.appdeployer.command.CommandContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ModuleWatchingConsumerTest {
+
+    private ModuleWatchingConsumer consumer = new ModuleWatchingConsumer(null, null);
+
+    @Test
+    public void shouldGenerateFunctionMetadata() {
+        Set<Resource> resources = new HashSet<>();
+        resources.add(new FileSystemResource("marklogic-data-hub/src/test/ml-modules/root/custom-modules/mapping-functions/custom-mapping-functions.sjs"));
+        assertTrue(consumer.shouldFunctionMetadataBeGenerated(resources));
+    }
+
+    @Test
+    public void shouldNotGenerateFunctionMetadata() {
+        Set<Resource> resources = new HashSet<>();
+        resources.add(new FileSystemResource("marklogic-data-hub/src/test/ml-modules/root/test/data-hub-test-helper.xqy"));
+        assertFalse(consumer.shouldFunctionMetadataBeGenerated(resources));
+    }
+
+    @Test
+    public void generatingThrowsAnException() {
+        TestCommand command = new TestCommand();
+        consumer = new ModuleWatchingConsumer(new CommandContext(null, null, null), command);
+
+        Set<Resource> resources = new HashSet<>();
+        resources.add(new FileSystemResource("marklogic-data-hub/src/test/ml-modules/root/custom-modules/mapping-functions/custom-mapping-functions.sjs"));
+        consumer.accept(resources);
+
+        assertTrue(command.wasExecuted, "The command should have been executed, which means it threw an exception that " +
+            "was logged and not rethrown, as we want mlWatch to keep running, even if function metadata cannot be generated.");
+    }
+}
+
+class TestCommand implements Command {
+
+    public boolean wasExecuted = false;
+
+    @Override
+    public void execute(CommandContext context) {
+        wasExecuted = true;
+        throw new RuntimeException("This should be caught and logged");
+    }
+
+    @Override
+    public Integer getExecuteSortOrder() {
+        return null;
+    }
+}

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -214,6 +214,8 @@ class DataHubPlugin implements Plugin<Project> {
         entityManager = ctx.getBean(EntityManagerImpl.class)
         generatePiiCommand = ctx.getBean(GeneratePiiCommand.class)
 
+        project.extensions.add("dataHubApplicationContext", ctx)
+
         initializeProjectExtensions(project)
     }
 

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/HubWatchTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/HubWatchTask.groovy
@@ -17,8 +17,13 @@
 
 package com.marklogic.gradle.task
 
+
 import com.marklogic.gradle.task.client.WatchTask
+import com.marklogic.hub.HubConfig
+import com.marklogic.hub.deploy.commands.GenerateFunctionMetadataCommand
 import com.marklogic.hub.deploy.commands.LoadUserModulesCommand
+import com.marklogic.hub.deploy.util.ModuleWatchingConsumer
+import com.marklogic.hub.impl.Versions
 
 /**
  * Extends ml-gradle's WatchTask so that after WatchTask loads modules, this task can invoke the custom DHF command for
@@ -29,6 +34,13 @@ import com.marklogic.hub.deploy.commands.LoadUserModulesCommand
 class HubWatchTask extends WatchTask {
 
     LoadUserModulesCommand command
+
+    HubWatchTask() {
+        HubConfig hubConfig = getProject().property("hubConfig")
+        Versions versions = getProject().property("dataHubApplicationContext").getBean(Versions.class)
+        GenerateFunctionMetadataCommand command = new GenerateFunctionMetadataCommand(hubConfig.newModulesDbClient(), versions)
+        onModulesLoaded = new ModuleWatchingConsumer(getCommandContext(), command)
+    }
 
     @Override
     void afterModulesLoaded() {


### PR DESCRIPTION
This includes during mlWatch, mlLoadModules, mlReloadModules, mlDeploy, and mlRedeploy.