### PR TITLE
WIP: Demonstration of using a data service to get a source data document

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'com.moowork.node' version '1.1.1'
     id 'org.springframework.boot' version '2.1.3.RELEASE'
     id "io.spring.dependency-management" version "1.0.7.RELEASE"
+    id 'com.marklogic.ml-development-tools' version '4.2.0'
 }
 
 repositories {
@@ -150,6 +151,11 @@ processResources {
         into "."
     }
 }
+
+task generateSourceDataInterface(type: com.marklogic.client.tools.gradle.EndpointProxiesGenTask, group: "Data Services") {
+    serviceDeclarationFile = "src/main/resources/ml-modules/root/data-hub/5/data-services/sourceData/service.json"
+}
+
 
 if (!(
     gradle.startParameter.taskNames*.toLowerCase().contains("bootrun") ||

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/SourceDataService.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/SourceDataService.java
@@ -1,0 +1,62 @@
+package com.marklogic.hub.dataservices;
+
+// IMPORTANT: Do not edit. This file is generated.
+
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.marker.AbstractWriteHandle;
+
+
+import com.marklogic.client.DatabaseClient;
+
+import com.marklogic.client.impl.BaseProxy;
+
+/**
+ * Provides a set of operations on the database server
+ */
+public interface SourceDataService {
+    /**
+     * Creates a SourceDataService object for executing operations on the database server.
+     *
+     * The DatabaseClientFactory class can create the DatabaseClient parameter. A single
+     * client object can be used for any number of requests and in multiple threads.
+     *
+     * @param db	provides a client for communicating with the database server
+     * @return	an object for session state
+     */
+    static SourceDataService on(DatabaseClient db) {
+        final class SourceDataServiceImpl implements SourceDataService {
+            private BaseProxy baseProxy;
+
+            private SourceDataServiceImpl(DatabaseClient dbClient) {
+                baseProxy = new BaseProxy(dbClient, "/data-hub/5/data-services/sourceData/");
+            }
+
+            @Override
+            public com.fasterxml.jackson.databind.JsonNode getSourceDataDocument(String sourceQuery, Long index) {
+              return BaseProxy.JsonDocumentType.toJsonNode(
+                baseProxy
+                .request("getSourceDataDocument.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_ATOMICS)
+                .withSession()
+                .withParams(
+                    BaseProxy.atomicParam("sourceQuery", false, BaseProxy.StringType.fromString(sourceQuery)),
+                    BaseProxy.atomicParam("index", false, BaseProxy.LongType.fromLong(index)))
+                .withMethod("POST")
+                .responseSingle(false, Format.JSON)
+                );
+            }
+
+        }
+
+        return new SourceDataServiceImpl(db);
+    }
+
+  /**
+   * Invokes the getSourceDataDocument operation on the database server
+   *
+   * @param sourceQuery	provides input
+   * @param index	provides input
+   * @return	as output
+   */
+    com.fasterxml.jackson.databind.JsonNode getSourceDataDocument(String sourceQuery, Long index);
+
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/sourceData/getSourceDataDocument.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/sourceData/getSourceDataDocument.api
@@ -1,0 +1,17 @@
+{
+    "functionName": "getSourceDataDocument",
+    "params": [
+        {
+            "name": "sourceQuery",
+            "datatype": "string"
+        },
+        {
+            "name": "index",
+            "datatype": "long"
+        }
+    ],
+    "return": {
+        "datatype": "jsonDocument",
+        "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+    }
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/sourceData/getSourceDataDocument.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/sourceData/getSourceDataDocument.sjs
@@ -1,0 +1,33 @@
+/*
+  Copyright 2012-2019 MarkLogic Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+'use strict';
+
+var sourceQuery;
+var index;
+
+let query = "cts.uris(null, ['truncate=1', 'skip=" + index + "'], " + sourceQuery + ")";
+
+let response;
+
+let uri = fn.head(xdmp.eval(query));
+if (uri != null) {
+  response = {
+    "uri": uri,
+    "document": cts.doc(uri).toObject()
+  };
+}
+
+response;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/sourceData/service.json
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/sourceData/service.json
@@ -1,0 +1,4 @@
+{
+  "endpointDirectory": "/data-hub/5/data-services/sourceData/",
+  "$javaClass": "com.marklogic.hub.dataservices.SourceDataService"
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/sourceData/getSourceDataDocument.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/sourceData/getSourceDataDocument.sjs
@@ -1,0 +1,33 @@
+const test = require("/test/test-helper.xqy");
+
+function invokeService(index) {
+  return fn.head(xdmp.invoke(
+    "/data-hub/5/data-services/getSourceDataDocument/getSourceDataDocument.sjs",
+    {
+      "sourceQuery": "cts.collectionQuery('raw-content')",
+      "index": index
+    }
+  ))
+}
+
+let assertions = [];
+
+let response = invokeService(1);
+assertions.push(
+  test.assertEqual("/content/customer1.json", response.uri),
+  test.assertEqual("111", response.document.envelope.instance.customerId)
+);
+
+response = invokeService(2);
+assertions.push(
+  test.assertEqual("/content/customer2.json", response.uri),
+  test.assertEqual("222", response.document.envelope.instance.customerId)
+);
+
+response = invokeService(3);
+assertions.push(
+  test.assertEqual(null, response,
+    "In the case of no matching document or an index that is higher than the number of results, null should be returned")
+);
+
+assertions

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/sourceData/suite-setup.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/sourceData/suite-setup.xqy
@@ -1,0 +1,6 @@
+xquery version "1.0-ml";
+
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+import module namespace test = "http://marklogic.com/test" at "/test/test-helper.xqy";
+
+hub-test:load-non-entities($test:__CALLER_FILE__)

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/sourceData/suite-teardown.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/sourceData/suite-teardown.xqy
@@ -1,0 +1,6 @@
+xquery version "1.0-ml";
+
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+import module namespace test = "http://marklogic.com/test" at "/test/test-helper.xqy";
+
+hub-test:delete-artifacts($test:__CALLER_FILE__)

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/sourceData/test-data/content/customer1.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/sourceData/test-data/content/customer1.json
@@ -1,0 +1,10 @@
+{
+  "envelope": {
+    "instance": {
+      "customerId": "111",
+      "firstName": "Jane",
+      "lastName": "Smith",
+      "emailAddress": "jane.smith@example.org"
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/sourceData/test-data/content/customer2.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/sourceData/test-data/content/customer2.json
@@ -1,0 +1,10 @@
+{
+  "envelope": {
+    "instance": {
+      "customerId": "222",
+      "firstName": "John",
+      "lastName": "Smith",
+      "emailAddress": "john.smith@example.org"
+    }
+  }
+}

--- a/web/src/main/java/com/marklogic/hub/web/web/SearchController.java
+++ b/web/src/main/java/com/marklogic/hub/web/web/SearchController.java
@@ -18,6 +18,7 @@ package com.marklogic.hub.web.web;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.hub.dataservices.SourceDataService;
 import com.marklogic.hub.impl.HubConfigImpl;
 import com.marklogic.hub.web.model.SJSSearchQuery;
 import com.marklogic.hub.web.model.SearchQuery;
@@ -55,10 +56,12 @@ public class SearchController {
         return searchService.search(searchQuery).get();
     }
 
-    @RequestMapping(value = "/sjsSearch", method = RequestMethod.POST)
+    @RequestMapping(value = "/getSourceDataDocument", method = RequestMethod.POST)
     @ResponseBody
-    public JsonNode sjsSearch(@RequestBody SJSSearchQuery SJSSearchQuery) {
-        return searchService.sjsSearch(SJSSearchQuery);
+    public JsonNode getSourceDataDocument(@RequestBody SJSSearchQuery query) {
+        // TODO Change the "count" to an "index" - i.e. the number showing in the GUI
+        return SourceDataService.on(hubConfig.newStagingClient(query.database))
+            .getSourceDataDocument(query.sourceQuery, query.count);
     }
 
     @RequestMapping(value = "/doc", method = RequestMethod.GET)

--- a/web/src/main/ui/app/components/search/search.service.ts
+++ b/web/src/main/ui/app/components/search/search.service.ts
@@ -37,7 +37,7 @@ export class SearchService {
       sourceQuery: ctsQuery,
       count: count
     }
-    return this.post(`/api/search/sjsSearch`, data);
+    return this.post(`/api/search/getSourceDataDocument`, data);
   }
 
   getDoc(database: string, docUri: string) {


### PR DESCRIPTION
Note the TODO in the controller code - the GUI should really pass the number shown to the user as opposed to a count. And the GUI would need to be changed to expect a single document to be returned as well. 

This should consistently perform very quickly, as we're only asking ML to find a single URI.

This isn't intended to be merged, but rather I want to see if there's consensus to move in this direction. If so, I'll open a ticket to change the design of the GUI to get a single document each time via a data service. 