### PR TITLE
DHFPROD-3303: New endpoint for returning default mastering collections

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'com.moowork.node' version '1.1.1'
     id 'org.springframework.boot' version '2.1.3.RELEASE'
     id "io.spring.dependency-management" version "1.0.7.RELEASE"
+    id 'com.marklogic.ml-development-tools' version '4.2.0'
 }
 
 repositories {
@@ -148,6 +149,22 @@ processResources {
     // Includes installer-specific files into the jar produced by bootJar
     from ("src/installer") {
         into "."
+    }
+}
+
+ext {
+    dataServicesGroup = "Data Services"
+    dataServicesPath = "src/main/resources/ml-modules/root/data-hub/5/data-services"
+}
+
+task generateSourceDataInterface(type: com.marklogic.client.tools.gradle.EndpointProxiesGenTask, group: dataServicesGroup) {
+    serviceDeclarationFile = dataServicesPath + "/mastering/service.json"
+}
+
+task generateDataServiceInterfaces {
+    description = "Generate Java interfaces for all Data Services. Must run this from the ./marklogic-data-hub directory"
+    dependsOn {
+        tasks.findAll { task -> dataServicesGroup.equals(task.group)}
     }
 }
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/MasteringService.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/MasteringService.java
@@ -1,0 +1,60 @@
+package com.marklogic.hub.dataservices;
+
+// IMPORTANT: Do not edit. This file is generated.
+
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.marker.AbstractWriteHandle;
+
+
+import com.marklogic.client.DatabaseClient;
+
+import com.marklogic.client.impl.BaseProxy;
+
+/**
+ * Provides a set of operations on the database server
+ */
+public interface MasteringService {
+    /**
+     * Creates a MasteringService object for executing operations on the database server.
+     *
+     * The DatabaseClientFactory class can create the DatabaseClient parameter. A single
+     * client object can be used for any number of requests and in multiple threads.
+     *
+     * @param db	provides a client for communicating with the database server
+     * @return	an object for session state
+     */
+    static MasteringService on(DatabaseClient db) {
+        final class MasteringServiceImpl implements MasteringService {
+            private BaseProxy baseProxy;
+
+            private MasteringServiceImpl(DatabaseClient dbClient) {
+                baseProxy = new BaseProxy(dbClient, "/data-hub/5/data-services/mastering/");
+            }
+
+            @Override
+            public com.fasterxml.jackson.databind.JsonNode getDefaultCollections(String entityType) {
+              return BaseProxy.JsonDocumentType.toJsonNode(
+                baseProxy
+                .request("getDefaultCollections.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC)
+                .withSession()
+                .withParams(
+                    BaseProxy.atomicParam("entityType", false, BaseProxy.StringType.fromString(entityType)))
+                .withMethod("POST")
+                .responseSingle(false, Format.JSON)
+                );
+            }
+
+        }
+
+        return new MasteringServiceImpl(db);
+    }
+
+  /**
+   * Invokes the getDefaultCollections operation on the database server
+   *
+   * @param entityType	provides input
+   * @return	as output
+   */
+    com.fasterxml.jackson.databind.JsonNode getDefaultCollections(String entityType);
+
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mastering/getDefaultCollections.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mastering/getDefaultCollections.api
@@ -1,0 +1,13 @@
+{
+    "functionName": "getDefaultCollections",
+    "params": [
+        {
+            "name": "entityType",
+            "datatype": "string"
+        }
+    ],
+    "return": {
+        "datatype": "jsonDocument",
+        "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+    }
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mastering/getDefaultCollections.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mastering/getDefaultCollections.sjs
@@ -1,0 +1,30 @@
+/*
+  Copyright 2012-2019 MarkLogic Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+'use strict';
+
+var entityType;
+
+let res = {
+  "onMerge": [
+    "sm-" + entityType + "-mastered",
+    "sm-" + entityType + "-merged"
+  ],
+  "onNoMatch": ["sm-" + entityType + "-mastered"],
+  "onArchive": ["sm-" + entityType + "-archived"],
+  "onNotification": ["sm-" + entityType + "-notification"]
+};
+
+res;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mastering/service.json
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mastering/service.json
@@ -1,0 +1,4 @@
+{
+  "endpointDirectory": "/data-hub/5/data-services/mastering/",
+  "$javaClass": "com.marklogic.hub.dataservices.MasteringService"
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mastering/getDefaultCollections.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mastering/getDefaultCollections.sjs
@@ -1,0 +1,18 @@
+const test = require("/test/test-helper.xqy");
+
+function invokeService(entityType) {
+  return fn.head(xdmp.invoke(
+    "/data-hub/5/data-services/mastering/getDefaultCollections.sjs",
+    {"entityType": entityType}
+  ));
+}
+
+let response = invokeService("Order");
+
+[
+  test.assertEqual("sm-Order-mastered", response.onMerge[0]),
+  test.assertEqual("sm-Order-merged", response.onMerge[1]),
+  test.assertEqual("sm-Order-mastered", response.onNoMatch[0]),
+  test.assertEqual("sm-Order-archived", response.onArchive[0]),
+  test.assertEqual("sm-Order-notification", response.onNotification[0])
+];

--- a/web/src/main/java/com/marklogic/hub/web/web/MasteringController.java
+++ b/web/src/main/java/com/marklogic/hub/web/web/MasteringController.java
@@ -1,0 +1,25 @@
+package com.marklogic.hub.web.web;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.hub.HubConfig;
+import com.marklogic.hub.dataservices.MasteringService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/mastering")
+public class MasteringController {
+
+    @Autowired
+    private HubConfig hubConfig;
+
+    @RequestMapping(value = "/defaultCollections/{entityType}", method = RequestMethod.GET)
+    public JsonNode getDefaultCollection(@PathVariable String entityType) {
+        return MasteringService
+            .on(hubConfig.newStagingClient(null))
+            .getDefaultCollections(entityType);
+    }
+}

--- a/web/src/test/java/com/marklogic/hub/web/web/MasteringControllerTest.java
+++ b/web/src/test/java/com/marklogic/hub/web/web/MasteringControllerTest.java
@@ -1,0 +1,33 @@
+package com.marklogic.hub.web.web;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.marklogic.hub.ApplicationConfig;
+import com.marklogic.hub.web.WebApplication;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {WebApplication.class, ApplicationConfig.class, MasteringControllerTest.class})
+@WebAppConfiguration
+class MasteringControllerTest extends BaseTestController {
+
+    @Autowired
+    MasteringController controller;
+
+    @Test
+    void verifyThatCorrectDatabaseClientIsUsed() {
+        JsonNode node = controller.getDefaultCollection("Order");
+
+        ArrayNode array = (ArrayNode) node.get("onMerge");
+        assertEquals("sm-Order-mastered", array.get(0).asText(),
+            "The unit test for the endpoint verifies all the collections; this test is here to ensure that a valid " +
+                "DatabaseClient is used by the controller to connect to MarkLogic");
+    }
+}


### PR DESCRIPTION
Using Data Services for this. @ryanjdew  I figure the implementation of the endpoint will change so that the collections are defined elsewhere, but that's fine - I wanted to get this over to Mike ASAP so he's not blocked. 