### PR TITLE
DHFPROD-3159: No longer overwriting ml-config directory during upgrade

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/DataHub.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/DataHub.java
@@ -97,7 +97,7 @@ public interface DataHub {
      *
      * @param listener
      */
-    void dhsInstall(HubDeployStatusListener listener);
+    void deployToDhs(HubDeployStatusListener listener);
 
     /**
      * Updates the indexes in the database based on the project
@@ -177,16 +177,6 @@ public interface DataHub {
      * @throws CantUpgradeException - exception thrown when an upgrade can't happen
      */
     boolean upgradeHub() throws CantUpgradeException;
-
-    /**
-     * Upgrades the hub based on list of provided updated flows. All flows SHOULD be provided.
-     * The method without params will handle this automatically.
-     * Must be run as a user with sufficient privileges to install a data hub.
-     * @param updatedFlows - the list of the name of the flows you want to update
-     * @return boolean - false if upgrade fails for a reason other than an upgrade exception
-     * @throws CantUpgradeException - should the hub fail to upgrade for incompatibility reasons
-     */
-    boolean upgradeHub(List<String> updatedFlows) throws CantUpgradeException;
 
     /**
      * Creates and returns the FlowRunner object using the datahub's autowired hubconfig

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/DeployToDhsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/DeployToDhsTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = ApplicationConfig.class)
-public class DhsInstallTest extends HubTestBase {
+public class DeployToDhsTest extends HubTestBase {
 
     private AppConfig originalAppConfig;
 
@@ -48,7 +48,7 @@ public class DhsInstallTest extends HubTestBase {
 
         adminHubConfig.setAppConfig(appConfig);
 
-        new DataHubImpl().prepareAppConfigForInstallingIntoDhs(adminHubConfig);
+        new DataHubImpl().prepareAppConfigForDeployingToDhs(adminHubConfig);
 
         assertEquals(adminHubConfig.getPort(DatabaseKind.STAGING), appConfig.getAppServicesPort(),
             "DHS does not allow access to the default App-Services port - 8000 - so it's set to the staging port instead so " +
@@ -97,7 +97,7 @@ public class DhsInstallTest extends HubTestBase {
         appConfig.setSchemasDatabaseName("my-final-schemas");
         appConfig.setModulesDatabaseName("my-modules");
 
-        new DataHubImpl().setKnownValuesForDhsInstall(hubConfig);
+        new DataHubImpl().setKnownValuesForDhsDeployment(hubConfig);
 
         assertEquals(HubConfig.DEFAULT_STAGING_NAME, hubConfig.getHttpName(DatabaseKind.STAGING));
         assertEquals(HubConfig.DEFAULT_FINAL_NAME, hubConfig.getHttpName(DatabaseKind.FINAL));
@@ -145,7 +145,7 @@ public class DhsInstallTest extends HubTestBase {
             adminHubConfig.setAuthMethod(DatabaseKind.STAGING, "basic");
             adminHubConfig.setSimpleSsl(DatabaseKind.STAGING, true);
 
-            new DataHubImpl().prepareAppConfigForInstallingIntoDhs(adminHubConfig);
+            new DataHubImpl().prepareAppConfigForDeployingToDhs(adminHubConfig);
 
             assertNotNull(appConfig.getAppServicesSslContext());
             assertEquals(SecurityContextType.BASIC, appConfig.getAppServicesSecurityContextType());
@@ -157,7 +157,7 @@ public class DhsInstallTest extends HubTestBase {
 
     @Test
     public void buildCommandList() {
-        List<Command> commands = dataHub.buildCommandListForInstallingIntoDhs();
+        List<Command> commands = dataHub.buildCommandListForDeployingToDhs();
         assertTrue(commands.get(0) instanceof DeployOtherDatabasesCommand);
         assertTrue(commands.get(1) instanceof LoadUserArtifactsCommand);
         assertTrue(commands.get(2) instanceof LoadUserModulesCommand);

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/UpgradeProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/UpgradeProjectTest.java
@@ -1,8 +1,12 @@
 package com.marklogic.hub.impl;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.hub.ApplicationConfig;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.HubTestBase;
+import com.marklogic.mgmt.api.database.Database;
+import com.marklogic.mgmt.api.database.ElementIndex;
+import com.marklogic.mgmt.util.ObjectMapperFactory;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -16,10 +20,11 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests various upgrade scenarios. General approach is to copy a stubbed out project from
@@ -29,28 +34,33 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = ApplicationConfig.class)
 public class UpgradeProjectTest extends HubTestBase {
-    @Autowired
-    private FlowManagerImpl flowManager;
 
     @Autowired
-    private HubProjectImpl hubProject;
+    FlowManagerImpl flowManager;
 
     @Autowired
-    private Versions versions;
+    HubProjectImpl hubProject;
+
+    @Autowired
+    Versions versions;
 
     @AfterEach
     public void cleanup() {
         deleteProjectDir();
     }
 
-
     @Test
-    public void upgrade43xToCurrentVersion() throws Exception {
+    public void upgrade43xToCurrentVersion() throws IOException {
         final String projectPath = "build/tmp/upgrade-projects/dhf43x";
         final File projectDir = Paths.get(projectPath).toFile();
         FileUtils.deleteDirectory(projectDir);
         FileUtils.copyDirectory(Paths.get("src/test/resources/upgrade-projects/dhf43x").toFile(), projectDir);
+
         hubProject.createProject(projectPath);
+
+        // This test is a little awkward because it's not clear if dataHub.upgradeProject can just be called in the
+        // context of this test. So instead, some of the methods called by that method are called directly here.
+        dataHub.prepareProjectBeforeUpgrading(hubProject, "5.1.0");
         hubProject.init(createMap());
         hubProject.upgradeProject();
 
@@ -58,20 +68,45 @@ public class UpgradeProjectTest extends HubTestBase {
         File entitiesDir = new File(projectDir, "entities");
         verifyDirContents(mappingDir, 1);
         verifyDirContents(entitiesDir, 3);
-    }
 
-    private Map<String, String> createMap() {
-        Map<String,String> myMap = new HashMap<>();
-        myMap.put("%%mlStagingSchemasDbName%%", HubConfig.DEFAULT_STAGING_SCHEMAS_DB_NAME);
-        return myMap;
-    }
+        File finalDbFile = hubProject.getUserConfigDir().resolve("databases").resolve("final-database.json").toFile();
+        ObjectNode db = (ObjectNode) ObjectMapperFactory.getObjectMapper().readTree(finalDbFile);
+        assertFalse(db.has("range-element-index"),
+            "range-element-index should have been removed because it was set to an empty array, which can cause " +
+                "unnecessary reindexing");
+        assertEquals("Parent", db.get("range-element-attribute-index").get(0).get("parent-localname").asText(),
+            "Other existing indexes should have been retained though; only range-element-index should have been removed");
 
-    private void verifyDirContents(File dir, int expectedCount) {
-        assertEquals(expectedCount, dir.listFiles().length);
+        File internalConfigBackupDir = hubProject.getProjectDir().resolve("src").resolve("main").resolve("hub-internal-config-pre-5.1.0").toFile();
+        assertTrue(internalConfigBackupDir.exists(), "The prepareProjectBeforeUpgrading method should backup the " +
+            "hub-internal-config directory in the rare event that a user has made changes to this directory and doesn't want to " +
+            "lose them (though a user really shouldn't be doing that)");
+
+        File mlConfigBackupDir = hubProject.getProjectDir().resolve("src").resolve("main").resolve("ml-config-pre-5.1.0").toFile();
+        assertFalse(mlConfigBackupDir.exists(), "As of DHFPROD-3159, ml-config should no longer be backed up. DHF rarely needs to " +
+            "change the files in this directory, and when it does need to, it'll make changes directly to the files so as to not " +
+            "lose changes made by users.");
     }
 
     @Test
-    public void testUpgradeTo510MappingStep() throws IOException {
+    public void hasEmptyRangeElementIndexArray() {
+        HubProjectImpl project = new HubProjectImpl();
+
+        Database db = new Database(null, "data-hub-FINAL");
+        assertFalse(project.hasEmptyRangeElementIndexArray(db.toObjectNode()),
+            "False should be returned since the range-element-index field isn't set");
+
+        db.setRangeElementIndex(new ArrayList<>());
+        assertTrue(project.hasEmptyRangeElementIndexArray(db.toObjectNode()));
+
+        ElementIndex index = new ElementIndex();
+        index.setLocalname("example");
+        db.getRangeElementIndex().add(index);
+        assertFalse(new HubProjectImpl().hasEmptyRangeElementIndexArray(db.toObjectNode()));
+    }
+
+    @Test
+    public void testUpgradeTo510MappingStep() {
         createProjectDir();
         adminHubConfig.createProject(PROJECT_PATH);
         Assumptions.assumingThat(versions.isVersionCompatibleWithES(), () -> {
@@ -81,5 +116,15 @@ public class UpgradeProjectTest extends HubTestBase {
             Assertions.assertEquals("entity-services-mapping", flowManager.getFlow("testFlow").getStep("6").getStepDefinitionName());
             Assertions.assertEquals("entity-services-mapping", flowManager.getFlow("CustomerXML").getStep("2").getStepDefinitionName());
         });
+    }
+
+    private Map<String, String> createMap() {
+        Map<String, String> myMap = new HashMap<>();
+        myMap.put("%%mlStagingSchemasDbName%%", HubConfig.DEFAULT_STAGING_SCHEMAS_DB_NAME);
+        return myMap;
+    }
+
+    private void verifyDirContents(File dir, int expectedCount) {
+        assertEquals(expectedCount, dir.listFiles().length);
     }
 }

--- a/marklogic-data-hub/src/test/resources/upgrade-projects/dhf43x/src/main/hub-internal-config/databases/staging-database.json
+++ b/marklogic-data-hub/src/test/resources/upgrade-projects/dhf43x/src/main/hub-internal-config/databases/staging-database.json
@@ -1,0 +1,8 @@
+{
+  "database-name": "%%mlStagingDbName%%",
+  "schema-database": "%%mlStagingSchemasDbName%%",
+  "triggers-database": "%%mlStagingTriggersDbName%%",
+  "triple-index": true,
+  "collection-lexicon": true,
+  "uri-lexicon": true
+}

--- a/marklogic-data-hub/src/test/resources/upgrade-projects/dhf43x/src/main/ml-config/databases/final-database.json
+++ b/marklogic-data-hub/src/test/resources/upgrade-projects/dhf43x/src/main/ml-config/databases/final-database.json
@@ -1,0 +1,21 @@
+{
+  "database-name": "%%mlFinalDbName%%",
+  "range-element-index": [],
+  "schema-database": "%%mlFinalSchemasDbName%%",
+  "triggers-database": "%%mlFinalTriggersDbName%%",
+  "triple-index": true,
+  "collection-lexicon": true,
+  "uri-lexicon": true,
+  "range-element-attribute-index": [
+    {
+      "collation": "http://marklogic.com/collation/codepoint",
+      "invalid-values": "reject",
+      "parent-localname": "Parent",
+      "parent-namespace-uri": "",
+      "localname": "someAttribute",
+      "namespace-uri": "",
+      "range-value-positions": false,
+      "scalar-type": "string"
+    }
+  ]
+}

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/dhs/DhsDeployTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/dhs/DhsDeployTask.groovy
@@ -7,6 +7,6 @@ class DhsDeployTask extends HubTask {
 
     @TaskAction
     void deployToDhs() {
-        getDataHub().dhsInstall(null)
+        getDataHub().deployToDhs(null)
     }
 }


### PR DESCRIPTION
Instead, upgradeHub only backs up the hub-internal-config directory. It then checks to see if range-element-index has an empty array in final-database.json, and if so, it's removed without overwriting the file. 

Also removed the support for replacing the DHF version in build.gradle via regex, as our instructions for an upgrade tell the user to do this themselves first. 

Also did a little renaming while I was in DataHubImpl so that "install into DHS" is now "deploy to DHS".