### PR TITLE
DHFPROD-3288: Limiting facets to 25 to improve Explorer performance 

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules-final/options/exp-default.xml
+++ b/marklogic-data-hub/src/main/resources/ml-modules-final/options/exp-default.xml
@@ -3,18 +3,13 @@
     <collection/>
   </constraint>
   <constraint name="createdByJob">
-    <value>
+    <range facet="false">
       <field name="datahubCreatedByJob"/>
-    </value>
+    </range>
   </constraint>
   <constraint name="createdByStep">
-    <value>
-      <field name="datahubCreatedByStep"/>
-    </value>
-  </constraint>
-  <constraint name="createdByJobRange">
     <range>
-      <field name="datahubCreatedByJob"/>
+      <field name="datahubCreatedByStep"/>
       <facet-option>limit=25</facet-option>
     </range>
   </constraint>
@@ -22,12 +17,6 @@
     <word>
       <field name="datahubCreatedByJob"/>
     </word>
-  </constraint>
-  <constraint name="createdByStepRange">
-    <range>
-      <field name="datahubCreatedByStep"/>
-      <facet-option>limit=25</facet-option>
-    </range>
   </constraint>
   <constraint name="createdOnRange">
     <range facet="false">

--- a/marklogic-data-hub/src/main/resources/ml-modules-final/options/exp-default.xml
+++ b/marklogic-data-hub/src/main/resources/ml-modules-final/options/exp-default.xml
@@ -1,0 +1,43 @@
+<options xmlns="http://marklogic.com/appservices/search">
+  <constraint name="Collection">
+    <collection/>
+  </constraint>
+  <constraint name="createdByJob">
+    <value>
+      <field name="datahubCreatedByJob"/>
+    </value>
+  </constraint>
+  <constraint name="createdByStep">
+    <value>
+      <field name="datahubCreatedByStep"/>
+    </value>
+  </constraint>
+  <constraint name="createdByJobRange">
+    <range>
+      <field name="datahubCreatedByJob"/>
+      <facet-option>limit=25</facet-option>
+    </range>
+  </constraint>
+  <constraint name="createdByJobWord">
+    <word>
+      <field name="datahubCreatedByJob"/>
+    </word>
+  </constraint>
+  <constraint name="createdByStepRange">
+    <range>
+      <field name="datahubCreatedByStep"/>
+      <facet-option>limit=25</facet-option>
+    </range>
+  </constraint>
+  <constraint name="createdOnRange">
+    <range facet="false">
+      <field name="datahubCreatedOn"/>
+    </range>
+  </constraint>
+  <constraint name="createdInFlowRange">
+    <range>
+      <field name="datahubCreatedInFlow"/>
+      <facet-option>limit=25</facet-option>
+    </range>
+  </constraint>
+</options>

--- a/marklogic-data-hub/src/main/resources/ml-modules-staging/options/exp-default.xml
+++ b/marklogic-data-hub/src/main/resources/ml-modules-staging/options/exp-default.xml
@@ -3,18 +3,13 @@
     <collection/>
   </constraint>
   <constraint name="createdByJob">
-    <value>
+    <range facet="false">
       <field name="datahubCreatedByJob"/>
-    </value>
+    </range>
   </constraint>
   <constraint name="createdByStep">
-    <value>
-      <field name="datahubCreatedByStep"/>
-    </value>
-  </constraint>
-  <constraint name="createdByJobRange">
     <range>
-      <field name="datahubCreatedByJob"/>
+      <field name="datahubCreatedByStep"/>
       <facet-option>limit=25</facet-option>
     </range>
   </constraint>
@@ -22,12 +17,6 @@
     <word>
       <field name="datahubCreatedByJob"/>
     </word>
-  </constraint>
-  <constraint name="createdByStepRange">
-    <range>
-      <field name="datahubCreatedByStep"/>
-      <facet-option>limit=25</facet-option>
-    </range>
   </constraint>
   <constraint name="createdOnRange">
     <range facet="false">

--- a/marklogic-data-hub/src/main/resources/ml-modules-staging/options/exp-default.xml
+++ b/marklogic-data-hub/src/main/resources/ml-modules-staging/options/exp-default.xml
@@ -1,0 +1,43 @@
+<options xmlns="http://marklogic.com/appservices/search">
+  <constraint name="Collection">
+    <collection/>
+  </constraint>
+  <constraint name="createdByJob">
+    <value>
+      <field name="datahubCreatedByJob"/>
+    </value>
+  </constraint>
+  <constraint name="createdByStep">
+    <value>
+      <field name="datahubCreatedByStep"/>
+    </value>
+  </constraint>
+  <constraint name="createdByJobRange">
+    <range>
+      <field name="datahubCreatedByJob"/>
+      <facet-option>limit=25</facet-option>
+    </range>
+  </constraint>
+  <constraint name="createdByJobWord">
+    <word>
+      <field name="datahubCreatedByJob"/>
+    </word>
+  </constraint>
+  <constraint name="createdByStepRange">
+    <range>
+      <field name="datahubCreatedByStep"/>
+      <facet-option>limit=25</facet-option>
+    </range>
+  </constraint>
+  <constraint name="createdOnRange">
+    <range facet="false">
+      <field name="datahubCreatedOn"/>
+    </range>
+  </constraint>
+  <constraint name="createdInFlowRange">
+    <range>
+      <field name="datahubCreatedInFlow"/>
+      <facet-option>limit=25</facet-option>
+    </range>
+  </constraint>
+</options>

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-entities.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-entities.xqy
@@ -170,6 +170,7 @@ declare %private function hent:fix-options-exp($nodes as node()*)
           <search:constraint name="createdByJobRange">
             <search:range>
               <search:field name="datahubCreatedByJob"/>
+              <search:facet-option>limit=25</search:facet-option>
             </search:range>
           </search:constraint>,
           <search:constraint name="createdByJobWord">
@@ -180,16 +181,18 @@ declare %private function hent:fix-options-exp($nodes as node()*)
           <search:constraint name="createdByStepRange">
             <search:range>
               <search:field name="datahubCreatedByStep"/>
+              <search:facet-option>limit=25</search:facet-option>
             </search:range>
           </search:constraint>,
           <search:constraint name="createdOnRange">
-            <search:range>
+            <search:range facet="false">
               <search:field name="datahubCreatedOn"/>
             </search:range>
           </search:constraint>,
           <search:constraint name="createdInFlowRange">
             <search:range>
               <search:field name="datahubCreatedInFlow"/>
+              <search:facet-option>limit=25</search:facet-option>
             </search:range>
           </search:constraint>,
           hent:fix-options-exp($n/node())

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-entities.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-entities.xqy
@@ -158,18 +158,13 @@ declare %private function hent:fix-options-exp($nodes as node()*)
             <search:collection/>
           </search:constraint>,
           <search:constraint name="createdByJob">
-            <search:value>
+            <search:range facet="false">
               <search:field name="datahubCreatedByJob"/>
-            </search:value>
+            </search:range>
           </search:constraint>,
           <search:constraint name="createdByStep">
-            <search:value>
-              <search:field name="datahubCreatedByStep"/>
-            </search:value>
-          </search:constraint>,
-          <search:constraint name="createdByJobRange">
             <search:range>
-              <search:field name="datahubCreatedByJob"/>
+              <search:field name="datahubCreatedByStep"/>
               <search:facet-option>limit=25</search:facet-option>
             </search:range>
           </search:constraint>,
@@ -177,12 +172,6 @@ declare %private function hent:fix-options-exp($nodes as node()*)
             <search:word>
               <search:field name="datahubCreatedByJob"/>
             </search:word>
-          </search:constraint>,
-          <search:constraint name="createdByStepRange">
-            <search:range>
-              <search:field name="datahubCreatedByStep"/>
-              <search:facet-option>limit=25</search:facet-option>
-            </search:range>
           </search:constraint>,
           <search:constraint name="createdOnRange">
             <search:range facet="false">

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/generateSearchOptions.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/generateSearchOptions.sjs
@@ -28,11 +28,20 @@ const expParams = true;
 const expOtions = hent.dumpSearchOptions(input, expParams);
 assertions.concat([
   test.assertEqual("limit=25", xs.string(fn.head(expOtions.xpath("/*:constraint[@name = 'title']/*:range/*:facet-option/text()"))),
-    "To avoid displaying large numbers of values in facets in QuickStart, range constraints default to a max of 25 values"
+    "To avoid displaying large numbers of values in facets in Explorer, range constraints default to a max of 25 values"
+  ),
+  test.assertEqual("limit=25", xs.string(fn.head(expOtions.xpath("/*:constraint[@name = 'createdByJobRange']/*:range/*:facet-option/text()"))),
+    "To avoid displaying large numbers of values in facets in Explorer, range constraints default to a max of 25 values"
+  ),
+  test.assertEqual("limit=25", xs.string(fn.head(expOtions.xpath("/*:constraint[@name = 'createdByStepRange']/*:range/*:facet-option/text()"))),
+    "To avoid displaying large numbers of values in facets in Explorer, range constraints default to a max of 25 values"
+  ),
+  test.assertEqual("limit=25", xs.string(fn.head(expOtions.xpath("/*:constraint[@name = 'createdInFlowRange']/*:range/*:facet-option/text()"))),
+    "To avoid displaying large numbers of values in facets in Explorer, range constraints default to a max of 25 values"
   ),
   test.assertExists(expOtions.xpath("/*:constraint[@name = 'createdByJobRange']")),
   test.assertExists(expOtions.xpath("/*:constraint[@name = 'createdByJobWord']")),
-  test.assertExists(expOtions.xpath("/*:constraint[@name = 'createdOnRange']")),
+  test.assertExists(expOtions.xpath("/*:constraint[@name = 'createdOnRange', @facet = 'false']")),
   test.assertExists(expOtions.xpath("/*:values[@name = 'Book']/*:range/*:element[@name = 'title']")),
   test.assertNotExists(expOtions.xpath("/*:values[@name = 'Book']/*:range/*:facet-option"),
     "A facet option does not need to be set on the values element"),

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/generateSearchOptions.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/generateSearchOptions.sjs
@@ -30,16 +30,13 @@ assertions.concat([
   test.assertEqual("limit=25", xs.string(fn.head(expOtions.xpath("/*:constraint[@name = 'title']/*:range/*:facet-option/text()"))),
     "To avoid displaying large numbers of values in facets in Explorer, range constraints default to a max of 25 values"
   ),
-  test.assertEqual("limit=25", xs.string(fn.head(expOtions.xpath("/*:constraint[@name = 'createdByJobRange']/*:range/*:facet-option/text()"))),
-    "To avoid displaying large numbers of values in facets in Explorer, range constraints default to a max of 25 values"
-  ),
-  test.assertEqual("limit=25", xs.string(fn.head(expOtions.xpath("/*:constraint[@name = 'createdByStepRange']/*:range/*:facet-option/text()"))),
+  test.assertEqual("limit=25", xs.string(fn.head(expOtions.xpath("/*:constraint[@name = 'createdByStep']/*:range/*:facet-option/text()"))),
     "To avoid displaying large numbers of values in facets in Explorer, range constraints default to a max of 25 values"
   ),
   test.assertEqual("limit=25", xs.string(fn.head(expOtions.xpath("/*:constraint[@name = 'createdInFlowRange']/*:range/*:facet-option/text()"))),
     "To avoid displaying large numbers of values in facets in Explorer, range constraints default to a max of 25 values"
   ),
-  test.assertExists(expOtions.xpath("/*:constraint[@name = 'createdByJobRange']")),
+  test.assertExists(expOtions.xpath("/*:constraint[@name = 'createdByJob', @facet = 'false']")),
   test.assertExists(expOtions.xpath("/*:constraint[@name = 'createdByJobWord']")),
   test.assertExists(expOtions.xpath("/*:constraint[@name = 'createdOnRange', @facet = 'false']")),
   test.assertExists(expOtions.xpath("/*:values[@name = 'Book']/*:range/*:element[@name = 'title']")),


### PR DESCRIPTION
This PR has 2 commits addressing the following issues
* Limiting facets to 25 to improve Explorer performance in case of a large number of facets
* Adding default query options file for the explorer