### PR TITLE
DHFPROD-3153: Reworking latest job query to avoid server bug

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/jobInfo/jobInfo.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/jobInfo/jobInfo.sjs
@@ -23,11 +23,16 @@ let res = {
   "latestJobDateTime": null
 };
 
-let query = [cts.collectionQuery(entityCollection), cts.fieldRangeQuery("datahubCreatedOn", "<=", fn.currentDateTime(), "score-function=reciprocal")];
-let seq = fn.subsequence(cts.search(cts.andQuery(query)), 1, 1);
+let latestJob = fn.subsequence(
+  cts.search(
+    cts.collectionQuery(entityCollection),
+    [cts.indexOrder(cts.fieldReference("datahubCreatedOn"), "descending")]
+  ),
+  1, 1
+);
 
-if (fn.count(seq) > 0) {
-  let docUri = xdmp.nodeUri(seq);
+if (fn.count(latestJob) > 0) {
+  let docUri = xdmp.nodeUri(latestJob);
 
   res.latestJobDateTime = xdmp.documentGetMetadataValue(docUri, "datahubCreatedOn");
 


### PR DESCRIPTION
Bug 53210 was impacting the use of score-reciprocal and was causing jobInfoTest.sjs to break on certain versions of ML. 