### PR TITLE
DHFPROD-3275: Remove pagination from Merge Collections table

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/merge-collections-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/merge-collections-ui.component.html
@@ -53,8 +53,7 @@
         <ng-container matColumnDef="actions">
           <mat-header-cell *matHeaderCellDef>Actions</mat-header-cell>
           <mat-cell class="merge-collection-menu" *matCellDef="let mColl; let i = index">
-            <mat-icon class="merge-menu-icon" [matMenuTriggerFor]="mergeCollectionsMenu" [matMenuTriggerData]="{mColl: mColl, i: paginator.pageIndex * paginator.pageSize + i}"
-                      disableRipple>more_vert</mat-icon>
+            <mat-icon class="merge-menu-icon" [matMenuTriggerFor]="mergeCollectionsMenu" [matMenuTriggerData]="{mColl: mColl}" disableRipple>more_vert</mat-icon>
           </mat-cell>
         </ng-container>
 
@@ -64,14 +63,6 @@
         </mat-row>
 
       </mat-table>
-
-      <mat-paginator id="merge-collection-pagination"
-                     #paginator
-                     [length]="mergeCollections.length"
-                     [pageIndex]="0"
-                     [pageSize]="10"
-                     [pageSizeOptions]="[5, 10, 25, 50]">
-      </mat-paginator>
 
     </div>
   </div>

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/merge-collections-ui.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mastering/merging/ui/merge-collections-ui.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Output, EventEmitter, OnInit, AfterViewInit, OnChanges, SimpleChanges, ViewChild, HostListener } from '@angular/core';
-import { MatDialog, MatPaginator, MatSort, MatTable, MatTableDataSource} from "@angular/material";
+import { MatDialog, MatSort, MatTable, MatTableDataSource} from "@angular/material";
 import { MergeCollection, Event } from "../merge-collections.model";
 import { AddMergeCollectionDialogComponent } from './add-merge-collection-dialog.component';
 import { ConfirmationDialogComponent } from "../../../../../common";
@@ -11,7 +11,6 @@ import { ConfirmationDialogComponent } from "../../../../../common";
 })
 export class MergeCollectionsUiComponent {
   @ViewChild(MatTable) table: MatTable<any>;
-  @ViewChild(MatPaginator) paginator: MatPaginator;
   @ViewChild(MatSort) sort: MatSort;
 
   @Input() mergeCollections: any;
@@ -35,7 +34,6 @@ export class MergeCollectionsUiComponent {
   }
 
   ngAfterViewInit() {
-    this.dataSource.paginator = this.paginator;
     this.dataSource.sort = this.sort;
   }
 


### PR DESCRIPTION
The updated Merge Collections table has four rows which are always present, pagination not needed.

@sbayatpur has approved this update.