### PR TITLE
DHFPROD-3229:Handle spaces in input field

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/entity-table-ui.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/entity-table-ui.component.ts
@@ -150,6 +150,9 @@ export class EntityTableUiComponent implements OnChanges {
   }
 
   insertField(fieldName, index, prop) {
+    if(String(fieldName).includes(" ")){
+      fieldName = "*[local-name(.)='" + fieldName + "']";
+    }
     this.insertContent(fieldName, index, prop)
   }
 


### PR DESCRIPTION
This PR handles spaces in input fields in case of json documents. For example, in the UI, input field "Sales Channel" will be converted to "*[local-name(.)='Sales Channel']" upon selection. 
@ryanjdew , let me know if this is an ok solution