### PR TITLE
DHFPROD-3106: Formatting some entity validation messages

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/entity-validation-lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/entity-validation-lib.sjs
@@ -1,0 +1,227 @@
+/**
+ * Main function in this library for validating an entity. If any validation errors are found and the "validateEntity"
+ * is set to "accept", then errors will be added to the options object under the "headers.datahub.validationErrors" key.
+ * This allows for them to be added to the envelope for an entity.
+ *
+ * If "validateEntity" is set to "reject", then an error will be thrown by this function.
+ *
+ * @param newInstance
+ * @param options
+ * @param entityInfo
+ */
+function validateEntity(newInstance, options = {}, entityInfo) {
+  if (shouldValidateEntity(options)) {
+    let value = fn.string(options.validateEntity).toLowerCase();
+    if ("xml" == options.outputFormat) {
+      validateXmlEntity(newInstance, options, value);
+    } else {
+      validateJsonEntity(newInstance, options, value, entityInfo);
+    }
+  }
+}
+
+function shouldValidateEntity(options = {}) {
+  let value = options.validateEntity;
+  if (value != null && value != undefined) {
+    value = fn.string(value).toLowerCase();
+    return value == "accept" || value == "reject";
+  }
+  return false;
+}
+
+function validateJsonEntity(newInstance, options = {}, validateEntityValue, entityInfo) {
+  // As of 5.1.0, this is safe to do. But eventually, we'll want to find a schema by querying the schema database, or,
+  // better yet, via some API function call that does the work for us.
+  const entitySchemaUri = "/entities/" + entityInfo.title + ".entity.schema.json";
+  try {
+    xdmp.jsonValidate(newInstance, entitySchemaUri, ["full"]);
+  } catch (e) {
+    if ("accept" == validateEntityValue) {
+      if (options.headers == null) {
+        options.headers = {};
+      }
+      if (options.headers.datahub == null) {
+        options.headers.datahub = {};
+      }
+
+      // Tossing information about the errors in the headers so that they're added to the envelope.
+      // Note that regardless of the number of errors, xdmp.jsonValidate will return all of them in a "data" array, with
+      // each array item being a string.
+      options.headers.datahub.validationErrors = {
+        "name": e.name,
+        "data": e.data,
+        "message": e.message,
+        "formattedMessages": []
+      }
+
+      for (let errorMessage of e.data) {
+        let formattedErrorMessage = formatErrorMessageForJson(errorMessage.toString());
+        if (formattedErrorMessage == null) {
+          formattedErrorMessage = {
+            message : errorMessage.trim()
+          };
+        }
+        options.headers.datahub.validationErrors.formattedMessages.push(formattedErrorMessage);
+      }
+    } else if ("reject" == validateEntityValue) {
+      throw Error(e);
+    }
+  }
+}
+
+/**
+ * Attempts to format the given error message into a JSON object with a propertyName and a message that is friendlier to
+ * a human. Only supports "Missing property: Required" messages so far.
+ */
+function formatErrorMessageForJson(errorMessage) {
+  const missingMessage = "Missing property: Required";
+  let pos = errorMessage.indexOf(missingMessage);
+  let formattedErrorMessage = null;
+  if (pos > -1) {
+    errorMessage = errorMessage.substring(pos + missingMessage.length).trim();
+    pos = errorMessage.indexOf("not found");
+    if (pos > -1) {
+      errorMessage = errorMessage.substring(0, pos + "not found".length);
+      let propertyName = errorMessage.split(" ")[0];
+      formattedErrorMessage = {
+        propertyName: propertyName,
+        message: "Required " + errorMessage
+      };
+    }
+  }
+  return formattedErrorMessage;
+}
+
+function validateXmlEntity(newInstance, options = {}, validateEntityValue) {
+  const result = fn.head(xdmp.xqueryEval(
+    'declare variable $newInstance external; xdmp:validate($newInstance, "strict")',
+    {newInstance: newInstance}
+  ));
+
+  if (result != null) {
+    let errorCount = result.xpath("count(/*:error)");
+    if (errorCount > 0) {
+      if ("accept" == validateEntityValue) {
+        if (options.headers == null) {
+          options.headers = {};
+        }
+        if (options.headers.datahub == null) {
+          options.headers.datahub = {};
+        }
+        options.headers.datahub.validationErrors = [];
+
+        for (error of result.xpath("/*:error")) {
+          let validationError = {
+            error : {
+              code: fn.string(error.xpath("./*:code/text()")),
+              name: fn.string(error.xpath("./*:name/text()")),
+              message: fn.string(error.xpath("./*:message/text()")),
+              formatString: fn.string(error.xpath("./*:format-string/text()"))
+            }
+          };
+          addFormattedMessagesForXml(validationError);
+          options.headers.datahub.validationErrors.push(validationError);
+        }
+      } else if ("reject" == validateEntityValue) {
+        throw Error(result);
+      }
+    }
+  }
+}
+
+function addFormattedMessagesForXml(validationError) {
+  if (validationError.error.code == "XDMP-VALIDATEMISSINGELT") {
+    buildFormattedMessagesForMissingElementsError(validationError);
+  }
+  else if (validationError.error.code == "XDMP-VALIDATEUNEXPECTED") {
+    buildFormattedMessagesForUnexpectedNodeError(validationError);
+  }
+}
+
+/**
+ * Example of what the formatString is expected to contain: "Missing required elements Expected (LastName,Email?)"
+ *
+ * @param validationError
+ */
+function buildFormattedMessagesForMissingElementsError(validationError = {}) {
+  if (validationError.error != null) {
+    let formatString = validationError.error.formatString;
+    let indicator = "Expected (";
+    let pos = formatString.indexOf(indicator);
+    if (pos > -1) {
+      let str = formatString.substring(pos + indicator.length);
+      pos = str.indexOf(")");
+      if (pos > -1) {
+        str = str.substring(0, pos);
+        let names = str.split(",");
+        let notRequiredPos = names.findIndex(val => val.endsWith("?"));
+        if (notRequiredPos > -1) {
+          validationError.error.formattedMessages = buildFormattedMessagesForMissingXmlPropertyNames(names.slice(0, notRequiredPos))
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Example of what the formatString is expected to contain: "Invalid node: Found LastName but expected (FirstName,LastName,Email?)"
+ *
+ * @param validationError
+ */
+function buildFormattedMessagesForUnexpectedNodeError(validationError = {}) {
+  if (validationError.error != null) {
+    let formatString = validationError.error.formatString;
+    let indicator = "Invalid node: Found ";
+    let pos = formatString.indexOf(indicator);
+    if (pos > -1) {
+      let str = formatString.substring(pos + indicator.length);
+      let tokens = str.split(" ");
+      let foundPropertyName = tokens[0];
+      let propertyNames = tokens[3].substring(1, tokens[3].length - 1).split(",");
+      let notRequiredPos = propertyNames.findIndex(val => val == foundPropertyName);
+      if (notRequiredPos > -1) {
+        validationError.error.formattedMessages = buildFormattedMessagesForMissingXmlPropertyNames(propertyNames.slice(0, notRequiredPos))
+      }
+    }
+  }
+}
+
+/**
+ * Convenience function for building an object per missing property name.
+ *
+ * @param missingPropertyNames
+ */
+function buildFormattedMessagesForMissingXmlPropertyNames(missingPropertyNames) {
+  return {
+    formattedMessage:
+      missingPropertyNames.map(name => {
+        return {
+          propertyName: name,
+          message: "Required " + name + " property not found"
+        };
+      })
+  };
+}
+
+/**
+ * In order for the validation errors to be added to the envelope of an entity, they must be in the options object. But
+ * that options object will be shared across the processing of multiple entities. So after the entity envelope has been
+ * constructed, the validationErrors need to be removed.
+ *
+ * @param options
+ */
+function removeValidationErrorsFromHeaders(options = {}) {
+  if (options.headers != null && options.headers.datahub != null && options.headers.datahub.validationErrors != null) {
+    delete options.headers.datahub.validationErrors;
+    let datahub = options.headers.datahub;
+    if (Object.keys(datahub).length == 0) {
+      delete options.headers.datahub;
+    }
+  }
+}
+
+module.exports = {
+  removeValidationErrorsFromHeaders,
+  shouldValidateEntity,
+  validateEntity
+};

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/main.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/main.sjs
@@ -3,6 +3,7 @@ const datahub = DataHubSingleton.instance();
 const defaultLib = require('/data-hub/5/builtins/steps/mapping/default/lib.sjs');
 const lib = require('/data-hub/5/builtins/steps/mapping/entity-services/lib.sjs');
 const es = require('/MarkLogic/entity-services/entity-services');
+const entityValidationLib = require('entity-validation-lib.sjs');
 
 // caching mappings in key to object since tests can have multiple mappings run in same transaction
 var mappings = {};
@@ -71,95 +72,15 @@ function main(content, options) {
   }
 
   // Must validate before building an envelope so that validaton errors can be added to the headers
-  validateEntity(newInstance, options, entity.info);
+  entityValidationLib.validateEntity(newInstance, options, entity.info);
 
   content.value = buildEnvelope(entity.info, doc, newInstance, outputFormat, options);
 
-  if (options.headers != null && options.headers != undefined) {
-    // Must delete this so it doesn't impact other items in the batch
-    delete options.headers.validationErrors;
-  }
+  // Must remove these so that they're not carried over to another item in a batch
+  entityValidationLib.removeValidationErrorsFromHeaders(options);
 
   content.provenance = { [content.uri]: provenance };
   return content;
-}
-
-function validateEntity(newInstance, options, entityInfo) {
-  let validateEntity = options.validateEntity;
-  if (shouldValidateEntity(options)) {
-    let value = fn.string(options.validateEntity).toLowerCase();
-    if ("xml" == options.outputFormat) {
-      validateXmlEntity(newInstance, options, value);
-    } else {
-      validateJsonEntity(newInstance, options, value, entityInfo);
-    }
-  }
-}
-
-function shouldValidateEntity(options) {
-  let value = options.validateEntity;
-  if (value != null && value != undefined) {
-    value = fn.string(value).toLowerCase();
-    return value == "accept" || value == "reject";
-  }
-  return false;
-}
-
-function validateJsonEntity(newInstance, options, validateEntityValue, entityInfo) {
-  // As of 5.1.0, this is safe to do. But eventually, we'll want to find a schema by querying the schema database, or,
-  // better yet, via some API function call that does the work for us.
-  const entitySchemaUri = "/entities/" + entityInfo.title + ".entity.schema.json";
-  try {
-    xdmp.jsonValidate(newInstance, entitySchemaUri, ["full"]);
-  } catch (e) {
-    if ("accept" == validateEntityValue) {
-      if (options.headers == null) {
-        options.headers = {};
-      }
-
-      // Tossing information about the errors in the headers so that they're added to the envelope.
-      // Note that regardless of the number of errors, xdmp.jsonValidate will return all of them in a "data" array, with
-      // each array item being a string.
-      options.headers.validationErrors = {
-        "name": e.name,
-        "data": e.data,
-        "message": e.message
-      }
-    } else if ("reject" == validateEntityValue) {
-      throw Error(e);
-    }
-  }
-}
-
-function validateXmlEntity(newInstance, options, validateEntityValue) {
-  const result = fn.head(xdmp.xqueryEval(
-    'declare variable $newInstance external; xdmp:validate($newInstance, "strict")',
-    {newInstance: newInstance}
-  ));
-
-  if (result != null) {
-    let errorCount = result.xpath("count(/*:error)");
-    if (errorCount > 0) {
-      if ("accept" == validateEntityValue) {
-        if (options.headers == null) {
-          options.headers = {};
-        }
-        options.headers.validationErrors = [];
-        for (error of result.xpath("/*:error")) {
-          options.headers.validationErrors.push({
-            error : {
-              code: error.xpath("./*:code/text()"),
-              name: error.xpath("./*:name/text()"),
-              message: error.xpath("./*:message/text()"),
-              formatString: error.xpath("./*:format-string/text()")
-            }
-          });
-        }
-      } else if ("reject" == validateEntityValue) {
-        throw Error(result);
-      }
-    }
-  }
 }
 
 // Extracted for unit testing purposes
@@ -276,6 +197,5 @@ function buildEnvelope(entityInfo, doc, instance, outputFormat, options) {
 
 module.exports = {
   main: main,
-  buildEnvelope: buildEnvelope,
-  shouldValidateEntity: shouldValidateEntity
+  buildEnvelope: buildEnvelope
 };

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/validate-entity/shouldValidateEntity.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/validate-entity/shouldValidateEntity.sjs
@@ -1,8 +1,8 @@
 const test = require("/test/test-helper.xqy");
-const mapping = require("/data-hub/5/builtins/steps/mapping/entity-services/main.sjs");
+const entityValidationLib = require("/data-hub/5/builtins/steps/mapping/entity-services/entity-validation-lib.sjs");
 
 function shouldValidate(validateEntityValue) {
-  return mapping.shouldValidateEntity({
+  return entityValidationLib.shouldValidateEntity({
     validateEntity: validateEntityValue
   });
 }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/validate-entity/test-data/content/customer-missing-first-name.xml
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/validate-entity/test-data/content/customer-missing-first-name.xml
@@ -1,0 +1,8 @@
+<envelope xmlns="http://marklogic.com/entity-services">
+  <instance>
+    <Customer xmlns="">
+      <customerId>888</customerId>
+      <lastName>Last</lastName>
+    </Customer>
+  </instance>
+</envelope>

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/validate-entity/test-data/content/customer-missing-last-name.xml
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/validate-entity/test-data/content/customer-missing-last-name.xml
@@ -1,0 +1,8 @@
+<envelope xmlns="http://marklogic.com/entity-services">
+  <instance>
+    <Customer xmlns="">
+      <customerId>999</customerId>
+      <firstName>first</firstName>
+    </Customer>
+  </instance>
+</envelope>

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/validate-entity/validateJsonAccept.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/validate-entity/validateJsonAccept.sjs
@@ -4,9 +4,26 @@ const test = require("/test/test-helper.xqy");
 
 if (lib.canTestJsonSchemaValidation() && esMappingLib.versionIsCompatibleWithES()) {
   const envelope = lib.mapInstance("/content/invalid-customer.json", "accept", "json").value.root.envelope;
+  let errors = envelope.headers.datahub.validationErrors;
+  
   [
-    test.assertEqual("XDMP-VALIDATEERRORS", fn.string(envelope.headers.validationErrors.name)),
-    test.assertTrue(fn.string(envelope.headers.validationErrors.data[0]).indexOf("Required FirstName property not found") > -1),
-    test.assertTrue(fn.string(envelope.headers.validationErrors.data[1]).indexOf("Required LastName property not found") > -1)
+    test.assertEqual("XDMP-VALIDATEERRORS", fn.string(errors.name)),
+    test.assertTrue(fn.string(errors.data[0]).indexOf("Required FirstName property not found") > -1),
+    test.assertTrue(fn.string(errors.data[1]).indexOf("Required LastName property not found") > -1),
+
+    /*
+    The other two error messages returned by xdmp.jsonValidate are of the form
+    "XDMP-JSVALIDATEINVNODE: Invalid node: Node Customer". They don't really add any value over the
+    XDMP-JSVALIDATEMISSING messages, but we can't reliably discard them either yet.
+     */
+    test.assertEqual(4, errors.formattedMessages.length,
+      "For 5.1.0, assuming that all error messages should be tossed into the formattedMessages array, even when they " +
+      "can't be formatted. That allows for a UI to choose which ones to display - i.e. the ones with a propertyName " +
+      "property are known to have messages that recognized and thus formatted and associated with a property."),
+
+    test.assertEqual("FirstName", fn.string(errors.formattedMessages[0].propertyName)),
+    test.assertEqual("Required FirstName property not found", fn.string(errors.formattedMessages[0].message)),
+    test.assertEqual("LastName", fn.string(errors.formattedMessages[1].propertyName)),
+    test.assertEqual("Required LastName property not found", fn.string(errors.formattedMessages[1].message))
   ];
 }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/validate-entity/validateXmlAccept.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/validate-entity/validateXmlAccept.sjs
@@ -6,16 +6,21 @@ if (esMappingLib.versionIsCompatibleWithES()) {
   const envelope = lib.mapInstance("/content/invalid-xml-customer.xml", "accept", "xml").value;
 
   let assertions = [
-    test.assertEqual(1, envelope.xpath("count(/*:envelope/*:headers/*:validationErrors/*:error)"),
+    test.assertEqual(1, envelope.xpath("count(/*:envelope/*:headers/datahub/validationErrors/error)"),
       "The xdmp:validate function reports the two missing elements as a single error, presumably " +
       "because they're the same type of error")
   ];
 
-  const validationError = fn.head(envelope.xpath("/*:envelope/*:headers/*:validationErrors/*:error"));
+  const validationError = fn.head(envelope.xpath("/*:envelope/*:headers/datahub/validationErrors/error"));
 
   assertions.concat(
-    test.assertEqual("XDMP-VALIDATEMISSINGELT", fn.string(validationError.xpath("./*:code/text()"))),
-    test.assertEqual("Missing required elements", fn.string(validationError.xpath("./*:message/text()"))),
-    test.assertTrue(fn.string(validationError.xpath("./*:formatString/text()")).indexOf("Missing required elements: Expected (FirstName,LastName") > -1)
+    test.assertEqual("XDMP-VALIDATEMISSINGELT", fn.string(validationError.xpath("./code/text()"))),
+    test.assertEqual("Missing required elements", fn.string(validationError.xpath("./message/text()"))),
+    test.assertTrue(fn.string(validationError.xpath("./*:formatString/text()")).indexOf("Missing required elements: Expected (FirstName,LastName") > -1),
+
+    test.assertEqual("FirstName", fn.string(validationError.xpath("./formattedMessages/formattedMessage[1]/propertyName/text()"))),
+    test.assertEqual("Required FirstName property not found", fn.string(validationError.xpath("./formattedMessages/formattedMessage[1]/message/text()"))),
+    test.assertEqual("LastName", fn.string(validationError.xpath("./formattedMessages/formattedMessage[2]/propertyName/text()"))),
+    test.assertEqual("Required LastName property not found", fn.string(validationError.xpath("./formattedMessages/formattedMessage[2]/message/text()")))
   );
 }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/validate-entity/xmlCustomerMissingFirstName.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/validate-entity/xmlCustomerMissingFirstName.sjs
@@ -1,0 +1,33 @@
+const esMappingLib = require("/data-hub/5/builtins/steps/mapping/entity-services/lib.sjs");
+const lib = require("lib/lib.sjs");
+const test = require("/test/test-helper.xqy");
+
+/*
+The following formatString is expected for this scenario:
+
+XDMP-VALIDATEUNEXPECTED: (err:XQDY0027) validate full strict { () } -- Invalid node: Found LastName but expected (FirstName,LastName,Email?) at
+fn:doc("/mappings/CustomerMapping/CustomerMapping-0.mapping.xml.xslt")/Customer/LastName using schema "/entities/Customer.entity.xsd"
+ */
+if (esMappingLib.versionIsCompatibleWithES()) {
+  const envelope = lib.mapInstance("/content/customer-missing-first-name.xml", "accept", "xml").value;
+
+  let assertions = [
+    test.assertEqual(1, envelope.xpath("count(/*:envelope/*:headers/datahub/validationErrors/error)"),
+      "Should have a validation error for the missing first name")
+  ];
+
+  const validationError = fn.head(envelope.xpath("/*:envelope/*:headers/datahub/validationErrors/error"));
+
+  assertions.concat(
+    test.assertEqual("XDMP-VALIDATEUNEXPECTED", fn.string(validationError.xpath("./code/text()")),
+      "When there's a missing element and it's the first element in the entity instance, we get an "),
+
+    test.assertEqual("Invalid node", fn.string(validationError.xpath("./message/text()"))),
+
+    test.assertTrue(fn.string(validationError.xpath("./*:formatString/text()"))
+      .indexOf("Invalid node: Found LastName but expected (FirstName,LastName,Email?") > -1),
+
+    test.assertEqual("FirstName", fn.string(validationError.xpath("./formattedMessages/formattedMessage/propertyName/text()"))),
+    test.assertEqual("Required FirstName property not found", fn.string(validationError.xpath("./formattedMessages/formattedMessage/message/text()")))
+  );
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/validate-entity/xmlCustomerMissingLastName.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/validate-entity/xmlCustomerMissingLastName.sjs
@@ -1,0 +1,34 @@
+const esMappingLib = require("/data-hub/5/builtins/steps/mapping/entity-services/lib.sjs");
+const lib = require("lib/lib.sjs");
+const test = require("/test/test-helper.xqy");
+
+/*
+The following formatString is expected for this scenario - even though there's only one missing element:
+
+XDMP-VALIDATEMISSINGELT: (err:XQDY0027) validate full strict { () } -- Missing required elements: Expected (LastName,Email?)
+at fn:doc("/mappings/CustomerMapping/CustomerMapping-0.mapping.xml.xslt")/Customer using schema "/entities/Customer.entity.xsd"
+ */
+if (esMappingLib.versionIsCompatibleWithES()) {
+  const envelope = lib.mapInstance("/content/customer-missing-last-name.xml", "accept", "xml").value;
+
+  let assertions = [
+    test.assertEqual(1, envelope.xpath("count(/*:envelope/*:headers/datahub/validationErrors/error)"),
+      "Should have a validation error for the missing last name")
+  ];
+
+  const validationError = fn.head(envelope.xpath("/*:envelope/*:headers/datahub/validationErrors/error"));
+
+  assertions.concat(
+    test.assertEqual("XDMP-VALIDATEMISSINGELT", fn.string(validationError.xpath("./code/text()"))),
+
+    test.assertEqual("Missing required elements", fn.string(validationError.xpath("./message/text()")),
+      "xdmp.validate returns this message even though there's only one missing required element; if the email property " +
+      "was set, then we'd actually get an XDMP-VALIDATEUNEXPECTED error code and the associated error message"),
+
+    test.assertTrue(fn.string(validationError.xpath("./*:formatString/text()"))
+      .indexOf("Missing required elements: Expected (LastName,Email?") > -1),
+
+    test.assertEqual("LastName", fn.string(validationError.xpath("./formattedMessages/formattedMessage/propertyName/text()"))),
+    test.assertEqual("Required LastName property not found", fn.string(validationError.xpath("./formattedMessages/formattedMessage/message/text()")))
+  );
+}


### PR DESCRIPTION
There are significant differences between the output of xdmp.validate and xdmp.jsonValidate, but this attempts to normalize some of the messages into a new headers.datahub.validationErrors.formattedMessages field/element.