### PR TITLE
DHFPROD-2784: Removed hubGenerateNifiTemplate

### DIFF
--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -185,11 +185,6 @@ class DataHubPlugin implements Plugin<Project> {
             description: "Deploy project resources and modules into a DHS instance"
         )
 
-        String nifiGroup = "MarkLogic Data Hub and NiFi Integration"
-        project.task("hubGenerateNifiTemplate", group: nifiGroup, type: GenerateNifiTemplateTask,
-            description: "Generate a NiFi template based on a flow. Use -PflowUri to specify the URI of the flow and " +
-            "-PtemplatePath to specify the file path to write the template to.")
-
         logger.info("Finished initializing ml-data-hub\n")
     }
 


### PR DESCRIPTION
The underlying code will all remain in case any user wants to try it out. But due to its minimal scope and the complexity of the generated template, it will not be included in the 5.1.0 release.