### PR TITLE
DHFPROD-3373:Remove xml/xslt when mapping is deleted

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/triggers/mapping/cleanUpMapping.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/triggers/mapping/cleanUpMapping.sjs
@@ -1,16 +1,32 @@
 'use strict';
-const es = require('/MarkLogic/entity-services/entity-services');
 declareUpdate();
+const DataHubSingleton = require("/data-hub/5/datahub-singleton.sjs");
+const datahub = DataHubSingleton.instance();
 
 var uri;
 
 let xmlURI = fn.replace(uri, '\\.json$', '.xml');
 
-xdmp.invokeFunction(function() {
-    if (fn.docAvailable(xmlURI)) {
-      xdmp.documentDelete(xmlURI);
-      es.mappingDelete(xmlURI);
-    }
+try {
+  xdmp.eval('if (fn.docAvailable("' + xmlURI + '")) { xdmp.documentDelete("' + xmlURI + '");xdmp.documentDelete("' + xmlURI  + '.xslt")}',
+  {
+    xmlURI:xmlURI
   },
-  { update: "true", commit: "auto" }
-);
+  {
+    database: xdmp.modulesDatabase(),
+    commit: 'auto',
+    update: 'true',
+    ignoreAmps: true
+  });
+} catch (err) {
+  datahub.debug.log({message: err, type: 'error'});
+  let errResp = "Failed to clean up mapping xml and compiled xslts: ";
+  if(err.stack) {
+    let stackLines = err.stack.split("\n");
+    errResp = errResp + stackLines[0] + " " + stackLines[1];
+  }
+  else if (err.stackFrames) {
+    errResp = errResp + err.message + ": " + err.data[0] + " in " + err.stackFrames[0].uri + " at " + err.stackFrames[0].line;
+  }
+  throw Error(errResp);
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/testCleanMapping.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/testCleanMapping.sjs
@@ -1,0 +1,36 @@
+declareUpdate();
+const test = require("/test/test-helper.xqy");
+
+
+let assertions = [];
+
+assertions.push(test.assertTrue(fn.head(xdmp.eval(
+    "fn.docAvailable('/mappings/OrdersMapping/OrdersMapping-1.mapping.xml') ",
+    {},{database:xdmp.modulesDatabase()}
+  ))));
+assertions.push(test.assertTrue(fn.head(xdmp.eval(
+    "  fn.docAvailable('/mappings/OrdersMapping/OrdersMapping-1.mapping.xml.xslt') ",
+    {},{database:xdmp.modulesDatabase()}
+  ))));
+
+
+
+xdmp.eval('xdmp.documentDelete("/mappings/OrdersMapping/OrdersMapping-1.mapping.json")',
+{},
+{
+  commit: 'auto',
+  update: 'true',
+  isolation: 'different-transaction',
+  ignoreAmps: true
+});
+
+assertions.push(test.assertFalse(fn.head(xdmp.eval(
+    "fn.docAvailable('/mappings/OrdersMapping/OrdersMapping-1.mapping.xml') ",
+    {},{database:xdmp.modulesDatabase()}
+  ))));
+assertions.push(test.assertFalse(fn.head(xdmp.eval(
+    " fn.docAvailable('/mappings/OrdersMapping/OrdersMapping-1.mapping.xml.xslt') ",
+    {},{database:xdmp.modulesDatabase()}
+  ))));
+
+assertions;


### PR DESCRIPTION
Remove xml/xslt when mapping is deleted. The current implementation has to be changed due to https://bugtrack.marklogic.com/53406