### PR TITLE
DHFPROD-3313: Don't clear modules unless needed in QS

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -299,6 +299,7 @@ public class DataHubImpl implements DataHub {
 
     @Override
     public void clearUserModules() {
+        logger.info("Clearing user modules");
         ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver(DataHub.class.getClassLoader());
         try {
             HashSet<String> options = new HashSet<>();
@@ -383,11 +384,10 @@ public class DataHubImpl implements DataHub {
                     "  )\n" +
                     "] ! xdmp:document-delete(.)\n";
             runInDatabase(query, hubConfig.getDbName(DatabaseKind.MODULES));
-        } catch (FailedRequestException e) {
-            logger.error("Failed to clear user modules");
-        } catch (IOException e) {
-            e.printStackTrace();
+        } catch (Exception e) {
+            logger.error("Failed to clear user modules, cause: " + e.getMessage(), e);
         }
+        logger.info("Finished clearing user modules");
     }
 
     public void deleteDocument(String uri, DatabaseKind databaseKind) {

--- a/web/src/main/java/com/marklogic/hub/web/service/DataHubService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/DataHubService.java
@@ -102,11 +102,13 @@ public class DataHubService {
 
     @Async
     public void installUserModules(HubConfig config, boolean forceLoad, DeployUserModulesListener deployListener, ValidateListener validateListener) {
+        logger.info("Installing user modules");
         long startTime = PerformanceLogger.monitorTimeInsideMethod();
-
         try {
             installUserModules(config, forceLoad, deployListener);
-            validateUserModules(config, validateListener);
+            if (validateListener != null) {
+                validateUserModules(config, validateListener);
+            }
         } catch (Throwable e) {
             throw new DataHubException(e.getMessage(), e);
         }
@@ -115,19 +117,15 @@ public class DataHubService {
 
     @Async
     public void reinstallUserModules(HubConfig config, DeployUserModulesListener deployListener, ValidateListener validateListener) {
+        logger.info("Reinstalling user modules");
         long startTime = PerformanceLogger.monitorTimeInsideMethod();
-
         try {
             dataHub.clearUserModules();
-            installUserModules(config, true, deployListener);
-            if(validateListener != null) {
-                validateUserModules(config, validateListener);
-            }
+            installUserModules(config, true, deployListener, validateListener);
         } catch(Throwable e) {
             throw new DataHubException(e.getMessage(), e);
         }
         PerformanceLogger.logTimeInsideMethod(startTime, "DataHubService.reinstallUserModules");
-
     }
 
     @Async
@@ -143,7 +141,6 @@ public class DataHubService {
     public void validateUserModules(HubConfig hubConfig, ValidateListener validateListener) {
         EntitiesValidator ev = EntitiesValidator.create(hubConfig.newStagingClient());
         validateListener.onValidate(ev.validateAll());
-
     }
 
     public void uninstall(HubConfig config, HubDeployStatusListener listener) throws DataHubException {
@@ -187,6 +184,7 @@ public class DataHubService {
         loadUserArtifactsCommand.setHubConfig(hubConfig);
         loadUserArtifactsCommand.setForceLoad(forceLoad);
 
+        // TODO Why load hub artifacts when this method is for loading user modules/artifacts?
         loadHubArtifactsCommand.setHubConfig(hubConfig);
         loadHubArtifactsCommand.setForceLoad(forceLoad);
 

--- a/web/src/main/java/com/marklogic/hub/web/service/EntityManagerService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/EntityManagerService.java
@@ -134,9 +134,7 @@ public class EntityManagerService {
         else {
             HubEntity renamedEntity = em.saveEntity(hubEntity, true);
             entity.setFilename(renamedEntity.getFilename());
-
-            // Redeploy the flows
-            dataHubService.reinstallUserModules(hubConfig, null, null);
+            dataHubService.installUserModules(hubConfig, true, null, null);
         }
 
 

--- a/web/src/main/java/com/marklogic/hub/web/service/FlowManagerService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/FlowManagerService.java
@@ -125,7 +125,7 @@ public class FlowManagerService {
             watcherService.watch(dir.toString());
         }
         if (checkExists) { //a new flow
-            dataHubService.reinstallUserModules(hubConfig, null, null);
+            dataHubService.installUserModules(hubConfig, true, null, null);
         }
 
         return fsm;

--- a/web/src/main/java/com/marklogic/hub/web/service/MappingManagerService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/MappingManagerService.java
@@ -75,7 +75,7 @@ public class MappingManagerService {
         MappingModel existingMapping= getMapping(mapName, false);
         if (existingMapping == null || existingMapping != null && !existingMapping.isEqual(mapping)) {
             mappingManager.saveMapping(mappingManager.createMappingFromJSON(mapping.toJson()),  existingMapping == null ? false : true);
-            dataHubService.reinstallUserModules(hubConfig, null, null);
+            dataHubService.installUserModules(hubConfig, true, null, null);
         }
         return mapping;
     }

--- a/web/src/main/java/com/marklogic/hub/web/web/CurrentProjectController.java
+++ b/web/src/main/java/com/marklogic/hub/web/web/CurrentProjectController.java
@@ -157,8 +157,7 @@ public class CurrentProjectController implements FileSystemEventListener, Valida
     }
 
     @RequestMapping(value = "/reinstall-user-modules", method = RequestMethod.POST)
-    public ResponseEntity<?> reinstallUserModules() throws IOException {
-        // reinstall the user modules
+    public ResponseEntity<?> reinstallUserModules() {
         dataHubService.reinstallUserModules(hubConfig, this, this);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }


### PR DESCRIPTION
When saving an artifact - e.g. an entity, flow, or mapping - I don't see any reason to clear user modules first. The dataHub.clearUserModules method isn't getting rid of old artifacts from the staging/final databases. 

Clearing user modules just runs the risk of bugs like this due to timing conditions where a user may then run a flow before the user modules have been reloaded.