### PR TITLE
DHFPROD-3407: Empty/missing expressions no longer throw errors

### DIFF
--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/emptyExpression.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/emptyExpression.sjs
@@ -1,0 +1,13 @@
+const lib = require("lib/lib.sjs");
+const mappingLib = require("/data-hub/5/builtins/steps/mapping/entity-services/lib.sjs");
+const test = require("/test/test-helper.xqy");
+
+if (mappingLib.versionIsCompatibleWithES()) {
+  let result = lib.invokeTestMapping("/content/person1.json", "PersonMapping", "2");
+  let person = result.Person;
+  [
+    test.assertEqual("111", fn.string(person.id)),
+    test.assertFalse(person.hasOwnProperty("nickname"),
+      "If the sourcedFrom expression is empty, it should be ignored so that an error is not thrown")
+  ];
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/lib/lib.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/lib/lib.sjs
@@ -1,0 +1,10 @@
+function invokeTestMapping(docURI, mappingName, mappingVersion ) {
+  return fn.head(xdmp.invoke(
+    "/data-hub/5/data-services/mapping/testMapping.sjs",
+    {"docURI": docURI, "mappingName":mappingName, "mappingVersion":mappingVersion}
+  ));
+}
+
+module.exports = {
+  invokeTestMapping
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/missingNestedPropertyExpression.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/missingNestedPropertyExpression.sjs
@@ -1,0 +1,15 @@
+const lib = require("lib/lib.sjs");
+const mappingLib = require("/data-hub/5/builtins/steps/mapping/entity-services/lib.sjs");
+const test = require("/test/test-helper.xqy");
+
+if (mappingLib.versionIsCompatibleWithES()) {
+  let result = lib.invokeTestMapping("/content/person1.json", "PersonMapping", "1");
+  let person = result.Person;
+  [
+    test.assertEqual("111", fn.string(person.id),
+      "The mapping should still succeed even though there's no sourcedFrom expression for the nested 'name' property. " +
+      "In this scenario, the mapping expression should be ignored instead of an error being thrown."),
+    test.assertFalse(person.hasOwnProperty("name"), "The name property should not be set since the mapping expression did not " +
+      "specify a sourcedFrom for 'name'.")
+  ];
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/nestedMapping.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/nestedMapping.sjs
@@ -1,0 +1,15 @@
+const lib = require("lib/lib.sjs");
+const mappingLib = require("/data-hub/5/builtins/steps/mapping/entity-services/lib.sjs");
+const test = require("/test/test-helper.xqy");
+
+if (mappingLib.versionIsCompatibleWithES()) {
+  let result = lib.invokeTestMapping("/content/person2.json", "PersonMapping", "3");
+  let person = result.Person;
+  [
+    test.assertEqual("222", fn.string(person.id)),
+    test.assertEqual("Middle", fn.string(person.name.Name.middle)),
+    test.assertEqual("Last", fn.string(person.name.Name.last)),
+    test.assertEqual("First", fn.string(person.name.Name.first.FirstName.value)),
+    test.assertEqual("SomePrefix", fn.string(person.name.Name.first.FirstName.prefix))
+  ];
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/runMapping.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/runMapping.sjs
@@ -1,3 +1,4 @@
+const lib = require("lib/lib.sjs");
 const mapping = require("/data-hub/5/builtins/steps/mapping/entity-services/main.sjs");
 const mappingLib = require("/data-hub/5/builtins/steps/mapping/entity-services/lib.sjs");
 const test = require("/test/test-helper.xqy");
@@ -26,15 +27,8 @@ function runMapping () {
   }
 }
 
-function invokeService(docURI, mappingName, mappingVersion ) {
-  return fn.head(xdmp.invoke(
-    "/data-hub/5/data-services/mapping/testMapping.sjs",
-    {"docURI": docURI, "mappingName":mappingName, "mappingVersion":mappingVersion}
-  ));
-}
-
 function testMapping() {
-    let instance = invokeService("/content/mapTest.json", "OrdersMapping" , "1");
+    let instance = lib.invokeTestMapping("/content/mapTest.json", "OrdersMapping" , "1");
     assertions.concat([
           test.assertEqual('2019-12-07', fn.string(instance.OrderType.purchaseDate)),
           test.assertEqual(165.05, fn.number(instance.OrderType.orderCost))]);

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/test-data/content/person1.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/test-data/content/person1.json
@@ -1,0 +1,8 @@
+{
+  "envelope": {
+    "instance": {
+      "personId": "111",
+      "theNickname": "Nicky"
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/test-data/content/person2.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/test-data/content/person2.json
@@ -1,0 +1,16 @@
+{
+  "envelope": {
+    "instance": {
+      "personId": "222",
+      "theNickname": "Nicky",
+      "theName": {
+        "middleName": "Middle",
+        "lastName": "Last",
+        "firstName": {
+          "theValue": "First",
+          "thePrefix": "SomePrefix"
+        }
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/test-data/mappings/PersonMapping/PersonMapping-1.mapping.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/test-data/mappings/PersonMapping/PersonMapping-1.mapping.json
@@ -1,0 +1,21 @@
+{
+  "lang": "zxx",
+  "name": "PersonMapping",
+  "description": "This is intentionally missing sourcedFrom for the nested 'name' property",
+  "version": 1,
+  "sourceContext": "/",
+  "targetEntityType": "http://marklogic.com/data-hub/example/Person-1.0.0/Person",
+  "properties": {
+    "id": {
+      "sourcedFrom": "personId"
+    },
+    "name": {
+      "targetEntityType": "http://marklogic.com/data-hub/example/Person-1.0.0/Name",
+      "properties": {
+        "middle" : {
+          "sourcedFrom": "middleName"
+        }
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/test-data/mappings/PersonMapping/PersonMapping-2.mapping.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/test-data/mappings/PersonMapping/PersonMapping-2.mapping.json
@@ -1,0 +1,16 @@
+{
+  "lang": "zxx",
+  "name": "PersonMapping",
+  "description": "This intentionally has an empty expression for nickname",
+  "version": 2,
+  "sourceContext": "/",
+  "targetEntityType": "http://marklogic.com/data-hub/example/Person-1.0.0/Person",
+  "properties": {
+    "id": {
+      "sourcedFrom": "personId"
+    },
+    "nickname": {
+      "sourcedFrom": ""
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/test-data/mappings/PersonMapping/PersonMapping-3.mapping.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/test-data/mappings/PersonMapping/PersonMapping-3.mapping.json
@@ -1,0 +1,37 @@
+{
+  "lang": "zxx",
+  "name": "PersonMapping",
+  "description": "TBD",
+  "version": 3,
+  "sourceContext": "/",
+  "targetEntityType": "http://marklogic.com/data-hub/example/Person-1.0.0/Person",
+  "properties": {
+    "id": {
+      "sourcedFrom": "personId"
+    },
+    "name": {
+      "sourcedFrom": "theName",
+      "targetEntityType": "http://marklogic.com/data-hub/example/Person-1.0.0/Name",
+      "properties": {
+        "middle" : {
+          "sourcedFrom": "middleName"
+        },
+        "last" : {
+          "sourcedFrom": "lastName"
+        },
+        "first": {
+          "sourcedFrom": "firstName",
+          "targetEntityType": "http://marklogic.com/data-hub/example/Person-1.0.0/FirstName",
+          "properties": {
+            "value": {
+              "sourcedFrom": "theValue"
+            },
+            "prefix": {
+              "sourcedFrom": "thePrefix"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I am not sure if this is the expected behavior, but it seems better to log and ignore these conditions as opposed to throwing errors, which happens via the Test button in QS - though the errors aren't reported, they're just logged.