### PR TITLE
DHFPROD-3380: Map prefix is guaranteed to exist in mapping stylesheet

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/lib.sjs
@@ -73,14 +73,9 @@ function buildMapProperties(mapping, entityModel) {
     xdmp.trace(dhMappingTrace, `Using entity definition: ${entityDefinition}`);
   }
   let namespacePrefix = entityDefinition.namespacePrefix ? `${entityDefinition.namespacePrefix}:` : '';
-  let requiredProps = entityDefinition.required || [entityModel.primaryKey];
-  if (!requiredProps.includes(entityModel.primaryKey)) {
-    requiredProps.push(entityModel.primaryKey);
-  }
   let entityProperties = entityDefinition.properties;
   for (let prop in mapProperties) {
     if (mapProperties.hasOwnProperty(prop)) {
-      let isRequired = requiredProps.includes(prop);
       if (!entityProperties.hasOwnProperty(prop)) {
         // TODO Can pass in a JSON object instead of a string message, but not able to reference the properties on it
         throw Error("The property '" + prop + "' is not defined by the entity model");

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/transforms/generateFunctionMetadata/addMapNamespace.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/transforms/generateFunctionMetadata/addMapNamespace.sjs
@@ -1,0 +1,40 @@
+const test = require("/test/test-helper.xqy");
+const transform = require("/marklogic.rest.transform/mlGenerateFunctionMetadata/assets/transform.sjs");
+
+function metadataWithoutMapNamespace() {
+  let metadata = fn.head(xdmp.unquote('<m:function-defs xml:lang="zxx" location="/data-hub/5/mapping-functions/core.sjs" xmlns:m="http://marklogic.com/entity-services/mapping">\n' +
+    '  <m:function-def name="memoryLookup">\n' +
+    '    <m:parameters>\n' +
+    '      <m:parameter name="input"/>\n' +
+    '      <m:parameter name="inputDictionary"/>\n' +
+    '    </m:parameters>\n' +
+    '    <m:return type=""/>\n' +
+    '  </m:function-def></m:function-defs>'));
+
+  metadata = transform.addMapNamespaceToMetadata(metadata);
+  metadata = xdmp.quote(metadata);
+  return test.assertTrue(metadata.indexOf('xmlns:map="http://marklogic.com/xdmp/map"') > -1,
+    "Expected the map prefix to be added to the metadata document: " + metadata);
+}
+
+function metadataThatAlreadyHasMapNamespace() {
+  let metadata = fn.head(xdmp.unquote('<m:function-defs xml:lang="zxx" location="/data-hub/5/mapping-functions/core.sjs" ' +
+    'xmlns:m="http://marklogic.com/entity-services/mapping" ' +
+    'xmlns:map="http://marklogic.com/xdmp/map">\n' +
+    '  <m:function-def name="memoryLookup">\n' +
+    '    <m:parameters>\n' +
+    '      <m:parameter name="input"/>\n' +
+    '      <m:parameter name="inputDictionary"/>\n' +
+    '    </m:parameters>\n' +
+    '    <m:return type=""/>\n' +
+    '  </m:function-def><map:map></map:map></m:function-defs>'));
+  metadata = transform.addMapNamespaceToMetadata(metadata);
+  metadata = xdmp.quote(metadata);
+  return test.assertTrue(metadata.indexOf('xmlns:map="http://marklogic.com/xdmp/map"') > -1,
+    "Just verifying that the map namespace declaration isn't dropped, and that the fact that it exists already " +
+    "doesn't cause an error");
+}
+
+[]
+//.concat(metadataWithoutMapNamespace())
+  .concat(metadataThatAlreadyHasMapNamespace());

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/transforms/generateFunctionMetadata/verifyCompiledStylesheets.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/transforms/generateFunctionMetadata/verifyCompiledStylesheets.xqy
@@ -1,0 +1,21 @@
+xquery version "1.0-ml";
+
+import module namespace test = "http://marklogic.com/test" at "/test/test-helper.xqy";
+
+declare function local:verify-stylesheet-has-map-namespace-declared($path as xs:string)
+{
+  let $stylesheet := xdmp:eval("fn:doc('" || $path || "')", (),
+    <options xmlns="xdmp:eval">
+      <database>{xdmp:database("data-hub-MODULES")}</database>
+    </options>
+  )/node()
+
+  return test:assert-true(
+    $stylesheet/namespace::* = "http://marklogic.com/xdmp/map",
+    "Each compiled stylesheet is expected to have the 'map' namespace prefix declared so that map functions " ||
+    "are guaranteed to resolve no matter what context the stylesheet is used in."
+  )
+};
+
+local:verify-stylesheet-has-map-namespace-declared("/data-hub/5/mapping-functions/core.xml.xslt"),
+local:verify-stylesheet-has-map-namespace-declared("/custom-modules/mapping-functions/custom-mapping-functions.xml.xslt")


### PR DESCRIPTION
This is needed for the stylesheet generated for core.sjs which results in several map:* references that don't always resolve, depending on the context in which es.mapToCanonical is called. This ensures - via some admittedly hacky code in mlGenerateFunctionMetadata - that the map namespace prefix is declared. 

Also removed some dead code from lib.sjs that was causing confusion about mapping validation.