### PR TITLE
DHFPROD-3461: Initializing onModulesLoader outside constructor

### DIFF
--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/HubWatchTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/HubWatchTask.groovy
@@ -35,11 +35,14 @@ class HubWatchTask extends WatchTask {
 
     LoadUserModulesCommand command
 
-    HubWatchTask() {
+    @Override
+    void watchModules() {
         HubConfig hubConfig = getProject().property("hubConfig")
         Versions versions = getProject().property("dataHubApplicationContext").getBean(Versions.class)
         GenerateFunctionMetadataCommand command = new GenerateFunctionMetadataCommand(hubConfig.newModulesDbClient(), versions)
         onModulesLoaded = new ModuleWatchingConsumer(getCommandContext(), command)
+
+        super.watchModules()
     }
 
     @Override


### PR DESCRIPTION
This avoids a bug when a project is first initialized and the constructor fails.