### PR TITLE
DHFPROD-3465: (and DHFPROD-3467) generating explorer query options file on upgrade to 5.1.0

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
@@ -23,6 +23,7 @@ import com.marklogic.hub.HubProject;
 import com.marklogic.hub.error.DataHubProjectException;
 import com.marklogic.hub.step.StepDefinition;
 import com.marklogic.hub.util.FileUtil;
+import com.marklogic.hub.util.HubModuleManager;
 import com.marklogic.mgmt.util.ObjectMapperFactory;
 import com.marklogic.rest.util.JsonNodeUtil;
 import org.apache.commons.io.FileUtils;
@@ -68,6 +69,9 @@ public class HubProjectImpl implements HubProject {
 
     @Autowired @Lazy
     private FlowManagerImpl flowManager;
+
+    @Autowired @Lazy
+    private EntityManagerImpl entityManager;
 
     @Autowired @Lazy
     private Versions versions;
@@ -498,8 +502,8 @@ public class HubProjectImpl implements HubProject {
             }
         }
         upgradeFlows();
-
         removeEmptyRangeElementIndexArrayFromFinalDatabaseFile();
+        generateSearchOptionsForExplorer();
     }
 
     protected void upgradeFlows() {
@@ -548,6 +552,13 @@ public class HubProjectImpl implements HubProject {
             }
         }
         return false;
+    }
+
+    protected void generateSearchOptionsForExplorer() {
+        String timestampFile = getUserModulesDeployTimestampFile();
+        HubModuleManager propertiesModuleManager = new HubModuleManager(timestampFile);
+        propertiesModuleManager.deletePropertiesFile();
+        entityManager.saveQueryOptions();
     }
 
     @Override  public String getHubModulesDeployTimestampFile() {

--- a/marklogic-data-hub/src/main/resources/ml-modules-final/options/exp-default.xml
+++ b/marklogic-data-hub/src/main/resources/ml-modules-final/options/exp-default.xml
@@ -1,6 +1,8 @@
 <options xmlns="http://marklogic.com/appservices/search">
   <constraint name="Collection">
-    <collection/>
+    <collection>
+      <facet-option>limit=25</facet-option>
+    </collection>
   </constraint>
   <constraint name="createdByJob">
     <range facet="false">

--- a/marklogic-data-hub/src/main/resources/ml-modules-staging/options/exp-default.xml
+++ b/marklogic-data-hub/src/main/resources/ml-modules-staging/options/exp-default.xml
@@ -1,6 +1,8 @@
 <options xmlns="http://marklogic.com/appservices/search">
   <constraint name="Collection">
-    <collection/>
+    <collection>
+      <facet-option>limit=25</facet-option>
+    </collection>
   </constraint>
   <constraint name="createdByJob">
     <range facet="false">

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-entities.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-entities.xqy
@@ -155,7 +155,9 @@ declare %private function hent:fix-options-exp($nodes as node()*)
           $n/namespace::node(),
           $n/@*,
           <search:constraint name="Collection">
-            <search:collection/>
+            <search:collection>
+              <search:facet-option>limit=25</search:facet-option>
+            </search:collection>
           </search:constraint>,
           <search:constraint name="createdByJob">
             <search:range facet="false">

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/UpgradeProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/UpgradeProjectTest.java
@@ -86,6 +86,10 @@ public class UpgradeProjectTest extends HubTestBase {
         assertFalse(mlConfigBackupDir.exists(), "As of DHFPROD-3159, ml-config should no longer be backed up. DHF rarely needs to " +
             "change the files in this directory, and when it does need to, it'll make changes directly to the files so as to not " +
             "lose changes made by users.");
+
+        File finalDbQueryOptionsFile = hubProject.getEntityConfigDir().resolve("exp-final-entity-options.xml").toFile();
+        assertTrue(finalDbQueryOptionsFile.exists(), "As of DHFPROD-3465, the hubUpdate task should generate the " +
+            "query options file for explorer.");
     }
 
     @Test

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/generateSearchOptions.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/generateSearchOptions.sjs
@@ -30,6 +30,9 @@ assertions.concat([
   test.assertEqual("limit=25", xs.string(fn.head(expOtions.xpath("/*:constraint[@name = 'title']/*:range/*:facet-option/text()"))),
     "To avoid displaying large numbers of values in facets in Explorer, range constraints default to a max of 25 values"
   ),
+  test.assertEqual("limit=25", xs.string(fn.head(expOtions.xpath("/*:constraint[@name = 'Collection']/*:collection/*:facet-option/text()"))),
+    "To avoid displaying large numbers of values in facets in Explorer, collection constraints default to a max of 25 values"
+  ),
   test.assertEqual("limit=25", xs.string(fn.head(expOtions.xpath("/*:constraint[@name = 'createdByStep']/*:range/*:facet-option/text()"))),
     "To avoid displaying large numbers of values in facets in Explorer, range constraints default to a max of 25 values"
   ),


### PR DESCRIPTION
* Generates the exp-final-entity-options.xml and exp-staging-entity-options.xml file in src/main/entity-config directory on upgrading hub to 5.1.0
* Limit number of facets on Collection facet type in explorer search options.
