### PR TITLE
DHFPROD-3423: Refactor entity loading in mapping component

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/mapping/mapping.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mapping/mapping.component.ts
@@ -117,26 +117,20 @@ export class MappingComponent implements OnInit {
         this.step.options.collections = [`${this.step.name}`, 'mdm-content', this.entityName];
       }
       this.loadEntity();
-      this.loadMap();
-      this.getFunctionList();
     }
   }
 
-  loadEntityDataSource() {
-      this.targetEntity
-  }
-
   loadEntity(): void {
-    this.entitiesService.entitiesChange.subscribe(entities => {
-      this.targetEntity = _.find(entities, (e: Entity) => {
-        return e.name === this.entityName;
-      });
-    });
-    this.entitiesService.getEntities();
-    // Get entity in full nested form
-    this.entitiesService.getEntityNested(this.entityName)
+    this.entitiesService.getEntity(this.entityName)
       .subscribe(result => {
-        this.entityNested = result;
+        this.targetEntity = result;
+        // Get entity in full nested form
+        this.entitiesService.getEntityNested(this.entityName)
+          .subscribe(result => {
+            this.entityNested = result;
+            this.loadMap();
+            this.getFunctionList();
+          });
       });
   }
 
@@ -405,7 +399,6 @@ export class MappingComponent implements OnInit {
         this.sourceDbType = 'FINAL';
       }
       this.loadEntity();
-      this.loadMap();
     }
   }
 

--- a/web/src/main/ui/app/models/entities.service.ts
+++ b/web/src/main/ui/app/models/entities.service.ts
@@ -60,6 +60,16 @@ export class EntitiesService {
     }));
   }
 
+  getEntity(entityName: string) {
+    return this.http
+      .get(this.url(`/entities/${entityName}`))
+      .pipe(map((res: Response) => { 
+        let result = new Entity().fromJSON(res.json());
+        return result; 
+      }
+    ));
+  }
+
   getEntityNested(entityName: string) {
     return this.http
       .get(this.url(`/entities/${entityName}?extendSubEntities=true`))
@@ -68,10 +78,6 @@ export class EntitiesService {
       }
     ));
   }
-
-  // getEntity(entityName: string) {
-  //   return this.get(this.url(`/entities/${entityName}`));
-  // }
 
   createEntity(entity: Entity) {
     return this.http.post(this.url('/entities/create'), entity).pipe(map((res: Response) => {


### PR DESCRIPTION
Make calls for entities, map, and functions sequentially.
Use more concise async calls in the services component.

I'm hoping this fixes the problems Firefox is having with the async loads in the mapping component. I'm no longer seeing the targetEntity errors in Firefox with this commit. 