### PR TITLE
DHFPROD-3509: Missing items in QS mapping source data table in case of array of xml/json elements

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/mapping/mapping.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mapping/mapping.component.ts
@@ -236,7 +236,7 @@ export class MappingComponent implements OnInit {
         
       });
       self.sampleDocNestedProps = this.updateNestedDataSourceNew(startRoot,ParentKeyValuePair);
-      //console.log("self.sampleDocNestedProps",self.sampleDocNestedProps)
+
       if (save) {
         this.saveMap();
         console.log('map saved');
@@ -300,9 +300,9 @@ export class MappingComponent implements OnInit {
             } else {
               let tempObj = {};
 
-              if (!obj[childNode.nodeName]) {
+              if (!obj[childNode.nodeName+"/"]) {
                 if (childNode.nodeName !== '#text') {
-                  obj[childNode.nodeName] = [];
+                  obj[childNode.nodeName+"/"] = [];
                 }
               };
 
@@ -310,8 +310,10 @@ export class MappingComponent implements OnInit {
               self.loadAttributes(childNode, obj, 'singleNode');
 
               nodeToJSON(tempObj, childNode);
-              if (obj[childNode.nodeName].constructor.name === 'Array') {
-                obj[childNode.nodeName].push(tempObj);
+              let ob = {[`${childNode.nodeName}`] : tempObj}
+              if (obj[childNode.nodeName+"/"].constructor.name === 'Array') {
+                
+                obj[childNode.nodeName+"/"].push(ob);
               }
             }
           } else {

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mapping/mapping.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mapping/mapping.component.ts
@@ -258,6 +258,7 @@ export class MappingComponent implements OnInit {
 
   normalizeToJSON(input: any): any {
     let self = this;
+    self.xmlSource = false;
     if (typeof input === 'string') {
       const parsedXML = new DOMParser().parseFromString(input, 'application/xml');
       const object = {};


### PR DESCRIPTION
1. Fix for the bug DHFPROD-3509.
2. Fixed the issue of Type not showing as Array and Object in source table for a JSON doc, if both XML and JSON Docs exists in same collection.
