### PR TITLE
Test users now have an easy-to-remember password

### DIFF
--- a/marklogic-data-hub/gradle.properties
+++ b/marklogic-data-hub/gradle.properties
@@ -18,12 +18,10 @@ mlAppName=data-hub
 
 mlIsHostLoadBalancer=false
 
-#mlUsername=flow-operator
-#mlPassword=eO3^)&X|j_O8m^k_2=xi
 mlUsername=flow-developer
-mlPassword=gO3^)&X|j_O8m^k_2=xi
+mlPassword=password
 mlManageUsername=flow-developer
-mlManagePassword=gO3^)&X|j_O8m^k_2=xi
+mlManagePassword=password
 mlSecurityUsername=admin
 mlSecurityPassword=admin
 
@@ -56,10 +54,10 @@ mlUseRoxyTokenPrefix=false
 ## These values are used by the testing infrastructure.
 mlFlowOperatorRole=flow-operator-role
 mlFlowOperatorUserName=flow-operator
-mlFlowOperatorPassword=eO3^)&X|j_O8m^k_2=xi
+mlFlowOperatorPassword=password
 mlFlowDeveloperRole=flow-developer-role
 mlFlowDeveloperUserName=flow-developer
-mlFlowDeveloperPassword=gO3^)&X|j_O8m^k_2=xi
+mlFlowDeveloperPassword=password
 mlDataHubAdminRole=data-hub-admin-role
 
 mlModulePermissions=rest-reader,read,rest-writer,insert,rest-writer,update,rest-extension-user,execute,flow-developer-role,read,flow-developer-role,execute,flow-developer-role,insert,flow-operator-role,read,flow-operator-role,execute

--- a/ml-data-hub-plugin/gradle.properties
+++ b/ml-data-hub-plugin/gradle.properties
@@ -21,9 +21,9 @@ mlIsHostLoadBalancer=false
 #mlUsername=admin
 #mlPassword=admin
 mlUsername=flow-developer
-mlPassword=gO3^)&X|j_O8m^k_2=xi
+mlPassword=password
 mlManageUsername=flow-developer
-mlManagePassword=gO3^)&X|j_O8m^k_2=xi
+mlManagePassword=password
 mlSecurityUsername=admin
 mlSecurityPassword=admin
 
@@ -55,10 +55,10 @@ mlUseRoxyTokenPrefix=false
 ## These values are used by the testing infrastructure.
 mlFlowOperatorRole=flow-operator-role
 mlFlowOperatorUserName=flow-operator
-mlFlowOperatorPassword=eO3^)&X|j_O8m^k_2=xi
+mlFlowOperatorPassword=password
 mlFlowDeveloperRole=flow-developer-role
 mlFlowDeveloperUserName=flow-developer
-mlFlowDeveloperPassword=gO3^)&X|j_O8m^k_2=xi
+mlFlowDeveloperPassword=password
 mlDataHubAdminRole=data-hub-admin-role
 
 group=com.marklogic

--- a/web/gradle.properties
+++ b/web/gradle.properties
@@ -20,12 +20,10 @@ mlAppName=data-hub
 
 mlIsHostLoadBalancer=false
 
-#mlUsername=flow-operator
-#mlPassword=eO3^)&X|j_O8m^k_2=xi
 mlUsername=flow-developer
-mlPassword=gO3^)&X|j_O8m^k_2=xi
+mlPassword=password
 mlManageUsername=flow-developer
-mlManagePassword=gO3^)&X|j_O8m^k_2=xi
+mlManagePassword=password
 mlSecurityUsername=admin
 mlSecurityPassword=admin
 
@@ -58,10 +56,10 @@ mlUseRoxyTokenPrefix=false
 ## These values are used by the testing infrastructure.
 mlFlowOperatorRole=flow-operator-role
 mlFlowOperatorUserName=flow-operator
-mlFlowOperatorPassword=eO3^)&X|j_O8m^k_2=xi
+mlFlowOperatorPassword=password
 mlFlowDeveloperRole=flow-developer-role
 mlFlowDeveloperUserName=flow-developer
-mlFlowDeveloperPassword=gO3^)&X|j_O8m^k_2=xi
+mlFlowDeveloperPassword=password
 mlDataHubAdminRole=data-hub-admin-role
 
 mlModulePermissions=rest-reader,read,rest-writer,insert,rest-writer,update,rest-extension-user,execute,flow-developer-role,read,flow-developer-role,execute,flow-developer-role,insert,flow-operator-role,read,flow-operator-role,execute


### PR DESCRIPTION
This is just to make life easier for when I want to run the unit tests via host:8011/test/default.xqy as flow-developer instead of as admin user. It has not impact on DHF application code. 