### PR TITLE
DHFPROD-3541: Renamed entity-model-reader to data-hub-entity-model-re…

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/InstallIntoDhsCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/InstallIntoDhsCommand.java
@@ -69,7 +69,7 @@ public class InstallIntoDhsCommand extends AbstractInstallerCommand {
 
         DeployRolesCommand deployRolesCommand = new DeployRolesCommand();
         deployRolesCommand.setResourceFilenamesIncludePattern(
-            Pattern.compile("(entity-model-reader|explorer-architect).*")
+            Pattern.compile("(data-hub-entity-model-reader|explorer-architect).*")
         );
         commands.add(deployRolesCommand);
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
@@ -332,7 +332,7 @@ public class HubProjectImpl implements HubProject {
         }
 
         writeRoleFile(rolesDir, "data-hub-admin-role.json");
-        writeRoleFile(rolesDir, "entity-model-reader.json");
+        writeRoleFile(rolesDir, "data-hub-entity-model-reader.json");
         writeRoleFile(rolesDir, "explorer-architect.json");
         writeRoleFile(rolesDir, "flow-developer-role.json");
         writeRoleFile(rolesDir, "flow-operator-role.json");

--- a/marklogic-data-hub/src/main/resources/dhf-defaults.properties
+++ b/marklogic-data-hub/src/main/resources/dhf-defaults.properties
@@ -63,8 +63,8 @@ mlHubLogLevel=default
 # Default module permissions which allow flow-operator-role to execute flows
 mlModulePermissions=rest-reader,read,rest-writer,insert,rest-writer,update,rest-extension-user,execute
 
-# entity-model-reader is the preferred role for users that wish to have read access to entity models
-mlEntityModelPermissions=rest-reader,read,rest-writer,insert,rest-writer,update,entity-model-reader,read
+# data-hub-entity-model-reader is the preferred role for users that wish to have read access to entity models
+mlEntityModelPermissions=rest-reader,read,rest-writer,insert,rest-writer,update,data-hub-entity-model-reader,read
 
 mlIsProvisionedEnvironment=false
 

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-entity-model-reader.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-entity-model-reader.json
@@ -1,4 +1,4 @@
 {
-  "role-name": "entity-model-reader",
+  "role-name": "data-hub-entity-model-reader",
   "description": "Data Hub role for permissions that grant read access to entity models"
 }

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/explorer-architect.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/explorer-architect.json
@@ -2,7 +2,7 @@
   "role-name": "explorer-architect",
   "description": "A role that can access entity models.",
   "role": [
-    "entity-model-reader"
+    "data-hub-entity-model-reader"
   ],
   "privilege": [
     {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/command/InstallIntoDhsCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/command/InstallIntoDhsCommandTest.java
@@ -108,10 +108,10 @@ public class InstallIntoDhsCommandTest extends HubTestBase {
         DeployRolesCommand deployRolesCommand = (DeployRolesCommand) commands.get(1);
         ResourceFilenameFilter filter = (ResourceFilenameFilter) deployRolesCommand.getResourceFilenameFilter();
         File dir = new File(PROJECT_PATH); // the directory doesn't matter, only the filename
-        assertTrue(filter.accept(dir, "entity-model-reader.json"));
+        assertTrue(filter.accept(dir, "data-hub-entity-model-reader.json"));
         assertTrue(filter.accept(dir, "explorer-architect.json"));
         assertFalse(filter.accept(dir, "flow-developer-role.json"),
-            "As of 5.1.0, the installer should only deploy entity-model-reader and explorer-architect");
+            "As of 5.1.0, the installer should only deploy data-hub-entity-model-reader and explorer-architect");
     }
 
     private void verifyDefaultProperties(Properties props) {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/core/HubProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/core/HubProjectTest.java
@@ -78,7 +78,7 @@ public class HubProjectTest extends HubTestBase {
 
         assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/explorer-architect.json").exists());
         assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/data-hub-admin-role.json").exists());
-        assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/entity-model-reader.json").exists());
+        assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/data-hub-entity-model-reader.json").exists());
         assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/flow-developer-role.json").exists());
         assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/flow-operator-role.json").exists());
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommandTest.java
@@ -113,7 +113,7 @@ public class LoadUserArtifactsCommandTest extends HubTestBase {
     @Test
     public void defaultEntityModelPermissions() {
         DocumentMetadataHandle.DocumentPermissions perms = loadUserArtifactsCommand.buildMetadataForEntityModels(adminHubConfig).getPermissions();
-        assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("entity-model-reader").iterator().next());
+        assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("data-hub-entity-model-reader").iterator().next());
     }
 
     @Test
@@ -135,6 +135,6 @@ public class LoadUserArtifactsCommandTest extends HubTestBase {
         final String message = "When entity model permissions are null, the command should use module permissions instead";
         assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("rest-reader").iterator().next(), message);
         assertEquals(DocumentMetadataHandle.Capability.UPDATE, perms.get("rest-writer").iterator().next(), message);
-        assertNull(perms.get("entity-model-reader"));
+        assertNull(perms.get("data-hub-entity-model-reader"));
     }
 }


### PR DESCRIPTION
…ader

This is so that all new DH roles have a prefix of "data-hub-"