### PR TITLE
DHFPROD-3539: Smart Mastering cleanup items

### DIFF
--- a/marklogic-data-hub/src/main/resources/hub-internal-artifacts/step-definitions/merging/marklogic/default-merging.step.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-artifacts/step-definitions/merging/marklogic/default-merging.step.json
@@ -12,7 +12,6 @@
     "stepUpdate": false,
     "sourceDatabase": "data-hub-FINAL",
     "targetDatabase": "data-hub-FINAL",
-    "sourceQuery": "cts.collectionQuery('mastering-summary')",
     "collections": [
       "default-merging","mastered"
     ]

--- a/marklogic-data-hub/src/main/resources/ml-database-field/final-database.xml
+++ b/marklogic-data-hub/src/main/resources/ml-database-field/final-database.xml
@@ -110,7 +110,7 @@
     <range-path-index>
       <scalar-type>string</scalar-type>
       <collation>http://marklogic.com/collation/</collation>
-      <path-expression>/matchSummary/URIsToActOn</path-expression>
+      <path-expression>/matchSummary/URIsToProcess</path-expression>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>
     </range-path-index>

--- a/marklogic-data-hub/src/main/resources/ml-database-field/staging-database.xml
+++ b/marklogic-data-hub/src/main/resources/ml-database-field/staging-database.xml
@@ -110,7 +110,7 @@
     <range-path-index>
       <scalar-type>string</scalar-type>
       <collation>http://marklogic.com/collation/</collation>
-      <path-expression>/matchSummary/URIsToActOn</path-expression>
+      <path-expression>/matchSummary/URIsToProcess</path-expression>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>
     </range-path-index>

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/auditing/base.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/auditing/base.xqy
@@ -12,6 +12,8 @@ import module namespace sem = "http://marklogic.com/semantics"
 
 import module namespace const = "http://marklogic.com/smart-mastering/constants"
   at "/com.marklogic.smart-mastering/constants.xqy";
+import module namespace coll = "http://marklogic.com/smart-mastering/collections"
+  at "/com.marklogic.smart-mastering/impl/collections.xqy";
 
 declare namespace prov = "http://www.w3.org/ns/prov#";
 declare namespace foaf = "http://xmlns.com/foaf/0.1/";
@@ -43,6 +45,7 @@ declare function auditing:audit-trace(
   $action as xs:string,
   $previous-uris as xs:string*,
   $new-uri as xs:string,
+  $options as node()?,
   $attachments as item()*
 ) as empty-sequence()
 {
@@ -50,6 +53,7 @@ declare function auditing:audit-trace(
         $action,
         $previous-uris,
         $new-uri,
+        $options,
         $attachments
       )
   return
@@ -70,6 +74,7 @@ declare function auditing:build-audit-trace(
   $action as xs:string,
   $previous-uris as xs:string*,
   $new-uri as xs:string,
+  $options as node()?,
   $attachments as item()*
 ) as map:map
 {
@@ -189,7 +194,7 @@ declare function auditing:build-audit-trace(
     map:map()
       => map:with("uri", "/com.marklogic.smart-mastering/auditing/"|| $action ||"/"||sem:uuid-string()||".xml")
       => map:with("value", $prov-xml)
-      => map:with("context", map:entry("collections",$const:AUDITING-COLL))
+      => map:with("context", map:entry("collections",coll:auditing-collections($options)))
 };
 
 (:
@@ -239,7 +244,7 @@ declare function auditing:auditing-receipts-for-doc-history($doc-uris as xs:stri
     $returned-docs
 };
 
-declare function auditing:audit-trace-rollback($prov-xml)
+declare function auditing:audit-trace-rollback($prov-xml, $merge-options as node()?)
 {
   let $merged-uri :=
     fn:string(
@@ -256,6 +261,7 @@ declare function auditing:audit-trace-rollback($prov-xml)
       $auditing:ROLLBACK-ACTION,
       $merged-uri,
       $orig-uri,
+      $merge-options,
       ()
     )
 };

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/impl/process.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/impl/process.xqy
@@ -598,7 +598,7 @@ declare function proc-impl:build-match-summary(
       => map:with(
         "matchSummary",
         map:map()
-        => map:with("URIsToActOn",
+        => map:with("URIsToProcess",
           json:to-array(fn:distinct-values(($no-matches-uris,map:keys($action-details)))))
         => map:with("actionDetails", $action-details)
       )
@@ -648,10 +648,10 @@ declare function proc-impl:process-match-and-merge-with-options(
       merge-impl:options-from-json($merge-options)
     else
       $merge-options
-  let $uris-to-act-on := $match-summary => map:get("matchSummary") => map:get("URIsToActOn") => json:array-values()
+  let $uris-to-process := $match-summary => map:get("matchSummary") => map:get("URIsToProcess") => json:array-values()
   return (
     proc-impl:build-content-objects-from-match-summary(
-      $uris-to-act-on,
+      $uris-to-process,
       $match-summary,
       $merge-options,
       $fine-grain-provenance

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/matcher-impl/blocks-impl.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/matcher-impl/blocks-impl.xqy
@@ -44,6 +44,7 @@ declare function blocks-impl:get-blocks-of-uris($uris as xs:string*)
   as xs:string*
 {
     if (fn:exists($uris)) then (
+      let $iris := $uris ! sem:iri(.)
       let $solution :=
         sem:sparql(
           "select distinct ?targetURI (?uri as ?blocked) where {
@@ -57,14 +58,11 @@ declare function blocks-impl:get-blocks-of-uris($uris as xs:string*)
             FILTER (?uri != ?targetURI)
           }",
           map:new((
-            map:entry("target", $uris ! sem:iri(.)),
+            map:entry("target", $iris),
             map:entry("isBlocked", $const:PRED-MATCH-BLOCK)
           )),
           ("map","optimize=0"),
-          cts:or-query((
-            cts:element-value-query((xs:QName("sem:subject"),xs:QName("sem:object")), $uris, "exact"),
-            cts:json-property-value-query(("subject","object"), $uris, "exact")
-          ))
+          cts:triple-range-query((),(), $iris, "=")
         )
       let $values :=
         fn:distinct-values(

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
@@ -444,7 +444,7 @@ declare function merge-impl:rollback-merge(
       )
     ),
     if ($retain-rollback-info) then (
-      $latest-auditing-receipt-for-doc ! auditing:audit-trace-rollback(.)
+      $latest-auditing-receipt-for-doc ! auditing:audit-trace-rollback(., $merge-options)
     ) else (
       $latest-auditing-receipt-for-doc ! xdmp:document-delete(xdmp:node-uri(.))
     )
@@ -578,6 +578,7 @@ declare function merge-impl:build-merge-models-by-uri(
           $const:MERGE-ACTION,
           $uris,
           $merge-uri,
+          $merge-options,
           merge-impl:generate-audit-attachments($merge-uri, $provenance-details)
         )
       )

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mastering/default/lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mastering/default/lib.sjs
@@ -125,7 +125,8 @@ function expectedCollectionEvents(entityType, existingMergeOptions) {
     "onMerge": collectionSettings.content.concat(collectionSettings.merged),
     "onNoMatch": collectionSettings.content,
     "onArchive": collectionSettings.archived,
-    "onNotification": collectionSettings.notification
+    "onNotification": collectionSettings.notification,
+    "onAuditing": collectionSettings.auditing
   };
 }
 
@@ -134,11 +135,13 @@ function getCollectionSettings(collectionsSettings, entityType) {
   let merged = getCollectionSetting(collectionsSettings, "merged", ["sm-" + entityType + "-merged"]);
   let archived = getCollectionSetting(collectionsSettings, "archived", ["sm-" + entityType + "-archived"]);
   let notification = getCollectionSetting(collectionsSettings, "notification", ["sm-" + entityType + "-notification"]);
+  let auditing = getCollectionSetting(collectionsSettings, "auditing", ["sm-" + entityType + "-auditing"]);
   return {
     content,
     merged,
     archived,
-    notification
+    notification,
+    auditing
   };
 }
 

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mastering/default/merging.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mastering/default/merging.sjs
@@ -50,7 +50,7 @@ function main(content, options) {
     let matchSummaryObj = matchSummary.toObject().matchSummary;
     let URIsToProcess = matchSummaryObj.URIsToProcess;
     let allURIsProcessed = URIsToProcess.every((uri) => processedURIs.includes(uri) || cts.exists(cts.andQuery([
-      cts.documentQuery(buildURI(uri, matchSummaryObj)),
+      cts.documentQuery(uri),
       cts.fieldWordQuery('datahubCreatedByJob', jobID)
     ])));
     if (allURIsProcessed) {
@@ -61,20 +61,6 @@ function main(content, options) {
     }
   }
   return results;
-}
-
-function buildURI(uri, matchSummaryObj) {
-  const actionDetails = matchSummaryObj.actionDetails[uri];
-  if (actionDetails) {
-    if (actionDetails.action === 'merge') {
-      const firstMergedUri = actionDetails.uris[0];
-      const format = firstMergedUri.substring(firstMergedUri.lastIndexOf('.') + 1);
-      uri = mergingImpl.buildMergeUri(uri, format);
-    } else if (actionDetails.action === 'notify') {
-      uri = notifyImpl.buildNotificationUri(actionDetails.threshold, Sequence.from(actionDetails.uris));
-    }
-  }
-  return uri;
 }
 
 function jobReport(jobID, stepResponse, options) {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mastering/default/merging.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mastering/default/merging.sjs
@@ -64,6 +64,19 @@ function main(content, options) {
 }
 
 function jobReport(jobID, stepResponse, options) {
+  if (stepResponse.success) {
+    const hubUtils = datahub.hubUtils;
+    const query = options.sourceQuery;
+    let urisEval;
+    if (/^\s*cts\.(uris|values)\(.*\)\s*$/.test(query)) {
+      urisEval = query;
+    } else {
+      urisEval = "cts.uris(null, null, " + query + ")";
+    }
+    const matchSummaryURIs = hubUtils.normalizeToArray(xdmp.eval(urisEval, {options: options}));
+    const summariesToDelete = matchSummaryURIs.map((uri) => ({uri, '$delete': true}));
+    hubUtils.writeDocuments(summariesToDelete);
+  }
   return masteringStepLib.jobReport(jobID, stepResponse, options, requiredOptionProperties);
 }
 

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mastering/default/merging.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mastering/default/merging.sjs
@@ -25,7 +25,7 @@ const processedURIs = [];
 function main(content, options) {
   // These index references can't be out this function scope or the jobReport will error, since they don't exist for the jobs DB
   const jobID = datahub.flow.globalContext.jobId;
-  const urisPathReference = cts.pathReference('/matchSummary/URIsToActOn', ['type=string','collation=http://marklogic.com/collation/']);
+  const urisPathReference = cts.pathReference('/matchSummary/URIsToProcess', ['type=string','collation=http://marklogic.com/collation/']);
   const datahubCreatedOnRef = cts.fieldReference('datahubCreatedOn', ['type=dateTime']);
   let uriToTakeActionOn = content.uri;
   masteringStepLib.checkOptions(null, options, null, requiredOptionProperties);
@@ -48,8 +48,8 @@ function main(content, options) {
   processedURIs.push(uriToTakeActionOn);
   for (let matchSummary of relatedMatchSummaries) {
     let matchSummaryObj = matchSummary.toObject().matchSummary;
-    let URIsToActOn = matchSummaryObj.URIsToActOn;
-    let allURIsProcessed = URIsToActOn.every((uri) => processedURIs.includes(uri) || cts.exists(cts.andQuery([
+    let URIsToProcess = matchSummaryObj.URIsToProcess;
+    let allURIsProcessed = URIsToProcess.every((uri) => processedURIs.includes(uri) || cts.exists(cts.andQuery([
       cts.documentQuery(buildURI(uri, matchSummaryObj)),
       cts.fieldWordQuery('datahubCreatedByJob', jobID)
     ])));

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/endpoints/collector.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/endpoints/collector.sjs
@@ -60,7 +60,7 @@ if(!combinedOptions.sourceQuery && flowDoc.sourceQuery) {
 }
 let query = combinedOptions.sourceQuery;
 let isMergingStep = baseStep.name === 'default-merging' && baseStep.type === 'merging';
-if (!(query || isMergingStep)) {
+if (!query) {
   datahub.debug.log("The collector query was empty");
   fn.error(null, "RESTAPI-SRVEXERR", Sequence.from([404, "Not Found", "The collector query was empty"]));
 }
@@ -69,7 +69,7 @@ if (isMergingStep) {
     cts.pathReference('/matchSummary/URIsToProcess', ['type=string','collation=http://marklogic.com/collation/']),
     null,
     null,
-    cts.collectionQuery('datahubMasteringMatchSummary${options.targetEntity ? `-${options.targetEntity}` : ''}')
+    ${query}
   )`);
 }
 try {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/endpoints/collector.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/endpoints/collector.sjs
@@ -66,7 +66,7 @@ if (!(query || isMergingStep)) {
 }
 if (isMergingStep) {
   query = fn.normalizeSpace(`cts.values(
-    cts.pathReference('/matchSummary/URIsToActOn', ['type=string','collation=http://marklogic.com/collation/']),
+    cts.pathReference('/matchSummary/URIsToProcess', ['type=string','collation=http://marklogic.com/collation/']),
     null,
     null,
     cts.collectionQuery('datahubMasteringMatchSummary${options.targetEntity ? `-${options.targetEntity}` : ''}')

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils.sjs
@@ -50,7 +50,7 @@ class HubUtils {
     }));
   }
 
-  writeDocuments(writeQueue, permissions = 'xdmp.defaultPermissions()', collections, database){
+  writeDocuments(writeQueue, permissions = 'xdmp.defaultPermissions()', collections = [], database = xdmp.databaseName(xdmp.database())){
     return fn.head(xdmp.eval(`
     const temporal = require("/MarkLogic/temporal.xqy");
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/master/MasterTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/master/MasterTest.java
@@ -169,7 +169,7 @@ public class MasterTest extends HubTestBase {
         // Check for datahubMasteringMatchSummary for matching with correct count
         String summaryQueryText = "cts:and-query((" +
             "cts:collection-query('datahubMasteringMatchSummary')," +
-            "cts:json-property-value-query('URIsToActOn', '/person-41.json')" +
+            "cts:json-property-value-query('URIsToProcess', '/person-41.json')" +
             "))";
         assertTrue(existsByQuery(summaryQueryText, HubConfig.DEFAULT_FINAL_NAME), "Missing valid matching summary document!");
         RunFlowResponse flowMergeResponse = flowRunner.runFlow("myMatchMergeFlow", Collections.singletonList("4"));

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/master/MasterTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/master/MasterTest.java
@@ -200,7 +200,7 @@ public class MasterTest extends HubTestBase {
         List<String> docsToMerge = Arrays.asList("/person-1.json","/person-1-1.json","/person-1-2.json","/person-1-3.json");
         masteringManager.merge(docsToMerge, "myNewFlow","3", Boolean.FALSE, new ObjectMapper().createObjectNode());
         assertEquals(1, getFinalDocCount("sm-person-merged"),"One merge should have occurred");
-        assertEquals(1, getFinalDocCount("mdm-auditing"),"One auditing document should have been created");
+        assertEquals(1, getFinalDocCount("sm-person-auditing"),"One auditing document should have been created");
         assertEquals(docsToMerge.size(), getFinalDocCount("sm-person-archived"),docsToMerge.size() + " documents should have been archived");
     }
 

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mastering/getDefaultCollections.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mastering/getDefaultCollections.sjs
@@ -14,5 +14,6 @@ let response = invokeService("Order");
   test.assertEqual("sm-Order-merged", response.onMerge[1]),
   test.assertEqual("sm-Order-mastered", response.onNoMatch[0]),
   test.assertEqual("sm-Order-archived", response.onArchive[0]),
-  test.assertEqual("sm-Order-notification", response.onNotification[0])
+  test.assertEqual("sm-Order-notification", response.onNotification[0]),
+  test.assertEqual("sm-Order-auditing", response.onAuditing[0])
 ];

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/auditing/audtingCollectionTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/auditing/audtingCollectionTest.sjs
@@ -1,0 +1,26 @@
+const lib = require("/data-hub/5/builtins/steps/mastering/default/lib.sjs");
+const auditing = require("/com.marklogic.smart-mastering/auditing/base.xqy");
+const test = require("/test/test-helper.xqy");
+const emptySequence = Sequence.from([]);
+
+let assertions = [];
+
+xdmp.invokeFunction(
+  function() {
+    const options = { targetEntity: 'Person', matchOptions: {}, mergeOptions: {}};
+    // create default options for matching/merging with target entity person
+    lib.checkOptions(emptySequence, options);
+    const mergeOptionsNode = new NodeBuilder().addNode({ options: options.mergeOptions }).toNode().xpath('/options');
+    const auditingContentObj = auditing.buildAuditTrace(
+      'merge',
+      Sequence.from(['/doc1.json','/doc3.json']),
+      '/merged.json',
+      mergeOptionsNode,
+      emptySequence
+    );
+    assertions.push(test.assertEqual("sm-Person-auditing", auditingContentObj.context.collections, `Auditing doc should have collection 'sm-Person-auditing'. has: '${auditingContentObj.context.collections}'`))
+  },
+  {update: 'true', commit: 'auto'}
+);
+
+assertions;

--- a/marklogic-data-hub/src/test/resources/master-test/flows/myMatchMergeFlow.flow.json
+++ b/marklogic-data-hub/src/test/resources/master-test/flows/myMatchMergeFlow.flow.json
@@ -35,6 +35,7 @@
       "options": {
         "targetEntity": "person",
         "sourceQuery": "cts.collectionQuery('mapping')",
+        "collections": ["myMatchingCollection"],
         "provenanceGranularityLevel": "fine",
         "sourceDatabase": "data-hub-FINAL",
         "targetDatabase": "data-hub-FINAL",
@@ -119,6 +120,7 @@
       "options": {
         "targetEntity": "person",
         "provenanceGranularityLevel": "fine",
+        "sourceQuery": "cts.collectionQuery('myMatchingCollection')",
         "sourceDatabase": "data-hub-FINAL",
         "targetDatabase": "data-hub-FINAL",
         "mergeOptions": {

--- a/web/src/main/ui/app/components/flows-new/edit-flow/edit-flow.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/edit-flow.component.ts
@@ -262,11 +262,11 @@ export class EditFlowComponent implements OnInit, OnDestroy {
   }
   setStepDefaults(step): void {
     const defaultCollections = [`${step.name}`];
-    if (step.stepDefinitionType === StepType.MAPPING && (step.stepDefinitionName === 'default-mapping' || step.stepDefinitionName === 'entity-services-mapping')) {
-      defaultCollections.push('mdm-content');
-    }
     if (step.options && step.options.targetEntity) {
       defaultCollections.push(step.options.targetEntity);
+    }
+    if (step.options.collections && step.options.collections.length === 0) {
+      delete step.options.collections;
     }
     step.options = Object.assign({ 'collections': defaultCollections }, step.options);
   }


### PR DESCRIPTION
Since we're changing the path for the merge range, this will require a re-deploy to get all the changes.

Items addressed:

 

- When I run a match step on a set of documents, a match summary JSON document is created (no change from previous behavior). This match summary JSON document is changed in the following ways:

  - The URIs are displayed so the user understands which URIs will be processed (instead of just hashes)
  - The name 'URIsToActOn' is changed to 'URIsToProcess'
  -  In the "actionDetails" section, "merge" actions should have the relevant threshold included similar to "notify" actions
  - Merge step should honor source collection/query instead of ignoring it for its own method. (e.g., the merge step should restrict the range index values to the collection/query specified)

- When I run a mastering step or a merge step, an audit file is created for each merge. These audit files should be added to the sm-entityname-audit collection (instead of the mdm-audit collection)
