### PR TITLE
DHFPROD-3606:Generate function metadata only if forceLoad is set to true

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/master/MasterTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/master/MasterTest.java
@@ -142,7 +142,7 @@ public class MasterTest extends HubTestBase {
         assertTrue(getFinalDocCount("master") > 0, "Documents didn't receive master collection");
         // Setting this to 208 or greater as occasionally we get 209 in the pipeline.
         int masteredCount = getFinalDocCount("sm-person-mastered");
-        assertTrue(masteredCount >= 208, "We end with the correct amount of final docs");
+        assertTrue(masteredCount >= 208, "We end with the correct amount of final docs: "+masteredCount);
         // Setting this to 40 or greater as occasionally we get 41 in the pipeline. See bug https://project.marklogic.com/jira/browse/DHFPROD-3178
         assertTrue(getFinalDocCount("sm-person-notification") >= 40, "Not enough notifications are created");
         // Check for JobReport for mastering with correct count

--- a/web/src/main/java/com/marklogic/hub/web/service/DataHubService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/DataHubService.java
@@ -188,7 +188,13 @@ public class DataHubService {
         loadHubArtifactsCommand.setHubConfig(hubConfig);
         loadHubArtifactsCommand.setForceLoad(forceLoad);
 
-        commands.add(generateFunctionMetadataCommand);
+        // Generating function metadata xslt causes running existing mapping (xslts) step to fail with undefined function
+        // for any mappings that use these functions. So, we have to generate function metadata xslt only when 'forceLoad'
+        // is set to true which would ensure that mappings are inserted and compiled to xslts as well.
+        // Added as a temporary fix for DHFPROD-3606.
+        if(forceLoad){
+            commands.add(generateFunctionMetadataCommand);
+        }
         commands.add(loadUserModulesCommand);
         commands.add(loadUserArtifactsCommand);
         commands.add(loadHubArtifactsCommand);


### PR DESCRIPTION
Generate function metadata only if forceLoad is set to true