### PR TITLE
DHFPROD-3616:Fix forceLoad in LoadUserModulesCommand

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommand.java
@@ -98,9 +98,6 @@ public class LoadUserArtifactsCommand extends AbstractCommand {
                 }
             }
         }
-        //Initializing the 'PropertiesModuleManager' instance so that timestamp file (local-user-modules-deploy-timestamps.properties)
-        // is read and only the modified files are deployed to server
-        pmm.initialize();
         return pmm;
     }
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserModulesCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserModulesCommand.java
@@ -98,7 +98,7 @@ public class LoadUserModulesCommand extends LoadModulesCommand {
                 }
             }
         }
-
+        pmm.initialize();
         return pmm;
     }
 
@@ -164,9 +164,6 @@ public class LoadUserModulesCommand extends LoadModulesCommand {
 
     @Override
     public void execute(CommandContext context) {
-        if (loadAllModules) {
-            loadModulesFromStandardMlGradleLocations(context);
-        }
 
         AppConfig config = context.getAppConfig();
 
@@ -180,6 +177,11 @@ public class LoadUserModulesCommand extends LoadModulesCommand {
         // load any user files under plugins/* int the modules database.
         // this will ignore REST folders under entities
         DefaultModulesLoader modulesLoader = getStagingModulesLoader(config);
+        // Load modules from standard ml-gradle location after 'PropertiesModuleManager' is initialized. This will ensure
+        // that in case of 'forceLoad', the ml-javaclient-utils timestamp file is deleted first.
+        if (loadAllModules) {
+            loadModulesFromStandardMlGradleLocations(context);
+        }
         modulesLoader.loadModules(baseDir, new UserModulesFinder(), stagingClient);
 
         // Don't load these while "watching" modules (i.e. mlWatch is being run), as users can't change these


### PR DESCRIPTION
This PR does 2 things

1. Fixes 'forceLoad' in LoadUserModulesCommand so that property file manager is initialized and timestamp file is deleted before loading from standard ml-gradle location when forceLoad is set to true
2. Load all user artifacts so that mappings get recompiled so that we don't run into XDMP-UNDFUN error (DHFPROD-3606)