### PR TITLE
DHFPROD-3108: Defining new set of DH roles

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/InstallIntoDhsCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/InstallIntoDhsCommand.java
@@ -73,6 +73,8 @@ public class InstallIntoDhsCommand extends AbstractInstallerCommand {
         );
         commands.add(deployRolesCommand);
 
+        commands.add(new CreateGranularPrivilegesCommand(hubConfig));
+
         return commands;
     }
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesCommand.java
@@ -1,0 +1,68 @@
+package com.marklogic.hub.deploy.commands;
+
+import com.marklogic.appdeployer.command.Command;
+import com.marklogic.appdeployer.command.CommandContext;
+import com.marklogic.hub.DatabaseKind;
+import com.marklogic.hub.HubConfig;
+import com.marklogic.mgmt.api.security.Privilege;
+import com.marklogic.mgmt.resource.databases.DatabaseManager;
+import com.marklogic.mgmt.resource.security.PrivilegeManager;
+import com.marklogic.rest.util.ResourcesFragment;
+
+import java.util.Arrays;
+
+/**
+ * Command for creating granular privileges after the resources that these privileges depend on have been created.
+ */
+public class CreateGranularPrivilegesCommand implements Command {
+
+    private HubConfig hubConfig;
+
+    public CreateGranularPrivilegesCommand(HubConfig hubConfig) {
+        this.hubConfig = hubConfig;
+    }
+
+    /**
+     * It is anticipated that these privileges can always be added at the end of a deployment because none of the steps
+     * before that should depend on the privileges being added.
+     *
+     * @return
+     */
+    @Override
+    public Integer getExecuteSortOrder() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public void execute(CommandContext context) {
+        final String finalDbName = hubConfig.getDbName(DatabaseKind.FINAL);
+        final String stagingDbName = hubConfig.getDbName(DatabaseKind.STAGING);
+
+        // Once RMA supports pseudo functions - https://bugtrack.marklogic.com/53540 - then we won't need to get the
+        // resource IDs here and can use resource names instead.
+        ResourcesFragment databasesXml = new DatabaseManager(context.getManageClient()).getAsXml();
+        final String finalDbId = databasesXml.getIdForNameOrId(finalDbName);
+        final String stagingDbId = databasesXml.getIdForNameOrId(stagingDbName);
+
+        PrivilegeManager mgr = new PrivilegeManager(context.getManageClient());
+        Privilege p = new Privilege(null, "admin-database-clear-" + finalDbName);
+        p.setKind("execute");
+        p.setAction("http://marklogic.com/xdmp/privileges/admin/database/clear/" + finalDbId);
+        p.setRole(Arrays.asList("data-hub-admin"));
+        mgr.save(p.getJson());
+
+        p.setPrivilegeName("admin-database-clear-" + stagingDbName);
+        p.setAction("http://marklogic.com/xdmp/privileges/admin/database/clear/" + stagingDbId);
+        mgr.save(p.getJson());
+
+        p.setPrivilegeName("admin-database-index-" + finalDbName);
+        p.setAction("http://marklogic.com/xdmp/privileges/admin/database/index/" + finalDbId);
+        p.setRole(Arrays.asList("data-hub-app-admin"));
+        mgr.save(p.getJson());
+
+        p.setPrivilegeName("admin-database-index-" + stagingDbName);
+        p.setAction("http://marklogic.com/xdmp/privileges/admin/database/index/" + stagingDbId);
+        mgr.save(p.getJson());
+    }
+
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -27,7 +27,6 @@ import com.marklogic.appdeployer.command.modules.DeleteTestModulesCommand;
 import com.marklogic.appdeployer.command.modules.LoadModulesCommand;
 import com.marklogic.appdeployer.command.security.*;
 import com.marklogic.appdeployer.impl.SimpleAppDeployer;
-import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.admin.QueryOptionsManager;
 import com.marklogic.client.admin.ResourceExtensionsManager;
 import com.marklogic.client.admin.ServerConfigurationManager;
@@ -723,6 +722,10 @@ public class DataHubImpl implements DataHub {
         List<Command> forestCommands = commandMap.get("mlForestCommands");
         DeployCustomForestsCommand deployCustomForestsCommand = (DeployCustomForestsCommand) forestCommands.get(0);
         deployCustomForestsCommand.setCustomForestsPath(hubConfig.getCustomForestPath());
+
+        List<Command> granularPrivilegeCommands = new ArrayList<>();
+        granularPrivilegeCommands.add(new CreateGranularPrivilegesCommand(hubConfig));
+        commandMap.put("hubGranularPrivilegeCommands", granularPrivilegeCommands);
 
         return commandMap;
     }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -174,6 +174,7 @@ public class HubConfigImpl implements HubConfig
     protected String modulePermissions;
 
     private String entityModelPermissions;
+    private String jobPermissions;
 
     private ManageConfig manageConfig;
     private ManageClient manageClient;
@@ -854,6 +855,15 @@ public class HubConfigImpl implements HubConfig
         return entityModelPermissions;
     }
 
+    public String getJobPermissions() {
+        return jobPermissions;
+    }
+
+    public void setJobPermissions(String jobPermissions) {
+        this.jobPermissions = jobPermissions;
+    }
+
+
     @Override
     @Deprecated
     public String getProjectDir() {
@@ -944,11 +954,6 @@ public class HubConfigImpl implements HubConfig
                 isHostLoadBalancer = false;
             }
         }
-    }
-
-
-    public void loadConfigurationFromProperties(){
-        loadConfigurationFromProperties(null, true);
     }
 
     public void loadConfigurationFromProperties(Properties properties, boolean loadGradleProperties) {
@@ -1304,6 +1309,13 @@ public class HubConfigImpl implements HubConfig
         }
         else {
             projectProperties.setProperty("mlEntityModelPermissions", entityModelPermissions);
+        }
+
+        if (jobPermissions == null) {
+            jobPermissions = getEnvPropString(projectProperties, "mlJobPermissions", environment.getProperty("mlJobPermissions"));
+        }
+        else {
+            projectProperties.setProperty("mlJobPermissions", jobPermissions);
         }
 
         DHFVersion = getEnvPropString(projectProperties, "mlDHFVersion", environment.getProperty("mlDHFVersion"));
@@ -1710,6 +1722,8 @@ public class HubConfigImpl implements HubConfig
         // and another random password for hub Admin User
         customTokens.put("%%mlFlowDeveloperPassword%%", randomStringGenerator.generate(20));
 
+        customTokens.put("%%mlJobPermissions%%", jobPermissions == null ? environment.getProperty("mlJobPermissions") : jobPermissions);
+
         customTokens.put("%%mlCustomForestPath%%", customForestPath == null ? environment.getProperty("mlCustomForestPath") : customForestPath);
 
         //version of DHF the user INTENDS to use
@@ -1725,17 +1739,6 @@ public class HubConfigImpl implements HubConfig
         if (projectProperties.containsKey("mlFlowDeveloperPassword")) {
             customTokens.put("%%mlFlowDeveloperPassword%%", projectProperties.getProperty("mlFlowDeveloperPassword"));
         }
-        /* can't iterate through env properties, so rely on custom tokens itself?
-        if (environment != null) {
-            Enumeration keyEnum = environment.propertyNames();
-            while (keyEnum.hasMoreElements()) {
-                String key = (String) keyEnum.nextElement();
-                if (key.matches("^ml[A-Z].+") && !customTokens.containsKey(key)) {
-                    customTokens.put("%%" + key + "%%", (String) environmentProperties.get(key));
-                }
-            }
-        }
-        */
     }
 
     /**
@@ -2045,6 +2048,7 @@ public class HubConfigImpl implements HubConfig
         customForestPath = null;
         modulePermissions = null;
         entityModelPermissions = null;
+        jobPermissions = null;
         hubLogLevel = null;
         loadBalancerHost = null;
         isHostLoadBalancer = null;

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
@@ -331,9 +331,23 @@ public class HubProjectImpl implements HubProject {
             IOUtils.closeQuietly(is);
         }
 
-        writeRoleFile(rolesDir, "data-hub-admin-role.json");
+        // New 5.2.0 roles
+        writeRoleFile(rolesDir, "data-hub-admin.json");
+        writeRoleFile(rolesDir, "data-hub-app-admin.json");
+        writeRoleFile(rolesDir, "data-hub-environment-manager.json");
+        writeRoleFile(rolesDir, "data-hub-job-internal.json");
+        writeRoleFile(rolesDir, "data-hub-job-reader.json");
+        writeRoleFile(rolesDir, "data-hub-monitor.json");
+        writeRoleFile(rolesDir, "data-hub-portal-security-admin.json");
+        writeRoleFile(rolesDir, "data-hub-security-admin.json");
+        writeRoleFile(rolesDir, "data-hub-user.json");
+
+        // New 5.1.0 roles
         writeRoleFile(rolesDir, "data-hub-entity-model-reader.json");
         writeRoleFile(rolesDir, "data-hub-explorer-architect.json");
+
+        // Legacy roles
+        writeRoleFile(rolesDir, "data-hub-admin-role.json");
         writeRoleFile(rolesDir, "flow-developer-role.json");
         writeRoleFile(rolesDir, "flow-operator-role.json");
 

--- a/marklogic-data-hub/src/main/resources/dhf-defaults.properties
+++ b/marklogic-data-hub/src/main/resources/dhf-defaults.properties
@@ -66,6 +66,8 @@ mlModulePermissions=rest-reader,read,rest-writer,insert,rest-writer,update,rest-
 # data-hub-entity-model-reader is the preferred role for users that wish to have read access to entity models
 mlEntityModelPermissions=rest-reader,read,rest-writer,insert,rest-writer,update,data-hub-entity-model-reader,read
 
+mlJobPermissions=data-hub-job-reader,read,data-hub-job-internal,update
+
 mlIsProvisionedEnvironment=false
 
 #Turn on/off Jaeger trace. It can be set as an arbitrary name (e.g: data-hub).

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-admin.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-admin.json
@@ -1,0 +1,7 @@
+{
+  "role-name": "data-hub-admin",
+  "description": "Data Hub role for users that can administer a Data Hub application and perform a few other administrative tasks as well",
+  "role": [
+    "data-hub-app-admin"
+  ]
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-app-admin.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-app-admin.json
@@ -1,0 +1,23 @@
+{
+  "role-name": "data-hub-app-admin",
+  "description": "Data Hub role for a user that can administer a Data Hub application but not fully manage its resources",
+  "role": [
+    "data-hub-user",
+    "manage-user",
+    "ps-user",
+    "rest-admin",
+    "tde-admin"
+  ],
+  "privilege": [
+    {
+      "privilege-name": "protect-path",
+      "action": "http://marklogic.com/xdmp/privileges/protect-path",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "get-system-logs",
+      "action": "http://marklogic.com/xdmp/privileges/logs/system",
+      "kind": "execute"
+    }
+  ]
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-environment-manager.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-environment-manager.json
@@ -1,0 +1,8 @@
+{
+  "role-name": "data-hub-environment-manager",
+  "description": "Data Hub role a user that can install a Data Hub application",
+  "role": [
+    "manage-admin",
+    "security"
+  ]
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-job-internal.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-job-internal.json
@@ -1,0 +1,4 @@
+{
+  "role-name": "data-hub-job-internal",
+  "description": "Data Hub role for permissions that grant update access to job documents"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-job-reader.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-job-reader.json
@@ -1,0 +1,4 @@
+{
+  "role-name": "data-hub-job-reader",
+  "description": "Data Hub role for permissions that grant read access to job documents"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-monitor.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-monitor.json
@@ -1,0 +1,15 @@
+{
+  "role-name": "data-hub-monitor",
+  "description": "Data Hub role for a user that can monitor Data Hub activity",
+  "role": [
+    "manage-user",
+    "data-hub-job-reader"
+  ],
+  "privilege": [
+    {
+      "privilege-name": "get-system-logs",
+      "action": "http://marklogic.com/xdmp/privileges/logs/system",
+      "kind": "execute"
+    }
+  ]
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-portal-security-admin.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-portal-security-admin.json
@@ -1,0 +1,8 @@
+{
+  "role-name": "data-hub-portal-security-admin",
+  "description": "DHS-specific role for users that can perform security tasks within the DHS portal",
+  "role": [
+    "manage-admin",
+    "security"
+  ]
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-security-admin.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-security-admin.json
@@ -1,0 +1,19 @@
+{
+  "role-name": "data-hub-security-admin",
+  "description": "Data Hub role for a user that can perform some security tasks for a Data Hub application",
+  "role": [
+    "manage"
+  ],
+  "privilege": [
+    {
+      "privilege-name": "role-set-external-names",
+      "action": "http://marklogic.com/xdmp/privileges/role-set-external-names",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "create-data-role",
+      "action": "http://marklogic.com/xdmp/privileges/create-data-role",
+      "kind": "execute"
+    }
+  ]
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-user.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-user.json
@@ -1,0 +1,122 @@
+{
+  "role-name": "data-hub-user",
+  "description": "Data Hub role for users that can run flows and view job details; it is intended to replace flow-operator-role, and thus it inherits all of the privileges that flow-operator-role does",
+  "role": [
+    "rest-extension-user",
+    "rest-reader",
+    "rest-writer",
+    "data-hub-job-reader"
+  ],
+  "privilege": [
+    {
+      "privilege-name": "xdmp:set-server-field",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-set-server-field",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:get-server-field",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-get-server-field",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "manage",
+      "action": "http://marklogic.com/xdmp/privileges/manage",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:eval",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-eval",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:eval-in",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-eval-in",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:xslt-eval",
+      "action": "http://marklogic.com/xdmp/privileges/xslt-eval",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:xslt-invoke",
+      "action": "http://marklogic.com/xdmp/privileges/xslt-invoke",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:invoke",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-invoke",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:invoke-in",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-invoke-in",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdbc:invoke",
+      "action": "http://marklogic.com/xdmp/privileges/xdbc-invoke",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdbc:invoke-in",
+      "action": "http://marklogic.com/xdmp/privileges/xdbc-invoke-in",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdbc:eval",
+      "action": "http://marklogic.com/xdmp/privileges/xdbc-eval",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdbc:eval-in",
+      "action": "http://marklogic.com/xdmp/privileges/xdbc-eval-in",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdbc:insert",
+      "action": "http://marklogic.com/xdmp/privileges/xdbc-insert",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdbc:insert-in",
+      "action": "http://marklogic.com/xdmp/privileges/xdbc-insert-in",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:document-load",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-document-load",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:get-server-field-names",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-get-server-field-names",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:value",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-value",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "unprotected-collections",
+      "action": "http://marklogic.com/xdmp/privileges/unprotected-collections",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "unprotected-uri",
+      "action": "http://marklogic.com/xdmp/privileges/unprotected-uri",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "ps-user",
+      "action": "http://marklogic.com/xdmp/privileges/ps-user",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "sem:sparql",
+      "action": "http://marklogic.com/xdmp/privileges/sem-sparql",
+      "kind": "execute"
+    }
+  ]
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.hub/config.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.hub/config.sjs
@@ -7,5 +7,6 @@ module.exports = {
   HUBVERSION: "%%mlHubVersion%%",
   HUBLOGLEVEL: "%%mlHubLogLevel%%",
   FLOWOPERATORROLE: "%%mlFlowOperatorRole%%",
-  FLOWDEVELOPERROLE: "%%mlFlowDeveloperRole%%"
+  FLOWDEVELOPERROLE: "%%mlFlowDeveloperRole%%",
+  JOBPERMISSIONS: "%%mlJobPermissions%%"
 };

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/command/InstallIntoDhsCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/command/InstallIntoDhsCommandTest.java
@@ -85,7 +85,7 @@ public class InstallIntoDhsCommandTest extends HubTestBase {
         command.dataHub = super.dataHub;
 
         List<Command> commands = command.buildCommandsForDhs();
-        assertEquals(15, commands.size());
+        assertEquals(16, commands.size());
         Collections.sort(commands, (c1, c2) -> c1.getExecuteSortOrder().compareTo(c2.getExecuteSortOrder()));
 
         int index = 0;
@@ -104,6 +104,7 @@ public class InstallIntoDhsCommandTest extends HubTestBase {
         assertTrue(commands.get(index++) instanceof DeployHubTriggersCommand);
         assertTrue(commands.get(index++) instanceof LoadUserArtifactsCommand);
         assertTrue(commands.get(index++) instanceof LoadHubArtifactsCommand);
+        assertTrue(commands.get(index++) instanceof CreateGranularPrivilegesCommand);
 
         DeployRolesCommand deployRolesCommand = (DeployRolesCommand) commands.get(1);
         ResourceFilenameFilter filter = (ResourceFilenameFilter) deployRolesCommand.getResourceFilenameFilter();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesTest.java
@@ -1,0 +1,52 @@
+package com.marklogic.hub.deploy.commands;
+
+import com.marklogic.hub.ApplicationConfig;
+import com.marklogic.hub.HubTestBase;
+import com.marklogic.mgmt.api.API;
+import com.marklogic.mgmt.api.security.Privilege;
+import com.marklogic.mgmt.mapper.DefaultResourceMapper;
+import com.marklogic.mgmt.mapper.ResourceMapper;
+import com.marklogic.mgmt.resource.databases.DatabaseManager;
+import com.marklogic.mgmt.resource.security.PrivilegeManager;
+import com.marklogic.rest.util.ResourcesFragment;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ApplicationConfig.class)
+public class CreateGranularPrivilegesTest extends HubTestBase {
+
+    /**
+     * The CreateGranularPrivilegesCommand is assumed to have been run as part of bootstrapping the test application,
+     * so this test just verifies the results of that command having been run.
+     */
+    @Test
+    public void verifyGranularPrivilegesExist() {
+        PrivilegeManager mgr = new PrivilegeManager(adminHubConfig.getManageClient());
+        ResourceMapper resourceMapper = new DefaultResourceMapper(new API(adminHubConfig.getManageClient()));
+
+        ResourcesFragment databasesXml = new DatabaseManager(adminHubConfig.getManageClient()).getAsXml();
+        final String finalDbId = databasesXml.getIdForNameOrId("data-hub-FINAL");
+        final String stagingDbId = databasesXml.getIdForNameOrId("data-hub-STAGING");
+
+        Privilege p = resourceMapper.readResource(mgr.getAsJson("admin-database-clear-data-hub-STAGING", "kind", "execute"), Privilege.class);
+        assertEquals("http://marklogic.com/xdmp/privileges/admin/database/clear/" + stagingDbId, p.getAction());
+        assertEquals("data-hub-admin", p.getRole().get(0));
+
+        p = resourceMapper.readResource(mgr.getAsJson("admin-database-clear-data-hub-FINAL", "kind", "execute"), Privilege.class);
+        assertEquals("http://marklogic.com/xdmp/privileges/admin/database/clear/" + finalDbId, p.getAction());
+        assertEquals("data-hub-admin", p.getRole().get(0));
+
+        p = resourceMapper.readResource(mgr.getAsJson("admin-database-index-data-hub-STAGING", "kind", "execute"), Privilege.class);
+        assertEquals("http://marklogic.com/xdmp/privileges/admin/database/index/" + stagingDbId, p.getAction());
+        assertEquals("data-hub-app-admin", p.getRole().get(0));
+
+        p = resourceMapper.readResource(mgr.getAsJson("admin-database-index-data-hub-FINAL", "kind", "execute"), Privilege.class);
+        assertEquals("http://marklogic.com/xdmp/privileges/admin/database/index/" + finalDbId, p.getAction());
+        assertEquals("data-hub-app-admin", p.getRole().get(0));
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunnerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunnerTest.java
@@ -66,24 +66,8 @@ public class FlowRunnerTest extends HubTestBase {
     }
 
     @BeforeEach
-    public void setupEach() throws IOException {
-        basicSetup();
-        getDataHubAdminConfig();
-        clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME, HubConfig.DEFAULT_JOB_NAME);
-        FileUtils.copyFileToDirectory(getResourceFile("flow-runner-test/entities/e2eentity.entity.json"),
-            hubConfig.getHubEntitiesDir().toFile());
-        installUserModules(getDataHubAdminConfig(), true);
-        FileUtils.copyDirectory(getResourceFile("flow-runner-test/flows"), hubConfig.getFlowsDir().toFile());
-        FileUtils.copyDirectory(getResourceFile("flow-runner-test/input"),
-            hubConfig.getHubProjectDir().resolve("input").toFile());
-        FileUtils.copyFileToDirectory(getResourceFile("flow-runner-test/step-definitions/json-ingestion.step.json"),
-            hubConfig.getStepsDirByType(StepDefinition.StepDefinitionType.INGESTION).resolve("json-ingestion").toFile());
-        FileUtils.copyFileToDirectory(getResourceFile("flow-runner-test/step-definitions/json-mapping.step.json"),
-            hubConfig.getStepsDirByType(StepDefinition.StepDefinitionType.MAPPING).resolve("json-mapping").toFile());
-        FileUtils.copyDirectory(getResourceFile("flow-runner-test/mappings"),
-            hubConfig.getHubMappingsDir().resolve("e2e-mapping").toFile());
-        installUserModules(getDataHubAdminConfig(), true);
-        installHubArtifacts(getDataHubAdminConfig(), true);
+    public void setupEach() {
+        setupProjectForRunningTestFlow();
         getHubFlowRunnerConfig();
     }
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/AbstractSecurityTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/AbstractSecurityTest.java
@@ -1,0 +1,105 @@
+package com.marklogic.hub.security;
+
+import com.marklogic.hub.ApplicationConfig;
+import com.marklogic.hub.HubTestBase;
+import com.marklogic.mgmt.ManageClient;
+import com.marklogic.mgmt.ManageConfig;
+import com.marklogic.mgmt.api.API;
+import com.marklogic.mgmt.api.security.Role;
+import com.marklogic.mgmt.api.security.User;
+import com.marklogic.mgmt.mapper.DefaultResourceMapper;
+import com.marklogic.mgmt.mapper.ResourceMapper;
+import com.marklogic.mgmt.resource.security.RoleManager;
+import com.marklogic.rest.util.ResourcesFragment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Base class for tests that verify that DHF roles can/cannot do what they're intended to do.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ApplicationConfig.class)
+public abstract class AbstractSecurityTest extends HubTestBase {
+
+    protected static final String FINAL_DB = "data-hub-FINAL";
+    protected static final String STAGING_DB = "data-hub-STAGING";
+
+    protected ManageClient adminUserClient;
+    protected API adminUserApi;
+    protected ResourceMapper resourceMapper;
+
+    protected Role roleBeingTested;
+    protected User userWithRoleBeingTested;
+    protected ManageClient userWithRoleBeingTestedClient;
+    protected API userWithRoleBeingTestedApi;
+
+    private List<String> customPrivilegeNames = new ArrayList<>();
+
+    @BeforeEach
+    public void setupFlowDeveloperApi() {
+        // It's assumed that the "admin" user is the default user for talking to the Manage API
+        adminUserClient = adminHubConfig.getManageClient();
+        adminUserApi = new API(adminUserClient);
+        resourceMapper = new DefaultResourceMapper(adminUserApi);
+
+        roleBeingTested = new DefaultResourceMapper(adminUserApi).readResource(
+            new RoleManager(adminUserClient).getAsJson(getRoleName()), Role.class
+        );
+
+        createUserWithRoleBeingTested();
+
+        userWithRoleBeingTestedClient = new ManageClient(
+            new ManageConfig(adminHubConfig.getHost(), 8002, userWithRoleBeingTested.getUserName(), userWithRoleBeingTested.getPassword())
+        );
+        userWithRoleBeingTestedApi = new API(userWithRoleBeingTestedClient);
+
+        logger.info("Finished setting up role to be tested and a user with that role");
+    }
+
+    @AfterEach
+    public void tearDown() {
+        logger.info("Deleting the role to be tested and the user with that role");
+        if (userWithRoleBeingTested != null) {
+            userWithRoleBeingTested.delete();
+        }
+    }
+
+    /**
+     * Subclasses must define the name of the role being tested. This class will then create a user
+     * with that role so that the user can be tested against different operations.
+     *
+     * @return
+     */
+    protected abstract String getRoleName();
+
+    protected void createUserWithRoleBeingTested() {
+        userWithRoleBeingTested = new User(adminUserApi, "userBeingTested");
+        userWithRoleBeingTested.setPassword("password");
+        userWithRoleBeingTested.setRole(Arrays.asList(roleBeingTested.getRoleName()));
+        userWithRoleBeingTested.delete();
+        userWithRoleBeingTested.save();
+    }
+
+    protected Role getRole(String roleName) {
+        return resourceMapper.readResource(new RoleManager(adminUserClient).getAsJson(roleName), Role.class);
+    }
+
+    protected void verifySystemLogsCanBeAccessed() {
+        ResourcesFragment xml = new ResourcesFragment(userWithRoleBeingTestedClient.getXml("/manage/v2/logs"));
+        List<String> logNames = xml.getListItemNameRefs();
+        // AuditLog.txt will only exist if auditing is enabled. Checking for ErrorLog.txt is just as good.
+        assertTrue(logNames.contains("ErrorLog.txt"),
+            "If the list of accessible log files includes ErrorLog.txt, then the user will be able to see " +
+                "AuditLog.txt as well, as both require the get-system-logs privilege; actual list of log names: " + logNames);
+    }
+
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubAdminTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubAdminTest.java
@@ -1,0 +1,66 @@
+package com.marklogic.hub.security;
+
+import com.marklogic.mgmt.api.database.Database;
+import com.marklogic.mgmt.resource.databases.DatabaseManager;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Needs manage-user for RMA access plus granular privileges for clearing the staging and final databases.
+ */
+public class DataHubAdminTest extends AbstractSecurityTest {
+
+    @Override
+    protected String getRoleName() {
+        return "data-hub-admin";
+    }
+
+    @Test
+    public void task7ClearStagingDatabase() {
+        try {
+            new DatabaseManager(userWithRoleBeingTestedClient).clearDatabase(STAGING_DB, false);
+            String count = adminHubConfig.newStagingClient().newServerEval().xquery("xdmp:estimate(fn:doc())").evalAs(String.class);
+            assertEquals(0, Integer.parseInt(count), "The database should have been cleared");
+        } finally {
+            installHubArtifacts(adminHubConfig, true);
+        }
+    }
+
+    @Test
+    public void task7CannotOtherwiseUpdateStagingDatabase() {
+        try {
+            Database db = new Database(userWithRoleBeingTestedApi, STAGING_DB);
+            db.setRebalancerThrottle(3);
+            db.save();
+            fail("The user should only have the ability to clear the database and modify indexes");
+        } catch (Exception ex) {
+            logger.info("Caught expected exception: " + ex.getMessage());
+        }
+    }
+
+    @Test
+    public void task8ClearFinalDatabase() {
+        try {
+            new DatabaseManager(userWithRoleBeingTestedClient).clearDatabase(FINAL_DB, false);
+            String count = adminHubConfig.newFinalClient().newServerEval().xquery("xdmp:estimate(fn:doc())").evalAs(String.class);
+            assertEquals(0, Integer.parseInt(count), "The database should have been cleared");
+        } finally {
+            installHubArtifacts(adminHubConfig, true);
+        }
+    }
+
+    @Test
+    public void task8CannotOtherwiseUpdateFinalDatabase() {
+        try {
+            Database db = new Database(userWithRoleBeingTestedApi, FINAL_DB);
+            db.setRebalancerThrottle(3);
+            db.save();
+            fail("The user should only have the ability to clear the database and modify indexes");
+        } catch (Exception ex) {
+            logger.info("Caught expected exception: " + ex.getMessage());
+        }
+    }
+
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubAppAdminTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubAppAdminTest.java
@@ -1,0 +1,262 @@
+package com.marklogic.hub.security;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.mgmt.api.database.Database;
+import com.marklogic.mgmt.api.database.GeospatialElementIndex;
+import com.marklogic.mgmt.api.security.protectedpath.Permission;
+import com.marklogic.mgmt.api.security.protectedpath.ProtectedPath;
+import com.marklogic.mgmt.api.task.Task;
+import com.marklogic.mgmt.api.trigger.*;
+import com.marklogic.mgmt.resource.alert.AlertConfigManager;
+import com.marklogic.mgmt.resource.security.ProtectedPathManager;
+import com.marklogic.mgmt.resource.tasks.TaskManager;
+import com.marklogic.mgmt.resource.temporal.TemporalAxesManager;
+import com.marklogic.mgmt.util.ObjectMapperFactory;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DataHubAppAdminTest extends AbstractSecurityTest {
+
+    @Override
+    protected String getRoleName() {
+        return "data-hub-app-admin";
+    }
+
+    @Test
+    @Disabled("This is not yet possible; a new granular privilege will be needed to only allow for temporal config to be " +
+        "added to a database while not being able to make any modification to the database")
+    public void task9ConfigureBitemporal() throws IOException {
+        final String temporalAxis = "{\n" +
+            "  \"axis-name\": \"test-axis\",\n" +
+            "  \"axis-start\": {\n" +
+            "    \"element-reference\": {\n" +
+            "      \"namespace-uri\": \"\",\n" +
+            "      \"localname\": \"test-systemStart\"\n" +
+            "    }\n" +
+            "  },\n" +
+            "  \"axis-end\": {\n" +
+            "    \"element-reference\": {\n" +
+            "      \"namespace-uri\": \"\",\n" +
+            "      \"localname\": \"test-systemEnd\"\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
+        new TemporalAxesManager(userWithRoleBeingTestedClient, FINAL_DB).save(temporalAxis);
+
+        // Verify and delete the axis as the admin user
+        TemporalAxesManager mgr = new TemporalAxesManager(adminUserClient, FINAL_DB);
+        try {
+            JsonNode json = ObjectMapperFactory.getObjectMapper().readTree(mgr.getPropertiesAsJson("test-axis"));
+            assertEquals("test-axis", json.get("axis-name").asText(),
+                "Sanity check that the axis was created; if it wasn't, an error should have been thrown already");
+        } finally {
+            mgr.delete(temporalAxis);
+        }
+    }
+
+    /**
+     * Note that protect-path seems to allow both create and update, but neither protect-path nor unprotect-path allow
+     * for deleting a protected path.
+     */
+    @Test
+    public void task10CreateProtectedPaths() {
+        final String pathExpression = "/some/path";
+        ProtectedPath path = new ProtectedPath(pathExpression);
+        path.setPermission(Arrays.asList(new com.marklogic.mgmt.api.security.protectedpath.Permission("rest-reader", "read")));
+        path.setApi(userWithRoleBeingTestedApi);
+
+        try {
+            path.save();
+
+            // And update it
+            path.setPermission(Arrays.asList(new Permission("rest-writer", "read")));
+            path.save();
+
+            // Verify it as the admin user
+            ProtectedPath updatedPath = resourceMapper.readResource(new ProtectedPathManager(adminUserClient).getAsJson(pathExpression), ProtectedPath.class);
+            assertEquals(1, updatedPath.getPermission().size());
+            assertEquals("rest-writer", updatedPath.getPermission().get(0).getRoleName(), "The protect-path privilege should allow " +
+                "the user to both create and update protected paths");
+        } finally {
+            path.setApi(adminUserApi);
+            path.delete();
+        }
+    }
+
+    @Test
+    @Disabled("Seem to be missing the granularity to only allow configuring triggers on a database")
+    public void task11CreateFinalTriggers() {
+        Trigger trigger = new Trigger();
+        trigger.setApi(userWithRoleBeingTestedApi);
+        trigger.setName("test-trigger");
+        trigger.setDatabaseName("data-hub-final-TRIGGERS");
+        Event event = new Event();
+        DataEvent dataEvent = new DataEvent();
+        dataEvent.setWhen("pre-commit");
+        dataEvent.setDocumentContent(new DocumentContent("create"));
+        dataEvent.setCollectionScope(new CollectionScope("test"));
+        event.setDataEvent(dataEvent);
+        trigger.setEvent(event);
+        trigger.setModule("/some/trigger.sjs");
+        trigger.setRecursive(false);
+        trigger.setEnabled(false);
+        trigger.setModuleDb("data-hub-MODULES");
+        try {
+            trigger.save();
+        } finally {
+            trigger.setApi(adminUserApi);
+            trigger.delete();
+        }
+    }
+
+    @Test
+    @Disabled("Can't get this working without giving the user the manage-admin role; see https://bugtrack.marklogic.com/53319")
+    public void task13ConfigureAlertsInFinal() {
+        ObjectNode node = ObjectMapperFactory.getObjectMapper().createObjectNode();
+        node.put("uri", "my-alert-config");
+        node.put("name", "my alerting app");
+        node.put("description", "my description");
+        try {
+            new AlertConfigManager(userWithRoleBeingTestedClient, FINAL_DB).save(node.toString());
+        } finally {
+            new AlertConfigManager(adminUserClient, FINAL_DB).delete(node.toString());
+        }
+    }
+
+    @Test
+    public void task14ViewAuditLog() {
+        verifySystemLogsCanBeAccessed();
+    }
+
+    @Test
+    public void task15MonitorDatabase() {
+        assertTrue(roleBeingTested.getRole().contains("manage-user"),
+            "The manage-user role grants access to the monitoring GUI on port 8002, which also provides visibility of deadlocks " +
+                "(as do the system logs)");
+    }
+
+    @Test
+    public void task16MonitorBackups() {
+        assertTrue(roleBeingTested.getRole().contains("manage-user"),
+            "The manage-user role (and the 'manage' role) grants access to 8002:/manage/v2, which provides read-only " +
+                "access to database and forest status, which can be used for checking backup status per the instructions at " +
+                "https://help.marklogic.com/Knowledgebase/Article/View/377/0/creating-a-web-service-for-monitoring-marklogic-backups");
+    }
+
+    @Test
+    @Disabled("Seems to still require manage-admin at the RMA level")
+    public void task17CreateScheduledTask() {
+        Task task = new Task(userWithRoleBeingTestedApi, null);
+        task.setTaskPath("/MarkLogic/flexrep/tasks/push-local-forests.xqy");
+        task.setGroupName("Default");
+        task.setTaskEnabled(false);
+        task.setTaskDatabase(FINAL_DB);
+        task.setTaskModules("");
+        task.setTaskRoot("Modules/");
+        task.setTaskPeriod(1);
+        task.setTaskType("minutely");
+        task.setTaskUser("nobody");
+
+        try {
+            task.save();
+        } finally {
+            new TaskManager(adminUserClient).deleteTaskWithPath(task.getTaskPath());
+        }
+    }
+
+    @Test
+    public void task18ConfigureFinalIndexes() {
+        Database db = new Database(userWithRoleBeingTestedApi, FINAL_DB);
+        db.setGeospatialElementIndex(Arrays.asList(buildGeoIndex()));
+        try {
+            db.save();
+        } finally {
+            db.setApi(adminUserApi);
+            db.setGeospatialElementIndex(Arrays.asList());
+            db.save();
+        }
+    }
+
+    @Test
+    public void task18ConfigureStagingIndexes() {
+        Database db = new Database(userWithRoleBeingTestedApi, STAGING_DB);
+        db.setGeospatialElementIndex(Arrays.asList(buildGeoIndex()));
+        try {
+            db.save();
+        } finally {
+            db.setApi(adminUserApi);
+            db.setGeospatialElementIndex(Arrays.asList());
+            db.save();
+        }
+    }
+
+    @Test
+    public void task19LoadModulesAndArtifacts() {
+        final String originalMlUsername = adminHubConfig.getMlUsername();
+        final String originalMlPassword = adminHubConfig.getMlPassword();
+        try {
+            adminHubConfig.setMlUsername(userWithRoleBeingTested.getUserName());
+            adminHubConfig.setMlPassword(userWithRoleBeingTested.getPassword());
+
+            installUserModules(adminHubConfig, true);
+        } finally {
+            adminHubConfig.setMlUsername(originalMlUsername);
+            adminHubConfig.setMlPassword(originalMlPassword);
+        }
+    }
+
+    /**
+     * Combining all of these since they're just simple role checks.
+     */
+    @Test
+    public void tasks19And20And22And23And24And26And27And29And30And31And37And38() {
+        assertTrue(roleBeingTested.getRole().contains("rest-admin"),
+            "Task 19: rest-admin allows the user to insert documents via /v1/documents");
+
+        assertTrue(roleBeingTested.getRole().contains("tde-admin"),
+            "Task 19 and 24: tde-admin allows the user to insert TDE schemas into the TDE protected collection");
+
+        assertTrue(roleBeingTested.getRole().contains("rest-admin"),
+            "Tasks 20 and 22: rest-admin is sufficient for allowing the user to perform CRUD operations on flows and " +
+                "schemas, as these both default to being inserted with rest-reader/rest-writer permissions via " +
+                "mlModulePermissions");
+
+        assertTrue(roleBeingTested.getRole().contains("ps-user"),
+            "Task 23: The ML provenance functions add ps-user/read and ps-internal/update permissions by default on " +
+                "provenance documents; thus, a user needs ps-user to read these documents");
+
+        assertTrue(roleBeingTested.getRole().contains("rest-admin"),
+            "Tasks 26 and 27: Artifacts get rest-reader and rest-writer by default via mlModulePermissions and " +
+                "mlEntityModelPermissions, and thus rest-admin provides access to reading these documents");
+
+        assertTrue(roleBeingTested.getRole().contains("manage-user"),
+            "Tasks 29 and 30: manage-user grants access to app-server logs, but not system logs");
+
+        assertTrue(roleBeingTested.getRole().contains("manage-user"),
+            "Task 31: manage-user grants read access to documents in the Meters database");
+
+        assertTrue(roleBeingTested.getRole().contains("rest-admin"),
+            "Tasks 37 and 38: these tasks are redundant with task 19; rest-admin allows a user to write these documents");
+
+
+    }
+
+    private GeospatialElementIndex buildGeoIndex() {
+        GeospatialElementIndex index = new GeospatialElementIndex();
+        index.setLocalname("someLocalname");
+        index.setNamespaceUri("someNamespace");
+        index.setPointFormat("point");
+        index.setCoordinateSystem("wgs84");
+        index.setInvalidValues("reject");
+        index.setRangeValuePositions(false);
+        return index;
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubEnvironmentManagerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubEnvironmentManagerTest.java
@@ -1,0 +1,24 @@
+package com.marklogic.hub.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DataHubEnvironmentManagerTest extends AbstractSecurityTest {
+
+    @Override
+    protected String getRoleName() {
+        return "data-hub-environment-manager";
+    }
+
+    @Test
+    public void task1InstallDataHub() {
+        final String message = "The data-hub-environment-manager is allowed to have manage-admin and security so " +
+            "that in any environment, it can be used to perform any DH operation (short of anything requiring " +
+            "the admin role). In DHS, this role will be used by DHS software to install DH without having to " +
+            "use the admin user. On-premise, this role should only be used for an initial install of DH.";
+
+        assertTrue(roleBeingTested.getRole().contains("manage-admin"), message);
+        assertTrue(roleBeingTested.getRole().contains("security"), message);
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubMonitorTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubMonitorTest.java
@@ -1,0 +1,45 @@
+package com.marklogic.hub.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DataHubMonitorTest extends AbstractSecurityTest {
+
+    @Override
+    protected String getRoleName() {
+        return "data-hub-monitor";
+    }
+
+    @Test
+    public void task14ViewAuditLog() {
+        verifySystemLogsCanBeAccessed();
+    }
+
+    @Test
+    public void task15MonitorDatabase() {
+        assertTrue(roleBeingTested.getRole().contains("manage-user"),
+            "The manage-user role grants access to the monitoring GUI on port 8002, which also provides visibility of deadlocks " +
+                "(as do the system logs)");
+    }
+
+    @Test
+    public void task16MonitorBackups() {
+        assertTrue(roleBeingTested.getRole().contains("manage-user"),
+            "The manage-user role (and the 'manage' role) grants access to 8002:/manage/v2, which provides read-only " +
+                "access to database and forest status, which can be used for checking backup status per the instructions at " +
+                "https://help.marklogic.com/Knowledgebase/Article/View/377/0/creating-a-web-service-for-monitoring-marklogic-backups");
+    }
+
+    @Test
+    public void task32ReadJobDocuments() {
+        assertTrue(roleBeingTested.getRole().contains("data-hub-job-reader"),
+            "The data-hub-job-reader role grants access to Job and Batch documents in the jobs database");
+    }
+
+    @Test
+    public void task33MonitorAppServerPerformance() {
+        assertTrue(roleBeingTested.getRole().contains("manage-user"),
+            "The manage-user role grants access to the monitoring GUI on port 8002, which is how app server performance is best monitored");
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubPortalSecurityAdminTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubPortalSecurityAdminTest.java
@@ -1,0 +1,23 @@
+package com.marklogic.hub.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DataHubPortalSecurityAdminTest extends AbstractSecurityTest {
+
+    @Override
+    protected String getRoleName() {
+        return "data-hub-portal-security-admin";
+    }
+
+    @Test
+    public void task4ConfigureExternalSecurity() {
+        final String message = "It is currently assumed that it's fine for this DHS-specific role to have the " +
+            "manage-admin and security roles; if not, new granular privileges will be needed to support managing " +
+            "external security resources without those roles";
+
+        assertTrue(roleBeingTested.getRole().contains("manage-admin"), message);
+        assertTrue(roleBeingTested.getRole().contains("security"), message);
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubSecurityAdminTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubSecurityAdminTest.java
@@ -1,0 +1,98 @@
+package com.marklogic.hub.security;
+
+import com.marklogic.mgmt.api.security.Role;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DataHubSecurityAdminTest extends AbstractSecurityTest {
+
+    @Override
+    protected String getRoleName() {
+        return "data-hub-security-admin";
+    }
+
+    /**
+     * Just need manage and the role-set-external-names privilege. Note that this is only ever updating an existing role,
+     * it's not able to create a role. But due to the "manage" role, the user is able to read the from via the
+     * Manage API, which is verified via the "save" call.
+     */
+    @Test
+    public void task3CreateRoleWithExternalName() {
+        final String externalName = "test-external-name";
+        final String testRoleName = "external-name-test-role";
+
+        try {
+            Role role = new Role(userWithRoleBeingTestedApi, testRoleName);
+            role.setExternalName(Arrays.asList(externalName));
+            role.save();
+
+            role = getRole(role.getRoleName());
+            assertEquals(externalName, role.getExternalName().get(0));
+        } finally {
+            new Role(adminUserApi, testRoleName).delete();
+        }
+    }
+
+    /**
+     * Note that in this scenario, if the role had been created by e.g. flow-developer, the user would not be able to
+     * modify it. ML enforces that, and that's what we want - the user can only modify roles per the rules of the
+     * create-data-role privilege.
+     */
+    @Test
+    public void task3AddExternalNameToExistingRole() {
+        final String externalName = "test-external-name";
+        final String testRoleName = "external-name-test-role";
+
+        try {
+            // First create the role
+            Role role = new Role(userWithRoleBeingTestedApi, testRoleName);
+            role.save();
+
+            // Now modify it as the limited user
+            role = new Role(userWithRoleBeingTestedApi, testRoleName);
+            role.setExternalName(Arrays.asList(externalName));
+            role.save();
+
+            role = getRole(role.getRoleName());
+            assertEquals(externalName, role.getExternalName().get(0));
+        } finally {
+            new Role(adminUserApi, testRoleName).delete();
+        }
+    }
+
+
+    @Test
+    public void task5CreateCustomRoles() {
+        final String roleName = "test-custom-role";
+        Role customRole = new Role(userWithRoleBeingTestedApi, roleName);
+
+        try {
+            customRole.save();
+            customRole = getRole(roleName);
+            assertEquals(roleName, customRole.getRoleName());
+            assertNull(customRole.getRole(), "Since the user has the create-date-role privilege, it can create new roles, " +
+                "though not ones that inherit existing ML-created roles");
+        } finally {
+            new Role(adminUserApi, roleName).delete();
+        }
+    }
+
+    @Test
+    public void task5CannotCreateCustomRoleInheritingExistingRole() {
+        final String roleName = "test-custom-role2";
+        Role customRole = new Role(userWithRoleBeingTestedApi, roleName);
+        customRole.setRole(Arrays.asList("manage-admin"));
+
+        try {
+            customRole.save();
+            fail("The role creation should have failed because the role inherits an existing ML-created role");
+        } catch (Exception ex) {
+            logger.info("Caught expected exception: " + ex.getMessage());
+        } finally {
+            new Role(adminUserApi, roleName).delete();
+        }
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubUserTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubUserTest.java
@@ -1,0 +1,71 @@
+package com.marklogic.hub.security;
+
+import com.marklogic.bootstrap.Installer;
+import com.marklogic.hub.HubConfig;
+import com.marklogic.hub.flow.impl.FlowRunnerImpl;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This includes most of the privileges inherited by flow-operator-role, as this role is intended to replace that
+ * one. It does not yet include the "manage" privilege, as there doesn't appear to be a use case for that yet.
+ * <p>
+ * XDBC privileges are retained to support mlcp usage when ingesting data.
+ */
+public class DataHubUserTest extends AbstractSecurityTest {
+
+    @Autowired
+    FlowRunnerImpl flowRunner;
+
+    @Override
+    protected String getRoleName() {
+        return "data-hub-user";
+    }
+
+    @BeforeAll
+    public static void setup() {
+        XMLUnit.setIgnoreWhitespace(true);
+        new Installer().deleteProjectDir();
+    }
+
+    @AfterAll
+    public static void cleanUp() {
+        new Installer().deleteProjectDir();
+    }
+
+    @Test
+    public void task30RunFlow() {
+        setupProjectForRunningTestFlow();
+
+        try {
+            getHubFlowRunnerConfig(userWithRoleBeingTested.getUserName(), userWithRoleBeingTested.getPassword());
+
+            flowRunner.runFlow("testFlow");
+            flowRunner.awaitCompletion();
+            assertEquals(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "xml-coll"), 1);
+            assertEquals(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "csv-coll"), 25);
+            assertEquals(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "csv-tab-coll"), 25);
+            assertEquals(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "json-coll"), 1);
+            assertEquals(getDocCount(HubConfig.DEFAULT_FINAL_NAME, "json-map"), 1);
+            assertEquals(getDocCount(HubConfig.DEFAULT_FINAL_NAME, "xml-map"), 1);
+            assertEquals(getDocCount(HubConfig.DEFAULT_JOB_NAME, "Jobs"), 3,
+                "For task 32, data-hub-user should be able to see documents in the Jobs collection via the " +
+                    "data-hub-job-reader role, and there should be 3 documents - 2 in Batch, and 1 in Job");
+        } finally {
+            adminHubConfig.setMlUsername(super.user);
+            adminHubConfig.setMlPassword(super.password);
+        }
+    }
+
+    @Test
+    public void task32ReadJobDocuments() {
+        assertTrue(roleBeingTested.getRole().contains("data-hub-job-reader"),
+            "The data-hub-job-reader role grants access to Job and Batch documents in the jobs database");
+    }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/jobs/buildJobPermissionsScript.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/jobs/buildJobPermissionsScript.sjs
@@ -1,0 +1,18 @@
+const config = require("/com.marklogic.hub/config.sjs");
+const test = require("/test/test-helper.xqy");
+const Jobs = require("/data-hub/5/impl/jobs.sjs");
+
+const result = new Jobs().buildJobPermissionsScript(config);
+[
+  test.assertEqual("data-hub-job-reader,read,data-hub-job-internal,update", config.JOBPERMISSIONS,
+    "The value of this is a token - %%mlJobPermissions%% - that should have been replaced when the config.sjs module was loaded"),
+
+  test.assertEqual("xdmp.defaultPermissions().concat([" +
+    "xdmp.permission('flow-developer-role', 'update'), " +
+    "xdmp.permission('flow-operator-role', 'update'), " +
+    "xdmp.permission('data-hub-job-reader', 'read'), " +
+    "xdmp.permission('data-hub-job-internal', 'update')" +
+    "])", result,
+    "The job permissions script should add the data-hub-job-reader/data-hub-job-internal perms to the default permissions of the current user; " +
+    "the flow-developer-role/flow-operator-role update permissions are being retained for backwards compatibility.")
+];

--- a/marklogic-data-hub/src/test/resources/logback.xml
+++ b/marklogic-data-hub/src/test/resources/logback.xml
@@ -28,4 +28,8 @@
     <appender-ref ref="STDOUT" />
   </logger>
 
+  <logger name="com.marklogic.mgmt" level="WARN" additivity="false">
+    <appender-ref ref="STDOUT" />
+  </logger>
+
 </configuration>


### PR DESCRIPTION
With the exception of data-hub-job-reader and data-hub-job-internal, these aren't being used anywhere, they're just being defined.

data-hub-job-reader and data-job-internal however have been added to support the "can read job documents" requirement in 3108. DHFPROD-3618 will then introduce an amp to allow for job documents to be updated without needing flow-developer-role/update and flow-operator-role/update permissions on them.