### PR TITLE
DHFPROD-3523: No longer depending on com.sun class for file watching

### DIFF
--- a/web/src/main/java/com/marklogic/hub/web/service/FileSystemWatcherService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/FileSystemWatcherService.java
@@ -18,7 +18,6 @@ package com.marklogic.hub.web.service;
 
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.impl.HubConfigImpl;
-import com.sun.nio.file.SensitivityWatchEventModifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
@@ -93,7 +92,7 @@ public class FileSystemWatcherService implements DisposableBean {
      * Register the given directory with the WatchService
      */
     private void register(Path dir) throws IOException {
-        WatchKey key = dir.register(watcher(), new Kind[]{StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY}, SensitivityWatchEventModifier.HIGH);
+        WatchKey key = dir.register(watcher(), new Kind[]{StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY});
         if (logger.isInfoEnabled()) {
             Path prev = keys.get(key);
             if (prev == null) {


### PR DESCRIPTION
This class isn't in OpenJDK, which means you can't compile/run QS on OpenJDK

@bsrikan When you test this, can you verify that there's no noticeable delay in when QS notices file changes? I can't tell since I'm running OpenJDK, and so I don't know if the removed class helps at all. 