### PR TITLE
DHFPROD-3176: Changed ResponseHolder.documents to a List

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/ResponseHolder.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/ResponseHolder.java
@@ -27,9 +27,14 @@ public class ResponseHolder {
     public List<String> completedItems;
     public List<String> failedItems;
     public List<JsonNode> errors;
-    public Map<String, JsonNode> documents;
+    public List<JsonNode> documents;
 
     public String toString() {
-        return String.format("{jobId: %d, totalCount: %d, errorCount: %d, completedItems: %d, failedItems: %d, errors: %d, documents: %d}", jobId, totalCount, errorCount, completedItems.size(), failedItems.size(), errors.size(), documents.get("documents").size());
+        int completedSize = completedItems != null ? completedItems.size() : 0;
+        int failedSize = failedItems != null ? failedItems.size() : 0;
+        int errorSize = errors != null ? errors.size() : 0;
+        int documentsSize = documents != null ? documents.size() : 0;
+        return String.format("{jobId: %d, totalCount: %d, errorCount: %d, completedItems: %d, failedItems: %d, errors: %d, documents: %d}",
+            jobId, totalCount, errorCount, completedSize, failedSize, errorSize, documentsSize);
     }
 }


### PR DESCRIPTION
The main cause of the error was that "documents" in the JSON returned by mlRunFlow was an array of objects, not a map. So ResponseHolder.documents is now a list. 
QueryStepRunner then had to be modified to convert this list into a map structure, where the key is the URI. 

This feature is undocumented and does not have any tests, so I put the change in QueryStepRunner into a try/catch to ensure it can never break anything. 