### PR TITLE
DHFPROD-3108: Renamed new roles to data-hub-developer and data-hub-operator

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesCommand.java
@@ -57,7 +57,7 @@ public class CreateGranularPrivilegesCommand implements Command {
 
         p.setPrivilegeName("admin-database-index-" + finalDbName);
         p.setAction("http://marklogic.com/xdmp/privileges/admin/database/index/" + finalDbId);
-        p.setRole(Arrays.asList("data-hub-app-admin"));
+        p.setRole(Arrays.asList("data-hub-developer"));
         mgr.save(p.getJson());
 
         p.setPrivilegeName("admin-database-index-" + stagingDbName);

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
@@ -340,14 +340,14 @@ public class HubProjectImpl implements HubProject {
 
         // New 5.2.0 roles
         writeRoleFile(rolesDir, "data-hub-admin.json");
-        writeRoleFile(rolesDir, "data-hub-app-admin.json");
+        writeRoleFile(rolesDir, "data-hub-developer.json");
         writeRoleFile(rolesDir, "data-hub-environment-manager.json");
         writeRoleFile(rolesDir, "data-hub-job-internal.json");
         writeRoleFile(rolesDir, "data-hub-job-reader.json");
         writeRoleFile(rolesDir, "data-hub-monitor.json");
+        writeRoleFile(rolesDir, "data-hub-operator.json");
         writeRoleFile(rolesDir, "data-hub-portal-security-admin.json");
         writeRoleFile(rolesDir, "data-hub-security-admin.json");
-        writeRoleFile(rolesDir, "data-hub-user.json");
 
         // New 5.1.0 roles
         writeRoleFile(rolesDir, "data-hub-entity-model-reader.json");

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-admin.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-admin.json
@@ -2,6 +2,6 @@
   "role-name": "data-hub-admin",
   "description": "Data Hub role for users that can administer a Data Hub application and perform a few other administrative tasks as well",
   "role": [
-    "data-hub-app-admin"
+    "data-hub-developer"
   ]
 }

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-developer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-developer.json
@@ -1,8 +1,8 @@
 {
-  "role-name": "data-hub-app-admin",
+  "role-name": "data-hub-developer",
   "description": "Data Hub role for a user that can administer a Data Hub application but not fully manage its resources",
   "role": [
-    "data-hub-user",
+    "data-hub-operator",
     "manage-user",
     "ps-user",
     "rest-admin",

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-operator.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-operator.json
@@ -1,5 +1,5 @@
 {
-  "role-name": "data-hub-user",
+  "role-name": "data-hub-operator",
   "description": "Data Hub role for users that can run flows and view job details; it is intended to replace flow-operator-role, and thus it inherits all of the privileges that flow-operator-role does",
   "role": [
     "rest-extension-user",

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesTest.java
@@ -43,10 +43,10 @@ public class CreateGranularPrivilegesTest extends HubTestBase {
 
         p = resourceMapper.readResource(mgr.getAsJson("admin-database-index-data-hub-STAGING", "kind", "execute"), Privilege.class);
         assertEquals("http://marklogic.com/xdmp/privileges/admin/database/index/" + stagingDbId, p.getAction());
-        assertEquals("data-hub-app-admin", p.getRole().get(0));
+        assertEquals("data-hub-developer", p.getRole().get(0));
 
         p = resourceMapper.readResource(mgr.getAsJson("admin-database-index-data-hub-FINAL", "kind", "execute"), Privilege.class);
         assertEquals("http://marklogic.com/xdmp/privileges/admin/database/index/" + finalDbId, p.getAction());
-        assertEquals("data-hub-app-admin", p.getRole().get(0));
+        assertEquals("data-hub-developer", p.getRole().get(0));
     }
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubDeveloperTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubDeveloperTest.java
@@ -22,11 +22,11 @@ import java.util.Arrays;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DataHubAppAdminTest extends AbstractSecurityTest {
+public class DataHubDeveloperTest extends AbstractSecurityTest {
 
     @Override
     protected String getRoleName() {
-        return "data-hub-app-admin";
+        return "data-hub-developer";
     }
 
     @Test

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubOperatorTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubOperatorTest.java
@@ -18,14 +18,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>
  * XDBC privileges are retained to support mlcp usage when ingesting data.
  */
-public class DataHubUserTest extends AbstractSecurityTest {
+public class DataHubOperatorTest extends AbstractSecurityTest {
 
     @Autowired
     FlowRunnerImpl flowRunner;
 
     @Override
     protected String getRoleName() {
-        return "data-hub-user";
+        return "data-hub-operator";
     }
 
     @BeforeAll
@@ -55,7 +55,7 @@ public class DataHubUserTest extends AbstractSecurityTest {
             assertEquals(getDocCount(HubConfig.DEFAULT_FINAL_NAME, "json-map"), 1);
             assertEquals(getDocCount(HubConfig.DEFAULT_FINAL_NAME, "xml-map"), 1);
             assertEquals(getDocCount(HubConfig.DEFAULT_JOB_NAME, "Jobs"), 3,
-                "For task 32, data-hub-user should be able to see documents in the Jobs collection via the " +
+                "For task 32, data-hub-operator should be able to see documents in the Jobs collection via the " +
                     "data-hub-job-reader role, and there should be 3 documents - 2 in Batch, and 1 in Job");
         } finally {
             adminHubConfig.setMlUsername(super.user);


### PR DESCRIPTION
Used to be data-hub-app-admin and data-hub-user