### PR TITLE
DHFPROD-2794: Collections list doesn't change immediately upon changing the database in New Mastering/Mapping/Custom step Window

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog-ui.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog-ui.component.ts
@@ -204,9 +204,9 @@ export class NewStepDialogUiComponent implements OnInit {
   //Update the source collection list as soon as the sourceDatabase value is changed.
   stepDatabaseChange() {
     this.getCollections.emit(this.newStepForm.value.sourceDatabase);
-    this.newStepForm.patchValue({
-      sourceCollection: ''
-    });
+    this.newStepForm.controls['sourceCollection'].reset();
+    this.newStepForm.get('sourceCollection').setValidators([Validators.required]);
+    this.newStepForm.get('sourceCollection').updateValueAndValidity();
   }
 
   stepTypeChange() {


### PR DESCRIPTION
Fix for the bug 2794.
Also, now the user will not be able to save the step without providing any value for sourceCollection field in Edit Step dialog box.