### PR TITLE
WIP Prototype of running a flow with no project dependency

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/HubConfig.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/HubConfig.java
@@ -616,4 +616,8 @@ public interface HubConfig {
      * and then call this method.
      */
     void refreshProject();
+
+    String getMlUsername();
+
+    String getMlPassword();
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/collector/impl/CollectorImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/collector/impl/CollectorImpl.java
@@ -23,8 +23,6 @@ import com.marklogic.client.MarkLogicIOException;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.collector.DiskQueue;
 import com.marklogic.hub.collector.Collector;
-import com.marklogic.hub.flow.Flow;
-import com.marklogic.hub.impl.HubConfigImpl;
 import com.marklogic.rest.util.MgmtResponseErrorHandler;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -32,8 +30,6 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.conn.ssl.X509HostnameVerifier;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
@@ -59,18 +55,16 @@ import java.security.cert.X509Certificate;
 import java.util.*;
 
 public class CollectorImpl implements Collector {
-    private DatabaseClient client = null;
-    private HubConfig hubConfig = null;
 
+    private DatabaseClient client;
+    private HubConfig hubConfig;
 
-    private Flow flow = null;
+    public CollectorImpl() {
+    }
 
-    private static Logger logger = LoggerFactory.getLogger(CollectorImpl.class);
-
-    public CollectorImpl() {}
-
-    public CollectorImpl(Flow flow) {
-        this.flow = flow;
+    public CollectorImpl(HubConfig hubConfig, DatabaseClient stagingClient) {
+        this.hubConfig = hubConfig;
+        this.client = stagingClient;
     }
 
     @Override
@@ -91,19 +85,16 @@ public class CollectorImpl implements Collector {
         return this.client;
     }
 
-
     @Override
     public DiskQueue<String> run(String flow, String step, Map<String, Object> options) {
         try {
             DiskQueue<String> results = new DiskQueue<>(5000);
 
-            // Important design info:
             // The collector is invoked with a regular http client due to streaming limitations in OkHttp.
             // https://github.com/marklogic/marklogic-data-hub/issues/632
             // https://github.com/marklogic/marklogic-data-hub/issues/633
-            //
+            RestTemplate template = newRestTemplate(hubConfig.getMlUsername(), hubConfig.getMlPassword());
 
-            RestTemplate template = newRestTemplate(  ((HubConfigImpl) hubConfig).getMlUsername(), ( (HubConfigImpl) hubConfig).getMlPassword());
             String uriString = String.format(
                 "%s://%s:%d%s?flow-name=%s&database=%s&step=%s",
                 client.getSecurityContext().getSSLContext() != null ? "https" : "http",
@@ -204,7 +195,7 @@ public class CollectorImpl implements Collector {
         protected HostnameVerifierAdapter(SSLHostnameVerifier verifier) {
           this.verifier = verifier;
         }
-        
+
         public void verify(String hostname, X509Certificate cert) throws SSLException {
           ArrayList<String> cnArray = new ArrayList<>();
           try {
@@ -242,12 +233,12 @@ public class CollectorImpl implements Collector {
         @Override
         public void verify(String hostname, SSLSocket ssl) throws IOException {
             Certificate[] certificates = ssl.getSession().getPeerCertificates();
-            verify(hostname, (X509Certificate) certificates[0]);             
+            verify(hostname, (X509Certificate) certificates[0]);
         }
 
         @Override
         public void verify(String hostname, String[] cns, String[] subjectAlts) throws SSLException {
-            verifier.verify(hostname, cns, subjectAlts);            
+            verifier.verify(hostname, cns, subjectAlts);
         }
 
         @Override
@@ -256,7 +247,7 @@ public class CollectorImpl implements Collector {
               Certificate[] certificates = session.getPeerCertificates();
               verify(hostname, (X509Certificate) certificates[0]);
               return true;
-              } 
+              }
             catch(SSLException e) {
               return false;
             }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/impl/FlowRunnerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/impl/FlowRunnerImpl.java
@@ -2,12 +2,13 @@ package com.marklogic.hub.flow.impl;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.hub.FlowManager;
+import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.flow.Flow;
 import com.marklogic.hub.flow.FlowRunner;
 import com.marklogic.hub.flow.FlowStatusListener;
 import com.marklogic.hub.flow.RunFlowResponse;
-import com.marklogic.hub.impl.HubConfigImpl;
 import com.marklogic.hub.job.JobDocManager;
 import com.marklogic.hub.job.JobStatus;
 import com.marklogic.hub.step.RunStepResponse;
@@ -31,7 +32,7 @@ import java.util.stream.Collectors;
 public class FlowRunnerImpl implements FlowRunner{
 
     @Autowired
-    private HubConfigImpl hubConfig;
+    private HubConfig hubConfig;
 
     @Autowired
     private FlowManager flowManager;
@@ -61,6 +62,14 @@ public class FlowRunnerImpl implements FlowRunner{
     private ThreadPoolExecutor threadPool;
     private JobDocManager jobDocManager;
     private boolean disableJobOutput = false;
+
+    public FlowRunnerImpl() {
+    }
+
+    public FlowRunnerImpl(HubConfig hubConfig, StepRunnerFactory stepRunnerFactory) {
+        this.hubConfig = hubConfig;
+        this.stepRunnerFactory = stepRunnerFactory;
+    }
 
     @Override
     public FlowRunner onStatusChanged(FlowStatusListener listener) {
@@ -93,21 +102,28 @@ public class FlowRunnerImpl implements FlowRunner{
     }
 
     public RunFlowResponse runFlow(String flowName, List<String> stepNums, String jobId, Map<String, Object> options, Map<String, Object> stepConfig) {
+        Flow flow = flowManager.getFlow(flowName);
+        if (flow == null) {
+            throw new RuntimeException("Flow " + flowName + " not found");
+        }
+        return runFlow(flow, stepNums, jobId, options, stepConfig);
+    }
+
+    public RunFlowResponse runFlowDefinedInMarkLogic(String flowName, List<String> stepNums, String jobId, Map<String, Object> options, Map<String, Object> stepConfig) {
+        JsonNode jsonFlow = hubConfig.newStagingClient().newJSONDocumentManager().read("/flows/" + flowName + ".flow.json", new JacksonHandle()).get();
+        Flow flow = new FlowImpl().deserialize(jsonFlow);
+        return runFlow(flow, stepNums, jobId, options, stepConfig);
+    }
+
+    public RunFlowResponse runFlow(Flow flow, List<String> stepNums, String jobId, Map<String, Object> options, Map<String, Object> stepConfig) {
         if (options != null && options.containsKey("disableJobOutput")) {
             disableJobOutput = Boolean.parseBoolean(options.get("disableJobOutput").toString());
         } else {
             disableJobOutput = false;
         }
 
-        Flow flow = flowManager.getFlow(flowName);
-
-        //Validation of flow, provided steps
-        if (flow == null){
-            throw new RuntimeException("Flow " + flowName + " not found");
-        }
-
         if(stepNums == null) {
-            stepNums = new ArrayList<String>(flow.getSteps().keySet());
+            stepNums = new ArrayList<>(flow.getSteps().keySet());
         }
 
         if(stepConfig != null && !stepConfig.isEmpty()) {
@@ -254,9 +270,6 @@ public class FlowRunnerImpl implements FlowRunner{
                                 listener.onStatusChanged(jobId, runningStep, jobStatus, percentComplete, successfulEvents, failedEvents, runningStep.getName() + " : " + message);
                             });
                         });
-                    //If step doc doesn't have batchnum and thread count specified, fallback to flow's values.
-                    Map<String,Step> steps = runningFlow.getSteps();
-                    Step step = steps.get(stepNum);
 
                     //If property values are overriden in UI, use those values over any other.
                     if(flow.getOverrideStepConfig() != null) {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/AbstractHubConfig.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/AbstractHubConfig.java
@@ -1,0 +1,1096 @@
+package com.marklogic.hub.impl;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marklogic.appdeployer.AppConfig;
+import com.marklogic.appdeployer.ConfigDir;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.DatabaseClientFactory;
+import com.marklogic.client.ext.DatabaseClientConfig;
+import com.marklogic.client.ext.SecurityContextType;
+import com.marklogic.client.ext.helper.LoggingObject;
+import com.marklogic.hub.DatabaseKind;
+import com.marklogic.hub.HubConfig;
+import com.marklogic.hub.error.DataHubConfigurationException;
+import com.marklogic.hub.error.InvalidDBOperationError;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+public abstract class AbstractHubConfig extends LoggingObject implements HubConfig {
+
+    protected AppConfig appConfig;
+
+    protected String host = "localhost";
+
+    protected String stagingDbName = "data-hub-STAGING";
+    protected String stagingHttpName = "data-hub-STAGING";
+    protected Integer stagingForestsPerHost = 3;
+    protected Integer stagingPort = 8010;
+    protected String stagingAuthMethod = "digest";
+    protected Boolean stagingSimpleSsl;
+    protected SSLContext stagingSslContext;
+    protected DatabaseClientFactory.SSLHostnameVerifier stagingSslHostnameVerifier;
+    protected String stagingCertFile;
+    protected String stagingCertPassword;
+    protected String stagingExternalName;
+    protected X509TrustManager stagingTrustManager;
+
+    protected String finalDbName = "data-hub-FINAL";
+    protected String finalHttpName = "data-hub-FINAL";
+    protected Integer finalForestsPerHost = 3;
+    protected Integer finalPort = 8011;
+    protected String finalAuthMethod = "digest";
+    protected Boolean finalSimpleSsl;
+    protected SSLContext finalSslContext;
+    protected DatabaseClientFactory.SSLHostnameVerifier finalSslHostnameVerifier;
+    protected String finalCertFile;
+    protected String finalCertPassword;
+    protected String finalExternalName;
+    protected X509TrustManager finalTrustManager;
+
+    protected String jobDbName = "data-hub-JOBS";
+    protected String jobHttpName = "data-hub-JOBS";
+    protected Integer jobForestsPerHost = 4;
+    protected Integer jobPort = 8013;
+    protected String jobAuthMethod = "digest";
+    protected Boolean jobSimpleSsl;
+    protected SSLContext jobSslContext;
+    protected DatabaseClientFactory.SSLHostnameVerifier jobSslHostnameVerifier;
+    protected String jobCertFile;
+    protected String jobCertPassword;
+    protected String jobExternalName;
+    protected X509TrustManager jobTrustManager;
+
+    protected String modulesDbName = "data-hub-MODULES";
+    protected Integer modulesForestsPerHost = 1;
+    protected String stagingTriggersDbName = "data-hub-staging-TRIGGERS";
+    protected Integer stagingTriggersForestsPerHost = 1;
+    protected String finalTriggersDbName = "data-hub-final-TRIGGERS";
+    protected Integer finalTriggersForestsPerHost = 1;
+    protected String stagingSchemasDbName = "data-hub-staging-SCHEMAS";
+    protected Integer stagingSchemasForestsPerHost = 1;
+    protected String finalSchemasDbName = "data-hub-final-SCHEMAS";
+    protected Integer finalSchemasForestsPerHost = 1;
+
+    protected String flowOperatorRoleName = "flow-operator-role";
+    protected String flowOperatorUserName = "flow-operator";
+    protected String flowDeveloperRoleName = "flow-developer-role";
+    protected String flowDeveloperUserName = "flow-developer";
+    protected String dataHubAdminRoleName = "data-hub-admin-role";
+
+    protected String DHFVersion;
+    protected String hubLogLevel = "default";
+
+    // these hold runtime credentials for flows.
+    protected String mlUsername;
+    protected String mlPassword;
+
+    protected String loadBalancerHost;
+    protected Boolean isHostLoadBalancer = false;
+    protected Boolean isProvisionedEnvironment = false;
+    protected String customForestPath;
+
+    protected String modulePermissions = "rest-reader,read,rest-writer,insert,rest-writer,update,rest-extension-user,execute";
+    protected String entityModelPermissions = "rest-reader,read,rest-writer,insert,rest-writer,update,data-hub-entity-model-reader,read";
+    protected String jobPermissions = "data-hub-job-reader,read,data-hub-job-internal,update";
+
+    @Override
+    public DatabaseClient newAppServicesClient() {
+        return getAppConfig().newAppServicesDatabaseClient(stagingDbName);
+    }
+
+    @Override
+    public DatabaseClient newStagingClient() {
+        return newStagingClient(stagingDbName);
+    }
+
+    public DatabaseClient newStagingClient(String dbName) {
+        AppConfig appConfig = getAppConfig();
+        DatabaseClientConfig config = new DatabaseClientConfig(appConfig.getHost(), stagingPort, getMlUsername(), getMlPassword());
+        config.setDatabase(dbName);
+        config.setSecurityContextType(SecurityContextType.valueOf(stagingAuthMethod.toUpperCase()));
+        config.setSslHostnameVerifier(stagingSslHostnameVerifier);
+        config.setSslContext(stagingSslContext);
+        config.setCertFile(stagingCertFile);
+        config.setCertPassword(stagingCertPassword);
+        config.setExternalName(stagingExternalName);
+        config.setTrustManager(stagingTrustManager);
+        if (isHostLoadBalancer) {
+            config.setConnectionType(DatabaseClient.ConnectionType.GATEWAY);
+        }
+        return appConfig.getConfiguredDatabaseClientFactory().newDatabaseClient(config);
+    }
+
+    @Override
+    // this method uses STAGING appserver but FINAL database.
+    // it's only use is for reverse flows, which need to use staging modules.
+    public DatabaseClient newReverseFlowClient() {
+        return newStagingClient(finalDbName);
+    }
+
+    @Override
+    public DatabaseClient newFinalClient() {
+        AppConfig appConfig = getAppConfig();
+        DatabaseClientConfig config = new DatabaseClientConfig(appConfig.getHost(), finalPort, getMlUsername(), getMlPassword());
+        config.setDatabase(finalDbName);
+        config.setSecurityContextType(SecurityContextType.valueOf(finalAuthMethod.toUpperCase()));
+        config.setSslHostnameVerifier(finalSslHostnameVerifier);
+        config.setSslContext(finalSslContext);
+        config.setCertFile(finalCertFile);
+        config.setCertPassword(finalCertPassword);
+        config.setExternalName(finalExternalName);
+        config.setTrustManager(finalTrustManager);
+        if (isHostLoadBalancer) {
+            config.setConnectionType(DatabaseClient.ConnectionType.GATEWAY);
+        }
+        return appConfig.getConfiguredDatabaseClientFactory().newDatabaseClient(config);
+    }
+
+    public DatabaseClient newJobDbClient() {
+        AppConfig appConfig = getAppConfig();
+        DatabaseClientConfig config = new DatabaseClientConfig(appConfig.getHost(), jobPort, mlUsername, mlPassword);
+        config.setDatabase(jobDbName);
+        config.setSecurityContextType(SecurityContextType.valueOf(jobAuthMethod.toUpperCase()));
+        config.setSslHostnameVerifier(jobSslHostnameVerifier);
+        config.setSslContext(jobSslContext);
+        config.setCertFile(jobCertFile);
+        config.setCertPassword(jobCertPassword);
+        config.setExternalName(jobExternalName);
+        config.setTrustManager(jobTrustManager);
+        if (isHostLoadBalancer) {
+            config.setConnectionType(DatabaseClient.ConnectionType.GATEWAY);
+        }
+        return appConfig.getConfiguredDatabaseClientFactory().newDatabaseClient(config);
+    }
+
+    public DatabaseClient newTraceDbClient() {
+        return newJobDbClient();
+    }
+
+    public DatabaseClient newModulesDbClient() {
+        AppConfig appConfig = getAppConfig();
+        // this has to be finalPort because final is a stock REST API.
+        // staging will not be; but its rewriter isn't loaded yet.
+        DatabaseClientConfig config = new DatabaseClientConfig(appConfig.getHost(), finalPort, mlUsername, mlPassword);
+        config.setDatabase(appConfig.getModulesDatabaseName());
+        config.setSecurityContextType(SecurityContextType.valueOf(finalAuthMethod.toUpperCase()));
+        config.setSslHostnameVerifier(finalSslHostnameVerifier);
+        config.setSslContext(finalSslContext);
+        config.setCertFile(finalCertFile);
+        config.setCertPassword(finalCertPassword);
+        config.setExternalName(finalExternalName);
+        config.setTrustManager(finalTrustManager);
+        if (isHostLoadBalancer) {
+            config.setConnectionType(DatabaseClient.ConnectionType.GATEWAY);
+        }
+        return appConfig.getConfiguredDatabaseClientFactory().newDatabaseClient(config);
+    }
+
+    @Override
+    public String getHost() { return appConfig.getHost(); }
+
+    @Override
+    public String getDbName(DatabaseKind kind) {
+        String name;
+        switch (kind) {
+            case STAGING:
+                name = stagingDbName;
+                break;
+            case FINAL:
+                name = finalDbName;
+                break;
+            case JOB:
+                name = jobDbName;
+                break;
+            case TRACE:
+                name = jobDbName;
+                break;
+            case MODULES:
+                name = modulesDbName;
+                break;
+            case STAGING_MODULES:
+                name = modulesDbName;
+                break;
+            case FINAL_MODULES:
+                name = modulesDbName;
+                break;
+            case STAGING_TRIGGERS:
+                name = stagingTriggersDbName;
+                break;
+            case FINAL_TRIGGERS:
+                name = finalTriggersDbName;
+                break;
+            case STAGING_SCHEMAS:
+                name = stagingSchemasDbName;
+                break;
+            case FINAL_SCHEMAS:
+                name = finalSchemasDbName;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "grab database name");
+        }
+        return name;
+    }
+
+    @Override
+    public void setDbName(DatabaseKind kind, String dbName) {
+        switch (kind) {
+            case STAGING:
+                stagingDbName = dbName;
+                break;
+            case FINAL:
+                finalDbName = dbName;
+                break;
+            case JOB:
+                jobDbName = dbName;
+                break;
+            case TRACE:
+                jobDbName = dbName;
+                break;
+            case MODULES:
+                modulesDbName = dbName;
+                break;
+            case STAGING_MODULES:
+                modulesDbName = dbName;
+                break;
+            case FINAL_MODULES:
+                modulesDbName = dbName;
+                break;
+            case STAGING_TRIGGERS:
+                stagingTriggersDbName = dbName;
+                break;
+            case FINAL_TRIGGERS:
+                finalTriggersDbName = dbName;
+                break;
+            case STAGING_SCHEMAS:
+                stagingSchemasDbName = dbName;
+                break;
+            case FINAL_SCHEMAS:
+                finalSchemasDbName = dbName;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "set database name");
+        }
+    }
+
+    @Override
+    public String getHttpName(DatabaseKind kind) {
+        String name;
+        switch (kind) {
+            case STAGING:
+                name = stagingHttpName;
+                break;
+            case FINAL:
+                name = finalHttpName;
+                break;
+            case JOB:
+                name = jobHttpName;
+                break;
+            case TRACE:
+                name = jobHttpName;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "grab http name");
+        }
+        return name;
+    }
+
+    @Override
+    public void setHttpName(DatabaseKind kind, String httpName) {
+        switch (kind) {
+            case STAGING:
+                stagingHttpName = httpName;
+                break;
+            case FINAL:
+                finalHttpName = httpName;
+                break;
+            case JOB:
+                jobHttpName = httpName;
+                break;
+            case TRACE:
+                jobHttpName = httpName;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "set http name");
+        }
+    }
+
+    @Override
+    public Integer getForestsPerHost(DatabaseKind kind) {
+        Integer forests;
+        switch (kind) {
+            case STAGING:
+                forests = stagingForestsPerHost;
+                break;
+            case FINAL:
+                forests = finalForestsPerHost;
+                break;
+            case JOB:
+                forests = jobForestsPerHost;
+                break;
+            case TRACE:
+                forests = jobForestsPerHost;
+                break;
+            case MODULES:
+                forests = modulesForestsPerHost;
+                break;
+            case STAGING_MODULES:
+                forests = modulesForestsPerHost;
+                break;
+            case FINAL_MODULES:
+                forests = modulesForestsPerHost;
+                break;
+            case STAGING_TRIGGERS:
+                forests = stagingTriggersForestsPerHost;
+                break;
+            case FINAL_TRIGGERS:
+                forests = finalTriggersForestsPerHost;
+                break;
+            case STAGING_SCHEMAS:
+                forests = stagingSchemasForestsPerHost;
+                break;
+            case FINAL_SCHEMAS:
+                forests = finalSchemasForestsPerHost;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "grab count of forests per host");
+        }
+        return forests;
+    }
+
+    @Override
+    public void setForestsPerHost(DatabaseKind kind, Integer forestsPerHost) {
+        switch (kind) {
+            case STAGING:
+                stagingForestsPerHost = forestsPerHost;
+                break;
+            case FINAL:
+                finalForestsPerHost = forestsPerHost;
+                break;
+            case JOB:
+                jobForestsPerHost = forestsPerHost;
+                break;
+            case TRACE:
+                jobForestsPerHost = forestsPerHost;
+                break;
+            case MODULES:
+                modulesForestsPerHost = forestsPerHost;
+                break;
+            case STAGING_MODULES:
+                modulesForestsPerHost = forestsPerHost;
+                break;
+            case FINAL_MODULES:
+                modulesForestsPerHost = forestsPerHost;
+                break;
+            case STAGING_TRIGGERS:
+                stagingTriggersForestsPerHost = forestsPerHost;
+                break;
+            case FINAL_TRIGGERS:
+                finalTriggersForestsPerHost = forestsPerHost;
+                break;
+            case STAGING_SCHEMAS:
+                stagingSchemasForestsPerHost = forestsPerHost;
+                break;
+            case FINAL_SCHEMAS:
+                finalSchemasForestsPerHost = forestsPerHost;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "set count of forests per host");
+        }
+    }
+
+    @Override
+    public Integer getPort(DatabaseKind kind) {
+        Integer port;
+        switch (kind) {
+            case STAGING:
+                port = stagingPort;
+                break;
+            case FINAL:
+                port = finalPort;
+                break;
+            case JOB:
+                port = jobPort;
+                break;
+            case TRACE:
+                port = jobPort;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "grab app port");
+        }
+        return port;
+    }
+
+    @Override
+    public void setPort(DatabaseKind kind, Integer port) {
+        switch (kind) {
+            case STAGING:
+                stagingPort = port;
+                break;
+            case FINAL:
+                finalPort = port;
+                break;
+            case JOB:
+                jobPort = port;
+                break;
+            case TRACE:
+                jobPort = port;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "set app port");
+        }
+    }
+
+
+    @Override
+    public SSLContext getSslContext(DatabaseKind kind) {
+        SSLContext sslContext;
+        switch (kind) {
+            case STAGING:
+                sslContext = this.stagingSslContext;
+                break;
+            case JOB:
+                sslContext = this.jobSslContext;
+                break;
+            case TRACE:
+                sslContext = this.jobSslContext;
+                break;
+            case FINAL:
+                sslContext = this.finalSslContext;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "get ssl context");
+        }
+        return sslContext;
+    }
+
+    @Override
+    public void setSslContext(DatabaseKind kind, SSLContext sslContext) {
+        switch (kind) {
+            case STAGING:
+                this.stagingSslContext = sslContext;
+                break;
+            case JOB:
+                this.jobSslContext = sslContext;
+                break;
+            case TRACE:
+                this.jobSslContext = sslContext;
+                break;
+            case FINAL:
+                this.finalSslContext = sslContext;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "set ssl context");
+        }
+    }
+
+    @Override
+    public DatabaseClientFactory.SSLHostnameVerifier getSslHostnameVerifier(DatabaseKind kind) {
+        DatabaseClientFactory.SSLHostnameVerifier sslHostnameVerifier;
+        switch (kind) {
+            case STAGING:
+                sslHostnameVerifier = this.stagingSslHostnameVerifier;
+                break;
+            case JOB:
+                sslHostnameVerifier = this.jobSslHostnameVerifier;
+                break;
+            case TRACE:
+                sslHostnameVerifier = this.jobSslHostnameVerifier;
+                break;
+            case FINAL:
+                sslHostnameVerifier = this.finalSslHostnameVerifier;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "get ssl hostname verifier");
+        }
+        return sslHostnameVerifier;
+    }
+
+    @Override
+    public void setSslHostnameVerifier(DatabaseKind kind, DatabaseClientFactory.SSLHostnameVerifier sslHostnameVerifier) {
+        switch (kind) {
+            case STAGING:
+                this.stagingSslHostnameVerifier = sslHostnameVerifier;
+                break;
+            case JOB:
+                this.jobSslHostnameVerifier = sslHostnameVerifier;
+                break;
+            case TRACE:
+                this.jobSslHostnameVerifier = sslHostnameVerifier;
+                break;
+            case FINAL:
+                this.finalSslHostnameVerifier = sslHostnameVerifier;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "set ssl hostname verifier");
+        }
+    }
+
+    @Override
+    public String getAuthMethod(DatabaseKind kind) {
+        String authMethod;
+        switch (kind) {
+            case STAGING:
+                authMethod = this.stagingAuthMethod;
+                break;
+            case FINAL:
+                authMethod = this.finalAuthMethod;
+                break;
+            case JOB:
+                authMethod = this.jobAuthMethod;
+                break;
+            case TRACE:
+                authMethod = this.jobAuthMethod;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "get auth method");
+        }
+        return authMethod;
+    }
+
+    @Override
+    public void setAuthMethod(DatabaseKind kind, String authMethod) {
+        switch (kind) {
+            case STAGING:
+                this.stagingAuthMethod = authMethod;
+                break;
+            case FINAL:
+                this.finalAuthMethod = authMethod;
+                break;
+            case JOB:
+                this.jobAuthMethod = authMethod;
+                break;
+            case TRACE:
+                this.jobAuthMethod = authMethod;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "set auth method");
+        }
+    }
+
+    public X509TrustManager getTrustManager(DatabaseKind kind) {
+        switch (kind) {
+            case STAGING:
+                return this.stagingTrustManager;
+            case JOB:
+                return this.jobTrustManager;
+            case FINAL:
+                return this.finalTrustManager;
+            default:
+                throw new InvalidDBOperationError(kind, "set auth method");
+        }
+    }
+
+    @Override
+    public void setTrustManager(DatabaseKind kind, X509TrustManager trustManager) {
+        switch (kind) {
+            case STAGING:
+                this.stagingTrustManager = trustManager;
+                break;
+            case JOB:
+                this.jobTrustManager = trustManager;
+                break;
+            case FINAL:
+                this.finalTrustManager = trustManager;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "set auth method");
+        }
+    }
+
+    @Deprecated
+    @Override
+    public String getScheme(DatabaseKind kind) {
+        return null;
+    }
+
+    @Deprecated
+    @Override
+    public void setScheme(DatabaseKind kind, String scheme) {
+    }
+
+    @Override
+    public boolean getSimpleSsl(DatabaseKind kind) {
+        boolean simple;
+        switch (kind) {
+            case STAGING:
+                simple = this.stagingSimpleSsl;
+                break;
+            case JOB:
+                simple = this.jobSimpleSsl;
+                break;
+            case TRACE:
+                simple = this.jobSimpleSsl;
+                break;
+            case FINAL:
+                simple = this.finalSimpleSsl;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "get simple ssl");
+        }
+        return simple;
+    }
+
+    @Override
+    public void setSimpleSsl(DatabaseKind kind, Boolean simpleSsl) {
+        switch (kind) {
+            case STAGING:
+                this.stagingSimpleSsl = simpleSsl;
+                break;
+            case JOB:
+                this.jobSimpleSsl = simpleSsl;
+                break;
+            case TRACE:
+                this.jobSimpleSsl = simpleSsl;
+                break;
+            case FINAL:
+                this.finalSimpleSsl = simpleSsl;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "set simple ssl");
+        }
+    }
+
+    @Override
+    public String getCertFile(DatabaseKind kind) {
+        String certFile;
+        switch (kind) {
+            case STAGING:
+                certFile = this.stagingCertFile;
+                break;
+            case JOB:
+                certFile = this.jobCertFile;
+                break;
+            case TRACE:
+                certFile = this.jobCertFile;
+                break;
+            case FINAL:
+                certFile = this.finalCertFile;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "get cert file");
+        }
+        return certFile;
+    }
+
+    @Override
+    public void setCertFile(DatabaseKind kind, String certFile) {
+        switch (kind) {
+            case STAGING:
+                this.stagingCertFile = certFile;
+                break;
+            case JOB:
+                this.jobCertFile = certFile;
+                break;
+            case TRACE:
+                this.jobCertFile = certFile;
+                break;
+            case FINAL:
+                this.finalCertFile = certFile;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "set certificate file");
+        }
+    }
+
+    @Override
+    public String getCertPassword(DatabaseKind kind) {
+        String certPass;
+        switch (kind) {
+            case STAGING:
+                certPass = this.stagingCertPassword;
+                break;
+            case JOB:
+                certPass = this.jobCertPassword;
+                break;
+            case TRACE:
+                certPass = this.jobCertPassword;
+                break;
+            case FINAL:
+                certPass = this.finalCertPassword;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "get cert password");
+        }
+        return certPass;
+    }
+
+    @Override
+    public void setCertPass(DatabaseKind kind, String certPassword) {
+        switch (kind) {
+            case STAGING:
+                this.stagingCertPassword = certPassword;
+                break;
+            case JOB:
+                this.jobCertPassword = certPassword;
+                break;
+            case TRACE:
+                this.jobCertPassword = certPassword;
+                break;
+            case FINAL:
+                this.finalCertPassword = certPassword;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "set certificate password");
+        }
+    }
+
+    @Override
+    public String getExternalName(DatabaseKind kind) {
+        String name;
+        switch (kind) {
+            case STAGING:
+                name = this.stagingExternalName;
+                break;
+            case JOB:
+                name = this.jobExternalName;
+                break;
+            case TRACE:
+                name = this.jobExternalName;
+                break;
+            case FINAL:
+                name = this.finalExternalName;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "get external name");
+        }
+        return name;
+    }
+
+    @Override
+    public void setExternalName(DatabaseKind kind, String externalName) {
+        switch (kind) {
+            case STAGING:
+                this.stagingExternalName = externalName;
+                break;
+            case JOB:
+                this.jobExternalName = externalName;
+                break;
+            case TRACE:
+                this.jobExternalName = externalName;
+                break;
+            case FINAL:
+                this.finalExternalName = externalName;
+                break;
+            default:
+                throw new InvalidDBOperationError(kind, "set auth method");
+        }
+    }
+
+    @Override
+    public String getFlowOperatorRoleName() {
+        return flowOperatorRoleName;
+    }
+
+    @Override
+    public void setFlowOperatorRoleName(String flowOperatorRoleName) {
+        this.flowOperatorRoleName = flowOperatorRoleName;
+    }
+
+    @Override
+    public String getFlowOperatorUserName() {
+        return flowOperatorUserName;
+    }
+
+    @Override
+    public void setFlowOperatorUserName(String flowOperatorUserName) {
+        this.flowOperatorUserName = flowOperatorUserName;
+    }
+
+    @Override
+    public String getFlowDeveloperRoleName() {
+        return flowDeveloperRoleName;
+    }
+
+    @Override
+    public void setFlowDeveloperRoleName(String flowDeveloperRoleName) {
+        this.flowDeveloperRoleName = flowDeveloperRoleName;
+    }
+
+    @Override
+    public String getFlowDeveloperUserName() {
+        return flowDeveloperUserName;
+    }
+
+    @Override
+    public void setFlowDeveloperUserName(String flowDeveloperUserName) {
+        this.flowDeveloperUserName = flowDeveloperUserName;
+    }
+
+    @Override
+    public String getMlUsername() {
+        return mlUsername;
+    }
+
+    @Override
+    public String getMlPassword() {
+        return mlPassword;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public void setMlUsername(String mlUsername) {
+        this.mlUsername = mlUsername;
+    }
+
+    public void setMlPassword(String mlPassword) {
+        this.mlPassword = mlPassword;
+    }
+
+    @JsonIgnore
+    @Override
+    public String getLoadBalancerHost() {
+        return loadBalancerHost;
+    }
+
+    @Override
+    public Boolean getIsHostLoadBalancer() {
+        return isHostLoadBalancer;
+    }
+
+    @Override
+    public Boolean getIsProvisionedEnvironment() {
+        return isProvisionedEnvironment;
+    }
+
+    public void setLoadBalancerHost(String loadBalancerHost) {
+        this.loadBalancerHost = loadBalancerHost;
+    }
+
+    @Override
+    public String getCustomForestPath() {
+        return customForestPath;
+    }
+
+    public void setCustomForestPath(String customForestPath) {
+        this.customForestPath = customForestPath;
+    }
+
+    @Override
+    public String getModulePermissions() {
+        return modulePermissions;
+    }
+
+    public void setModulePermissions(String modulePermissions) {
+        this.modulePermissions = modulePermissions;
+    }
+
+    @Override
+    public String getEntityModelPermissions() {
+        return entityModelPermissions;
+    }
+
+    public void setEntityModelPermissions(String entityModelPermissions) {
+        this.entityModelPermissions = entityModelPermissions;
+    }
+
+    public String getJobPermissions() {
+        return jobPermissions;
+    }
+
+    public void setJobPermissions(String jobPermissions) {
+        this.jobPermissions = jobPermissions;
+    }
+
+    @JsonIgnore
+    @Override
+    public AppConfig getAppConfig() {
+        return appConfig;
+    }
+
+    @Override
+    public void setAppConfig(AppConfig config) {
+        this.appConfig = config;
+    }
+
+    @Override
+    public void setAppConfig(AppConfig config, boolean skipUpdate) {
+        this.appConfig = config;
+    }
+
+    @Override
+    public String getJarVersion() {
+        Properties properties = new Properties();
+        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream("version.properties")) {
+            properties.load(inputStream);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to read version.properties from classpath, cause: " + e.getMessage(), e);
+        }
+
+        String version = (String)properties.get("version");
+        // this lets debug builds work from an IDE
+        if (version.equals("${project.version}")) {
+            version = "5.2-SNAPSHOT";
+        }
+        return version;
+    }
+
+    @Override
+    public String getDHFVersion() {
+        return this.DHFVersion;
+    }
+
+    @Override
+    public String getHubLogLevel() {
+        return this.hubLogLevel;
+    }
+
+    public String getStagingSchemasDbName() {
+        return this.stagingSchemasDbName;
+    }
+
+    public String getStagingTriggersDbName() {
+        return this.stagingTriggersDbName;
+    }
+
+    /**
+     * Makes DHF-specific updates to the AppConfig, after it's been constructed by ml-gradle.
+     *
+     * @param config
+     */
+    protected void updateAppConfig(AppConfig config) {
+        // If the user hasn't set the app name then override it to "DHF" instead of "my-app"
+        if ("my-app".equals(config.getName())) {
+            config.setName("DHF");
+        }
+
+        // DHF never needs the default REST server provided by ml-gradle
+        config.setNoRestServer(true);
+
+        applyFinalConnectionSettingsToMlGradleDefaultRestSettings(config);
+
+        config.setTriggersDatabaseName(finalTriggersDbName);
+        config.setSchemasDatabaseName(finalSchemasDbName);
+        config.setModulesDatabaseName(modulesDbName);
+        config.setContentDatabaseName(finalDbName);
+
+        config.setReplaceTokensInModules(true);
+        config.setUseRoxyTokenPrefix(false);
+        config.setModulePermissions(modulePermissions);
+
+        Map<String, Integer> forestCounts = config.getForestCounts();
+        forestCounts.put(jobDbName, jobForestsPerHost);
+        forestCounts.put(modulesDbName, modulesForestsPerHost);
+        forestCounts.put(stagingDbName, stagingForestsPerHost);
+        forestCounts.put(stagingTriggersDbName, stagingTriggersForestsPerHost);
+        forestCounts.put(stagingSchemasDbName, stagingSchemasForestsPerHost);
+        forestCounts.put(finalDbName, finalForestsPerHost);
+        forestCounts.put(finalTriggersDbName, finalTriggersForestsPerHost);
+        forestCounts.put(finalSchemasDbName, finalSchemasForestsPerHost);
+        config.setForestCounts(forestCounts);
+
+        initializeConfigDirs(config);
+
+        initializeModulePaths(config);
+
+        config.setSchemasPath(getUserSchemasDir().toString());
+
+        String version = getJarVersion();
+        config.getCustomTokens().put("%%mlHubVersion%%", version);
+
+        this.appConfig = config;
+    }
+
+    /**
+     * ml-app-deployer defaults to a single config path of src/main/ml-config. If that's still the only path present,
+     * it's overridden with the DHF defaults - src/main/hub-internal-config first, then src/main/ml-config second, with
+     * both of those being relative to the DHF project directory.
+     *
+     * But if the config paths have been customized - most likely via mlConfigPaths in gradle.properties - then this
+     * method just ensures that they're relative to the DHF project directory.
+     *
+     * @param config an AppConfig object
+     */
+    protected void initializeConfigDirs(AppConfig config) {
+        final String defaultConfigPath = String.join(File.separator, "src", "main", "ml-config");
+
+        boolean configDirsIsSetToTheMlAppDeployerDefault = config.getConfigDirs().size() == 1 && config.getConfigDirs().get(0).getBaseDir().toString().endsWith(defaultConfigPath);
+
+        if (configDirsIsSetToTheMlAppDeployerDefault) {
+            List<ConfigDir> configDirs = new ArrayList<>();
+            configDirs.add(new ConfigDir(getHubConfigDir().toFile()));
+            configDirs.add(new ConfigDir(getUserConfigDir().toFile()));
+            config.setConfigDirs(configDirs);
+        }
+        else {
+            // Need to make each custom config dir relative to the project dir
+            List<ConfigDir> configDirs = new ArrayList<>();
+            for (ConfigDir configDir : config.getConfigDirs()) {
+                File f = getHubProject().getProjectDir().resolve(configDir.getBaseDir().toString()).normalize().toAbsolutePath().toFile();
+                configDirs.add(new ConfigDir(f));
+            }
+            config.setConfigDirs(configDirs);
+        }
+
+        if (logger.isInfoEnabled()) {
+            config.getConfigDirs().forEach(configDir -> logger.info("Config path: " + configDir.getBaseDir().getAbsolutePath()));
+        }
+    }
+
+    /**
+     * Need to initialize every module path as being relative to the current project directory.
+     *
+     * @param config an AppConfig object
+     */
+    protected void initializeModulePaths(AppConfig config) {
+        List<String> modulePaths = new ArrayList<>();
+        Path projectDir = getHubProject().getProjectDir();
+        for (String modulePath : config.getModulePaths()) {
+            modulePaths.add(projectDir.resolve(modulePath).normalize().toAbsolutePath().toString());
+        }
+        config.setModulePaths(modulePaths);
+        if (logger.isInfoEnabled()) {
+            logger.info("Module paths: " + modulePaths);
+        }
+    }
+
+    /**
+     * This is needed so that mlFinal* properties that configure the connection to the final REST server are also used
+     * for any feature in ml-gradle that expects to use the same mlRest* properties. For example, LoadModulesCommand
+     * uses those properties to construct a DatabaseClient for loading modules; we want to ensure that the properties
+     * mirror the mlFinal* properties.
+     *
+     * @param config
+     */
+    private void applyFinalConnectionSettingsToMlGradleDefaultRestSettings(AppConfig config) {
+        if (finalAuthMethod != null) {
+            config.setRestSecurityContextType(SecurityContextType.valueOf(finalAuthMethod.toUpperCase()));
+        }
+        config.setRestPort(finalPort);
+        config.setRestCertFile(finalCertFile);
+        config.setRestCertPassword(finalCertPassword);
+        config.setRestExternalName(finalExternalName);
+        config.setRestSslContext(finalSslContext);
+        config.setRestSslHostnameVerifier(finalSslHostnameVerifier);
+        config.setRestTrustManager(finalTrustManager);
+    }
+
+    @JsonIgnore
+    public String getInfo()
+    {
+        try {
+            return new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(this);
+        }
+        catch(Exception e)
+        {
+            throw new DataHubConfigurationException("Your datahub configuration could not serialize", e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return getInfo();
+    }
+
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -43,6 +43,7 @@ import com.marklogic.mgmt.admin.AdminManager;
 import com.marklogic.mgmt.admin.DefaultAdminConfigFactory;
 import org.apache.commons.text.CharacterPredicate;
 import org.apache.commons.text.RandomStringGenerator;
+import org.omg.CORBA.Object;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -68,7 +69,7 @@ import java.util.Properties;
     setterVisibility = JsonAutoDetect.Visibility.ANY)
 @Component
 @PropertySource({"classpath:dhf-defaults.properties"})
-public class HubConfigImpl implements HubConfig
+public class HubConfigImpl extends AbstractHubConfig implements HubConfig
 {
     @Autowired
     private HubProject hubProject;
@@ -88,110 +89,15 @@ public class HubConfigImpl implements HubConfig
     @Autowired
     JobMonitorImpl jobMonitor;
 
-
-    protected String host;
-
-    protected String stagingDbName;
-    protected String stagingHttpName;
-    protected Integer stagingForestsPerHost;
-    protected Integer stagingPort;
-    protected String stagingAuthMethod;
-    private Boolean stagingSimpleSsl;
-
-    private SSLContext stagingSslContext;
-    private DatabaseClientFactory.SSLHostnameVerifier stagingSslHostnameVerifier;
-    private String stagingCertFile;
-    private String stagingCertPassword;
-    private String stagingExternalName;
-    private X509TrustManager stagingTrustManager;
-
-
-    protected String finalDbName;
-    protected String finalHttpName;
-    protected Integer finalForestsPerHost;
-    protected Integer finalPort;
-    protected String finalAuthMethod;
-
-    private Boolean finalSimpleSsl;
-    private SSLContext finalSslContext;
-    private DatabaseClientFactory.SSLHostnameVerifier finalSslHostnameVerifier;
-    private String finalCertFile;
-    private String finalCertPassword;
-    private String finalExternalName;
-    private X509TrustManager finalTrustManager;
-
-
-    protected String jobDbName;
-    protected String jobHttpName;
-    protected Integer jobForestsPerHost;
-    protected Integer jobPort;
-    protected String jobAuthMethod;
-
-    private Boolean jobSimpleSsl;
-    private SSLContext jobSslContext;
-    private DatabaseClientFactory.SSLHostnameVerifier jobSslHostnameVerifier;
-    private String jobCertFile;
-    private String jobCertPassword;
-    private String jobExternalName;
-    private X509TrustManager jobTrustManager;
-
-
-    protected String modulesDbName;
-    protected Integer modulesForestsPerHost;
-    protected String stagingTriggersDbName;
-    protected Integer stagingTriggersForestsPerHost;
-    protected String finalTriggersDbName;
-    protected Integer finalTriggersForestsPerHost;
-    protected String stagingSchemasDbName;
-    protected Integer stagingSchemasForestsPerHost;
-    protected String finalSchemasDbName;
-    protected Integer finalSchemasForestsPerHost;
-
-
-    private String flowOperatorRoleName;
-    private String flowOperatorUserName;
-
-    private String flowDeveloperRoleName;
-    private String flowDeveloperUserName;
-
-    private String dataHubAdminRoleName;
-
-    private String DHFVersion;
-
-    private String hubLogLevel;
-
-    // these hold runtime credentials for flows.
-    private String mlUsername = null;
-    private String mlPassword = null;
-
-    private String loadBalancerHost;
-    private Boolean isHostLoadBalancer;
-
-    private Boolean isProvisionedEnvironment;
-
-    protected String customForestPath;
-
-    protected String modulePermissions;
-
-    private String entityModelPermissions;
-    private String jobPermissions;
-
     private ManageConfig manageConfig;
     private ManageClient manageClient;
     private AdminConfig adminConfig;
     private AdminManager adminManager;
 
-    private AppConfig appConfig;
-
-    private static final Logger logger = LoggerFactory.getLogger(HubConfigImpl.class);
-
-    private ObjectMapper objmapper;
-
     // By default, DHF uses gradle-local.properties for your local environment.
     private String envString = "local";
 
     public HubConfigImpl() {
-        objmapper = new ObjectMapper();
         projectProperties = new Properties();
     }
 
@@ -204,684 +110,14 @@ public class HubConfigImpl implements HubConfig
         hubProject.createProject(projectDirString);
     }
 
-    public String getHost() { return appConfig.getHost(); }
-
-    @Override public String getDbName(DatabaseKind kind){
-        String name;
-        switch (kind) {
-            case STAGING:
-                name = stagingDbName;
-                break;
-            case FINAL:
-                name = finalDbName;
-                break;
-            case JOB:
-                name = jobDbName;
-                break;
-            case TRACE:
-                name = jobDbName;
-                break;
-            case MODULES:
-                name = modulesDbName;
-                break;
-            case STAGING_MODULES:
-                name = modulesDbName;
-                break;
-            case FINAL_MODULES:
-                name = modulesDbName;
-                break;
-            case STAGING_TRIGGERS:
-                name = stagingTriggersDbName;
-                break;
-            case FINAL_TRIGGERS:
-                name = finalTriggersDbName;
-                break;
-            case STAGING_SCHEMAS:
-                name = stagingSchemasDbName;
-                break;
-            case FINAL_SCHEMAS:
-                name = finalSchemasDbName;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "grab database name");
-        }
-        return name;
-    }
-
-    @Override public void setDbName(DatabaseKind kind, String dbName){
-        switch (kind) {
-            case STAGING:
-                stagingDbName = dbName;
-                break;
-            case FINAL:
-                finalDbName = dbName;
-                break;
-            case JOB:
-                jobDbName = dbName;
-                break;
-            case TRACE:
-                jobDbName = dbName;
-                break;
-            case MODULES:
-                modulesDbName = dbName;
-                break;
-            case STAGING_MODULES:
-                modulesDbName = dbName;
-                break;
-            case FINAL_MODULES:
-                modulesDbName = dbName;
-                break;
-            case STAGING_TRIGGERS:
-                stagingTriggersDbName = dbName;
-                break;
-            case FINAL_TRIGGERS:
-                finalTriggersDbName = dbName;
-                break;
-            case STAGING_SCHEMAS:
-                stagingSchemasDbName = dbName;
-                break;
-            case FINAL_SCHEMAS:
-                finalSchemasDbName = dbName;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "set database name");
-        }
-    }
-
-    @Override public String getHttpName(DatabaseKind kind){
-        String name;
-        switch (kind) {
-            case STAGING:
-                name = stagingHttpName;
-                break;
-            case FINAL:
-                name = finalHttpName;
-                break;
-            case JOB:
-                name = jobHttpName;
-                break;
-            case TRACE:
-                name = jobHttpName;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "grab http name");
-        }
-        return name;
-    }
-
-    @Override public void setHttpName(DatabaseKind kind, String httpName){
-        switch (kind) {
-            case STAGING:
-                stagingHttpName = httpName;
-                break;
-            case FINAL:
-                finalHttpName = httpName;
-                break;
-            case JOB:
-                jobHttpName = httpName;
-                break;
-            case TRACE:
-                jobHttpName = httpName;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "set http name");
-        }
-    }
-
-    @Override public Integer getForestsPerHost(DatabaseKind kind){
-        Integer forests;
-        switch (kind) {
-            case STAGING:
-                forests = stagingForestsPerHost;
-                break;
-            case FINAL:
-                forests = finalForestsPerHost;
-                break;
-            case JOB:
-                forests = jobForestsPerHost;
-                break;
-            case TRACE:
-                forests = jobForestsPerHost;
-                break;
-            case MODULES:
-                forests = modulesForestsPerHost;
-                break;
-            case STAGING_MODULES:
-                forests = modulesForestsPerHost;
-                break;
-            case FINAL_MODULES:
-                forests = modulesForestsPerHost;
-                break;
-            case STAGING_TRIGGERS:
-                forests = stagingTriggersForestsPerHost;
-                break;
-            case FINAL_TRIGGERS:
-                forests = finalTriggersForestsPerHost;
-                break;
-            case STAGING_SCHEMAS:
-                forests = stagingSchemasForestsPerHost;
-                break;
-            case FINAL_SCHEMAS:
-                forests = finalSchemasForestsPerHost;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "grab count of forests per host");
-        }
-        return forests;
-    }
-
-    @Override public void setForestsPerHost(DatabaseKind kind, Integer forestsPerHost){
-        switch (kind) {
-            case STAGING:
-                stagingForestsPerHost = forestsPerHost;
-                break;
-            case FINAL:
-                finalForestsPerHost = forestsPerHost;
-                break;
-            case JOB:
-                jobForestsPerHost = forestsPerHost;
-                break;
-            case TRACE:
-                jobForestsPerHost = forestsPerHost;
-                break;
-            case MODULES:
-                modulesForestsPerHost = forestsPerHost;
-                break;
-            case STAGING_MODULES:
-                modulesForestsPerHost = forestsPerHost;
-                break;
-            case FINAL_MODULES:
-                modulesForestsPerHost = forestsPerHost;
-                break;
-            case STAGING_TRIGGERS:
-                stagingTriggersForestsPerHost = forestsPerHost;
-                break;
-            case FINAL_TRIGGERS:
-                finalTriggersForestsPerHost = forestsPerHost;
-                break;
-            case STAGING_SCHEMAS:
-                stagingSchemasForestsPerHost = forestsPerHost;
-                break;
-            case FINAL_SCHEMAS:
-                finalSchemasForestsPerHost = forestsPerHost;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "set count of forests per host");
-        }
-    }
-
-    @Override public Integer getPort(DatabaseKind kind){
-        Integer port;
-        switch (kind) {
-            case STAGING:
-                port = stagingPort;
-                break;
-            case FINAL:
-                port = finalPort;
-                break;
-            case JOB:
-                port = jobPort;
-                break;
-            case TRACE:
-                port = jobPort;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "grab app port");
-        }
-        return port;
-    }
-
-    @Override public void setPort(DatabaseKind kind, Integer port){
-        switch (kind) {
-            case STAGING:
-                stagingPort = port;
-                break;
-            case FINAL:
-                finalPort = port;
-                break;
-            case JOB:
-                jobPort = port;
-                break;
-            case TRACE:
-                jobPort = port;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "set app port");
-        }
-    }
-
-
-    @Override public SSLContext getSslContext(DatabaseKind kind) {
-        SSLContext sslContext;
-        switch (kind) {
-            case STAGING:
-                sslContext = this.stagingSslContext;
-                break;
-            case JOB:
-                sslContext = this.jobSslContext;
-                break;
-            case TRACE:
-                sslContext = this.jobSslContext;
-                break;
-            case FINAL:
-                sslContext = this.finalSslContext;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "get ssl context");
-        }
-        return sslContext;
-    }
-
-    @Override public void setSslContext(DatabaseKind kind, SSLContext sslContext) {
-        switch (kind) {
-            case STAGING:
-                this.stagingSslContext = sslContext;
-                break;
-            case JOB:
-                this.jobSslContext = sslContext;
-                break;
-            case TRACE:
-                this.jobSslContext = sslContext;
-                break;
-            case FINAL:
-                this.finalSslContext = sslContext;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "set ssl context");
-        }
-    }
-
-    @Override public DatabaseClientFactory.SSLHostnameVerifier getSslHostnameVerifier(DatabaseKind kind) {
-        DatabaseClientFactory.SSLHostnameVerifier sslHostnameVerifier;
-        switch (kind) {
-            case STAGING:
-                sslHostnameVerifier = this.stagingSslHostnameVerifier;
-                break;
-            case JOB:
-                sslHostnameVerifier = this.jobSslHostnameVerifier;
-                break;
-            case TRACE:
-                sslHostnameVerifier = this.jobSslHostnameVerifier;
-                break;
-            case FINAL:
-                sslHostnameVerifier = this.finalSslHostnameVerifier;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "get ssl hostname verifier");
-        }
-        return sslHostnameVerifier;
-    }
-
-    @Override public void setSslHostnameVerifier(DatabaseKind kind, DatabaseClientFactory.SSLHostnameVerifier sslHostnameVerifier) {
-        switch (kind) {
-            case STAGING:
-                this.stagingSslHostnameVerifier = sslHostnameVerifier;
-                break;
-            case JOB:
-                this.jobSslHostnameVerifier = sslHostnameVerifier;
-                break;
-            case TRACE:
-                this.jobSslHostnameVerifier = sslHostnameVerifier;
-                break;
-            case FINAL:
-                this.finalSslHostnameVerifier = sslHostnameVerifier;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "set ssl hostname verifier");
-        }
-    }
-
-    @Override public String getAuthMethod(DatabaseKind kind){
-        String authMethod;
-        switch (kind) {
-            case STAGING:
-                authMethod = this.stagingAuthMethod;
-                break;
-            case FINAL:
-                authMethod = this.finalAuthMethod;
-                break;
-            case JOB:
-                authMethod = this.jobAuthMethod;
-                break;
-            case TRACE:
-                authMethod = this.jobAuthMethod;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "get auth method");
-        }
-        return authMethod;
-    }
-
-    @Override public void setAuthMethod(DatabaseKind kind, String authMethod) {
-        switch (kind) {
-            case STAGING:
-                this.stagingAuthMethod = authMethod;
-                break;
-            case FINAL:
-                this.finalAuthMethod = authMethod;
-                break;
-            case JOB:
-                this.jobAuthMethod = authMethod;
-                break;
-            case TRACE:
-                this.jobAuthMethod = authMethod;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "set auth method");
-        }
-    }
-
-    public X509TrustManager getTrustManager(DatabaseKind kind) {
-        switch (kind) {
-            case STAGING:
-                return this.stagingTrustManager;
-            case JOB:
-                return this.jobTrustManager;
-            case FINAL:
-                return this.finalTrustManager;
-            default:
-                throw new InvalidDBOperationError(kind, "set auth method");
-        }
-    }
-
     @Override
-    public void setTrustManager(DatabaseKind kind, X509TrustManager trustManager) {
-        switch (kind) {
-            case STAGING:
-                this.stagingTrustManager = trustManager;
-                break;
-            case JOB:
-                this.jobTrustManager = trustManager;
-                break;
-            case FINAL:
-                this.finalTrustManager = trustManager;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "set auth method");
-        }
-    }
-
-    @Deprecated
-    @Override public String getScheme(DatabaseKind kind){
-        return null;
-    }
-
-    @Deprecated
-    @Override public void setScheme(DatabaseKind kind, String scheme) {
-    }
-
-    @Override public boolean getSimpleSsl(DatabaseKind kind){
-        boolean simple;
-        switch (kind) {
-            case STAGING:
-                simple = this.stagingSimpleSsl;
-                break;
-            case JOB:
-                simple = this.jobSimpleSsl;
-                break;
-            case TRACE:
-                simple = this.jobSimpleSsl;
-                break;
-            case FINAL:
-                simple = this.finalSimpleSsl;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "get simple ssl");
-        }
-        return simple;
-    }
-
-    @Override public void setSimpleSsl(DatabaseKind kind, Boolean simpleSsl) {
-        switch (kind) {
-            case STAGING:
-                this.stagingSimpleSsl = simpleSsl;
-                break;
-            case JOB:
-                this.jobSimpleSsl = simpleSsl;
-                break;
-            case TRACE:
-                this.jobSimpleSsl = simpleSsl;
-                break;
-            case FINAL:
-                this.finalSimpleSsl = simpleSsl;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "set simple ssl");
-        }
-    }
-
-    @Override public String getCertFile(DatabaseKind kind){
-        String certFile;
-        switch (kind) {
-            case STAGING:
-                certFile = this.stagingCertFile;
-                break;
-            case JOB:
-                certFile = this.jobCertFile;
-                break;
-            case TRACE:
-                certFile = this.jobCertFile;
-                break;
-            case FINAL:
-                certFile = this.finalCertFile;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "get cert file");
-        }
-        return certFile;
-    }
-
-    @Override public void setCertFile(DatabaseKind kind, String certFile) {
-        switch (kind) {
-            case STAGING:
-                this.stagingCertFile = certFile;
-                break;
-            case JOB:
-                this.jobCertFile = certFile;
-                break;
-            case TRACE:
-                this.jobCertFile = certFile;
-                break;
-            case FINAL:
-                this.finalCertFile = certFile;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "set certificate file");
-        }
-    }
-
-    @Override public String getCertPassword(DatabaseKind kind){
-        String certPass;
-        switch (kind) {
-            case STAGING:
-                certPass = this.stagingCertPassword;
-                break;
-            case JOB:
-                certPass = this.jobCertPassword;
-                break;
-            case TRACE:
-                certPass = this.jobCertPassword;
-                break;
-            case FINAL:
-                certPass = this.finalCertPassword;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "get cert password");
-        }
-        return certPass;
-    }
-
-    @Override public void setCertPass(DatabaseKind kind, String certPassword) {
-        switch (kind) {
-            case STAGING:
-                this.stagingCertPassword = certPassword;
-                break;
-            case JOB:
-                this.jobCertPassword = certPassword;
-                break;
-            case TRACE:
-                this.jobCertPassword = certPassword;
-                break;
-            case FINAL:
-                this.finalCertPassword = certPassword;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "set certificate password");
-        }
-    }
-
-    @Override public String getExternalName(DatabaseKind kind){
-        String name;
-        switch (kind) {
-            case STAGING:
-                name = this.stagingExternalName;
-                break;
-            case JOB:
-                name = this.jobExternalName;
-                break;
-            case TRACE:
-                name = this.jobExternalName;
-                break;
-            case FINAL:
-                name = this.finalExternalName;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "get external name");
-        }
-        return name;
-    }
-
-    @Override public void setExternalName(DatabaseKind kind, String externalName) {
-        switch (kind) {
-            case STAGING:
-                this.stagingExternalName = externalName;
-                break;
-            case JOB:
-                this.jobExternalName = externalName;
-                break;
-            case TRACE:
-                this.jobExternalName = externalName;
-                break;
-            case FINAL:
-                this.finalExternalName = externalName;
-                break;
-            default:
-                throw new InvalidDBOperationError(kind, "set auth method");
-        }
-    }
-
-    // roles and users
-    @Override public String getFlowOperatorRoleName() {
-        return flowOperatorRoleName;
-    }
-    @Override public void setFlowOperatorRoleName(String flowOperatorRoleName) {
-        this.flowOperatorRoleName = flowOperatorRoleName;
-    }
-
-    @Override public String getFlowOperatorUserName() {
-        return flowOperatorUserName;
-    }
-    @Override  public void setFlowOperatorUserName(String flowOperatorUserName) {
-        this.flowOperatorUserName = flowOperatorUserName;
-    }
-
-    @Override public String getFlowDeveloperRoleName() {
-        return flowDeveloperRoleName;
-    }
-    @Override public void setFlowDeveloperRoleName(String flowDeveloperRoleName) {
-        this.flowDeveloperRoleName = flowDeveloperRoleName;
-    }
-
-    @Override public String getFlowDeveloperUserName() {
-        return flowDeveloperUserName;
-    }
-    @Override  public void setFlowDeveloperUserName(String flowDeveloperUserName) {
-        this.flowDeveloperUserName = flowDeveloperUserName;
-    }
-
-    // impl only pending refactor to Flow Component
-    public String getMlUsername() {
-        return mlUsername;
-    }
-    // impl only pending refactor to Flow Component
-    public String getMlPassword() {
-        return mlPassword;
-    }
-
-    public void setHost(String host ) { this.host = host; }
-
-    public void setMlUsername(String mlUsername) {
-        this.mlUsername = mlUsername;
-    }
-
-    public void setMlPassword(String mlPassword) {
-        this.mlPassword = mlPassword;
-    }
-
-
-
-    @JsonIgnore
-    @Override  public String getLoadBalancerHost() {
-        return loadBalancerHost;
-    }
-
-    @Override
-    public Boolean getIsHostLoadBalancer(){
-        return isHostLoadBalancer;
-    }
-
-    @Override
-    public Boolean getIsProvisionedEnvironment(){
-        return isProvisionedEnvironment;
-    }
-
-    public void setLoadBalancerHost(String loadBalancerHost) {
-        this.loadBalancerHost = loadBalancerHost;
-    }
-
-    @Override public String getCustomForestPath() {
-        return customForestPath;
-    }
-    public void setCustomForestPath(String customForestPath) {
-        this.customForestPath = customForestPath;
-    }
-
-    @Override public String getModulePermissions() {
-        return modulePermissions;
-    }
-
-    @Override
-    public String getEntityModelPermissions() {
-        return entityModelPermissions;
-    }
-
-    public String getJobPermissions() {
-        return jobPermissions;
-    }
-
-    public void setJobPermissions(String jobPermissions) {
-        this.jobPermissions = jobPermissions;
-    }
-
-
-    @Override
-    @Deprecated
     public String getProjectDir() {
         return hubProject.getProjectDirString();
     }
 
     @Override
-    @Deprecated
     public void setProjectDir(String projectDir) {
         createProject(projectDir);
-    }
-
-    public void setModulePermissions(String modulePermissions) {
-        this.modulePermissions = modulePermissions;
-    }
-
-    public void setEntityModelPermissions(String entityModelPermissions) {
-        this.entityModelPermissions = entityModelPermissions;
     }
 
     @JsonIgnore
@@ -1443,97 +679,6 @@ public class HubConfigImpl implements HubConfig
     }
     public void setAdminManager(AdminManager adminManager) { this.adminManager = adminManager; }
 
-    public DatabaseClient newAppServicesClient() {
-        return getAppConfig().newAppServicesDatabaseClient(stagingDbName);
-    }
-
-    @Override
-    public DatabaseClient newStagingClient() {
-        return newStagingClient(stagingDbName);
-    }
-
-    public DatabaseClient newStagingClient(String dbName) {
-        AppConfig appConfig = getAppConfig();
-        DatabaseClientConfig config = new DatabaseClientConfig(appConfig.getHost(), stagingPort, getMlUsername(), getMlPassword());
-        config.setDatabase(dbName);
-        config.setSecurityContextType(SecurityContextType.valueOf(stagingAuthMethod.toUpperCase()));
-        config.setSslHostnameVerifier(stagingSslHostnameVerifier);
-        config.setSslContext(stagingSslContext);
-        config.setCertFile(stagingCertFile);
-        config.setCertPassword(stagingCertPassword);
-        config.setExternalName(stagingExternalName);
-        config.setTrustManager(stagingTrustManager);
-        if (isHostLoadBalancer) {
-            config.setConnectionType(DatabaseClient.ConnectionType.GATEWAY);
-        }
-        return appConfig.getConfiguredDatabaseClientFactory().newDatabaseClient(config);
-    }
-
-    @Override
-    // this method uses STAGING appserver but FINAL database.
-    // it's only use is for reverse flows, which need to use staging modules.
-    public DatabaseClient newReverseFlowClient() {
-        return newStagingClient(finalDbName);
-    }
-
-    @Override
-    public DatabaseClient newFinalClient() {
-        AppConfig appConfig = getAppConfig();
-        DatabaseClientConfig config = new DatabaseClientConfig(appConfig.getHost(), finalPort, getMlUsername(), getMlPassword());
-        config.setDatabase(finalDbName);
-        config.setSecurityContextType(SecurityContextType.valueOf(finalAuthMethod.toUpperCase()));
-        config.setSslHostnameVerifier(finalSslHostnameVerifier);
-        config.setSslContext(finalSslContext);
-        config.setCertFile(finalCertFile);
-        config.setCertPassword(finalCertPassword);
-        config.setExternalName(finalExternalName);
-        config.setTrustManager(finalTrustManager);
-        if (isHostLoadBalancer) {
-            config.setConnectionType(DatabaseClient.ConnectionType.GATEWAY);
-        }
-        return appConfig.getConfiguredDatabaseClientFactory().newDatabaseClient(config);
-    }
-
-    public DatabaseClient newJobDbClient() {
-        AppConfig appConfig = getAppConfig();
-        DatabaseClientConfig config = new DatabaseClientConfig(appConfig.getHost(), jobPort, mlUsername, mlPassword);
-        config.setDatabase(jobDbName);
-        config.setSecurityContextType(SecurityContextType.valueOf(jobAuthMethod.toUpperCase()));
-        config.setSslHostnameVerifier(jobSslHostnameVerifier);
-        config.setSslContext(jobSslContext);
-        config.setCertFile(jobCertFile);
-        config.setCertPassword(jobCertPassword);
-        config.setExternalName(jobExternalName);
-        config.setTrustManager(jobTrustManager);
-        if (isHostLoadBalancer) {
-            config.setConnectionType(DatabaseClient.ConnectionType.GATEWAY);
-        }
-        return appConfig.getConfiguredDatabaseClientFactory().newDatabaseClient(config);
-    }
-
-    public DatabaseClient newTraceDbClient() {
-        return newJobDbClient();
-    }
-
-    public DatabaseClient newModulesDbClient() {
-        AppConfig appConfig = getAppConfig();
-        // this has to be finalPort because final is a stock REST API.
-        // staging will not be; but its rewriter isn't loaded yet.
-        DatabaseClientConfig config = new DatabaseClientConfig(appConfig.getHost(), finalPort, mlUsername, mlPassword);
-        config.setDatabase(appConfig.getModulesDatabaseName());
-        config.setSecurityContextType(SecurityContextType.valueOf(finalAuthMethod.toUpperCase()));
-        config.setSslHostnameVerifier(finalSslHostnameVerifier);
-        config.setSslContext(finalSslContext);
-        config.setCertFile(finalCertFile);
-        config.setCertPassword(finalCertPassword);
-        config.setExternalName(finalExternalName);
-        config.setTrustManager(finalTrustManager);
-        if (isHostLoadBalancer) {
-            config.setConnectionType(DatabaseClient.ConnectionType.GATEWAY);
-        }
-        return appConfig.getConfiguredDatabaseClientFactory().newDatabaseClient(config);
-    }
-
     @JsonIgnore
     @Override public Path getModulesDir() {
         return hubProject.getModulesDir();
@@ -1613,52 +758,36 @@ public class HubConfigImpl implements HubConfig
     }
 
     @JsonIgnore
-    @Override public Path getUserServersDir() {
+    @Override
+    public Path getUserServersDir() {
         return hubProject.getUserServersDir();
     }
 
-    @JsonIgnore
-    @Override public AppConfig getAppConfig() {
-        return appConfig;
-    }
-
-
-    @Override public void setAppConfig(AppConfig config) {
+    @Override
+    public void setAppConfig(AppConfig config) {
         setAppConfig(config, false);
     }
 
-    @Override public void setAppConfig(AppConfig config, boolean skipUpdate) {
+    @Override
+    public void setAppConfig(AppConfig config, boolean skipUpdate) {
         this.appConfig = config;
         if (!skipUpdate) {
             updateAppConfig(this.appConfig);
         }
     }
 
-    @Override public String getJarVersion() {
-        Properties properties = new Properties();
-        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream("version.properties")) {
-            properties.load(inputStream);
-        } catch (IOException e)
-        {
-            throw new RuntimeException(e);
+    protected void updateAppConfig(AppConfig config) {
+        super.updateAppConfig(config);
+
+        if (envString != null) {
+            String defaultPath = config.getModuleTimestampsPath();
+            int index = defaultPath.lastIndexOf("/") + 1;
+            config.setModuleTimestampsPath(defaultPath.substring(0, index) + envString + "-" + defaultPath.substring(index));
         }
-        String version = (String)properties.get("version");
 
-        // this lets debug builds work from an IDE
-        if (version.equals("${project.version}")) {
-            version = "5.2-SNAPSHOT";
-        }
-        return version;
-    }
+        modifyCustomTokensMap(config);
 
-    @Override public String getDHFVersion() {
-
-        return this.DHFVersion;
-    }
-
-    @Override public String getHubLogLevel() {
-
-        return this.hubLogLevel;
+        this.appConfig = config;
     }
 
     private Map<String, String> getCustomTokens() {
@@ -1740,136 +869,6 @@ public class HubConfigImpl implements HubConfig
         }
     }
 
-    /**
-     * Makes DHF-specific updates to the AppConfig, after it's been constructed by ml-gradle.
-     *
-     * @param config
-     */
-    private void updateAppConfig(AppConfig config) {
-        // If the user hasn't set the app name then override it to "DHF" instead of "my-app"
-        if ("my-app".equals(config.getName())) {
-            config.setName("DHF");
-        }
-
-        // DHF never needs the default REST server provided by ml-gradle
-        config.setNoRestServer(true);
-
-        applyFinalConnectionSettingsToMlGradleDefaultRestSettings(config);
-
-        config.setTriggersDatabaseName(finalTriggersDbName);
-        config.setSchemasDatabaseName(finalSchemasDbName);
-        config.setModulesDatabaseName(modulesDbName);
-        config.setContentDatabaseName(finalDbName);
-
-        config.setReplaceTokensInModules(true);
-        config.setUseRoxyTokenPrefix(false);
-        config.setModulePermissions(modulePermissions);
-
-        if (envString != null) {
-            String defaultPath = config.getModuleTimestampsPath();
-            int index = defaultPath.lastIndexOf("/") + 1;
-            config.setModuleTimestampsPath(defaultPath.substring(0, index) + envString + "-" + defaultPath.substring(index));
-        }
-
-        Map<String, Integer> forestCounts = config.getForestCounts();
-        forestCounts.put(jobDbName, jobForestsPerHost);
-        forestCounts.put(modulesDbName, modulesForestsPerHost);
-        forestCounts.put(stagingDbName, stagingForestsPerHost);
-        forestCounts.put(stagingTriggersDbName, stagingTriggersForestsPerHost);
-        forestCounts.put(stagingSchemasDbName, stagingSchemasForestsPerHost);
-        forestCounts.put(finalDbName, finalForestsPerHost);
-        forestCounts.put(finalTriggersDbName, finalTriggersForestsPerHost);
-        forestCounts.put(finalSchemasDbName, finalSchemasForestsPerHost);
-        config.setForestCounts(forestCounts);
-
-        initializeConfigDirs(config);
-
-        initializeModulePaths(config);
-
-        config.setSchemasPath(getUserSchemasDir().toString());
-
-        modifyCustomTokensMap(config);
-
-        String version = getJarVersion();
-        config.getCustomTokens().put("%%mlHubVersion%%", version);
-
-        appConfig = config;
-    }
-
-    /**
-     * ml-app-deployer defaults to a single config path of src/main/ml-config. If that's still the only path present,
-     * it's overridden with the DHF defaults - src/main/hub-internal-config first, then src/main/ml-config second, with
-     * both of those being relative to the DHF project directory.
-     *
-     * But if the config paths have been customized - most likely via mlConfigPaths in gradle.properties - then this
-     * method just ensures that they're relative to the DHF project directory.
-     *
-     * @param config an AppConfig object
-     */
-    protected void initializeConfigDirs(AppConfig config) {
-        final String defaultConfigPath = String.join(File.separator, "src", "main", "ml-config");
-
-        boolean configDirsIsSetToTheMlAppDeployerDefault = config.getConfigDirs().size() == 1 && config.getConfigDirs().get(0).getBaseDir().toString().endsWith(defaultConfigPath);
-
-        if (configDirsIsSetToTheMlAppDeployerDefault) {
-            List<ConfigDir> configDirs = new ArrayList<>();
-            configDirs.add(new ConfigDir(getHubConfigDir().toFile()));
-            configDirs.add(new ConfigDir(getUserConfigDir().toFile()));
-            config.setConfigDirs(configDirs);
-        }
-        else {
-            // Need to make each custom config dir relative to the project dir
-            List<ConfigDir> configDirs = new ArrayList<>();
-            for (ConfigDir configDir : config.getConfigDirs()) {
-                File f = getHubProject().getProjectDir().resolve(configDir.getBaseDir().toString()).normalize().toAbsolutePath().toFile();
-                configDirs.add(new ConfigDir(f));
-            }
-            config.setConfigDirs(configDirs);
-        }
-
-        if (logger.isInfoEnabled()) {
-            config.getConfigDirs().forEach(configDir -> logger.info("Config path: " + configDir.getBaseDir().getAbsolutePath()));
-        }
-    }
-
-    /**
-     * Need to initialize every module path as being relative to the current project directory.
-     *
-     * @param config an AppConfig object
-     */
-    protected void initializeModulePaths(AppConfig config) {
-        List<String> modulePaths = new ArrayList<>();
-        Path projectDir = getHubProject().getProjectDir();
-        for (String modulePath : config.getModulePaths()) {
-            modulePaths.add(projectDir.resolve(modulePath).normalize().toAbsolutePath().toString());
-        }
-        config.setModulePaths(modulePaths);
-        if (logger.isInfoEnabled()) {
-            logger.info("Module paths: " + modulePaths);
-        }
-    }
-
-    /**
-     * This is needed so that mlFinal* properties that configure the connection to the final REST server are also used
-     * for any feature in ml-gradle that expects to use the same mlRest* properties. For example, LoadModulesCommand
-     * uses those properties to construct a DatabaseClient for loading modules; we want to ensure that the properties
-     * mirror the mlFinal* properties.
-     *
-     * @param config
-     */
-    private void applyFinalConnectionSettingsToMlGradleDefaultRestSettings(AppConfig config) {
-        if (finalAuthMethod != null) {
-            config.setRestSecurityContextType(SecurityContextType.valueOf(finalAuthMethod.toUpperCase()));
-        }
-        config.setRestPort(finalPort);
-        config.setRestCertFile(finalCertFile);
-        config.setRestCertPassword(finalCertPassword);
-        config.setRestExternalName(finalExternalName);
-        config.setRestSslContext(finalSslContext);
-        config.setRestSslHostnameVerifier(finalSslHostnameVerifier);
-        config.setRestTrustManager(finalTrustManager);
-    }
-
     private String getEnvPropString(Properties properties, String key, String fallback) {
         String value = properties.getProperty(key);
         if (value == null) {
@@ -1903,21 +902,6 @@ public class HubConfigImpl implements HubConfig
     }
 
     @JsonIgnore
-    public String getInfo()
-    {
-
-        try {
-            return objmapper.writerWithDefaultPrettyPrinter().writeValueAsString(this);
-        }
-        catch(Exception e)
-        {
-            throw new DataHubConfigurationException("Your datahub configuration could not serialize");
-
-        }
-
-    }
-
-    @JsonIgnore
     public void refreshProject() {
         refreshProject(null, true);
     }
@@ -1947,10 +931,6 @@ public class HubConfigImpl implements HubConfig
         return this;
     }
 
-    public String toString() {
-        return getInfo();
-    }
-
     // loads properties from a .properties file
     private void loadPropertiesFromFile(File propertiesFile, Properties loadedProperties) {
         InputStream is;
@@ -1964,14 +944,6 @@ public class HubConfigImpl implements HubConfig
         catch (IOException e) {
             throw new DataHubProjectException("No properties file found in project " + hubProject.getProjectDirString());
         }
-    }
-
-    public String getStagingSchemasDbName() {
-        return this.stagingSchemasDbName;
-    }
-
-    public String getStagingTriggersDbName() {
-        return this.stagingTriggersDbName;
     }
 
     // Only used by QS for login

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/SimpleHubConfig.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/SimpleHubConfig.java
@@ -1,0 +1,165 @@
+package com.marklogic.hub.impl;
+
+import com.marklogic.hub.HubConfig;
+import com.marklogic.hub.HubProject;
+import com.marklogic.hub.step.StepDefinition;
+import org.springframework.util.Assert;
+
+import java.nio.file.Path;
+
+/**
+ * Implementation of HubConfig that does not have a hard dependency on a HubProject. If a HubProject is not set, then
+ * any HubConfig method that depends on a HubProject being present will throw an exception.
+ */
+public class SimpleHubConfig extends AbstractHubConfig {
+
+    private HubProject hubProject;
+
+    public SimpleHubConfig() {
+    }
+
+    public SimpleHubConfig(HubProject hubProject) {
+        this.hubProject = hubProject;
+    }
+
+    protected HubProject requireHubProject() {
+        Assert.notNull(hubProject, "A HubProject has not been set, and thus this operation cannot be performed");
+        return hubProject;
+    }
+
+    @Override
+    public String getProjectDir() {
+        return requireHubProject().getProjectDirString();
+    }
+
+    @Override
+    public void setProjectDir(String projectDir) {
+        requireHubProject().createProject(projectDir);
+    }
+
+    @Override
+    public HubProject getHubProject() {
+        return hubProject;
+    }
+
+    @Override
+    public void initHubProject() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getHubModulesDeployTimestampFile() {
+        return requireHubProject().getHubModulesDeployTimestampFile();
+    }
+
+    @Override
+    public String getUserModulesDeployTimestampFile() {
+        return requireHubProject().getUserModulesDeployTimestampFile();
+    }
+
+    @Override
+    public Path getModulesDir() {
+        return requireHubProject().getModulesDir();
+    }
+
+    @Override
+    public Path getHubPluginsDir() {
+        return requireHubProject().getHubPluginsDir();
+    }
+
+    @Override
+    public Path getHubEntitiesDir() {
+        return requireHubProject().getHubEntitiesDir();
+    }
+
+    @Override
+    public Path getHubMappingsDir() {
+        return requireHubProject().getHubMappingsDir();
+    }
+
+    @Override
+    public Path getStepsDirByType(StepDefinition.StepDefinitionType type) {
+        return requireHubProject().getStepsDirByType(type);
+    }
+
+    @Override
+    public Path getHubConfigDir() {
+        return requireHubProject().getHubConfigDir();
+    }
+
+    @Override
+    public Path getHubDatabaseDir() {
+        return requireHubProject().getHubDatabaseDir();
+    }
+
+    @Override
+    public Path getHubServersDir() {
+        return requireHubProject().getHubServersDir();
+    }
+
+    @Override
+    public Path getHubSecurityDir() {
+        return requireHubProject().getHubSecurityDir();
+    }
+
+    @Override
+    public Path getUserConfigDir() {
+        return requireHubProject().getUserConfigDir();
+    }
+
+    @Override
+    public Path getUserSecurityDir() {
+        return requireHubProject().getUserSecurityDir();
+    }
+
+    @Override
+    public Path getUserDatabaseDir() {
+        return requireHubProject().getUserDatabaseDir();
+    }
+
+    @Override
+    public Path getUserSchemasDir() {
+        return requireHubProject().getUserSchemasDir();
+    }
+
+    @Override
+    public Path getUserServersDir() {
+        return requireHubProject().getUserServersDir();
+    }
+
+    @Override
+    public Path getEntityDatabaseDir() {
+        return requireHubProject().getEntityDatabaseDir();
+    }
+
+    @Override
+    public Path getFlowsDir() {
+        return requireHubProject().getFlowsDir();
+    }
+
+    @Override
+    public Path getStepDefinitionsDir() {
+        return requireHubProject().getStepDefinitionsDir();
+    }
+
+    @Override
+    public void createProject(String projectDirString) {
+        requireHubProject().createProject(projectDirString);
+    }
+
+    @Override
+    public HubConfig withPropertiesFromEnvironment(String environment) {
+        requireHubProject().setUserModulesDeployTimestampFile(environment + "-" + USER_MODULES_DEPLOY_TIMESTAMPS_PROPERTIES);
+        return this;
+    }
+
+    @Override
+    public void refreshProject() {
+        // This is only used by QuickStart, but since it doesn't need to technically do anything, no need to throw an
+        // UnsupportedOperationException
+    }
+
+    public void setHubProject(HubProject hubProject) {
+        this.hubProject = hubProject;
+    }
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/job/JobDocManager.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/job/JobDocManager.java
@@ -46,7 +46,7 @@ public class JobDocManager extends ResourceManager {
         try {
             resultItr = this.getServices().post(params, new StringHandle("{}").withFormat(Format.JSON));
         } catch (Exception e) {
-            throw new RuntimeException("Unable to update the job document");
+            throw new RuntimeException("Unable to update the job document; cause: " + e.getMessage(), e);
         }
         if (resultItr == null || !resultItr.hasNext()) {
             return null;

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/legacy/collector/impl/LegacyCollectorImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/legacy/collector/impl/LegacyCollectorImpl.java
@@ -115,7 +115,7 @@ public class LegacyCollectorImpl implements LegacyCollector {
             // https://github.com/marklogic/marklogic-data-hub/issues/633
             //
 
-            RestTemplate template = newRestTemplate(  ((HubConfigImpl) hubConfig).getMlUsername(), ( (HubConfigImpl) hubConfig).getMlPassword());
+            RestTemplate template = newRestTemplate(hubConfig.getMlUsername(), hubConfig.getMlPassword());
             String uriString = String.format(
                 "%s://%s:%d%s?job-id=%s&entity-name=%s&flow-name=%s&database=%s",
                 client.getSecurityContext().getSSLContext() != null ? "https" : "http",
@@ -192,7 +192,7 @@ public class LegacyCollectorImpl implements LegacyCollector {
                     @Override
                     public void verify(String host, String[] cns, String[] subjectAlts) throws SSLException {}
                 };
-                
+
             } else if (verifier == SSLHostnameVerifier.COMMON) {
                 hostnameVerifier = null;
             } else if (verifier == SSLHostnameVerifier.STRICT) {
@@ -216,7 +216,7 @@ public class LegacyCollectorImpl implements LegacyCollector {
         protected HostnameVerifierAdapter(DatabaseClientFactory.SSLHostnameVerifier verifier) {
           this.verifier = verifier;
         }
-        
+
         public void verify(String hostname, X509Certificate cert) throws SSLException {
           ArrayList<String> cnArray = new ArrayList<>();
           try {
@@ -254,12 +254,12 @@ public class LegacyCollectorImpl implements LegacyCollector {
         @Override
         public void verify(String hostname, SSLSocket ssl) throws IOException {
             Certificate[] certificates = ssl.getSession().getPeerCertificates();
-            verify(hostname, (X509Certificate) certificates[0]);             
+            verify(hostname, (X509Certificate) certificates[0]);
         }
 
         @Override
         public void verify(String hostname, String[] cns, String[] subjectAlts) throws SSLException {
-            verifier.verify(hostname, cns, subjectAlts);            
+            verifier.verify(hostname, cns, subjectAlts);
         }
 
         @Override
@@ -268,7 +268,7 @@ public class LegacyCollectorImpl implements LegacyCollector {
               Certificate[] certificates = session.getPeerCertificates();
               verify(hostname, (X509Certificate) certificates[0]);
               return true;
-              } 
+              }
             catch(SSLException e) {
               return false;
             }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/MarkLogicStepDefinitionProvider.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/MarkLogicStepDefinitionProvider.java
@@ -1,0 +1,24 @@
+package com.marklogic.hub.step;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.io.JacksonHandle;
+
+public class MarkLogicStepDefinitionProvider implements StepDefinitionProvider {
+
+    private DatabaseClient databaseClient;
+
+    public MarkLogicStepDefinitionProvider(DatabaseClient databaseClient) {
+        this.databaseClient = databaseClient;
+    }
+
+    @Override
+    public StepDefinition getStepDefinition(String name, StepDefinition.StepDefinitionType type) {
+        // TODO Support custom step definitions
+        String uri = String.format("/step-definitions/%s/marklogic/%s.step.json", type.name().toLowerCase(), name);
+        JsonNode json = databaseClient.newJSONDocumentManager().read(uri, new JacksonHandle()).get();
+        StepDefinition step = StepDefinition.create(name, type);
+        step.deserialize(json);
+        return step;
+    }
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/ProjectStepDefinitionProvider.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/ProjectStepDefinitionProvider.java
@@ -1,0 +1,22 @@
+package com.marklogic.hub.step;
+
+import com.marklogic.hub.StepDefinitionManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Depends on a StepDefinitionManager, which ultimately depends on a HubProject being available so that a step
+ * definition can be read from disk. This is marked as a Spring Component so that it is used by default for backwards
+ * compatibility purposes.
+ */
+@Component
+public class ProjectStepDefinitionProvider implements StepDefinitionProvider {
+
+    @Autowired
+    private StepDefinitionManager stepDefMgr;
+
+    @Override
+    public StepDefinition getStepDefinition(String name, StepDefinition.StepDefinitionType type) {
+        return stepDefMgr.getStepDefinition(name, type);
+    }
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/StepDefinitionProvider.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/StepDefinitionProvider.java
@@ -1,0 +1,11 @@
+package com.marklogic.hub.step;
+
+/**
+ * Abstracts how a StepDefinition is provided to a client so that it can come from MarkLogic, from a filesystem, or from
+ * other location.
+ */
+public interface StepDefinitionProvider {
+
+    StepDefinition getStepDefinition(String name, StepDefinition.StepDefinitionType type);
+
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/StepRunnerFactory.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/StepRunnerFactory.java
@@ -18,23 +18,29 @@ public class StepRunnerFactory {
 
     @Autowired
     private HubConfig hubConfig;
+
     @Autowired
-    private StepDefinitionManagerImpl stepDefMgr;
+    private StepDefinitionProvider stepDefinitionProvider;
+
     private StepRunner stepRunner;
     private int batchSize = 100;
     private int threadCount = 4;
     private String sourceDatabase;
     private String targetDatabase;
 
+    public StepRunnerFactory() {
+    }
+
+    public StepRunnerFactory(HubConfig hubConfig) {
+        this.hubConfig = hubConfig;
+    }
+
     public StepRunner getStepRunner(Flow flow, String stepNum)  {
         Map<String, Step> steps = flow.getSteps();
         Step step = steps.get(stepNum);
-        StepDefinition stepDef = stepDefMgr.getStepDefinition(step.getStepDefinitionName(), step.getStepDefinitionType());
+        StepDefinition stepDef = stepDefinitionProvider.getStepDefinition(step.getStepDefinitionName(), step.getStepDefinitionType());
 
         switch (step.getStepDefinitionType()) {
-            case MAPPING:
-                stepRunner = new QueryStepRunner(hubConfig);
-                break;
             case INGESTION:
                 stepRunner = new WriteStepRunner(hubConfig);
                 break;
@@ -102,4 +108,7 @@ public class StepRunnerFactory {
         return stepRunner;
     }
 
+    public void setStepDefinitionProvider(StepDefinitionProvider stepDefinitionProvider) {
+        this.stepDefinitionProvider = stepDefinitionProvider;
+    }
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
@@ -303,10 +303,8 @@ public class QueryStepRunner implements StepRunner {
         return this.batchSize;
     }
 
-    private Collection<String> runCollector() throws Exception {
-        Collector c = new CollectorImpl(this.flow);
-        c.setHubConfig(hubConfig);
-        c.setClient(stagingClient);
+    private Collection<String> runCollector() {
+        Collector c = new CollectorImpl(hubConfig, stagingClient);
 
         stepStatusListeners.forEach((StepStatusListener listener) -> {
             listener.onStatusChange(this.jobId, 0, JobStatus.RUNNING_PREFIX + step, 0, 0,  "running collector");

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
@@ -534,7 +534,7 @@ public class WriteStepRunner implements StepRunner {
         metadataValues.add("datahubCreatedByStep", flow.getStep(step).getStepDefinitionName());
         // TODO createdOn/createdBy data may not be accurate enough. Unfortunately REST transforms don't allow for writing metadata
         metadataValues.add("datahubCreatedOn", DATE_TIME_FORMAT.format(new Date()));
-        metadataValues.add("datahubCreatedBy", ((HubConfigImpl) hubConfig).getMlUsername());
+        metadataValues.add("datahubCreatedBy", hubConfig.getMlUsername());
         writeBatcher.withDefaultMetadata(metadataHandle);
         Format format = null;
         switch (inputFileType.toLowerCase()) {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/RunStepTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/RunStepTest.java
@@ -1,0 +1,52 @@
+package com.marklogic.hub.flow;
+
+import com.marklogic.appdeployer.AppConfig;
+import com.marklogic.hub.flow.impl.FlowRunnerImpl;
+import com.marklogic.hub.impl.SimpleHubConfig;
+import com.marklogic.hub.step.MarkLogicStepDefinitionProvider;
+import com.marklogic.hub.step.StepRunnerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class RunStepTest {
+
+    /**
+     * To use QueryStepRunner, we need a staging client (which can point to any "source" database), a job
+     * client, and a destination database. So we add a constructor to QueryStepRunner to accept that so
+     * we don't have to construct a HubConfig.
+     *
+     * @param args
+     * @throws IOException
+     */
+    public static void main(String[] args) {
+        final String host = "localhost";
+        final String username = "admin";
+        final String password = "admin";
+
+        SimpleHubConfig hubConfig = new SimpleHubConfig();
+        AppConfig config = new AppConfig();
+        config.setHost(host);
+        hubConfig.setHost(host);
+        hubConfig.setAppConfig(new AppConfig());
+        hubConfig.setMlUsername(username);
+        hubConfig.setMlPassword(password);
+
+        Map<String, Object> flowOptions = new HashMap<>();
+        //flowOptions.put("disableJobOutput", true);
+
+        Map<String, Object> stepConfig = new HashMap<>();
+        Map<String, String> fileLocations = new HashMap<>();
+        fileLocations.put("inputFilePath", "/Users/rrudin/dev/workspace/marklogic-data-hub/examples/json-mapping-example/data");
+        stepConfig.put("fileLocations", fileLocations);
+
+        StepRunnerFactory stepRunnerFactory = new StepRunnerFactory(hubConfig);
+        stepRunnerFactory.setStepDefinitionProvider(new MarkLogicStepDefinitionProvider(hubConfig.newStagingClient()));
+        FlowRunnerImpl flowRunner = new FlowRunnerImpl(hubConfig, stepRunnerFactory);
+        RunFlowResponse response = flowRunner.runFlowDefinedInMarkLogic("jsonToJson", Arrays.asList("1", "2"), "run123", flowOptions, stepConfig);
+        flowRunner.awaitCompletion();
+        System.out.println(response);
+    }
+}


### PR DESCRIPTION
This is a WIP, looking for feedback on this approach of making a new implementation of HubConfig to avoid HubConfigImpl's hard dependency on a HubProject. 

SimpleHubConfig is a new impl of HubConfig that does not have a hard dependency on a HubProject. It extends the new AbstractHubConfig class, to which I moved as much of HubConfigImpl as possible for reuse purposes. 

Modified a few clients of HubConfig that were casting to HubConfigImpl to call getMlUsername and getMlPassword - those are now part of the HubConfig interface so that those casts aren't needed. 

Added a new method to FlowRunnerImpl so that a Flow is retrieved from ML instead of the filesystem. 

Added StepDefinitionProvider so that StepRunnerFactory can get a StepDefinition from ML instead of from the filesystem. 

RunStepTest isn't yet a real test, it's just a sample program to show the new stuff in action