### PR TITLE
DHFPROD-3761: Save button is disabled when trying to change source database in mapping step

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog-ui.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ui/new-step-dialog-ui.component.ts
@@ -204,9 +204,11 @@ export class NewStepDialogUiComponent implements OnInit {
   //Update the source collection list as soon as the sourceDatabase value is changed.
   stepDatabaseChange() {
     this.getCollections.emit(this.newStepForm.value.sourceDatabase);
-    this.newStepForm.controls['sourceCollection'].reset();
-    this.newStepForm.get('sourceCollection').setValidators([Validators.required]);
-    this.newStepForm.get('sourceCollection').updateValueAndValidity();
+    if (this.newStepForm.value.selectedSource === 'collection'){
+      this.newStepForm.controls['sourceCollection'].reset();
+      this.newStepForm.get('sourceCollection').setValidators([Validators.required]);
+      this.newStepForm.get('sourceCollection').updateValueAndValidity();
+    }
   }
 
   stepTypeChange() {


### PR DESCRIPTION
Users will now be able to save the step when the 'Query' option is chosen for the source type, but will be enforced to choose a collection name from the updated list, if source type is 'collection'.