### PR TITLE
DHFPROD-3812: Lazily instantiate command in ModuleWatchingConsumer

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/util/ModuleWatchingConsumerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/util/ModuleWatchingConsumerTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ModuleWatchingConsumerTest {
 
-    private ModuleWatchingConsumer consumer = new ModuleWatchingConsumer(null, null);
+    private ModuleWatchingConsumer consumer = new ModuleWatchingConsumer(null, null, null);
 
     @Test
     public void shouldGenerateFunctionMetadata() {

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -140,7 +140,7 @@ class DataHubPlugin implements Plugin<Project> {
         WatchTask watchTask = project.tasks.getByName("mlWatch")
         CommandContext commandContext = new CommandContext(hubConfig.getAppConfig(), hubConfig.getManageClient(), hubConfig.getAdminManager())
         Versions versions = ((ApplicationContext)project.property("dataHubApplicationContext")).getBean(Versions.class)
-        watchTask.onModulesLoaded = new ModuleWatchingConsumer(commandContext, new GenerateFunctionMetadataCommand(hubConfig.newModulesDbClient(), versions))
+        watchTask.onModulesLoaded = new ModuleWatchingConsumer(commandContext, hubConfig, versions)
         watchTask.afterModulesLoadedCallback = new AfterModulesLoadedCallback(loadUserModulesCommand, commandContext)
 
         ((ClearModulesDatabaseTask)project.tasks.getByName("mlClearModulesDatabase")).command = new ClearDHFModulesCommand(hubConfig, dataHub)


### PR DESCRIPTION
This avoids problems when the user runs hubInit and no username/password is set yet.