### PR TITLE
DHFPROD-3617:Insert artifacts with new roles

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/HubConfig.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/HubConfig.java
@@ -362,6 +362,33 @@ public interface HubConfig {
     String getEntityModelPermissions();
 
     /**
+     * Prior to 5.2.0, entities were assigned permissions returned by getModulePermissions. For 5.2.0 and later, this
+     * method should be used to know which permissions to assign to flow document.
+     *
+     * @return a comma-delimited string of role1,capability1,role2,capability2 that defines the permissions to add to
+     * each flow document
+     */
+    String getFlowPermissions();
+
+    /**
+     * Prior to 5.2.0, entities were assigned permissions returned by getModulePermissions. For 5.2.0 and later, this
+     * method should be used to know which permissions to assign to mapping document.
+     *
+     * @return a comma-delimited string of role1,capability1,role2,capability2 that defines the permissions to add to
+     * each mapping document
+     */
+    String getMappingPermissions();
+
+    /**
+     * Prior to 5.2.0, entities were assigned permissions returned by getModulePermissions. For 5.2.0 and later, this
+     * method should be used to know which permissions to assign to step definition document.
+     *
+     * @return a comma-delimited string of role1,capability1,role2,capability2 that defines the permissions to add to
+     * each step definition document
+     */
+    String getStepDefinitionPermissions();
+
+    /**
      * Obtains the project directory as a string
      * @return project directory
      */

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommand.java
@@ -147,7 +147,7 @@ public class LoadUserArtifactsCommand extends AbstractCommand {
                             entityDefModulesFinder,
                             propertiesModuleManager,
                             entityResourceToURI,
-                            buildMetadataForEntityModels(hubConfig),
+                            buildMetadata(hubConfig.getEntityModelPermissions(), "http://marklogic.com/entity-services/models"),
                             stagingEntityDocumentWriteSet,
                             finalEntityDocumentWriteSet
                         );
@@ -166,7 +166,7 @@ public class LoadUserArtifactsCommand extends AbstractCommand {
                                 mappingDefModulesFinder,
                                 propertiesModuleManager,
                                 mappingResourceToURI,
-                                buildMetadata("http://marklogic.com/data-hub/mappings", hubConfig.getModulePermissions()),
+                                buildMetadata(hubConfig.getMappingPermissions(), "http://marklogic.com/data-hub/mappings"),
                                 stagingMappingDocumentWriteSet,
                                 finalMappingDocumentWriteSet
                             );
@@ -189,7 +189,7 @@ public class LoadUserArtifactsCommand extends AbstractCommand {
                             stepDefModulesFinder,
                             propertiesModuleManager,
                             stepResourceToURI,
-                            buildMetadata("http://marklogic.com/data-hub/step-definition", hubConfig.getModulePermissions()),
+                            buildMetadata(hubConfig.getStepDefinitionPermissions(), "http://marklogic.com/data-hub/step-definition"),
                             stagingStepDefDocumentWriteSet,
                             finalStepDefDocumentWriteSet
                         );
@@ -209,7 +209,7 @@ public class LoadUserArtifactsCommand extends AbstractCommand {
                             flowDefModulesFinder,
                             propertiesModuleManager,
                             flowResourceToURI,
-                            buildMetadata("http://marklogic.com/data-hub/flow", hubConfig.getModulePermissions()),
+                            buildMetadata(hubConfig.getFlowPermissions(), "http://marklogic.com/data-hub/flow"),
                             stagingFlowDocumentWriteSet,
                             finalFlowDocumentWriteSet
                         );
@@ -242,25 +242,6 @@ public class LoadUserArtifactsCommand extends AbstractCommand {
         }
     }
 
-    /**
-     * As of 5.1.0, entity model permissions are separate from module permissions. Though if entity model permissions
-     * are not defined, then this falls back to using module permissions.
-     *
-     * @param config
-     * @return
-     */
-    protected DocumentMetadataHandle buildMetadataForEntityModels(HubConfig config) {
-        String permissions = config.getEntityModelPermissions();
-        if (permissions == null || permissions.trim().length() < 1) {
-            if (logger.isInfoEnabled()) {
-                logger.info("Entity model permissions were not set, so using module permissions; consider setting mlEntityModelPermissions " +
-                    "in case you want entity models to have custom permissions.");
-            }
-            permissions = config.getModulePermissions();
-        }
-        return buildMetadata("http://marklogic.com/entity-services/models", permissions);
-    }
-
     private void executeWalk(
         Path dir,
         ModulesFinder modulesFinder,
@@ -281,7 +262,15 @@ public class LoadUserArtifactsCommand extends AbstractCommand {
         }
     }
 
-    private DocumentMetadataHandle buildMetadata(String collection, String permissions) {
+    /**
+     * As of 5.2.0, artifact permissions are separate from module permissions. If artifact permissions
+     * are not defined, then it falls back to using default permissions.
+     *
+     * @param permissions
+     * @param collection
+     * @return
+     */
+    protected DocumentMetadataHandle buildMetadata(String permissions, String collection) {
         DocumentMetadataHandle meta = new DocumentMetadataHandle();
         meta.getCollections().add(collection);
         documentPermissionsParser.parsePermissions(permissions, meta.getPermissions());

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -173,6 +173,9 @@ public class HubConfigImpl implements HubConfig
 
     protected String modulePermissions;
 
+    private String mappingPermissions;
+    private String flowPermissions;
+    private String stepDefinitionPermissions;
     private String entityModelPermissions;
     private String jobPermissions;
 
@@ -855,6 +858,21 @@ public class HubConfigImpl implements HubConfig
         return entityModelPermissions;
     }
 
+    @Override
+    public String getFlowPermissions() {
+        return flowPermissions;
+    }
+
+    @Override
+    public String getMappingPermissions() {
+        return mappingPermissions;
+    }
+
+    @Override
+    public String getStepDefinitionPermissions() {
+        return stepDefinitionPermissions;
+    }
+
     public String getJobPermissions() {
         return jobPermissions;
     }
@@ -882,6 +900,18 @@ public class HubConfigImpl implements HubConfig
 
     public void setEntityModelPermissions(String entityModelPermissions) {
         this.entityModelPermissions = entityModelPermissions;
+    }
+
+    public void setFlowPermissions(String flowPermissions) {
+        this.flowPermissions = flowPermissions;
+    }
+
+    public void setMappingPermissions(String mappingPermissions) {
+        this.mappingPermissions = mappingPermissions;
+    }
+
+    public void setStepDefinitionPermissions(String stepDefinitionPermissions) {
+        this.stepDefinitionPermissions = stepDefinitionPermissions;
     }
 
     @JsonIgnore
@@ -1309,6 +1339,27 @@ public class HubConfigImpl implements HubConfig
         }
         else {
             projectProperties.setProperty("mlEntityModelPermissions", entityModelPermissions);
+        }
+
+        if (mappingPermissions == null) {
+            mappingPermissions = getEnvPropString(projectProperties, "mlMappingPermissions", environment.getProperty("mlMappingPermissions"));
+        }
+        else {
+            projectProperties.setProperty("mlMappingPermissions", mappingPermissions);
+        }
+
+        if (flowPermissions == null) {
+            flowPermissions = getEnvPropString(projectProperties, "mlFlowPermissions", environment.getProperty("mlFlowPermissions"));
+        }
+        else {
+            projectProperties.setProperty("mlFlowPermissions", flowPermissions);
+        }
+
+        if (stepDefinitionPermissions == null) {
+            stepDefinitionPermissions = getEnvPropString(projectProperties, "mlStepDefinitionPermissions", environment.getProperty("mlStepDefinitionPermissions"));
+        }
+        else {
+            projectProperties.setProperty("mlStepDefinitionPermissions", stepDefinitionPermissions);
         }
 
         if (jobPermissions == null) {
@@ -2047,6 +2098,9 @@ public class HubConfigImpl implements HubConfig
         customForestPath = null;
         modulePermissions = null;
         entityModelPermissions = null;
+        mappingPermissions = null;
+        stepDefinitionPermissions = null;
+        flowPermissions = null;
         jobPermissions = null;
         hubLogLevel = null;
         loadBalancerHost = null;

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
@@ -348,6 +348,14 @@ public class HubProjectImpl implements HubProject {
         writeRoleFile(rolesDir, "data-hub-operator.json");
         writeRoleFile(rolesDir, "data-hub-portal-security-admin.json");
         writeRoleFile(rolesDir, "data-hub-security-admin.json");
+        writeRoleFile(rolesDir, "data-hub-flow-reader.json");
+        writeRoleFile(rolesDir, "data-hub-flow-writer.json");
+        writeRoleFile(rolesDir, "data-hub-mapping-reader.json");
+        writeRoleFile(rolesDir, "data-hub-mapping-writer.json");
+        writeRoleFile(rolesDir, "data-hub-step-definition-reader.json");
+        writeRoleFile(rolesDir, "data-hub-step-definition-writer.json");
+        writeRoleFile(rolesDir, "data-hub-entity-model-writer.json");
+
 
         // New 5.1.0 roles
         writeRoleFile(rolesDir, "data-hub-entity-model-reader.json");

--- a/marklogic-data-hub/src/main/resources/dhf-defaults.properties
+++ b/marklogic-data-hub/src/main/resources/dhf-defaults.properties
@@ -63,9 +63,11 @@ mlHubLogLevel=default
 # Default module permissions which allow flow-operator-role to execute flows
 mlModulePermissions=rest-reader,read,rest-writer,insert,rest-writer,update,rest-extension-user,execute
 
-# data-hub-entity-model-reader is the preferred role for users that wish to have read access to entity models
-mlEntityModelPermissions=rest-reader,read,rest-writer,insert,rest-writer,update,data-hub-entity-model-reader,read
-
+# Default roles for reading and updating user artifacts
+mlEntityModelPermissions=data-hub-entity-model-reader,read,data-hub-entity-model-writer,update
+mlMappingPermissions=data-hub-mapping-reader,read,data-hub-mapping-writer,update
+mlFlowPermissions=data-hub-flow-reader,read,data-hub-flow-writer,update
+mlStepDefinitionPermissions=data-hub-step-definition-reader,read,data-hub-step-definition-writer,update
 mlJobPermissions=data-hub-job-reader,read,data-hub-job-internal,update
 
 mlIsProvisionedEnvironment=false

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-developer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-developer.json
@@ -6,7 +6,12 @@
     "manage-user",
     "ps-user",
     "rest-admin",
-    "tde-admin"
+    "tde-admin",
+    "data-hub-flow-writer",
+    "data-hub-mapping-writer",
+    "data-hub-step-definition-writer",
+    "data-hub-entity-model-writer"
+
   ],
   "privilege": [
     {

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-entity-model-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-entity-model-writer.json
@@ -1,0 +1,4 @@
+{
+  "role-name": "data-hub-entity-model-writer",
+  "description": "Data Hub role for permissions that grant update access to entity models"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-flow-reader.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-flow-reader.json
@@ -1,0 +1,4 @@
+{
+  "role-name": "data-hub-flow-reader",
+  "description": "Data Hub role for permissions that grant read access to flow documents"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-flow-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-flow-writer.json
@@ -1,0 +1,4 @@
+{
+  "role-name": "data-hub-flow-writer",
+  "description": "Data Hub role for permissions that grant write access to flow documents"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-mapping-reader.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-mapping-reader.json
@@ -1,0 +1,4 @@
+{
+  "role-name": "data-hub-mapping-reader",
+  "description": "Data Hub role for permissions that grant read access to mapping documents"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-mapping-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-mapping-writer.json
@@ -1,0 +1,4 @@
+{
+  "role-name": "data-hub-mapping-writer",
+  "description": "Data Hub role for permissions that grant write access to mapping documents"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-operator.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-operator.json
@@ -5,7 +5,11 @@
     "rest-extension-user",
     "rest-reader",
     "rest-writer",
-    "data-hub-job-reader"
+    "data-hub-job-reader",
+    "data-hub-flow-reader",
+    "data-hub-mapping-reader",
+    "data-hub-entity-model-reader",
+    "data-hub-step-definition-reader"
   ],
   "privilege": [
     {

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-step-definition-reader.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-step-definition-reader.json
@@ -1,0 +1,4 @@
+{
+  "role-name": "data-hub-step-definition-reader",
+  "description": "Data Hub role for permissions that grant read access to step definition documents"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-step-definition-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-step-definition-writer.json
@@ -1,0 +1,4 @@
+{
+  "role-name": "data-hub-step-definition-writer",
+  "description": "Data Hub role for permissions that grant write access to step definition documents"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/flow-developer-role.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/flow-developer-role.json
@@ -2,7 +2,11 @@
   "role-name": "%%mlFlowDeveloperRole%%",
   "description": "A role can deploy modules to a data hub instance.",
   "role": [
-    "rest-admin","manage-admin","tde-admin"
+    "rest-admin","manage-admin","tde-admin",
+    "data-hub-flow-writer",
+    "data-hub-mapping-writer",
+    "data-hub-step-definition-writer",
+    "data-hub-entity-model-writer"
   ],
   "privilege": [
     {

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/flow-operator-role.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/flow-operator-role.json
@@ -4,7 +4,12 @@
   "role": [
     "rest-reader",
     "rest-extension-user",
-    "rest-writer"
+    "rest-writer",
+    "data-hub-job-reader",
+    "data-hub-flow-reader",
+    "data-hub-mapping-reader",
+    "data-hub-entity-model-reader",
+    "data-hub-step-definition-reader"
   ],
   "privilege": [
     {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/core/HubProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/core/HubProjectTest.java
@@ -82,6 +82,15 @@ public class HubProjectTest extends HubTestBase {
         assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/flow-developer-role.json").exists());
         assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/flow-operator-role.json").exists());
 
+        assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/data-hub-flow-reader.json").exists());
+        assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/data-hub-flow-writer.json").exists());
+        assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/data-hub-mapping-reader.json").exists());
+        assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/data-hub-mapping-writer.json").exists());
+        assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/data-hub-step-definition-reader.json").exists());
+        assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/data-hub-step-definition-writer.json").exists());
+        assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/data-hub-entity-model-reader.json").exists());
+        assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/data-hub-entity-model-writer.json").exists());
+
         assertTrue(new File(projectPath, "src/main/ml-config/servers/final-server.json").exists());
         assertTrue(new File(projectPath, "src/main/ml-config/databases/final-database.json").exists());
         assertTrue(new File(projectPath, "src/main/ml-config/databases/modules-database.json").exists());

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadHubArtifactsCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadHubArtifactsCommandTest.java
@@ -3,6 +3,7 @@ package com.marklogic.hub.deploy.commands;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.hub.ApplicationConfig;
 import com.marklogic.hub.HubTestBase;
+import com.marklogic.hub.impl.HubConfigImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,10 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.util.Set;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = ApplicationConfig.class)
@@ -33,31 +31,37 @@ public class LoadHubArtifactsCommandTest extends HubTestBase {
 
     @Test
     public void verifyDefaultPermissions() {
-        DocumentMetadataHandle h = loadHubArtifactsCommand.buildDocumentMetadata("some-collection");
+        DocumentMetadataHandle h = loadHubArtifactsCommand.buildMetadata(adminHubConfig.getFlowPermissions(),"http://marklogic.com/data-hub/flow");
         assertEquals(1, h.getCollections().size());
-        assertEquals("some-collection", h.getCollections().iterator().next());
+        assertEquals("http://marklogic.com/data-hub/flow", h.getCollections().iterator().next());
 
-        final String message = "To ensure that hub artifacts have at least some permissions on them when " +
-            "deploying DHF to ML 10, mlModulePermissions is expected to be used to set permissions. This " +
-            "should result in rest-reader and rest-writer permissions being added.";
 
         DocumentMetadataHandle.DocumentPermissions perms = h.getPermissions();
-        Set<DocumentMetadataHandle.Capability> capabilities = perms.get("rest-reader");
-        assertEquals(1, capabilities.size(), message);
-        assertEquals(DocumentMetadataHandle.Capability.READ, capabilities.iterator().next());
+        assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("data-hub-flow-reader").iterator().next());
 
-        capabilities = perms.get("rest-writer");
-        assertEquals(2, capabilities.size(), message);
-        assertTrue(capabilities.contains(DocumentMetadataHandle.Capability.INSERT));
-        assertTrue(capabilities.contains(DocumentMetadataHandle.Capability.UPDATE));
+        h = loadHubArtifactsCommand.buildMetadata(adminHubConfig.getStepDefinitionPermissions(),"http://marklogic.com/data-hub/step-definition");
+        assertEquals(1, h.getCollections().size());
+        assertEquals("http://marklogic.com/data-hub/step-definition", h.getCollections().iterator().next());
+
+
+        perms = h.getPermissions();
+        assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("data-hub-step-definition-reader").iterator().next());
     }
 
     @Test
-    public void noModulePermissions() {
-        adminHubConfig.setModulePermissions("");
-        DocumentMetadataHandle h = loadHubArtifactsCommand.buildDocumentMetadata("some-collection");
-        assertEquals(0, h.getPermissions().size(), "If the user for some reason sets mlModulePermissions to an empty string, " +
-            "no error should occur; the document permissions should just be empty");
+    public void customPermissions() {
+        HubConfigImpl config = new HubConfigImpl();
+
+        config.setFlowPermissions("manage-user,read,manage-admin,update");
+        config.setStepDefinitionPermissions("manage-user,read,manage-admin,update");
+
+        DocumentMetadataHandle.DocumentPermissions perms = loadUserArtifactsCommand.buildMetadata(config.getStepDefinitionPermissions(),"http://marklogic.com/data-hub/step-definition").getPermissions();
+        assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("manage-user").iterator().next());
+        assertEquals(DocumentMetadataHandle.Capability.UPDATE, perms.get("manage-admin").iterator().next());
+
+        perms = loadUserArtifactsCommand.buildMetadata(config.getFlowPermissions(),"http://marklogic.com/data-hub/flow").getPermissions();
+        assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("manage-user").iterator().next());
+        assertEquals(DocumentMetadataHandle.Capability.UPDATE, perms.get("manage-admin").iterator().next());
     }
 }
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommandTest.java
@@ -19,9 +19,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.hub.ApplicationConfig;
 import com.marklogic.hub.HubTestBase;
-import com.marklogic.hub.ApplicationConfig;
-import com.marklogic.mgmt.util.ObjectMapperFactory;
 import com.marklogic.hub.impl.HubConfigImpl;
+import com.marklogic.mgmt.util.ObjectMapperFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -112,29 +111,41 @@ public class LoadUserArtifactsCommandTest extends HubTestBase {
 
     @Test
     public void defaultEntityModelPermissions() {
-        DocumentMetadataHandle.DocumentPermissions perms = loadUserArtifactsCommand.buildMetadataForEntityModels(adminHubConfig).getPermissions();
-        assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("data-hub-entity-model-reader").iterator().next());
+        DocumentMetadataHandle.DocumentPermissions perms = loadUserArtifactsCommand.buildMetadata(adminHubConfig.getEntityModelPermissions(), "http://marklogic.com/entity-services/models").getPermissions();
+        assertEquals(DocumentMetadataHandle.Capability.UPDATE, perms.get("data-hub-entity-model-writer").iterator().next());
+
+        perms = loadUserArtifactsCommand.buildMetadata(adminHubConfig.getStepDefinitionPermissions(), "http://marklogic.com/data-hub/step-definition").getPermissions();
+        assertEquals(DocumentMetadataHandle.Capability.UPDATE, perms.get("data-hub-step-definition-writer").iterator().next());
+
+        perms = loadUserArtifactsCommand.buildMetadata(adminHubConfig.getFlowPermissions(), "http://marklogic.com/data-hub/flow").getPermissions();
+        assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("data-hub-flow-reader").iterator().next());
+
+        perms = loadUserArtifactsCommand.buildMetadata(adminHubConfig.getMappingPermissions(), "http://marklogic.com/data-hub/mappings").getPermissions();
+        assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("data-hub-mapping-reader").iterator().next());
     }
 
     @Test
     public void customEntityModelPermissions() {
         HubConfigImpl config = new HubConfigImpl();
         config.setEntityModelPermissions("manage-user,read,manage-admin,update");
-        DocumentMetadataHandle.DocumentPermissions perms = loadUserArtifactsCommand.buildMetadataForEntityModels(config).getPermissions();
+        config.setFlowPermissions("manage-user,read,manage-admin,update");
+        config.setMappingPermissions("manage-user,read,manage-admin,update");
+        config.setStepDefinitionPermissions("manage-user,read,manage-admin,update");
+        DocumentMetadataHandle.DocumentPermissions perms = loadUserArtifactsCommand.buildMetadata(config.getEntityModelPermissions(),"http://marklogic.com/entity-services/models").getPermissions();
         assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("manage-user").iterator().next());
         assertEquals(DocumentMetadataHandle.Capability.UPDATE, perms.get("manage-admin").iterator().next());
-    }
 
-    @Test
-    public void nullEntityModelPermissions() {
-        HubConfigImpl config = new HubConfigImpl();
-        config.setEntityModelPermissions(null);
-        config.setModulePermissions("rest-reader,read,rest-writer,update");
+        perms = loadUserArtifactsCommand.buildMetadata(config.getStepDefinitionPermissions(),"http://marklogic.com/data-hub/step-definition").getPermissions();
+        assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("manage-user").iterator().next());
+        assertEquals(DocumentMetadataHandle.Capability.UPDATE, perms.get("manage-admin").iterator().next());
 
-        DocumentMetadataHandle.DocumentPermissions perms = loadUserArtifactsCommand.buildMetadataForEntityModels(config).getPermissions();
-        final String message = "When entity model permissions are null, the command should use module permissions instead";
-        assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("rest-reader").iterator().next(), message);
-        assertEquals(DocumentMetadataHandle.Capability.UPDATE, perms.get("rest-writer").iterator().next(), message);
-        assertNull(perms.get("data-hub-entity-model-reader"));
+        perms = loadUserArtifactsCommand.buildMetadata(config.getFlowPermissions(),"http://marklogic.com/data-hub/flow").getPermissions();
+        assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("manage-user").iterator().next());
+        assertEquals(DocumentMetadataHandle.Capability.UPDATE, perms.get("manage-admin").iterator().next());
+
+        perms = loadUserArtifactsCommand.buildMetadata(config.getMappingPermissions(),"http://marklogic.com/data-hub/mappings").getPermissions();
+        assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("manage-user").iterator().next());
+        assertEquals(DocumentMetadataHandle.Capability.UPDATE, perms.get("manage-admin").iterator().next());
+
     }
 }


### PR DESCRIPTION
Insert artifacts with new roles.

@rjrudin ,
I don't think anything needs to be done for upgrade scenario as hubInit would initialize the new roles and deploying them would take care of writing them with appropriate roles.