### PR TITLE
DHFPROD-3108: Fixing reference to jobsPermissions

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/jobs.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/jobs.sjs
@@ -49,9 +49,16 @@ class Jobs {
         stepResponses :{}
       }
     };
-
-    this.hubutils.writeDocument("/jobs/"+job.job.jobId+".json", job, this.jobPermissionsScript,  ['Jobs','Job'], this.config.JOBDATABASE);
+    this.writeJobDocument(job);
     return job;
+  }
+
+  writeJobDocument(job) {
+    this.hubutils.writeDocument("/jobs/" + job.job.jobId + ".json", job, this.jobPermissionsScript, ['Jobs', 'Job'], this.config.JOBDATABASE);
+  }
+
+  writeBatchDocument(batch) {
+    this.hubutils.writeDocument("/jobs/batches/" + batch.batch.batchId + ".json", batch , this.jobPermissionsScript, ['Jobs','Batch'], this.config.JOBDATABASE);
   }
 
   buildJobPermissionsScript(config) {
@@ -107,7 +114,7 @@ class Jobs {
     if (jobStatus === "finished" || jobStatus === "finished_with_errors" || jobStatus === "failed"){
       docObj.job.timeEnded = fn.currentDateTime();
     }
-    this.hubutils.writeDocument("/jobs/"+ jobId +".json", docObj, this.jobPermissionsScript, ['Jobs','Job'], this.config.JOBDATABASE);
+    this.writeJobDocument(docObj);
   }
 
   getLastStepAttempted(jobId) {
@@ -267,7 +274,7 @@ class Jobs {
       }
     };
 
-    this.hubutils.writeDocument("/jobs/batches/" + batch.batch.batchId + ".json", batch , this.jobPermissionsScript, ['Jobs','Batch'], this.config.JOBDATABASE);
+    this.writeBatchDocument(batch);
     return batch;
   }
 
@@ -323,8 +330,7 @@ class Jobs {
     docObj.batch.writeTimeStamp = writeTransactionInfo.dateTime;
     let cacheId = jobId + "-" + batchId;
     cachedBatchDocuments[cacheId] = docObj;
-    this.hubutils.writeDocument("/jobs/batches/"+ batchId +".json", docObj, this.jobPermissionsScript, ['Jobs','Batch'], this.config.JOBDATABASE);
-
+    this.writeBatchDocument(docObj);
   }
 
   getBatchDoc(jobId, batchId) {

--- a/marklogic-data-hub/src/main/resources/ml-modules/services/mlJobs.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/services/mlJobs.sjs
@@ -104,14 +104,14 @@ function post(context, params, input) {
               options.targetDatabase || datahub.config.FINALDATABASE
             ));
             if (jobReport) {
-              datahub.hubUtils.writeDocument(`/jobs/reports/${stepResp.flowName}/${step}/${jobId}.json`, jobReport, datahub.jobs.jobsPermissions, ['Jobs','JobReport'], datahub.config.JOBDATABASE);
+              datahub.hubUtils.writeDocument(`/jobs/reports/${stepResp.flowName}/${step}/${jobId}.json`, jobReport, datahub.jobs.jobPermissionsScript, ['Jobs','JobReport'], datahub.config.JOBDATABASE);
             }
           }
         }
     }
 
     //Update the job doc
-    datahub.hubUtils.writeDocument("/jobs/"+ jobId +".json", jobDoc, datahub.jobs.jobsPermissions, ['Jobs','Job'], datahub.config.JOBDATABASE);
+    datahub.jobs.writeJobDocument(jobDoc);
     resp = jobDoc;
   }
   else {


### PR DESCRIPTION
I missed the two references to jobsPermissions in mlJobs.sjs. To cut down on references, I added writeJobDocument and writeBatchDocument.

Also added the assertions back to FlowRunnerTest in the hopes that this fix will make testRunFlow run correctly on Jenkins.