### PR TITLE
DHFPROD-3504:Configure DH resources requiring new granular privileges

### DIFF
--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-developer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-developer.json
@@ -23,6 +23,16 @@
       "privilege-name": "get-system-logs",
       "action": "http://marklogic.com/xdmp/privileges/logs/system",
       "kind": "execute"
+    },
+    {
+      "privilege-name": "create-trigger",
+      "action": "http://marklogic.com/xdmp/privileges/create-trigger",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "temporal-admin",
+      "action": "http://marklogic.com/xdmp/privileges/temporal-admin",
+      "kind": "execute"
     }
   ]
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -1192,6 +1192,15 @@ public class HubTestBase {
         return strHandle.get();
     }
 
+    //Not checking the dates for nightly as we expect tests to run on latest nightly
+    protected boolean isVersionCompatibleWithGranularPrivilege() {
+        Versions.MarkLogicVersion serverVersion = versions.getMLVersion();
+        if(!serverVersion.isNightly()){
+            return (serverVersion.getMajor() == 10 && serverVersion.getMinor() >= 300) ;
+        }
+        return true;
+    }
+
     protected void setupProjectForRunningTestFlow() {
         basicSetup();
         getDataHubAdminConfig();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesTest.java
@@ -8,8 +8,11 @@ import com.marklogic.mgmt.api.security.Privilege;
 import com.marklogic.mgmt.mapper.DefaultResourceMapper;
 import com.marklogic.mgmt.mapper.ResourceMapper;
 import com.marklogic.mgmt.resource.databases.DatabaseManager;
+import com.marklogic.mgmt.resource.groups.GroupManager;
 import com.marklogic.mgmt.resource.security.PrivilegeManager;
 import com.marklogic.rest.util.ResourcesFragment;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
@@ -20,6 +23,11 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = ApplicationConfig.class)
 public class CreateGranularPrivilegesTest extends HubTestBase {
+
+    @BeforeEach
+    public void setUp(){
+        Assumptions.assumeTrue(isVersionCompatibleWithGranularPrivilege());
+    }
 
     /**
      * The CreateGranularPrivilegesCommand is assumed to have been run as part of bootstrapping the test application,
@@ -33,6 +41,8 @@ public class CreateGranularPrivilegesTest extends HubTestBase {
         ResourcesFragment databasesXml = new DatabaseManager(adminHubConfig.getManageClient()).getAsXml();
         final String finalDbId = databasesXml.getIdForNameOrId("data-hub-FINAL");
         final String stagingDbId = databasesXml.getIdForNameOrId("data-hub-STAGING");
+        final String finalTriggersDbId = databasesXml.getIdForNameOrId("data-hub-final-TRIGGERS");
+        final String stagingTriggersDbId = databasesXml.getIdForNameOrId("data-hub-staging-TRIGGERS");
 
         Privilege p = resourceMapper.readResource(mgr.getAsJson("admin-database-clear-data-hub-STAGING", "kind", "execute"), Privilege.class);
         assertEquals("http://marklogic.com/xdmp/privileges/admin/database/clear/" + stagingDbId, p.getAction());
@@ -49,6 +59,37 @@ public class CreateGranularPrivilegesTest extends HubTestBase {
         p = resourceMapper.readResource(mgr.getAsJson("admin-database-index-data-hub-FINAL", "kind", "execute"), Privilege.class);
         assertEquals("http://marklogic.com/xdmp/privileges/admin/database/index/" + finalDbId, p.getAction());
         assertEquals("data-hub-developer", p.getRole().get(0));
+
+        p = resourceMapper.readResource(mgr.getAsJson("admin-database-triggers-data-hub-staging-TRIGGERS", "kind", "execute"), Privilege.class);
+        assertEquals("http://marklogic.com/xdmp/privileges/admin/database/triggers/" + stagingTriggersDbId, p.getAction());
+        assertEquals("data-hub-developer", p.getRole().get(0));
+
+        p = resourceMapper.readResource(mgr.getAsJson("admin-database-triggers-data-hub-final-TRIGGERS", "kind", "execute"), Privilege.class);
+        assertEquals("http://marklogic.com/xdmp/privileges/admin/database/triggers/" + finalTriggersDbId, p.getAction());
+        assertEquals("data-hub-developer", p.getRole().get(0));
+
+        p = resourceMapper.readResource(mgr.getAsJson("admin-database-temporal-data-hub-STAGING", "kind", "execute"), Privilege.class);
+        assertEquals("http://marklogic.com/xdmp/privileges/admin/database/temporal/" + stagingDbId, p.getAction());
+        assertEquals("data-hub-developer", p.getRole().get(0));
+
+        p = resourceMapper.readResource(mgr.getAsJson("admin-database-temporal-data-hub-FINAL", "kind", "execute"), Privilege.class);
+        assertEquals("http://marklogic.com/xdmp/privileges/admin/database/temporal/" + finalDbId, p.getAction());
+        assertEquals("data-hub-developer", p.getRole().get(0));
+
+        p = resourceMapper.readResource(mgr.getAsJson("admin-database-alerts-data-hub-STAGING", "kind", "execute"), Privilege.class);
+        assertEquals("http://marklogic.com/xdmp/privileges/admin/database/alerts/" + stagingDbId, p.getAction());
+        assertEquals("data-hub-developer", p.getRole().get(0));
+
+        p = resourceMapper.readResource(mgr.getAsJson("admin-database-alerts-data-hub-FINAL", "kind", "execute"), Privilege.class);
+        assertEquals("http://marklogic.com/xdmp/privileges/admin/database/alerts/" + finalDbId, p.getAction());
+        assertEquals("data-hub-developer", p.getRole().get(0));
+
+        String groupName = adminHubConfig.getAppConfig().getGroupName();
+        ResourcesFragment groupsXml = new GroupManager(adminHubConfig.getManageClient()).getAsXml();
+        final String groupId = groupsXml.getIdForNameOrId(groupName);
+        p = resourceMapper.readResource(mgr.getAsJson("admin-group-scheduled-task-"+groupName, "kind", "execute"), Privilege.class);
+        assertEquals("http://marklogic.com/xdmp/privileges/admin/group/scheduled-task/" + groupId, p.getAction());
+        assertEquals("data-hub-developer", p.getRole().get(0));
     }
 
     @Test
@@ -59,6 +100,15 @@ public class CreateGranularPrivilegesTest extends HubTestBase {
         assertTrue(privileges.resourceExists("admin-database-clear-data-hub-FINAL"));
         assertTrue(privileges.resourceExists("admin-database-index-data-hub-STAGING"));
         assertTrue(privileges.resourceExists("admin-database-index-data-hub-FINAL"));
+        assertTrue(privileges.resourceExists("admin-database-triggers-data-hub-staging-TRIGGERS"));
+        assertTrue(privileges.resourceExists("admin-database-triggers-data-hub-final-TRIGGERS"));
+        assertTrue(privileges.resourceExists("admin-database-temporal-data-hub-STAGING"));
+        assertTrue(privileges.resourceExists("admin-database-temporal-data-hub-FINAL"));
+        assertTrue(privileges.resourceExists("admin-database-alerts-data-hub-STAGING"));
+        assertTrue(privileges.resourceExists("admin-database-alerts-data-hub-FINAL"));
+
+        String groupName = adminHubConfig.getAppConfig().getGroupName();
+        assertTrue(privileges.resourceExists("admin-group-scheduled-task-"+groupName));
 
         final CreateGranularPrivilegesCommand command = new CreateGranularPrivilegesCommand(adminHubConfig);
         final CommandContext context = new CommandContext(adminHubConfig.getAppConfig(), adminHubConfig.getManageClient(), null);
@@ -70,6 +120,13 @@ public class CreateGranularPrivilegesTest extends HubTestBase {
             assertFalse(privileges.resourceExists("admin-database-clear-data-hub-FINAL"));
             assertFalse(privileges.resourceExists("admin-database-index-data-hub-STAGING"));
             assertFalse(privileges.resourceExists("admin-database-index-data-hub-FINAL"));
+            assertFalse(privileges.resourceExists("admin-database-triggers-data-hub-staging-TRIGGERS"));
+            assertFalse(privileges.resourceExists("admin-database-triggers-data-hub-final-TRIGGERS"));
+            assertFalse(privileges.resourceExists("admin-database-temporal-data-hub-STAGING"));
+            assertFalse(privileges.resourceExists("admin-database-temporal-data-hub-FINAL"));
+            assertFalse(privileges.resourceExists("admin-database-alerts-data-hub-STAGING"));
+            assertFalse(privileges.resourceExists("admin-database-alerts-data-hub-FINAL"));
+            assertFalse(privileges.resourceExists("admin-group-scheduled-task-"+groupName));
         } finally {
             // Need to deploy these privileges back so the lack of them doesn't impact other tests
             command.execute(context);

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubAdminTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubAdminTest.java
@@ -2,6 +2,7 @@ package com.marklogic.hub.security;
 
 import com.marklogic.mgmt.api.database.Database;
 import com.marklogic.mgmt.resource.databases.DatabaseManager;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,6 +20,7 @@ public class DataHubAdminTest extends AbstractSecurityTest {
 
     @Test
     public void task7ClearStagingDatabase() {
+        Assumptions.assumeTrue(isVersionCompatibleWithGranularPrivilege());
         try {
             new DatabaseManager(userWithRoleBeingTestedClient).clearDatabase(STAGING_DB, false);
             String count = adminHubConfig.newStagingClient().newServerEval().xquery("xdmp:estimate(fn:doc())").evalAs(String.class);
@@ -42,6 +44,7 @@ public class DataHubAdminTest extends AbstractSecurityTest {
 
     @Test
     public void task8ClearFinalDatabase() {
+        Assumptions.assumeTrue(isVersionCompatibleWithGranularPrivilege());
         try {
             new DatabaseManager(userWithRoleBeingTestedClient).clearDatabase(FINAL_DB, false);
             String count = adminHubConfig.newFinalClient().newServerEval().xquery("xdmp:estimate(fn:doc())").evalAs(String.class);


### PR DESCRIPTION
Configure DH resources requiring new granular privileges.

@SameeraPriyathamTadikonda ,
This PR should be run on 10.0-nightly, this will fail on 10.0-2.1 against which all PRs usually run.