### PR TITLE
DHFPROD-3510: Metadata files get operator/execute

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/transforms/mlGenerateFunctionMetadata.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/transforms/mlGenerateFunctionMetadata.sjs
@@ -27,7 +27,7 @@ function mlGenerateFunctionMetadata(context, params, content) {
       xdmp.permission('${datahub.config.FLOWDEVELOPERROLE}','update'),
       xdmp.permission('${datahub.config.FLOWOPERATORROLE}','read'),
       xdmp.permission('${datahub.config.FLOWDEVELOPERROLE}','read'),
-      xdmp.permission('${datahub.consts.DATA_HUB_DEVELOPER_ROLE}','execute'),
+      xdmp.permission('${datahub.consts.DATA_HUB_OPERATOR_ROLE}','execute'),
       xdmp.permission('${datahub.consts.DATA_HUB_DEVELOPER_ROLE}','update'),
       xdmp.permission('${datahub.consts.DATA_HUB_OPERATOR_ROLE}','read')
       ])`;

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/GenerateFunctionMetadataCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/GenerateFunctionMetadataCommandTest.java
@@ -25,8 +25,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
 
-import static com.marklogic.client.io.DocumentMetadataHandle.Capability.READ;
-import static com.marklogic.client.io.DocumentMetadataHandle.Capability.UPDATE;
+import static com.marklogic.client.io.DocumentMetadataHandle.Capability.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
@@ -93,6 +92,7 @@ public class GenerateFunctionMetadataCommandTest extends HubTestBase {
             Assertions.assertNotEquals(0, handle.get().length);
             DocumentMetadataHandle.DocumentPermissions permissions = metadata.getPermissions();
             Assertions.assertTrue(permissions.get("data-hub-operator").contains(READ));
+            Assertions.assertTrue(permissions.get("data-hub-operator").contains(EXECUTE));
             Assertions.assertTrue(permissions.get("data-hub-developer").contains(UPDATE));
         }
     }


### PR DESCRIPTION
This is needed so that an operator can run a mapping step