### PR TITLE
DHFPROD-3984: Add data services for artifacts (load data configuration API)

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/ArtifactService.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/ArtifactService.java
@@ -1,0 +1,175 @@
+package com.marklogic.hub.dataservices;
+
+// IMPORTANT: Do not edit. This file is generated.
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.impl.BaseProxy;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.JacksonHandle;
+
+/**
+ * Provides a set of operations on the database server
+ */
+public interface ArtifactService {
+    /**
+     * Creates a ArtifactService object for executing operations on the database server.
+     *
+     * The DatabaseClientFactory class can create the DatabaseClient parameter. A single
+     * client object can be used for any number of requests and in multiple threads.
+     *
+     * @param db	provides a client for communicating with the database server
+     * @return	an object for session state
+     */
+    static ArtifactService on(DatabaseClient db) {
+        final class ArtifactServiceImpl implements ArtifactService {
+            private BaseProxy baseProxy;
+
+            private ArtifactServiceImpl(DatabaseClient dbClient) {
+                baseProxy = new BaseProxy(dbClient, "/data-hub/5/data-services/artifacts/");
+            }
+
+            @Override
+            public JsonNode getArtifactTypesInfo() {
+                return BaseProxy.JsonDocumentType.toJsonNode(
+                    baseProxy
+                        .request("getArtifactTypesInfo.mjs", BaseProxy.ParameterValuesKind.NONE)
+                        .withSession()
+                        .withMethod("POST")
+                        .responseSingle(false, Format.JSON)
+                );
+            }
+
+            @Override
+            public JsonNode getList(String artifactType) {
+                return BaseProxy.JsonDocumentType.toJsonNode(
+                    baseProxy
+                        .request("getList.mjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC)
+                        .withSession()
+                        .withParams(
+                            BaseProxy.atomicParam("artifactType", false, BaseProxy.StringType.fromString(artifactType)))
+                        .withMethod("POST")
+                        .responseSingle(false, Format.JSON)
+                );
+            }
+
+            @Override
+            public JsonNode getArtifact(String artifactType, String artifactName) {
+                return BaseProxy.JsonDocumentType.toJsonNode(
+                    baseProxy
+                        .request("getArtifact.mjs", BaseProxy.ParameterValuesKind.MULTIPLE_ATOMICS)
+                        .withSession()
+                        .withParams(
+                            BaseProxy.atomicParam("artifactType", false, BaseProxy.StringType.fromString(artifactType)),
+                            BaseProxy.atomicParam("artifactName", false, BaseProxy.StringType.fromString(artifactName))
+                         )
+                        .withMethod("POST")
+                        .responseSingle(false, Format.JSON)
+                );
+            }
+
+            @Override
+            public JsonNode setArtifact(String artifactType, String artifactName, JsonNode artifact) {
+                return BaseProxy.JsonDocumentType.toJsonNode(
+                    baseProxy
+                        .request("setArtifact.mjs", BaseProxy.ParameterValuesKind.MULTIPLE_MIXED)
+                        .withSession()
+                        .withParams(
+                            BaseProxy.atomicParam("artifactType", false, BaseProxy.StringType.fromString(artifactType)),
+                            BaseProxy.atomicParam("artifactName", false, BaseProxy.StringType.fromString(artifactName)),
+                            BaseProxy.documentParam("artifact", false, new JacksonHandle().with(artifact))
+                        )
+                        .withMethod("POST")
+                        .responseSingle(false, Format.JSON)
+                );
+            }
+
+            @Override
+            public JsonNode deleteArtifact(String artifactType, String artifactName) {
+                return BaseProxy.JsonDocumentType.toJsonNode(
+                    baseProxy
+                        .request("deleteArtifact.mjs", BaseProxy.ParameterValuesKind.MULTIPLE_ATOMICS)
+                        .withSession()
+                        .withParams(
+                            BaseProxy.atomicParam("artifactType", false, BaseProxy.StringType.fromString(artifactType)),
+                            BaseProxy.atomicParam("artifactName", false, BaseProxy.StringType.fromString(artifactName))
+                        )
+                        .withMethod("POST")
+                        .responseSingle(false, Format.JSON)
+                );
+            }
+
+            @Override
+            public JsonNode validateArtifact(String artifactType, String artifactName, JsonNode artifact) {
+                return BaseProxy.JsonDocumentType.toJsonNode(
+                    baseProxy
+                        .request("validateArtifact.mjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC)
+                        .withSession()
+                        .withParams(
+                            BaseProxy.atomicParam("artifactType", false, BaseProxy.StringType.fromString(artifactType)),
+                            BaseProxy.atomicParam("artifactName", false, BaseProxy.StringType.fromString(artifactName)),
+                            BaseProxy.documentParam("artifact", false, new JacksonHandle().with(artifact))
+                        )
+                        .withMethod("POST")
+                        .responseSingle(false, Format.JSON)
+                );
+            }
+
+        }
+
+        return new ArtifactServiceImpl(db);
+    }
+
+    /**
+     * Invokes the getArtifactTypesInfo operation on the database server
+     *
+     * @return	as output
+     */
+    com.fasterxml.jackson.databind.JsonNode getArtifactTypesInfo();
+
+    /**
+     * Invokes the getList operation on the database server
+     *
+     * @param artifactType	provides input
+     * @return	as output
+     */
+    com.fasterxml.jackson.databind.JsonNode getList(String artifactType);
+
+    /**
+     * Invokes the getArtifact operation on the database server
+     *
+     * @param artifactType	provides input
+     * @param artifactName	provides input
+     * @return	as output
+     */
+    com.fasterxml.jackson.databind.JsonNode getArtifact(String artifactType, String artifactName);
+
+    /**
+     * Invokes the getList operation on the database server
+     *
+     * @param artifactType	provides input
+     * @param artifactName	provides input
+     * @param artifact	provides input
+     * @return	as output
+     */
+    com.fasterxml.jackson.databind.JsonNode setArtifact(String artifactType, String artifactName, JsonNode artifact);
+
+    /**
+     * Invokes the getList operation on the database server
+     *
+     * @param artifactType	provides input
+     * @param artifactName	provides input
+     * @return	as output
+     */
+    com.fasterxml.jackson.databind.JsonNode deleteArtifact(String artifactType, String artifactName);
+
+    /**
+     * Invokes the validateArtifact operation on the database server
+     *
+     * @param artifactType	provides input
+     * @param artifactName	provides input
+     * @param artifact	provides input
+     * @return	as output
+     */
+    com.fasterxml.jackson.databind.JsonNode validateArtifact(String artifactType, String artifactName, JsonNode artifact);
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/core.mjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/core.mjs
@@ -1,0 +1,129 @@
+/**
+ Copyright 2012-2019 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+import * as LoadData from './loadData';
+
+const DataHubSingleton = require('/data-hub/5/datahub-singleton.sjs');
+const dataHub = DataHubSingleton.instance();
+// define constants for caching expensive operations
+const cachedArtifacts = {};
+const registeredArtifactTypes = {
+    loadData: LoadData
+};
+
+export function getTypesInfo() {
+    const typesInfo = [];
+    for (const artifactType of Object.keys(registeredArtifactTypes)) {
+        if (registeredArtifactTypes.hasOwnProperty(artifactType)) {
+            const artifactLibrary = registeredArtifactTypes[artifactType];
+            typesInfo.push({
+                type: artifactType,
+                storageDatabases: artifactLibrary.getStorageDatabases(),
+                collections: artifactLibrary.getCollections(),
+                fileExtension: getArtifactFileExtension(artifactType),
+                directory: getArtifactDirectory(artifactType),
+                nameProperty: artifactLibrary.getNameProperty(),
+                versionProperty: artifactLibrary.getVersionProperty()
+            });
+        }
+    }
+    return typesInfo;
+}
+
+export function getArtifacts(artifactType) {
+    const artifacts = [];
+    const queriesForAnd = [];
+    const artifactLibrary =  getArtifactTypeLibrary(artifactType);
+    for (const coll of artifactLibrary.getCollections()) {
+        queriesForAnd.push(cts.collectionQuery(coll));
+    }
+    if (queriesForAnd.length) {
+        const results = cts.search(queriesForAnd.length > 1 ? cts.andQuery(queriesForAnd) : queriesForAnd[0]);
+        for (const result of results) {
+            artifacts.push(result.toObject());
+        }
+    }
+    return artifacts;
+}
+
+export function deleteArtifact(artifactType, artifactName, artifactVersion = 'latest') {
+    const artifactKey = generateArtifactKey(artifactType, artifactName, artifactVersion);
+    const artifactLibrary =  getArtifactTypeLibrary(artifactType);
+    // Currently there is no versioning for loadData artifacts
+    const node = artifactLibrary.getArtifactNode(artifactName, artifactVersion);
+    for (const db of artifactLibrary.getStorageDatabases()) {
+        dataHub.hubUtils.deleteDocument(xdmp.nodeUri(node), db);
+    }
+    delete cachedArtifacts[artifactKey];
+    return { success: true };
+}
+
+export function getArtifact(artifactType, artifactName, artifactVersion = 'latest') {
+    const artifactKey = generateArtifactKey(artifactType, artifactName, artifactVersion);
+    if (!cachedArtifacts[artifactKey]) {
+        const artifactLibrary =  getArtifactTypeLibrary(artifactType);
+        const artifactNode = artifactLibrary.getArtifactNode(artifactName, artifactVersion);
+        cachedArtifacts[artifactKey] = artifactNode.toObject();
+    }
+    return cachedArtifacts[artifactKey];
+}
+
+export function setArtifact(artifactType, artifactName, artifact) {
+    const artifactKey = generateArtifactKey(artifactType, artifactName);
+    let validArtifact = validateArtifact(artifactType, artifactName, artifact) || artifact;
+    if (validArtifact instanceof Error) {
+        throw new Error(`Invalid artifact with error message: ${validArtifact.message}`);
+    }
+    const artifactLibrary =  getArtifactTypeLibrary(artifactType);
+    const artifactDatabases = artifactLibrary.getStorageDatabases();
+    const artifactDirectory = getArtifactDirectory(artifactType, artifactName);
+    const artifactFileExtension = getArtifactFileExtension(artifactType);
+    const artifactPermissions = artifactLibrary.getPermissions();
+    const artifactCollections = artifactLibrary.getCollections();
+    for (const db of artifactDatabases) {
+        dataHub.hubUtils.writeDocument(`${artifactDirectory}${xdmp.urlEncode(artifactName)}${artifactFileExtension}`, artifact, artifactPermissions, artifactCollections, db);
+    }
+    cachedArtifacts[artifactKey] = artifact;
+    return artifact;
+}
+
+export function validateArtifact(artifactType, artifactName, artifact) {
+    const artifactLibrary =  getArtifactTypeLibrary(artifactType);
+    return artifactLibrary.validateArtifact(artifact, artifactName);
+}
+
+function getArtifactDirectory(artifactType, artifactName) {
+    const artifactLibrary =  getArtifactTypeLibrary(artifactType);
+    return artifactLibrary.getDirectory ? artifactLibrary.getDirectory(artifactName): `/${artifactType}/`;
+}
+
+function getArtifactFileExtension(artifactType) {
+    const artifactLibrary =  getArtifactTypeLibrary(artifactType);
+    return artifactLibrary.getFileExtension ? artifactLibrary.getFileExtension(): `.${artifactType}.json`;
+}
+
+function getArtifactTypeLibrary(artifactType) {
+    const artifactLibrary = registeredArtifactTypes[artifactType];
+    if (!artifactLibrary) {
+        throw new Error(`Invalid artifact type: ${artifactType}. Valid types: ${JSON.stringify(Object.keys(registeredArtifactTypes))}`)
+    }
+    return artifactLibrary;
+}
+
+function generateArtifactKey(artifactType, artifactName, artifactVersion = 'latest') {
+    return `${artifactType}:${artifactName}:${artifactVersion}`;
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/loadData.mjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/loadData.mjs
@@ -1,0 +1,69 @@
+/**
+ Copyright 2012-2019 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+const DataHubSingleton = require('/data-hub/5/datahub-singleton.sjs');
+
+// define constants for caching expensive operations
+const dataHub = DataHubSingleton.instance();
+
+const collections = ['http://marklogic.com/data-hub/load-data-artifact'];
+const databases = [dataHub.config.STAGINGDATABASE, dataHub.config.FINALDATABASE];
+const permissions = [xdmp.permission(dataHub.consts.DATA_HUB_DEVELOPER_ROLE, 'update'), xdmp.permission(dataHub.consts.DATA_HUB_OPERATOR_ROLE, 'read')];
+const requiredProperties = ['name', 'sourceFormat', 'targetFormat'];
+
+export function getNameProperty() {
+    return 'name';
+}
+
+export function getVersionProperty() {
+    return null;
+}
+
+export function getCollections() {
+    return collections;
+}
+
+export function getStorageDatabases() {
+    return databases;
+}
+
+export function getPermissions() {
+    return permissions;
+}
+
+export function getArtifactNode(artifactName, artifactVersion) {
+    // Currently there is no versioning for loadData artifacts
+    const results = cts.search(cts.andQuery([cts.collectionQuery(collections[0]), cts.jsonPropertyValueQuery('name', artifactName)]));
+    if (fn.empty(results)) {
+        returnErrToClient(404, 'Not found!');
+    }
+    return fn.head(results);
+}
+
+export function validateArtifact(artifact) {
+    const missingProperties = requiredProperties.filter((propName) => !artifact[propName]);
+    if (missingProperties.length) {
+        returnErrToClient(400, 'BAD REQUEST', `Missing the following required properties: ${JSON.stringify(missingProperties)}`);
+    }
+    return artifact;
+}
+
+function returnErrToClient(statusCode, statusMsg, body)
+{
+    fn.error(null, 'RESTAPI-SRVEXERR',
+        Sequence.from([statusCode, statusMsg, body]));
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/deleteArtifact.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/deleteArtifact.api
@@ -1,0 +1,17 @@
+{
+    "functionName": "deleteArtifact",
+    "params": [
+        {
+            "name": "artifactType",
+            "datatype": "string"
+        },
+        {
+            "name": "artifactName",
+            "datatype": "string"
+        }
+    ],
+    "return": {
+        "datatype": "jsonDocument",
+        "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+    }
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/deleteArtifact.mjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/deleteArtifact.mjs
@@ -1,0 +1,20 @@
+/**
+ Copyright 2012-2019 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+import * as Artifacts from '/data-hub/5/artifacts/core.mjs';
+
+Artifacts.deleteArtifact(external.artifactType, external.artifactName, external.artifactVersion);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/getArtifact.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/getArtifact.api
@@ -1,0 +1,17 @@
+{
+    "functionName": "getArtifact",
+    "params": [
+        {
+            "name": "artifactType",
+            "datatype": "string"
+        },
+        {
+            "name": "artifactName",
+            "datatype": "string"
+        }
+    ],
+    "return": {
+        "datatype": "jsonDocument",
+        "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+    }
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/getArtifact.mjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/getArtifact.mjs
@@ -1,0 +1,20 @@
+/**
+ Copyright 2012-2019 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+import * as Artifacts from '/data-hub/5/artifacts/core.mjs';
+
+Artifacts.getArtifact(external.artifactType, external.artifactName, external.artifactVersion);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/getArtifactTypesInfo.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/getArtifactTypesInfo.api
@@ -1,0 +1,8 @@
+{
+    "functionName": "getArtifactTypesInfo",
+    "params": [],
+    "return": {
+        "datatype": "jsonDocument",
+        "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+    }
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/getArtifactTypesInfo.mjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/getArtifactTypesInfo.mjs
@@ -1,0 +1,20 @@
+/**
+ Copyright 2012-2019 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+import * as Artifacts from '/data-hub/5/artifacts/core.mjs';
+
+Artifacts.getTypesInfo();

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/getList.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/getList.api
@@ -1,0 +1,13 @@
+{
+    "functionName": "getList",
+    "params": [
+        {
+            "name": "artifactType",
+            "datatype": "string"
+        }
+    ],
+    "return": {
+        "datatype": "jsonDocument",
+        "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+    }
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/getList.mjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/getList.mjs
@@ -1,0 +1,21 @@
+/**
+ Copyright 2012-2019 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+import * as Artifacts from '/data-hub/5/artifacts/core.mjs';
+
+Artifacts.getArtifacts(external.artifactType);
+

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/service.json
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/service.json
@@ -1,0 +1,4 @@
+{
+  "endpointDirectory": "/data-hub/5/data-services/artifacts/",
+  "$javaClass": "com.marklogic.hub.dataservices.ArtifactService"
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/setArtifact.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/setArtifact.api
@@ -1,0 +1,22 @@
+{
+    "functionName": "setArtifact",
+    "params": [
+        {
+            "name": "artifactType",
+            "datatype": "string"
+        },
+        {
+            "name": "artifactName",
+            "datatype": "string"
+        },
+        {
+         "name": "artifact",
+         "datatype": "jsonDocument",
+         "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+        }
+    ],
+    "return": {
+        "datatype": "jsonDocument",
+        "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+    }
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/setArtifact.mjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/setArtifact.mjs
@@ -1,0 +1,20 @@
+/**
+ Copyright 2012-2019 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+import * as Artifacts from '/data-hub/5/artifacts/core.mjs';
+
+Artifacts.setArtifact(external.artifactType, external.artifactName, external.artifact.toObject());

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/validateArtifact.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/validateArtifact.api
@@ -1,0 +1,22 @@
+{
+    "functionName": "validateArtifact",
+    "params": [
+        {
+            "name": "artifactType",
+            "datatype": "string"
+        },
+        {
+            "name": "artifactName",
+            "datatype": "string"
+        },
+        {
+         "name": "artifact",
+         "datatype": "jsonDocument",
+         "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+        }
+    ],
+    "return": {
+        "datatype": "jsonDocument",
+        "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+    }
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/validateArtifact.mjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/artifacts/validateArtifact.mjs
@@ -1,0 +1,20 @@
+/**
+ Copyright 2012-2019 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+import * as Artifacts from '/data-hub/5/artifacts/core.mjs';
+
+Artifacts.validateArtifact(external.artifactType, external.artifactName, external.artifact.toObject());

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow.sjs
@@ -225,7 +225,7 @@ class Flow {
     //let's update our jobdoc now
     if (!combinedOptions.noWrite) {
       try {
-        writeTransactionInfo = this.datahub.hubUtils.writeDocuments(this.writeQueue, 'xdmp.defaultPermissions()', collections, this.globalContext.targetDatabase);
+        writeTransactionInfo = this.datahub.hubUtils.writeDocuments(this.writeQueue, xdmp.defaultPermissions(), collections, this.globalContext.targetDatabase);
       } catch (e) {
         this.handleWriteError(this, e);
       }

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils/invoke-queue-write.mjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils/invoke-queue-write.mjs
@@ -1,0 +1,63 @@
+/**
+ Copyright 2012-2019 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+const temporal = require("/MarkLogic/temporal.xqy");
+
+const temporalCollections = temporal.collections().toArray().reduce((acc, col) => {
+    acc[col] = true;
+    return acc;
+}, {});
+let basePermissions = external.permissions;
+for (let content of external.writeQueue) {
+    let context = (content.context||{});
+    let permissions = (basePermissions || []).concat((context.permissions||[]));
+    let existingCollections = xdmp.documentGetCollections(content.uri);
+    let collections = fn.distinctValues(Sequence.from(external.baseCollections.concat((context.collections||[])))).toArray();
+    let metadata = context.metadata;
+    let temporalCollection = collections.concat(existingCollections).find((col) => temporalCollections[col]);
+    let isDeleteOp = !!content['$delete'];
+    if (isDeleteOp) {
+        if (fn.docAvailable(content.uri)) {
+            if (temporalCollection) {
+                temporal.documentDelete(temporalCollection, content.uri);
+            } else {
+                xdmp.documentDelete(content.uri);
+            }
+        }
+    } else {
+        if (temporalCollection) {
+            // temporalDocURI is managed by the temporal package and must not be carried forward.
+            if (metadata) {
+                delete metadata.temporalDocURI;
+            }
+            temporal.documentInsert(temporalCollection, content.uri, content.value,
+                {
+                    permissions,
+                    collections: collections.filter((col) => !temporalCollections[col]),
+                    metadata
+                }
+            );
+        } else {
+            xdmp.documentInsert(content.uri, content.value, {permissions, collections, metadata});
+        }
+    }
+}
+let writeInfo = {
+    transaction: xdmp.transaction(),
+    dateTime: fn.currentDateTime()
+};
+writeInfo;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils/invoke-single-delete.mjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils/invoke-single-delete.mjs
@@ -1,0 +1,20 @@
+/**
+ Copyright 2012-2019 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+if (fn.docAvailable(external.docUri)) {
+    xdmp.documentDelete(external.docUri);
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils/invoke-single-write.mjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils/invoke-single-write.mjs
@@ -1,0 +1,23 @@
+/**
+ Copyright 2012-2019 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+xdmp.documentInsert(external.docUri, external.content, {permissions: external.permissions, collections: external.collections });
+let writeInfo = {
+    transaction: xdmp.transaction(),
+    dateTime: fn.currentDateTime()
+};
+writeInfo;

--- a/marklogic-data-hub/src/main/resources/ml-modules/transforms/mlGenerateFunctionMetadata.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/transforms/mlGenerateFunctionMetadata.sjs
@@ -21,17 +21,17 @@ function mlGenerateFunctionMetadata(context, params, content) {
       }
       metadataXml = addMapNamespaceToMetadata(metadataXml);
       let collection = 'http://marklogic.com/entity-services/function-metadata';
-      let permissionsExpression = `xdmp.defaultPermissions().concat([
-      xdmp.permission('${datahub.config.FLOWOPERATORROLE}','execute'),
-      xdmp.permission('${datahub.config.FLOWDEVELOPERROLE}','execute'),
-      xdmp.permission('${datahub.config.FLOWDEVELOPERROLE}','update'),
-      xdmp.permission('${datahub.config.FLOWOPERATORROLE}','read'),
-      xdmp.permission('${datahub.config.FLOWDEVELOPERROLE}','read'),
-      xdmp.permission('${datahub.consts.DATA_HUB_OPERATOR_ROLE}','execute'),
-      xdmp.permission('${datahub.consts.DATA_HUB_DEVELOPER_ROLE}','update'),
-      xdmp.permission('${datahub.consts.DATA_HUB_OPERATOR_ROLE}','read')
-      ])`;
-      let writeInfo = datahub.hubUtils.writeDocument(uriVal + ".xml", metadataXml, permissionsExpression, [collection], datahub.config.MODULESDATABASE);
+      let permissions = xdmp.defaultPermissions().concat([
+      xdmp.permission(datahub.config.FLOWOPERATORROLE,'execute'),
+      xdmp.permission(datahub.config.FLOWDEVELOPERROLE,'execute'),
+      xdmp.permission(datahub.config.FLOWDEVELOPERROLE,'update'),
+      xdmp.permission(datahub.config.FLOWOPERATORROLE,'read'),
+      xdmp.permission(datahub.config.FLOWDEVELOPERROLE,'read'),
+      xdmp.permission(datahub.consts.DATA_HUB_OPERATOR_ROLE,'execute'),
+      xdmp.permission(datahub.consts.DATA_HUB_DEVELOPER_ROLE,'update'),
+      xdmp.permission(datahub.consts.DATA_HUB_OPERATOR_ROLE,'read')
+      ]);
+      let writeInfo = datahub.hubUtils.writeDocument(uriVal + ".xml", metadataXml, permissions, [collection], datahub.config.MODULESDATABASE);
       if (writeInfo && fn.exists(writeInfo.transaction)) {
         // try/catch workaround to avoid XSLT-UNBPRFX error. See https://bugtrack.marklogic.com/52870
         try {

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/com/marklogic/hub/hub-utils/temporal-document-write.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/com/marklogic/hub/hub-utils/temporal-document-write.sjs
@@ -10,10 +10,10 @@ let emptySequence = Sequence.from([]);
 let temporalCollection = 'temporalCollection';
 let temporalDoc = {uri: "/test.json", value: { systemStart: null, systemEnd: null, validStart: fn.currentDateTime(), validEnd: fn.currentDateTime().add(xs.yearMonthDuration('P1Y')) }};
 
-hubUtils.writeDocuments([temporalDoc], 'xdmp.defaultPermissions()', [temporalCollection], xdmp.databaseName(xdmp.database()));
+hubUtils.writeDocuments([temporalDoc], xdmp.defaultPermissions(), [temporalCollection], xdmp.databaseName(xdmp.database()));
 
 let readTemporalDoc = fn.head(xdmp.eval(`
- cts.doc('${temporalDoc.uri}'); 
+ cts.doc('${temporalDoc.uri}');
 `));
 [
   test.assertTrue(temporalCollections.filter((col) => fn.string(col) === temporalCollection).length === 1, `Temporal collections: ${xdmp.describe(temporalCollections, emptySequence, emptySequence)}`),

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/artifacts/artifactTypesInfoTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/artifacts/artifactTypesInfoTest.sjs
@@ -1,0 +1,20 @@
+
+const test = require("/test/test-helper.xqy");
+
+function invokeService() {
+  return fn.head(xdmp.invoke(
+    "/data-hub/5/data-services/artifacts/getArtifactTypesInfo.mjs",
+    {}
+  ));
+}
+
+function accurateLoadDataArtifactType() {
+  const loadDataTypeInfo = invokeService().filter((typeInfo) => typeInfo.type === 'loadData');
+  return [
+    test.assertEqual(1, loadDataTypeInfo.length, 'should only be one type for loadData'),
+    test.assertEqual('/loadData/', loadDataTypeInfo[0].directory),
+    test.assertEqual('.loadData.json', loadDataTypeInfo[0].fileExtension)
+  ];
+}
+
+accurateLoadDataArtifactType();

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/artifacts/setGetTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/artifacts/setGetTest.sjs
@@ -1,0 +1,37 @@
+const test = require("/test/test-helper.xqy");
+
+function invokeSetService(artifactType, artifactName, artifact) {
+  return fn.head(xdmp.invoke(
+    "/data-hub/5/data-services/artifacts/setArtifact.mjs",
+    {artifactType, artifactName, artifact: xdmp.toJSON(artifact)}
+  ));
+}
+
+function invokeGetService(artifactType, artifactName) {
+  return fn.head(xdmp.invoke(
+    "/data-hub/5/data-services/artifacts/getArtifact.mjs",
+    {artifactType, artifactName}
+  ));
+}
+
+function insertValidArtifact() {
+  const result = invokeSetService('loadData','validArtifact', { name: 'validArtifact', sourceFormat: 'xml', targetFormat: 'json'});
+  return [
+    test.assertEqual("validArtifact", result.name),
+    test.assertEqual("xml", result.sourceFormat),
+    test.assertEqual("json", result.targetFormat)
+  ];
+}
+
+function getArtifact() {
+  const result = invokeGetService('loadData','validArtifact');
+  return [
+    test.assertEqual("validArtifact", result.name),
+    test.assertEqual("xml", result.sourceFormat),
+    test.assertEqual("json", result.targetFormat)
+  ];
+}
+
+[]
+  .concat(insertValidArtifact())
+  .concat(getArtifact());

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/artifacts/validateTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/artifacts/validateTest.sjs
@@ -1,0 +1,36 @@
+const test = require("/test/test-helper.xqy");
+
+function invokeService(artifactType, artifactName, artifact) {
+  return fn.head(xdmp.invoke(
+    "/data-hub/5/data-services/artifacts/validateArtifact.mjs",
+    {artifactType, artifactName, artifact: xdmp.toJSON(artifact)}
+  ));
+}
+
+function validArtifact() {
+  const result = invokeService('loadData','validArtifact', { name: 'validArtifact', sourceFormat: 'xml', targetFormat: 'json'});
+  return [
+    test.assertEqual("validArtifact", result.name),
+    test.assertEqual("xml", result.sourceFormat),
+    test.assertEqual("json", result.targetFormat)
+  ];
+}
+
+function invalidArtifact() {
+  try {
+    const result = invokeService('loadData', "invalidArtifact", { name: 'invalidArtifact'});
+    return [test.assertTrue(false, 'Should have thrown a validation error')];
+  } catch (e) {
+    let msg = e.data[2];
+    return [
+      test.assertTrue(fn.contains(msg, 'required')),
+      test.assertTrue(fn.contains(msg, 'targetFormat')),
+      test.assertTrue(fn.contains(msg, 'sourceFormat')),
+      test.assertFalse(fn.contains(msg, 'name'))
+    ];
+  }
+}
+
+[]
+  .concat(validArtifact())
+  .concat(invalidArtifact());

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/jobs/buildJobPermissionsScript.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/jobs/buildJobPermissionsScript.sjs
@@ -2,17 +2,14 @@ const config = require("/com.marklogic.hub/config.sjs");
 const test = require("/test/test-helper.xqy");
 const Jobs = require("/data-hub/5/impl/jobs.sjs");
 
-const result = new Jobs.Jobs().buildJobPermissionsScript(config);
-[
-  test.assertEqual("data-hub-job-reader,read,data-hub-job-internal,update", config.JOBPERMISSIONS,
-    "The value of this is a token - %%mlJobPermissions%% - that should have been replaced when the config.sjs module was loaded"),
+const result = new Jobs.Jobs().buildJobPermissions(config);
+const assertions = [
+    test.assertEqual("data-hub-job-reader,read,data-hub-job-internal,update", config.JOBPERMISSIONS,
+      "The value of this is a token - %%mlJobPermissions%% - that should have been replaced when the config.sjs module was loaded")
+  ];
+const expectedParsedPermissions = [xdmp.permission('data-hub-job-reader', 'read'), xdmp.permission('data-hub-job-internal', 'update')];
+expectedParsedPermissions.forEach((expectedPermission) => {
+  assertions.push(test.assertTrue(result.some((permission) => fn.string(expectedPermission.roleId) === fn.string(permission.roleId) && fn.string(expectedPermission.capability) === fn.string(permission.capability)), `The job permissions script should add the data-hub-job-reader/data-hub-job-internal perms to the default permissions of the current user; the flow-developer-role/flow-operator-role update permissions are being retained for backwards compatibility. result: ${xdmp.describe(result, Sequence.from([]), Sequence.from([]))} expected: ${xdmp.describe(expectedPermission)}`));
+});
 
-  test.assertEqual("xdmp.defaultPermissions().concat([" +
-    "xdmp.permission('flow-developer-role', 'update'), " +
-    "xdmp.permission('flow-operator-role', 'update'), " +
-    "xdmp.permission('data-hub-job-reader', 'read'), " +
-    "xdmp.permission('data-hub-job-internal', 'update')" +
-    "])", result,
-    "The job permissions script should add the data-hub-job-reader/data-hub-job-internal perms to the default permissions of the current user; " +
-    "the flow-developer-role/flow-operator-role update permissions are being retained for backwards compatibility.")
-];
+assertions;

--- a/web/src/main/java/com/marklogic/hub/web/web/AbstractArtifactController.java
+++ b/web/src/main/java/com/marklogic/hub/web/web/AbstractArtifactController.java
@@ -1,0 +1,39 @@
+package com.marklogic.hub.web.web;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.hub.HubConfig;
+import com.marklogic.hub.dataservices.ArtifactService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public abstract class AbstractArtifactController {
+    @Autowired
+    private HubConfig hubConfig;
+
+    protected ResponseEntity<JsonNode> getArtifacts() {
+        return new ResponseEntity<>(getArtifactService().getList(this.getArtifactType()), HttpStatus.OK);
+    }
+
+    protected ResponseEntity<JsonNode> updateArtifact(String artifactName, JsonNode loadDataJson) {
+        return new ResponseEntity<>(getArtifactService().setArtifact(this.getArtifactType(), artifactName, loadDataJson), HttpStatus.OK);
+    }
+
+    protected ResponseEntity<JsonNode> getArtifact(String artifactName) {
+        return new ResponseEntity<>(getArtifactService().getArtifact(this.getArtifactType(), artifactName), HttpStatus.OK);
+    }
+
+    protected ResponseEntity<JsonNode> deleteArtifact(String artifactName) {
+        return new ResponseEntity<>(getArtifactService().deleteArtifact(this.getArtifactType(), artifactName), HttpStatus.OK);
+    }
+
+    protected ResponseEntity<JsonNode> validateArtifact(String artifactName, JsonNode artifactJson) {
+        return new ResponseEntity<>(getArtifactService().validateArtifact(this.getArtifactType(), artifactName, artifactJson), HttpStatus.OK);
+    }
+
+    protected ArtifactService getArtifactService() {
+        return ArtifactService.on(hubConfig.newStagingClient(null));
+    }
+
+    protected abstract String getArtifactType();
+}

--- a/web/src/main/java/com/marklogic/hub/web/web/LoadDataController.java
+++ b/web/src/main/java/com/marklogic/hub/web/web/LoadDataController.java
@@ -1,0 +1,51 @@
+package com.marklogic.hub.web.web;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@RequestMapping("/api/current-project/loadData")
+@EnableAsync
+public class LoadDataController extends AbstractArtifactController {
+
+    @RequestMapping(method = RequestMethod.GET)
+    @ResponseBody
+    public ResponseEntity<JsonNode> getArtifacts() {
+        return super.getArtifacts();
+    }
+
+    @RequestMapping(value = "/{artifactName}", method = RequestMethod.POST)
+    @ResponseBody
+    public ResponseEntity<JsonNode> updateArtifact(@PathVariable String artifactName, @RequestBody JsonNode loadDataJson) {
+        return super.updateArtifact(artifactName, loadDataJson);
+    }
+
+    @RequestMapping(value = "/{artifactName}", method = RequestMethod.GET)
+    @ResponseBody
+    public ResponseEntity<JsonNode> getArtifact(@PathVariable String artifactName) {
+        return super.getArtifact(artifactName);
+    }
+
+    @RequestMapping(value = "/{artifactName}", method = RequestMethod.DELETE)
+    @ResponseBody
+    public ResponseEntity<JsonNode> deleteLoadDataConfig(@PathVariable String artifactName) {
+        return super.deleteArtifact(artifactName);
+    }
+
+    @RequestMapping(value = "/{artifactName}/validate", method = RequestMethod.POST)
+    @ResponseBody
+    public ResponseEntity<JsonNode> validateArtifact(@PathVariable String artifactName, @RequestBody JsonNode loadDataJson) {
+        return super.validateArtifact(artifactName, loadDataJson);
+    }
+
+    public String getArtifactType() {
+        return "loadData";
+    }
+}

--- a/web/src/test/java/com/marklogic/hub/web/web/LoadDataControllerTest.java
+++ b/web/src/test/java/com/marklogic/hub/web/web/LoadDataControllerTest.java
@@ -1,0 +1,57 @@
+package com.marklogic.hub.web.web;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.FailedRequestException;
+import com.marklogic.hub.ApplicationConfig;
+import com.marklogic.hub.web.WebApplication;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {WebApplication.class, ApplicationConfig.class, LoadDataControllerTest.class})
+public class LoadDataControllerTest {
+    @Autowired
+    LoadDataController controller;
+
+    JsonNode validLoadDataConfig = new ObjectMapper().readTree("{ \"name\": \"validArtifact\", \"sourceFormat\": \"xml\", \"targetFormat\": \"json\"}");
+
+    public LoadDataControllerTest() throws IOException {
+    }
+
+    @Test
+    void testLoadDataController() {
+        controller.updateArtifact("validArtifact", validLoadDataConfig);
+
+        ArrayNode resultList = (ArrayNode) controller.getArtifacts().getBody();
+
+        assertEquals(1, resultList.size(), "List of load data artifacts should now be 1");
+
+        ObjectNode resultByName = (ObjectNode) controller.getArtifact("validArtifact").getBody();
+        assertEquals("validArtifact", resultByName.get("name").asText(), "Getting artifact by name should return object with expected properties");
+        assertEquals("xml", resultByName.get("sourceFormat").asText(), "Getting artifact by name should return object with expected properties");
+        assertEquals("json", resultByName.get("targetFormat").asText(), "Getting artifact by name should return object with expected properties");
+
+        ResponseEntity<JsonNode> deleteResp = controller.deleteArtifact("validArtifact");
+
+        assertEquals(HttpStatus.OK, deleteResp.getStatusCode(), "Delete should have been successful");
+
+        resultList = (ArrayNode) controller.getArtifacts().getBody();
+
+        assertEquals(0, resultList.size(), "List of load data artifacts should now be 0 after deleting validArtifact");
+
+        assertThrows(FailedRequestException.class, () -> controller.getArtifact("validArtifact"));
+    }
+}


### PR DESCRIPTION
Also adjusted the hub utils to invoke javascript modules, because I was finding that the way external variables were recognized in the evals was changing depending on whether called via mjs or sjs.