### PR TITLE
DHFPROD-3779: Can now run flows without Spring or a HubProject

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -162,6 +162,10 @@ task generateSourceDataInterface(type: com.marklogic.client.tools.gradle.Endpoin
     serviceDeclarationFile = dataServicesPath + "/mastering/service.json"
 }
 
+task generateStepDefinitionInterface(type: com.marklogic.client.tools.gradle.EndpointProxiesGenTask, group: dataServicesGroup) {
+    serviceDeclarationFile = dataServicesPath + "/stepDefinition/service.json"
+}
+
 task generateDataServiceInterfaces {
     description = "Generate Java interfaces for all Data Services. Must run this from the ./marklogic-data-hub directory"
     dependsOn {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/collector/impl/CollectorImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/collector/impl/CollectorImpl.java
@@ -23,7 +23,6 @@ import com.marklogic.client.MarkLogicIOException;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.collector.DiskQueue;
 import com.marklogic.hub.collector.Collector;
-import com.marklogic.hub.flow.Flow;
 import com.marklogic.hub.impl.HubConfigImpl;
 import com.marklogic.rest.util.MgmtResponseErrorHandler;
 import org.apache.http.auth.AuthScope;
@@ -32,8 +31,6 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.conn.ssl.X509HostnameVerifier;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
@@ -59,18 +56,16 @@ import java.security.cert.X509Certificate;
 import java.util.*;
 
 public class CollectorImpl implements Collector {
-    private DatabaseClient client = null;
-    private HubConfig hubConfig = null;
 
+    private DatabaseClient client;
+    private HubConfig hubConfig;
 
-    private Flow flow = null;
+    public CollectorImpl() {
+    }
 
-    private static Logger logger = LoggerFactory.getLogger(CollectorImpl.class);
-
-    public CollectorImpl() {}
-
-    public CollectorImpl(Flow flow) {
-        this.flow = flow;
+    public CollectorImpl(HubConfig hubConfig, DatabaseClient stagingClient) {
+        this.hubConfig = hubConfig;
+        this.client = stagingClient;
     }
 
     @Override
@@ -204,7 +199,7 @@ public class CollectorImpl implements Collector {
         protected HostnameVerifierAdapter(SSLHostnameVerifier verifier) {
           this.verifier = verifier;
         }
-        
+
         public void verify(String hostname, X509Certificate cert) throws SSLException {
           ArrayList<String> cnArray = new ArrayList<>();
           try {
@@ -242,12 +237,12 @@ public class CollectorImpl implements Collector {
         @Override
         public void verify(String hostname, SSLSocket ssl) throws IOException {
             Certificate[] certificates = ssl.getSession().getPeerCertificates();
-            verify(hostname, (X509Certificate) certificates[0]);             
+            verify(hostname, (X509Certificate) certificates[0]);
         }
 
         @Override
         public void verify(String hostname, String[] cns, String[] subjectAlts) throws SSLException {
-            verifier.verify(hostname, cns, subjectAlts);            
+            verifier.verify(hostname, cns, subjectAlts);
         }
 
         @Override
@@ -256,7 +251,7 @@ public class CollectorImpl implements Collector {
               Certificate[] certificates = session.getPeerCertificates();
               verify(hostname, (X509Certificate) certificates[0]);
               return true;
-              } 
+              }
             catch(SSLException e) {
               return false;
             }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/StepDefinitionService.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/StepDefinitionService.java
@@ -1,0 +1,62 @@
+package com.marklogic.hub.dataservices;
+
+// IMPORTANT: Do not edit. This file is generated.
+
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.marker.AbstractWriteHandle;
+
+
+import com.marklogic.client.DatabaseClient;
+
+import com.marklogic.client.impl.BaseProxy;
+
+/**
+ * Provides a set of operations on the database server
+ */
+public interface StepDefinitionService {
+    /**
+     * Creates a StepDefinitionService object for executing operations on the database server.
+     *
+     * The DatabaseClientFactory class can create the DatabaseClient parameter. A single
+     * client object can be used for any number of requests and in multiple threads.
+     *
+     * @param db	provides a client for communicating with the database server
+     * @return	an object for session state
+     */
+    static StepDefinitionService on(DatabaseClient db) {
+        final class StepDefinitionServiceImpl implements StepDefinitionService {
+            private BaseProxy baseProxy;
+
+            private StepDefinitionServiceImpl(DatabaseClient dbClient) {
+                baseProxy = new BaseProxy(dbClient, "/data-hub/5/data-services/stepDefinition/");
+            }
+
+            @Override
+            public com.fasterxml.jackson.databind.JsonNode getStepDefinition(String name, String type) {
+              return BaseProxy.JsonDocumentType.toJsonNode(
+                baseProxy
+                .request("getStepDefinition.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_ATOMICS)
+                .withSession()
+                .withParams(
+                    BaseProxy.atomicParam("name", false, BaseProxy.StringType.fromString(name)),
+                    BaseProxy.atomicParam("type", false, BaseProxy.StringType.fromString(type)))
+                .withMethod("POST")
+                .responseSingle(false, Format.JSON)
+                );
+            }
+
+        }
+
+        return new StepDefinitionServiceImpl(db);
+    }
+
+  /**
+   * Invokes the getStepDefinition operation on the database server
+   *
+   * @param name	provides input
+   * @param type	provides input
+   * @return	as output
+   */
+    com.fasterxml.jackson.databind.JsonNode getStepDefinition(String name, String type);
+
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/FlowInputs.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/FlowInputs.java
@@ -1,0 +1,67 @@
+package com.marklogic.hub.flow;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class FlowInputs {
+
+    private String flowName;
+    private List<String> steps;
+    private String jobId;
+    private Map<String, Object> options;
+    private Map<String, Object> stepConfig;
+
+    public FlowInputs() {
+    }
+
+    public FlowInputs(String flowName) {
+        this.flowName = flowName;
+    }
+
+    public FlowInputs(String flowName, String... steps) {
+        this.flowName = flowName;
+        this.steps = Arrays.asList(steps);
+    }
+
+    public String getFlowName() {
+        return flowName;
+    }
+
+    public void setFlowName(String flowName) {
+        this.flowName = flowName;
+    }
+
+    public List<String> getSteps() {
+        return steps;
+    }
+
+    public void setSteps(List<String> steps) {
+        this.steps = steps;
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public void setJobId(String jobId) {
+        this.jobId = jobId;
+    }
+
+    public Map<String, Object> getOptions() {
+        return options;
+    }
+
+    public void setOptions(Map<String, Object> options) {
+        this.options = options;
+    }
+
+    public Map<String, Object> getStepConfig() {
+        return stepConfig;
+    }
+
+    public void setStepConfig(Map<String, Object> stepConfig) {
+        this.stepConfig = stepConfig;
+    }
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/FlowRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/FlowRunner.java
@@ -8,6 +8,20 @@ import java.util.concurrent.TimeoutException;
 
 public interface FlowRunner {
 
+    /**
+     * Run a flow without any dependency on an underlying HubProject for either finding artifacts (flows and step
+     * definitions) or for resolving file paths for an ingestion step. If an ingestion step does have a relative
+     * file path, then the ingestion step will fail due to not being able to resolve the relative file path to an
+     * absolute file path.
+     *
+     * Aside from retrieving flows and step definitions from MarkLogic instead of from the filesystem, the behavior of
+     * this method - the output of each step and the returned RunFlowResponse - will be identical to that of every
+     * other "runFlow" method in this class.
+     *
+     * @param flowInputs
+     * @return
+     */
+    RunFlowResponse runFlowWithoutProject(FlowInputs flowInputs);
 
     /**
      * Runs the flow, with a specific set of steps, with all custom settings

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -41,6 +41,7 @@ import com.marklogic.mgmt.ManageConfig;
 import com.marklogic.mgmt.admin.AdminConfig;
 import com.marklogic.mgmt.admin.AdminManager;
 import com.marklogic.mgmt.admin.DefaultAdminConfigFactory;
+import com.marklogic.mgmt.util.SimplePropertySource;
 import org.apache.commons.text.CharacterPredicate;
 import org.apache.commons.text.RandomStringGenerator;
 import org.slf4j.Logger;
@@ -48,7 +49,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.env.Environment;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
@@ -57,10 +60,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
+import java.util.function.Consumer;
 
 @JsonAutoDetect(
     fieldVisibility = JsonAutoDetect.Visibility.PROTECTED_AND_PUBLIC,
@@ -186,13 +187,17 @@ public class HubConfigImpl implements HubConfig
 
     private static final Logger logger = LoggerFactory.getLogger(HubConfigImpl.class);
 
-    private ObjectMapper objmapper;
-
     // By default, DHF uses gradle-local.properties for your local environment.
     private String envString = "local";
 
+    // Defines functions for consuming properties from a PropertySource
+    private Map<String, Consumer<String>> propertyConsumerMap;
+
+    /**
+     * No-arg constructor that does not initialize any HubConfigImpl property values. The expectation is that these will
+     * be set via a Spring Environment.
+     */
     public HubConfigImpl() {
-        objmapper = new ObjectMapper();
         projectProperties = new Properties();
     }
 
@@ -201,8 +206,83 @@ public class HubConfigImpl implements HubConfig
         this.environment = environment;
     }
 
+    /**
+     * Static method for a new instance of HubConfigImpl based on default DHF property values with no dependency on
+     * Spring or on project files. The no-arg constructor is already reserved for use within a Spring container, where
+     * default values are expected to be set via the Spring Environment.
+     *
+     * @return
+     */
+    public static HubConfigImpl withDefaultProperties() {
+        HubConfigImpl hubConfig = new HubConfigImpl();
+        hubConfig.applyDefaultProperties();
+        return hubConfig;
+    }
+
+    /**
+     * Provides a minimally-configured instance of SimpleHubConfig based on DHF default properties, with no dependency
+     * on Spring or on project files.
+     *
+     * @param host
+     * @param mlUsername
+     * @param mlPassword
+     */
+    public HubConfigImpl(String host, String mlUsername, String mlPassword) {
+        this();
+        applyDefaultProperties();
+        setHost(host);
+        setMlUsername(mlUsername);
+        setMlPassword(mlPassword);
+    }
+
+    /**
+     * When this class is not used in a Spring environment, this method is used to apply properties for the
+     * dhf-defaults.properties file to initialize an instance of this class.
+     */
+    public void applyDefaultProperties() {
+        Properties props = new Properties();
+        try {
+            props.load(new ClassPathResource("dhf-defaults.properties").getInputStream());
+        } catch (IOException ex) {
+            throw new RuntimeException("Unable to initialize HubConfigImpl; could not find dhf-defaults.properties on the classpath; cause: " + ex.getMessage(), ex);
+        }
+        applyProperties(new SimplePropertySource(props));
+    }
+
+    /**
+     * Applies properties in the given property source to this instance. This allows for an instance of HubConfigImpl
+     * to be populated via properties from any source, such as a command line program or an external orchestration tool,
+     * as opposed to just from a Spring Environment.
+     *
+     * Note that this differs substantially from how loadConfigurationFromProperties works. That function's behavior
+     * depends on whether a field has a value or not. This method is intended to set a field's value regardless of
+     * whether it has a value or not.
+     *
+     * @param propertySource
+     */
+    public void applyProperties(com.marklogic.mgmt.util.PropertySource propertySource) {
+        if (propertyConsumerMap == null) {
+            // This is necessary because some old DHF tests "reset" all the properties in the HubConfigImpl object,
+            // which results in propertyConsumerMap being nulled out. In the real world, it's unlikely that
+            // propertyConsumerMap will ever be null after an instance of this class is instantiated.
+            initializePropertyConsumerMap();
+        }
+
+        for (String propertyName : propertyConsumerMap.keySet()) {
+            String value = propertySource.getProperty(propertyName);
+            if (value != null) {
+                propertyConsumerMap.get(propertyName).accept(value);
+            }
+        }
+    }
+
+    protected HubProject requireHubProject() {
+        Assert.notNull(hubProject, "A HubProject has not been set, and thus this operation cannot be performed");
+        return hubProject;
+    }
+
     public void createProject(String projectDirString) {
-        hubProject.createProject(projectDirString);
+        requireHubProject().createProject(projectDirString);
     }
 
     public String getHost() { return appConfig.getHost(); }
@@ -801,15 +881,30 @@ public class HubConfigImpl implements HubConfig
     }
 
     // impl only pending refactor to Flow Component
+    @JsonIgnore
     public String getMlUsername() {
         return mlUsername;
     }
     // impl only pending refactor to Flow Component
+    @JsonIgnore
     public String getMlPassword() {
         return mlPassword;
     }
 
-    public void setHost(String host ) { this.host = host; }
+    public void setHost(String host ) {
+        this.host = host;
+        /**
+         * It's not clear why HubConfig has its own 'host' property, as that's already defined on AppConfig. But since
+         * getHost returns appConfig.getHost, then it follows that when setHost is called, both this class's 'host'
+         * property and the AppConfig should be modified.
+         */
+        if (appConfig != null) {
+            appConfig.setHost(host);
+        } else {
+            appConfig = new AppConfig();
+            appConfig.setHost(host);
+        }
+    }
 
     public void setMlUsername(String mlUsername) {
         this.mlUsername = mlUsername;
@@ -883,7 +978,7 @@ public class HubConfigImpl implements HubConfig
     @Override
     @Deprecated
     public String getProjectDir() {
-        return hubProject.getProjectDirString();
+        return requireHubProject().getProjectDirString();
     }
 
     @Override
@@ -918,19 +1013,19 @@ public class HubConfigImpl implements HubConfig
     }
 
     @Override  public void initHubProject() {
-        this.hubProject.init(getCustomTokens());
+        this.requireHubProject().init(getCustomTokens());
     }
 
     @Override
     @Deprecated
     public String getHubModulesDeployTimestampFile() {
-        return hubProject.getHubModulesDeployTimestampFile();
+        return requireHubProject().getHubModulesDeployTimestampFile();
     }
 
     @Override
     @Deprecated
     public String getUserModulesDeployTimestampFile() {
-        return hubProject.getUserModulesDeployTimestampFile();
+        return requireHubProject().getUserModulesDeployTimestampFile();
     }
 
 
@@ -984,30 +1079,45 @@ public class HubConfigImpl implements HubConfig
         }
     }
 
+    /**
+     * Expected to be used when an instance of this class is managed by a Spring container, as it depends on a Spring
+     * environment object being set.
+     *
+     * This method also operates in one of two ways for each field. If a field value is null, it is set based on the
+     * value in the incoming Properties object, or based on the Spring environment as a fallback. But if the field value
+     * is already set, then its value is stored in the class's projectProperties field.
+     *
+     * @param properties
+     * @param loadGradleProperties
+     */
     public void loadConfigurationFromProperties(Properties properties, boolean loadGradleProperties) {
+        if (environment == null) {
+            throw new RuntimeException("Unable to load configuration from properties, the Spring environment object is null");
+        }
+
         projectProperties = new Properties();
 
-        /*
-         * Not sure if this code should still be here. We don't want to do this in a Gradle environment because the
-         * properties have already been loaded and processed by the Gradle properties plugin, and they should be in
-         * the incoming Properties object. So the use case for this would be when there's a gradle.properties file
-         * available but Gradle isn't being used.
+        /**
+         * The primary use case for this block of code is when an instance of this class is used in the QuickStart
+         * application, where properties are read from a Gradle properties file but Gradle itself is not used. In a
+         * Gradle environment, properties will have already been loaded and processed by the Gradle properties plugin,
+         * and they should be in the incoming Properties object.
          */
         if (loadGradleProperties) {
             if (logger.isInfoEnabled()) {
                 logger.info("Loading properties from gradle.properties");
             }
-            File file = hubProject.getProjectDir().resolve("gradle.properties").toFile();
+            File file = requireHubProject().getProjectDir().resolve("gradle.properties").toFile();
             loadPropertiesFromFile(file, projectProperties);
 
             if (envString != null) {
-                File envPropertiesFile = hubProject.getProjectDir().resolve("gradle-" + envString + ".properties").toFile();
+                File envPropertiesFile = requireHubProject().getProjectDir().resolve("gradle-" + envString + ".properties").toFile();
                 if (envPropertiesFile != null && envPropertiesFile.exists()) {
                     if (logger.isInfoEnabled()) {
                         logger.info("Loading additional properties from " + envPropertiesFile.getAbsolutePath());
                     }
                     loadPropertiesFromFile(envPropertiesFile, projectProperties);
-                    hubProject.setUserModulesDeployTimestampFile(envString + "-" + USER_MODULES_DEPLOY_TIMESTAMPS_PROPERTIES);
+                    requireHubProject().setUserModulesDeployTimestampFile(envString + "-" + USER_MODULES_DEPLOY_TIMESTAMPS_PROPERTIES);
                 }
             }
         }
@@ -1414,15 +1524,6 @@ public class HubConfigImpl implements HubConfig
 
     private void hydrateAppConfigs(Properties properties) {
         com.marklogic.mgmt.util.PropertySource propertySource = properties::getProperty;
-        hydrateAppConfigs(propertySource);
-    }
-
-    private void hydrateAppConfigs(Environment environment) {
-        com.marklogic.mgmt.util.PropertySource propertySource = environment::getProperty;
-        hydrateAppConfigs(propertySource);
-    }
-
-    private void hydrateAppConfigs(com.marklogic.mgmt.util.PropertySource propertySource) {
         if (appConfig != null) {
             setAppConfig(appConfig);
         }
@@ -1497,7 +1598,9 @@ public class HubConfigImpl implements HubConfig
     public DatabaseClient newStagingClient(String dbName) {
         AppConfig appConfig = getAppConfig();
         DatabaseClientConfig config = new DatabaseClientConfig(appConfig.getHost(), stagingPort, getMlUsername(), getMlPassword());
-        config.setDatabase(dbName);
+        if (dbName != null) {
+            config.setDatabase(dbName);
+        }
         config.setSecurityContextType(SecurityContextType.valueOf(stagingAuthMethod.toUpperCase()));
         config.setSslHostnameVerifier(stagingSslHostnameVerifier);
         config.setSslContext(stagingSslContext);
@@ -1578,85 +1681,85 @@ public class HubConfigImpl implements HubConfig
 
     @JsonIgnore
     @Override public Path getModulesDir() {
-        return hubProject.getModulesDir();
+        return requireHubProject().getModulesDir();
     }
 
     @JsonIgnore
-    public Path getHubProjectDir() { return hubProject.getProjectDir(); }
+    public Path getHubProjectDir() { return requireHubProject().getProjectDir(); }
 
     @JsonIgnore
     @Override public Path getHubPluginsDir() {
-        return hubProject.getHubPluginsDir();
+        return requireHubProject().getHubPluginsDir();
     }
 
     @JsonIgnore
-    @Override public Path getHubEntitiesDir() { return hubProject.getHubEntitiesDir(); }
+    @Override public Path getHubEntitiesDir() { return requireHubProject().getHubEntitiesDir(); }
 
     @JsonIgnore
-    @Override public Path getHubMappingsDir() { return hubProject.getHubMappingsDir(); }
+    @Override public Path getHubMappingsDir() { return requireHubProject().getHubMappingsDir(); }
 
     @JsonIgnore
     @Override
     public Path getStepsDirByType(StepDefinition.StepDefinitionType type) {
-        return hubProject.getStepsDirByType(type);
+        return requireHubProject().getStepsDirByType(type);
     }
 
     @JsonIgnore
     @Override public Path getHubConfigDir() {
-        return hubProject.getHubConfigDir();
+        return requireHubProject().getHubConfigDir();
     }
 
     @JsonIgnore
     @Override public Path getHubDatabaseDir() {
-        return hubProject.getHubDatabaseDir();
+        return requireHubProject().getHubDatabaseDir();
     }
 
     @JsonIgnore
     @Override public Path getHubServersDir() {
-        return hubProject.getHubServersDir();
+        return requireHubProject().getHubServersDir();
     }
 
     @JsonIgnore
     @Override public Path getHubSecurityDir() {
-        return hubProject.getHubSecurityDir();
+        return requireHubProject().getHubSecurityDir();
     }
 
     @JsonIgnore
     @Override public Path getUserSecurityDir() {
-        return hubProject.getUserSecurityDir();
+        return requireHubProject().getUserSecurityDir();
     }
 
     @JsonIgnore
     @Override public Path getUserConfigDir() {
-        return hubProject.getUserConfigDir();
+        return requireHubProject().getUserConfigDir();
     }
 
     @JsonIgnore
     @Override public Path getUserDatabaseDir() {
-        return hubProject.getUserDatabaseDir();
+        return requireHubProject().getUserDatabaseDir();
     }
 
     @JsonIgnore
-    @Override public Path getUserSchemasDir() { return hubProject.getUserSchemasDir(); }
+    @Override public Path getUserSchemasDir() { return requireHubProject().getUserSchemasDir(); }
 
     @JsonIgnore
     @Override public Path getEntityDatabaseDir() {
-        return hubProject.getEntityDatabaseDir();
+        return requireHubProject().getEntityDatabaseDir();
     }
 
     @Override
     public Path getFlowsDir() {
-        return hubProject.getFlowsDir();
+        return requireHubProject().getFlowsDir();
     }
 
     @Override
     public Path getStepDefinitionsDir() {
-        return hubProject.getStepDefinitionsDir();
+        return requireHubProject().getStepDefinitionsDir();
     }
 
     @JsonIgnore
     @Override public Path getUserServersDir() {
-        return hubProject.getUserServersDir();
+        return requireHubProject().getUserServersDir();
     }
 
     @JsonIgnore
@@ -1712,7 +1815,19 @@ public class HubConfigImpl implements HubConfig
         return appConfig.getCustomTokens();
     }
 
+    /**
+     * Populates the custom tokens map in the given AppConfig object. For each field, if its value is set, then that value
+     * is stored in the custom tokens map. Else, an attempt is made to retrieve a value for the field from the Spring
+     * Environment. Thus, the expectation is that this class is used in a Spring context where a Spring Environment
+     * object is set.
+     *
+     * @param appConfig
+     */
     protected void modifyCustomTokensMap(AppConfig appConfig) {
+        if (environment == null) {
+            throw new RuntimeException("Unable to modify custom tokens map, the Spring environment object is null");
+        }
+
         Map<String, String> customTokens = appConfig.getCustomTokens();
         customTokens.put("%%mlHost%%", appConfig == null ? environment.getProperty("mlHost") : appConfig.getHost());
         customTokens.put("%%mlStagingAppserverName%%", stagingHttpName == null ? environment.getProperty("mlStagingAppserverName") : stagingHttpName);
@@ -1948,7 +2063,7 @@ public class HubConfigImpl implements HubConfig
     {
 
         try {
-            return objmapper.writerWithDefaultPrettyPrinter().writeValueAsString(this);
+            return new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(this);
         }
         catch(Exception e)
         {
@@ -1984,7 +2099,7 @@ public class HubConfigImpl implements HubConfig
     @JsonIgnore
     public HubConfig withPropertiesFromEnvironment(String environment) {
         this.envString = environment;
-        hubProject.setUserModulesDeployTimestampFile(envString + "-" + USER_MODULES_DEPLOY_TIMESTAMPS_PROPERTIES);
+        requireHubProject().setUserModulesDeployTimestampFile(envString + "-" + USER_MODULES_DEPLOY_TIMESTAMPS_PROPERTIES);
         return this;
     }
 
@@ -2003,7 +2118,7 @@ public class HubConfigImpl implements HubConfig
             }
         }
         catch (IOException e) {
-            throw new DataHubProjectException("No properties file found in project " + hubProject.getProjectDirString());
+            throw new DataHubProjectException("No properties file found in project " + requireHubProject().getProjectDirString());
         }
     }
 
@@ -2096,4 +2211,66 @@ public class HubConfigImpl implements HubConfig
         isHostLoadBalancer = null;
     }
 
+    /**
+     * Defines functions for consuming properties from a PropertySource. This differs substantially from
+     * loadConfigurationFromProperties, as that function's behavior depends on whether a field has a value or not.
+     */
+    protected void initializePropertyConsumerMap() {
+        propertyConsumerMap = new LinkedHashMap<>();
+
+        propertyConsumerMap.put("mlDHFVersion", prop -> DHFVersion = prop);
+        propertyConsumerMap.put("mlHost", prop -> setHost(prop));
+        propertyConsumerMap.put("mlIsHostLoadBalancer", prop -> isHostLoadBalancer = Boolean.parseBoolean(prop));
+        propertyConsumerMap.put("mlIsProvisionedEnvironment", prop -> isProvisionedEnvironment = Boolean.parseBoolean(prop));
+
+        propertyConsumerMap.put("mlStagingAppserverName", prop -> stagingHttpName = prop);
+        propertyConsumerMap.put("mlStagingPort", prop -> stagingPort = Integer.parseInt(prop));
+        propertyConsumerMap.put("mlStagingDbName", prop -> stagingDbName = prop);
+        propertyConsumerMap.put("mlStagingForestsPerHost", prop -> stagingForestsPerHost = Integer.parseInt(prop));
+        propertyConsumerMap.put("mlStagingAuth", prop -> stagingAuthMethod = prop);
+        propertyConsumerMap.put("mlStagingSimpleSsl", prop -> stagingSimpleSsl = Boolean.parseBoolean(prop));
+
+        propertyConsumerMap.put("mlFinalAppserverName", prop -> finalHttpName = prop);
+        propertyConsumerMap.put("mlFinalPort", prop -> finalPort = Integer.parseInt(prop));
+        propertyConsumerMap.put("mlFinalDbName", prop -> finalDbName = prop);
+        propertyConsumerMap.put("mlFinalForestsPerHost", prop -> finalForestsPerHost = Integer.parseInt(prop));
+        propertyConsumerMap.put("mlFinalAuth", prop -> finalAuthMethod = prop);
+        propertyConsumerMap.put("mlFinalSimpleSsl", prop -> finalSimpleSsl = Boolean.parseBoolean(prop));
+
+        propertyConsumerMap.put("mlJobAppserverName", prop -> jobHttpName = prop);
+        propertyConsumerMap.put("mlJobPort", prop -> jobPort = Integer.parseInt(prop));
+        propertyConsumerMap.put("mlJobDbName", prop -> jobDbName = prop);
+        propertyConsumerMap.put("mlJobForestsPerHost", prop -> jobForestsPerHost = Integer.parseInt(prop));
+        propertyConsumerMap.put("mlJobAuth", prop -> jobAuthMethod = prop);
+        propertyConsumerMap.put("mlJobSimpleSsl", prop -> jobSimpleSsl = Boolean.parseBoolean(prop));
+
+        propertyConsumerMap.put("mlModulesDbName", prop -> modulesDbName = prop);
+        propertyConsumerMap.put("mlModulesForestsPerHost", prop -> modulesForestsPerHost = Integer.parseInt(prop));
+
+        propertyConsumerMap.put("mlStagingTriggersDbName", prop -> stagingTriggersDbName = prop);
+        propertyConsumerMap.put("mlStagingTriggersForestsPerHost", prop -> stagingTriggersForestsPerHost = Integer.parseInt(prop));
+        propertyConsumerMap.put("mlStagingSchemasDbName", prop -> stagingSchemasDbName = prop);
+        propertyConsumerMap.put("mlStagingSchemasForestsPerHost", prop -> stagingSchemasForestsPerHost = Integer.parseInt(prop));
+
+        propertyConsumerMap.put("mlFinalTriggersDbName", prop -> finalTriggersDbName = prop);
+        propertyConsumerMap.put("mlFinalTriggersForestsPerHost", prop -> finalTriggersForestsPerHost = Integer.parseInt(prop));
+        propertyConsumerMap.put("mlFinalSchemasDbName", prop -> finalSchemasDbName = prop);
+        propertyConsumerMap.put("mlFinalSchemasForestsPerHost", prop -> finalSchemasForestsPerHost = Integer.parseInt(prop));
+
+        propertyConsumerMap.put("mlCustomForestPath", prop -> customForestPath = prop);
+
+        propertyConsumerMap.put("mlFlowOperatorRole", prop -> flowOperatorRoleName = prop);
+        propertyConsumerMap.put("mlFlowOperatorUserName", prop -> flowOperatorUserName = prop);
+        propertyConsumerMap.put("mlFlowDeveloperRole", prop -> flowDeveloperRoleName = prop);
+        propertyConsumerMap.put("mlFlowDeveloperUserName", prop -> flowDeveloperUserName = prop);
+
+        propertyConsumerMap.put("mlHubLogLevel", prop -> hubLogLevel = prop);
+
+        propertyConsumerMap.put("mlEntityModelPermissions", prop -> entityModelPermissions = prop);
+        propertyConsumerMap.put("mlFlowPermissions", prop -> flowPermissions = prop);
+        propertyConsumerMap.put("mlJobPermissions", prop -> jobPermissions = prop);
+        propertyConsumerMap.put("mlMappingPermissions", prop -> mappingPermissions = prop);
+        propertyConsumerMap.put("mlModulePermissions", prop -> modulePermissions = prop);
+        propertyConsumerMap.put("mlStepDefinitionPermissions", prop -> stepDefinitionPermissions = prop);
+    }
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/job/JobDocManager.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/job/JobDocManager.java
@@ -46,7 +46,7 @@ public class JobDocManager extends ResourceManager {
         try {
             resultItr = this.getServices().post(params, new StringHandle("{}").withFormat(Format.JSON));
         } catch (Exception e) {
-            throw new RuntimeException("Unable to update the job document");
+            throw new RuntimeException("Unable to update the job document; cause: " + e.getMessage(), e);
         }
         if (resultItr == null || !resultItr.hasNext()) {
             return null;

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/MarkLogicStepDefinitionProvider.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/MarkLogicStepDefinitionProvider.java
@@ -1,0 +1,25 @@
+package com.marklogic.hub.step;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.hub.dataservices.StepDefinitionService;
+
+/**
+ * Implementation that retrieves step definitions from MarkLogic via a data service.
+ */
+public class MarkLogicStepDefinitionProvider implements StepDefinitionProvider {
+
+    private StepDefinitionService service;
+
+    public MarkLogicStepDefinitionProvider(DatabaseClient databaseClient) {
+        this.service = StepDefinitionService.on(databaseClient);
+    }
+
+    @Override
+    public StepDefinition getStepDefinition(String name, StepDefinition.StepDefinitionType type) {
+        JsonNode json = service.getStepDefinition(name, type.name());
+        StepDefinition step = StepDefinition.create(name, type);
+        step.deserialize(json);
+        return step;
+    }
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/ProjectStepDefinitionProvider.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/ProjectStepDefinitionProvider.java
@@ -1,0 +1,22 @@
+package com.marklogic.hub.step;
+
+import com.marklogic.hub.StepDefinitionManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Depends on a StepDefinitionManager, which ultimately depends on a HubProject being available so that a step
+ * definition can be read from disk. This is marked as a Spring Component so that it is used by default for backwards
+ * compatibility purposes.
+ */
+@Component
+public class ProjectStepDefinitionProvider implements StepDefinitionProvider {
+
+    @Autowired
+    private StepDefinitionManager stepDefMgr;
+
+    @Override
+    public StepDefinition getStepDefinition(String name, StepDefinition.StepDefinitionType type) {
+        return stepDefMgr.getStepDefinition(name, type);
+    }
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/StepDefinitionProvider.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/StepDefinitionProvider.java
@@ -1,0 +1,11 @@
+package com.marklogic.hub.step;
+
+/**
+ * Abstracts how a StepDefinition is provided to a client so that it can come from MarkLogic, from a filesystem, or from
+ * other location.
+ */
+public interface StepDefinitionProvider {
+
+    StepDefinition getStepDefinition(String name, StepDefinition.StepDefinitionType type);
+
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/StepRunnerFactory.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/StepRunnerFactory.java
@@ -18,23 +18,29 @@ public class StepRunnerFactory {
 
     @Autowired
     private HubConfig hubConfig;
+
     @Autowired
-    private StepDefinitionManagerImpl stepDefMgr;
+    private StepDefinitionProvider stepDefinitionProvider;
+
     private StepRunner stepRunner;
     private int batchSize = 100;
     private int threadCount = 4;
     private String sourceDatabase;
     private String targetDatabase;
 
+    public StepRunnerFactory() {
+    }
+
+    public StepRunnerFactory(HubConfig hubConfig) {
+        this.hubConfig = hubConfig;
+    }
+
     public StepRunner getStepRunner(Flow flow, String stepNum)  {
         Map<String, Step> steps = flow.getSteps();
         Step step = steps.get(stepNum);
-        StepDefinition stepDef = stepDefMgr.getStepDefinition(step.getStepDefinitionName(), step.getStepDefinitionType());
+        StepDefinition stepDef = stepDefinitionProvider.getStepDefinition(step.getStepDefinitionName(), step.getStepDefinitionType());
 
         switch (step.getStepDefinitionType()) {
-            case MAPPING:
-                stepRunner = new QueryStepRunner(hubConfig);
-                break;
             case INGESTION:
                 stepRunner = new WriteStepRunner(hubConfig);
                 break;
@@ -102,4 +108,7 @@ public class StepRunnerFactory {
         return stepRunner;
     }
 
+    public void setStepDefinitionProvider(StepDefinitionProvider stepDefinitionProvider) {
+        this.stepDefinitionProvider = stepDefinitionProvider;
+    }
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
@@ -303,10 +303,8 @@ public class QueryStepRunner implements StepRunner {
         return this.batchSize;
     }
 
-    private Collection<String> runCollector() throws Exception {
-        Collector c = new CollectorImpl(this.flow);
-        c.setHubConfig(hubConfig);
-        c.setClient(stagingClient);
+    private Collection<String> runCollector() {
+        Collector c = new CollectorImpl(hubConfig, stagingClient);
 
         stepStatusListeners.forEach((StepStatusListener listener) -> {
             listener.onStatusChange(this.jobId, 0, JobStatus.RUNNING_PREFIX + step, 0, 0,  "running collector");

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepDefinition/getStepDefinition.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepDefinition/getStepDefinition.api
@@ -1,0 +1,17 @@
+{
+    "functionName": "getStepDefinition",
+    "params": [
+        {
+            "name": "name",
+            "datatype": "string"
+        },
+        {
+            "name": "type",
+            "datatype": "string"
+        }
+    ],
+    "return": {
+        "datatype": "jsonDocument",
+        "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+    }
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepDefinition/getStepDefinition.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepDefinition/getStepDefinition.sjs
@@ -1,0 +1,33 @@
+/*
+  Copyright 2012-2019 MarkLogic Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+'use strict';
+
+var name;
+var type;
+
+let query = cts.andQuery([
+  cts.collectionQuery("http://marklogic.com/data-hub/step-definition"),
+  cts.directoryQuery("/step-definitions/" + type.toLowerCase() + "/", "infinity"),
+  cts.jsonPropertyValueQuery("name", name)
+]);
+
+let result = fn.head(fn.subsequence(cts.search(query), 1, 1));
+
+if (result != undefined) {
+  result
+} else {
+  throw Error(`Unable to find a step definition with name ${name} and type ${type}`)
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepDefinition/service.json
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepDefinition/service.json
@@ -1,0 +1,4 @@
+{
+  "endpointDirectory": "/data-hub/5/data-services/stepDefinition/",
+  "$javaClass": "com.marklogic.hub.dataservices.StepDefinitionService"
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/RunFlowRunnerTestsWithoutProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/RunFlowRunnerTestsWithoutProjectTest.java
@@ -1,0 +1,52 @@
+package com.marklogic.hub.flow;
+
+import com.marklogic.hub.flow.impl.FlowRunnerImpl;
+import com.marklogic.hub.step.MarkLogicStepDefinitionProvider;
+import com.marklogic.hub.step.StepDefinition;
+import com.marklogic.hub.step.StepDefinitionProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Extends FlowRunnerTest so that each test can be run with a non-Spring-managed instance of FlowRunnerImpl that doesn't
+ * depend on an instance of HubProject.
+ */
+public class RunFlowRunnerTestsWithoutProjectTest extends FlowRunnerTest {
+
+    @Override
+    protected RunFlowResponse runFlow(String flowName, String commaDelimitedSteps, String jobId, Map<String, Object> options, Map<String, Object> stepConfig) {
+        FlowInputs inputs = new FlowInputs(flowName);
+        if (commaDelimitedSteps != null) {
+            inputs.setSteps(Arrays.asList(commaDelimitedSteps.split(",")));
+        }
+        inputs.setJobId(jobId);
+        inputs.setOptions(options);
+        inputs.setStepConfig(stepConfig);
+
+        flowRunner = new FlowRunnerImpl(host, flowRunnerUser, flowRunnerPassword);
+        makeInputFilePathsAbsoluteInFlow(flowName);
+        verifyStepDefinitionsCanBeFound(flowRunner);
+
+        return flowRunner.runFlowWithoutProject(inputs);
+    }
+
+    /**
+     * Before running the flow, we do a little testing to verify that both default and custom step definitions can be
+     * found by MarkLogicStepDefinitionProvider.
+     *
+     * @param flowRunner
+     */
+    private void verifyStepDefinitionsCanBeFound(FlowRunnerImpl flowRunner) {
+        StepDefinitionProvider provider = new MarkLogicStepDefinitionProvider(flowRunner.getHubConfig().newStagingClient(null));
+
+        StepDefinition stepDef = provider.getStepDefinition("default-mapping", StepDefinition.StepDefinitionType.MAPPING);
+        assertEquals("default-mapping", stepDef.getName());
+
+        stepDef = provider.getStepDefinition("json-mapping", StepDefinition.StepDefinitionType.MAPPING);
+        assertEquals("json-mapping", stepDef.getName());
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/HubConfigImplTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/HubConfigImplTest.java
@@ -1,0 +1,84 @@
+package com.marklogic.hub.impl;
+
+import com.marklogic.hub.DatabaseKind;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HubConfigImplTest {
+
+    @Test
+    void withDefaultValues() {
+        HubConfigImpl config = HubConfigImpl.withDefaultProperties();
+        assertEquals("localhost", config.getHost());
+        assertNull(config.getMlUsername());
+        assertNull(config.getMlPassword());
+        verifyDefaultValues(config);
+    }
+
+    @Test
+    void withHostUsernameAndPasswordPlusDefaultValues() {
+        HubConfigImpl config = new HubConfigImpl("somehost", "someuser", "something");
+        assertEquals("somehost", config.getHost());
+        assertEquals("someuser", config.getMlUsername());
+        assertEquals("something", config.getMlPassword());
+        verifyDefaultValues(config);
+    }
+
+    private void verifyDefaultValues(HubConfigImpl config) {
+        assertEquals("2.0.0", config.getDHFVersion());
+        assertFalse(config.getIsHostLoadBalancer());
+
+        assertEquals("data-hub-STAGING", config.getHttpName(DatabaseKind.STAGING));
+        assertEquals(8010, config.getPort(DatabaseKind.STAGING));
+        assertEquals("data-hub-STAGING", config.getDbName(DatabaseKind.STAGING));
+        assertEquals(3, config.getForestsPerHost(DatabaseKind.STAGING));
+        assertEquals("digest", config.getAuthMethod(DatabaseKind.STAGING));
+        assertFalse(config.getSimpleSsl(DatabaseKind.STAGING));
+
+        assertEquals("data-hub-FINAL", config.getHttpName(DatabaseKind.FINAL));
+        assertEquals(8011, config.getPort(DatabaseKind.FINAL));
+        assertEquals("data-hub-FINAL", config.getDbName(DatabaseKind.FINAL));
+        assertEquals(3, config.getForestsPerHost(DatabaseKind.FINAL));
+        assertEquals("digest", config.getAuthMethod(DatabaseKind.FINAL));
+        assertFalse(config.getSimpleSsl(DatabaseKind.FINAL));
+
+        assertEquals("data-hub-JOBS", config.getHttpName(DatabaseKind.JOB));
+        assertEquals(8013, config.getPort(DatabaseKind.JOB));
+        assertEquals("data-hub-JOBS", config.getDbName(DatabaseKind.JOB));
+        assertEquals(4, config.getForestsPerHost(DatabaseKind.JOB));
+        assertEquals("digest", config.getAuthMethod(DatabaseKind.JOB));
+        assertFalse(config.getSimpleSsl(DatabaseKind.JOB));
+
+        assertEquals("data-hub-MODULES", config.getDbName(DatabaseKind.MODULES));
+        assertEquals(1, config.getForestsPerHost(DatabaseKind.MODULES));
+
+        assertEquals("data-hub-staging-TRIGGERS", config.getDbName(DatabaseKind.STAGING_TRIGGERS));
+        assertEquals(1, config.getForestsPerHost(DatabaseKind.STAGING_TRIGGERS));
+        assertEquals("data-hub-staging-SCHEMAS", config.getDbName(DatabaseKind.STAGING_SCHEMAS));
+        assertEquals(1, config.getForestsPerHost(DatabaseKind.STAGING_SCHEMAS));
+
+        assertEquals("data-hub-final-TRIGGERS", config.getDbName(DatabaseKind.FINAL_TRIGGERS));
+        assertEquals(1, config.getForestsPerHost(DatabaseKind.FINAL_TRIGGERS));
+        assertEquals("data-hub-final-SCHEMAS", config.getDbName(DatabaseKind.FINAL_SCHEMAS));
+        assertEquals(1, config.getForestsPerHost(DatabaseKind.FINAL_SCHEMAS));
+
+        assertEquals("forests", config.getCustomForestPath());
+
+        assertEquals("flow-operator-role", config.getFlowOperatorRoleName());
+        assertEquals("flow-operator", config.getFlowOperatorUserName());
+        assertEquals("flow-developer-role", config.getFlowDeveloperRoleName());
+        assertEquals("flow-developer", config.getFlowDeveloperUserName());
+
+        assertEquals("default", config.getHubLogLevel());
+
+        assertEquals("data-hub-module-reader,read,data-hub-module-reader,execute,data-hub-module-writer,update,rest-extension-user,execute", config.getModulePermissions());
+        assertEquals("data-hub-entity-model-reader,read,data-hub-entity-model-writer,update", config.getEntityModelPermissions());
+        assertEquals("data-hub-mapping-reader,read,data-hub-mapping-writer,update", config.getMappingPermissions());
+        assertEquals("data-hub-flow-reader,read,data-hub-flow-writer,update", config.getFlowPermissions());
+        assertEquals("data-hub-step-definition-reader,read,data-hub-step-definition-writer,update", config.getStepDefinitionPermissions());
+        assertEquals("data-hub-job-reader,read,data-hub-job-internal,update", config.getJobPermissions());
+
+        assertFalse(config.getIsProvisionedEnvironment());
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/mapping/RunMappingTestsWithoutProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/mapping/RunMappingTestsWithoutProjectTest.java
@@ -1,0 +1,23 @@
+package com.marklogic.hub.mapping;
+
+import com.marklogic.hub.flow.FlowInputs;
+import com.marklogic.hub.flow.FlowRunner;
+import com.marklogic.hub.flow.RunFlowResponse;
+import com.marklogic.hub.flow.impl.FlowRunnerImpl;
+
+/**
+ * Extends MappingTest so that each of its tests can be run via the runFlowWithoutProject method.
+ */
+public class RunMappingTestsWithoutProjectTest extends MappingTest {
+
+    @Override
+    protected RunFlowResponse runFlow(String flowName, String... stepIds) {
+        makeInputFilePathsAbsoluteInFlow(flowName);
+        FlowRunner flowRunner = new FlowRunnerImpl(host, flowRunnerUser, flowRunnerPassword);
+        FlowInputs inputs = new FlowInputs(flowName, stepIds);
+        RunFlowResponse response = flowRunner.runFlowWithoutProject(inputs);
+        flowRunner.awaitCompletion();
+        return response;
+    }
+
+}

--- a/marklogic-data-hub/src/test/resources/flow-runner-test/flows/testFlow.flow.json
+++ b/marklogic-data-hub/src/test/resources/flow-runner-test/flows/testFlow.flow.json
@@ -29,6 +29,10 @@
       "customHook": {},
       "options": {
         "permissions": "data-hub-operator,read,data-hub-operator,update"
+      },
+      "fileLocations": {
+        "inputFilePath": "input",
+        "outputURIReplacement": ".*/input,''"
       }
     },
     "3": {

--- a/web/src/test/java/com/marklogic/hub/web/web/HubConfigJsonTest.java
+++ b/web/src/test/java/com/marklogic/hub/web/web/HubConfigJsonTest.java
@@ -18,6 +18,8 @@
 package com.marklogic.hub.web.web;
 
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.hub.ApplicationConfig;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.impl.HubConfigImpl;
@@ -34,6 +36,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {WebApplication.class, ApplicationConfig.class, HubConfigJsonTest.class, JsonTest.class})
@@ -53,6 +56,10 @@ public class HubConfigJsonTest {
         hubConfig.createProject(PROJECT_PATH);
         hubConfig.initHubProject();
         hubConfig.refreshProject();
+
+        hubConfig.setMlUsername("mluser");
+        hubConfig.setMlPassword("mlpassword");
+        hubConfig.setLoadBalancerHost("somehost");
 
         String expected = "{\n" +
             "  \"stagingDbName\": \"data-hub-STAGING\",\n" +
@@ -85,6 +92,16 @@ public class HubConfigJsonTest {
             "  \"customForestPath\": \"forests\",\n" +
             "  \"jarVersion\": \"" + hubConfig.getJarVersion() + "\"\n" +
             "}";
+
         assertThat(json.write(hubConfig)).isEqualToJson(expected);
+
+        // Verify some fields were not serialized
+        JsonNode actualJson = new ObjectMapper().readTree(json.write(hubConfig).getJson());
+        assertFalse(actualJson.has("mlUsername"), "mlUsername and mlPassword were previously serialized because they " +
+            "had public getters in HubConfigImpl, but this seems like an unintended error, as we wouldn't want to " +
+            "serialize passwords out into a JSON string");
+        assertFalse(actualJson.has("mlPassword"));
+        assertFalse(actualJson.has("loadBalancerHost"), "It is not known why this is JsonIgnore'd, but that was the " +
+            "case with HubConfigImpl, so it's expected to be enforced by AbstractHubConfig as well");
     }
 }


### PR DESCRIPTION
Summary of changes:

- Extracted AbstractHubConfig from HubConfigImpl so that SimpleHubConfig can be used without depending on Spring
- Introduced StepDefinitionProvider so that StepRunnerFactory is no longer bound to retrieving step definitions from files. An ML-based implementation of this now retrieves step definitions via a new data service.
- Added FlowRunner.runFlowWithoutProject, along with new FlowInputs class to encapsulate all the possible inputs
- Subclassed FlowRunnerTest and MappingTest so that all of the tests in those two classes are now also run via runFlowWithoutProject