### PR TITLE
DHFPROD-3935: Can now constrain a source query to a job ID

### DIFF
--- a/marklogic-data-hub/gradle.properties
+++ b/marklogic-data-hub/gradle.properties
@@ -60,3 +60,5 @@ mlFlowDeveloperUserName=flow-developer
 mlFlowDeveloperPassword=password
 
 mlIsProvisionedEnvironment=false
+
+mlHubLogLevel=default

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
@@ -240,13 +240,19 @@ public class QueryStepRunner implements StepRunner {
                 isFullOutput = Boolean.parseBoolean(options.get("fullOutput").toString());
             }
         }
+
         if(options.get("sourceDatabase") != null) {
             this.stagingClient = hubConfig.newStagingClient(StepRunnerUtil.objectToString(options.get("sourceDatabase")));
         }
         if(options.get("targetDatabase") != null) {
             this.destinationDatabase = StepRunnerUtil.objectToString(options.get("targetDatabase"));
         }
+
         options.put("flow", this.flow.getName());
+
+        // Needed to support constrainSourceQueryToJob
+        options.put("jobId", jobId);
+
         Collection<String> uris = null;
         //If current step is the first run step job output isn't disabled, a job doc is created
         if (!disableJobOutput) {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/endpoints/collectorLib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/endpoints/collectorLib.sjs
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016-2019 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const DataHub = require("/data-hub/5/datahub.sjs");
+
+class CollectorLib {
+
+  prepareSourceQuery(combinedOptions, stepDefinition) {
+    let sourceQuery = combinedOptions.sourceQuery;
+
+    let isMergingStep = stepDefinition.name === 'default-merging' && stepDefinition.type === 'merging';
+
+    if (isMergingStep) {
+      sourceQuery = fn.normalizeSpace(`cts.values(cts.pathReference('/matchSummary/URIsToProcess', ['type=string','collation=http://marklogic.com/collation/']), null, null, ${sourceQuery})`);
+    } else if (true == combinedOptions.constrainSourceQueryToJob) {
+      if (combinedOptions.jobId) {
+        sourceQuery = fn.normalizeSpace(`cts.andQuery([cts.fieldWordQuery('datahubCreatedByJob', '${combinedOptions.jobId}'), ${sourceQuery}])`);
+      } else {
+        new DataHub().debug.log({
+          message: "Ignoring constrainSourceQueryToJob=true because no jobId was provided in the options",
+          type: "warning"
+        });
+      }
+    }
+
+    return sourceQuery;
+  }
+}
+
+module.exports = CollectorLib;

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/ConstrainSourceQueryToJobTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/ConstrainSourceQueryToJobTest.java
@@ -1,0 +1,73 @@
+package com.marklogic.hub.flow;
+
+import com.marklogic.bootstrap.Installer;
+import com.marklogic.hub.ApplicationConfig;
+import com.marklogic.hub.HubTestBase;
+import com.marklogic.hub.flow.impl.FlowRunnerImpl;
+import com.marklogic.hub.step.RunStepResponse;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ApplicationConfig.class)
+public class ConstrainSourceQueryToJobTest extends HubTestBase {
+
+    @Autowired
+    FlowRunnerImpl flowRunner;
+
+    @BeforeAll
+    public static void setup() {
+        XMLUnit.setIgnoreWhitespace(true);
+        new Installer().deleteProjectDir();
+    }
+
+    @AfterAll
+    public static void cleanUp() {
+        new Installer().deleteProjectDir();
+    }
+
+    @BeforeEach
+    public void setupEach() {
+        setupProjectForRunningTestFlow(getDataHubAdminConfig());
+        getHubFlowRunnerConfig();
+    }
+
+    @Test
+    public void test() {
+        RunFlowResponse flowResponse = flowRunner.runFlow("testFlow", Arrays.asList("1"), "job1", null, null);
+        flowRunner.awaitCompletion();
+        RunStepResponse stepResponse = flowResponse.getStepResponses().get("1");
+        assertEquals("job1", stepResponse.getJobId());
+        assertEquals(1, stepResponse.getSuccessfulBatches(), "The XML document should have been ingested successfully");
+
+        final String mapXmlStep = "6";
+
+        final Map<String, Object> options = new HashMap<>();
+        options.put("constrainSourceQueryToJob", true);
+
+        flowResponse = flowRunner.runFlow("testFlow", Arrays.asList(mapXmlStep), "job2", options, null);
+        flowRunner.awaitCompletion();
+        stepResponse = flowResponse.getStepResponses().get(mapXmlStep);
+        assertEquals(0, stepResponse.getSuccessfulBatches(), "Since the sourceQuery was constrained to job2, and " +
+            "no documents have that value for their datahubCreatedByJob metadata key, then nothing should have been processed");
+
+        flowResponse = flowRunner.runFlow("testFlow", Arrays.asList(mapXmlStep), "job1", options, null);
+        flowRunner.awaitCompletion();
+        stepResponse = flowResponse.getStepResponses().get(mapXmlStep);
+        assertEquals(1, stepResponse.getSuccessfulBatches(), "Since the sourceQuery was constrained to job1, and the " +
+            "ingestion step was executed before with that jobId, then the ingested XML document should have been processed");
+    }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/endpoints/processSourceQuery.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/endpoints/processSourceQuery.sjs
@@ -1,0 +1,74 @@
+const test = require("/test/test-helper.xqy");
+const CollectorLib = require("/data-hub/5/endpoints/collectorLib.sjs");
+
+const lib = new CollectorLib();
+let assertions = [];
+
+// Query is for a default-merging step
+let sourceQuery = lib.prepareSourceQuery(
+  {
+    sourceQuery: "cts.collectionQuery('test')"
+  },
+  {
+    name: "default-merging",
+    type: "merging"
+  }
+);
+assertions.push(
+  test.assertEqual(
+    "cts.values(cts.pathReference('/matchSummary/URIsToProcess', ['type=string','collation=http://marklogic.com/collation/']), null, null, cts.collectionQuery('test'))",
+    sourceQuery,
+    "Because the step definition is default-merging, the query is expected to be wrapped into a cts.values so that the " +
+    "default-merging step can process the values of URIsToProcess"
+  )
+);
+
+// Query constrained to job
+sourceQuery = lib.prepareSourceQuery(
+  {
+    sourceQuery: "cts.collectionQuery('test')",
+    constrainSourceQueryToJob: true,
+    jobId: "job123"
+  }, {}
+);
+assertions.push(
+  test.assertEqual(
+    "cts.andQuery([cts.fieldWordQuery('datahubCreatedByJob', 'job123'), cts.collectionQuery('test')])",
+    sourceQuery,
+    "When constrainSourceQueryToJob is set to true, and a jobId is set, then the sourceQuery is and'ed with a " +
+    "query on datahubCreatedByJob (the contents of the step definition don't matter)"
+  )
+);
+
+// Query constrained to job, user source query with double quotes in it
+let options = {
+  constrainSourceQueryToJob: true,
+  jobId: "job123"
+};
+options.sourceQuery = 'cts.collectionQuery("test")';
+sourceQuery = lib.prepareSourceQuery(options, {});
+assertions.push(
+  test.assertEqual(
+    "cts.andQuery([cts.fieldWordQuery('datahubCreatedByJob', 'job123'), cts.collectionQuery(\"test\")])",
+    sourceQuery,
+    "Just verifying that if the user's query has double quotes on it, things still work"
+  )
+);
+
+// Query constrained to job, but no job ID
+sourceQuery = lib.prepareSourceQuery(
+  {
+    sourceQuery: "cts.collectionQuery('test')",
+    constrainSourceQueryToJob: true
+  }, {}
+);
+assertions.push(
+  test.assertEqual(
+    "cts.collectionQuery('test')",
+    sourceQuery,
+    "If no jobId is provided in the options, then the query won't be constrained by a job"
+  )
+);
+
+
+assertions;


### PR DESCRIPTION
Also defined mlHubLogLevel in gradle.properties for the test application so that debug.log messages will show up, so those can be verified.