### PR TITLE
DHFPROD-3755: Can now run a flow via an executable jar

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot', version: '2.1.3.RELEASE'
     compile group: 'org.springframework.integration', name: 'spring-integration-http', version: '5.1.3.RELEASE'
     compile group: 'org.springframework.boot', name: 'spring-boot-autoconfigure', version: '2.1.3.RELEASE'
-    testCompile group: 'org.springframework', name: 'spring-test', version: '5.1.5.RELEASE'
 
     compile 'com.marklogic:mlcp-util:0.9.0'
     compile 'com.marklogic:marklogic-data-movement-components:1.0'
@@ -48,7 +47,8 @@ dependencies {
     compile 'org.apache.commons:commons-text:1.1'
 
     // For installer program
-    implementation "com.beust:jcommander:1.72"
+    compile "com.beust:jcommander:1.72"
+
     //https://github.com/jaegertracing/jaeger-client-java/tree/master/jaeger-core
     compile("io.jaegertracing:jaeger-core:0.35.4")
     compile("io.jaegertracing:jaeger-thrift:0.35.4")
@@ -63,6 +63,8 @@ dependencies {
 
     // Only needed to run tests in an (IntelliJ) IDE(A) that bundles an older version
     testRuntime "org.junit.platform:junit-platform-launcher:${junitPlatformVersion}"
+
+    testCompile group: 'org.springframework', name: 'spring-test', version: '5.1.5.RELEASE'
 
     testCompile 'xmlunit:xmlunit:1.3'
     testCompile 'org.skyscreamer:jsonassert:1.5.0'
@@ -92,8 +94,23 @@ configurations.all {
 
 // The Spring Boot bootJar task produces an executable jar with all dependencies that runs the DHF installer
 bootJar {
-    classifier = "installer"
+    archiveClassifier = "installer"
     mainClassName = "com.marklogic.hub.cli.Installer"
+}
+
+task clientJar(type: Jar) {
+    manifest {
+        attributes "Main-Class": "com.marklogic.hub.cli.client.Main"
+    }
+    archiveBaseName = "marklogic-data-hub-client"
+    from(configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }) {
+        exclude "META-INF/*.SF"
+        exclude "META-INF/*.DSA"
+        exclude "META-INF/*.RSA"
+    }
+    exclude "spring-boot*.jar"
+    exclude "*jaeger*.jar"
+    with jar
 }
 
 node {
@@ -183,6 +200,8 @@ if (!(
         gradle.startParameter.taskNames*.toLowerCase().contains("javadoc") ||
         gradle.startParameter.taskNames*.toLowerCase().contains("bootjar") ||
         gradle.startParameter.taskNames*.toLowerCase().contains("marklogic-data-hub:bootjar") ||
+        gradle.startParameter.taskNames*.toLowerCase().contains("clientjar") ||
+        gradle.startParameter.taskNames*.toLowerCase().contains("marklogic-data-hub:clientjar") ||
         project.hasProperty('skipui')
 )
 ) {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/client/CommandLineFlowInputs.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/client/CommandLineFlowInputs.java
@@ -1,0 +1,258 @@
+package com.marklogic.hub.cli.client;
+
+import com.beust.jcommander.Parameter;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marklogic.hub.flow.FlowInputs;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.util.FileCopyUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Defines command-line-specific inputs for running a flow. JCommander Parameter annotations are used so that a
+ * JCommander Command class can extend this to inherit all of the parameters. Usable in a Gradle context as well for
+ * collecting Gradle properties and then constructing flow inputs.
+ */
+public class CommandLineFlowInputs {
+
+    @Parameter(names = "-flow_name", required = true, description = "The name of the flow to run")
+    private String flowName;
+
+    @Parameter(names = "-batch_size", description = "The number of items to process in each batch")
+    private Integer batchSize;
+
+    @Parameter(names = "-thread_count", description = "The number of threads to process batches with")
+    private Integer threadCount;
+
+    @Parameter(names = "-input_file_path", description = "The directory path for an ingestion step to read from")
+    private String inputFilePath;
+
+    @Parameter(names = "-input_file_type", description = "The type of files for an ingestion step to process")
+    private String inputFileType;
+
+    @Parameter(names = "-output_uri_replacement", description = "The pattern for replacing a portion of a file-based URI during an ingestion step")
+    private String outputURIReplacement;
+
+    @Parameter(names = "-separator", description = "The separator value to use when processing a file during an ingestion step")
+    private String separator;
+
+    @Parameter(names = "-fail_hard", description = "If true, forces a job to stop once a batch fails")
+    private Boolean failHard = false;
+
+    @Parameter(names = "-steps", description = "Comma-delimited string of step numbers to run")
+    private List<String> steps;
+
+    @Parameter(names = "-job_id", description = "A user-specified job ID")
+    private String jobId;
+
+    @Parameter(names = "-options_json", description = "JSON object for overriding step options")
+    private String optionsJSON;
+
+    @Parameter(names = "-options_file", description = "Path to a file containing a JSON object for overriding step options")
+    private String optionsFile;
+
+    @Parameter(names = "-show_options", description = "If true, prints the options JSON object set via '-options_json' or '-options_file'")
+    private Boolean showOptions = false;
+
+    public Pair<FlowInputs, String> buildFlowInputs() {
+        StringBuilder runFlowString = new StringBuilder("Running flow: [" + flowName + "]");
+
+        if (steps != null) {
+            runFlowString.append(", steps: " + steps);
+        }
+
+        FlowInputs flowInputs = new FlowInputs(flowName);
+        flowInputs.setSteps(steps);
+        flowInputs.setJobId(jobId);
+        flowInputs.setStepConfig(buildStepConfig(runFlowString));
+
+        Map<String, Object> flowOptions = buildFlowOptions();
+        flowInputs.setOptions(flowOptions);
+        if (showOptions && flowOptions != null) {
+            runFlowString.append("\n\tand options:");
+            for (String key : flowOptions.keySet()) {
+                runFlowString.append("\n\t\t" + key + " = " + flowOptions.get(key));
+            }
+        }
+
+        return Pair.of(flowInputs, runFlowString.toString());
+    }
+
+    protected Map<String, Object> buildStepConfig(StringBuilder runFlowString) {
+        Map<String, Object> stepConfig = new HashMap<>();
+
+        if (batchSize != null) {
+            runFlowString.append("\n\twith batch size: " + batchSize);
+            stepConfig.put("batchSize", batchSize);
+        }
+        if (threadCount != null) {
+            runFlowString.append("\n\twith thread count: " + threadCount);
+            stepConfig.put("threadCount", threadCount);
+        }
+        if (failHard) {
+            runFlowString.append("\n\t\twith fail hard: " + failHard);
+            stepConfig.put("stopOnFailure", failHard);
+        }
+
+        if (inputFileType != null || inputFilePath != null || outputURIReplacement != null || separator != null) {
+            runFlowString.append("\n\tWith File Locations Settings:");
+            Map<String, String> fileLocations = new HashMap<>();
+            if (inputFileType != null) {
+                runFlowString.append("\n\t\tInput File Type: " + inputFileType);
+                fileLocations.put("inputFileType", inputFileType);
+            }
+            if (inputFilePath != null) {
+                runFlowString.append("\n\t\tInput File Path: " + inputFilePath);
+                fileLocations.put("inputFilePath", inputFilePath);
+            }
+            if (outputURIReplacement != null) {
+                runFlowString.append("\n\t\tOutput URI Replacement: " + outputURIReplacement);
+                fileLocations.put("outputURIReplacement", outputURIReplacement);
+            }
+            if (separator != null) {
+                if (inputFileType != null && !inputFileType.equalsIgnoreCase("csv")) {
+                    throw new IllegalArgumentException("Invalid argument for file type " + inputFileType + ". When specifying a separator, the file type must be 'csv'");
+                }
+                runFlowString.append("\n\t\tSeparator: " + separator);
+                fileLocations.put("separator", separator);
+            }
+
+            stepConfig.put("fileLocations", fileLocations);
+        }
+
+        return stepConfig;
+    }
+
+    protected Map<String, Object> buildFlowOptions() {
+        String optionsString = null;
+        if (StringUtils.isNotEmpty(optionsFile)) {
+            try {
+                optionsString = new String(FileCopyUtils.copyToByteArray(new File(optionsFile)));
+            } catch (IOException ex) {
+                throw new RuntimeException("Unable to read options file at: " + optionsFile, ex);
+            }
+        } else {
+            optionsString = optionsJSON;
+        }
+
+        if (StringUtils.isNotEmpty(optionsString)) {
+            try {
+                return new ObjectMapper().readValue(optionsString, new TypeReference<Map<String, Object>>() {
+                });
+            } catch (IOException ex) {
+                throw new RuntimeException("Unable to parse JSON options string: " + optionsString, ex);
+            }
+        }
+        return null;
+    }
+
+    public String getFlowName() {
+        return flowName;
+    }
+
+    public void setFlowName(String flowName) {
+        this.flowName = flowName;
+    }
+
+    public Integer getBatchSize() {
+        return batchSize;
+    }
+
+    public void setBatchSize(Integer batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    public Integer getThreadCount() {
+        return threadCount;
+    }
+
+    public void setThreadCount(Integer threadCount) {
+        this.threadCount = threadCount;
+    }
+
+    public String getInputFilePath() {
+        return inputFilePath;
+    }
+
+    public void setInputFilePath(String inputFilePath) {
+        this.inputFilePath = inputFilePath;
+    }
+
+    public String getInputFileType() {
+        return inputFileType;
+    }
+
+    public void setInputFileType(String inputFileType) {
+        this.inputFileType = inputFileType;
+    }
+
+    public String getOutputURIReplacement() {
+        return outputURIReplacement;
+    }
+
+    public void setOutputURIReplacement(String outputURIReplacement) {
+        this.outputURIReplacement = outputURIReplacement;
+    }
+
+    public String getSeparator() {
+        return separator;
+    }
+
+    public void setSeparator(String separator) {
+        this.separator = separator;
+    }
+
+    public Boolean getShowOptions() {
+        return showOptions;
+    }
+
+    public void setShowOptions(Boolean showOptions) {
+        this.showOptions = showOptions;
+    }
+
+    public Boolean getFailHard() {
+        return failHard;
+    }
+
+    public void setFailHard(Boolean failHard) {
+        this.failHard = failHard;
+    }
+
+    public List<String> getSteps() {
+        return steps;
+    }
+
+    public void setSteps(List<String> steps) {
+        this.steps = steps;
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public void setJobId(String jobId) {
+        this.jobId = jobId;
+    }
+
+    public String getOptionsFile() {
+        return optionsFile;
+    }
+
+    public void setOptionsFile(String optionsFile) {
+        this.optionsFile = optionsFile;
+    }
+
+    public String getOptionsJSON() {
+        return optionsJSON;
+    }
+
+    public void setOptionsJSON(String optionsJSON) {
+        this.optionsJSON = optionsJSON;
+    }
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/client/Main.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/client/Main.java
@@ -1,0 +1,32 @@
+package com.marklogic.hub.cli.client;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterException;
+
+/**
+ * Main program for the executable DHF client jar.
+ */
+public class Main {
+
+    public static void main(String[] args) {
+        JCommander commander = JCommander
+            .newBuilder()
+            .addCommand("runFlow", new RunFlowCommand())
+            .build();
+        commander.setProgramName("java -jar <name of jar>");
+
+        try {
+            commander.parse(args);
+        } catch (ParameterException ex) {
+            System.err.println(ex.getMessage());
+            System.exit(0);
+        }
+
+        String parsedCommand = commander.getParsedCommand();
+        if (parsedCommand == null) {
+            commander.usage();
+        } else {
+            ((Runnable) commander.getCommands().get(parsedCommand).getObjects().get(0)).run();
+        }
+    }
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/client/RunFlowCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/client/RunFlowCommand.java
@@ -1,0 +1,83 @@
+package com.marklogic.hub.cli.client;
+
+import com.beust.jcommander.DynamicParameter;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.marklogic.hub.flow.FlowInputs;
+import com.marklogic.hub.flow.RunFlowResponse;
+import com.marklogic.hub.flow.impl.FlowRunnerImpl;
+import com.marklogic.hub.impl.HubConfigImpl;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Parameters(commandDescription = "Run a flow defined by a flow artifact in a MarkLogic server. Parameters may also be provided " +
+    "via a file - see https://jcommander.org/#_syntax for an example. ")
+public class RunFlowCommand extends CommandLineFlowInputs implements Runnable {
+
+    @Parameter(names = "-host", required = true, description = "The MarkLogic host to connect to")
+    private String host;
+
+    @Parameter(names = "-username", description = "The username of the MarkLogic user to connect as")
+    private String username;
+
+    @Parameter(names = "-password", password = true, description = "The password for the MarkLogic user specified by '-username'")
+    private String password;
+
+    @DynamicParameter(
+        names = "-P",
+        description = "Override any default Data Hub property; e.g. -PmlStagingPort=8410 -PmlFinalPort=8411"
+    )
+    private Map<String, String> params = new HashMap<>();
+
+    @Override
+    public void run() {
+        FlowRunnerImpl flowRunner = new FlowRunnerImpl(buildHubConfig());
+        Pair<FlowInputs, String> pair = super.buildFlowInputs();
+        System.out.println(pair.getRight());
+
+        RunFlowResponse response = flowRunner.runFlowWithoutProject(pair.getLeft());
+        flowRunner.awaitCompletion();
+        System.out.println("\nOutput:");
+        System.out.println(response.toJson());
+    }
+
+    protected HubConfigImpl buildHubConfig() {
+        HubConfigImpl hubConfig = new HubConfigImpl(host, username, password);
+        hubConfig.applyProperties(params::get);
+        return hubConfig;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public Map<String, String> getParams() {
+        return params;
+    }
+
+    public void setParams(Map<String, String> params) {
+        this.params = params;
+    }
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/RunFlowResponse.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/RunFlowResponse.java
@@ -1,6 +1,8 @@
 package com.marklogic.hub.flow;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.marklogic.hub.step.RunStepResponse;
 
 import java.util.HashMap;
@@ -25,6 +27,16 @@ public class RunFlowResponse {
     }
 
     public RunFlowResponse() {}
+
+    public String toJson() {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+            return objectMapper.writeValueAsString(this);
+        } catch (Exception ex) {
+            throw new RuntimeException("Unable to serialize to JSON, cause: " + ex.getMessage(), ex);
+        }
+    }
 
     @JsonProperty("flow")
     public String getFlowName() {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/impl/FlowRunnerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/impl/FlowRunnerImpl.java
@@ -14,6 +14,7 @@ import com.marklogic.hub.step.RunStepResponse;
 import com.marklogic.hub.step.StepRunner;
 import com.marklogic.hub.step.StepRunnerFactory;
 import com.marklogic.hub.step.impl.Step;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -141,9 +142,13 @@ public class FlowRunnerImpl implements FlowRunner{
      */
     @Override
     public RunFlowResponse runFlowWithoutProject(FlowInputs flowInputs) {
+        final String flowName = flowInputs.getFlowName();
+        if (StringUtils.isEmpty(flowName)) {
+            throw new IllegalArgumentException("Cannot run flow; no flow name provided");
+        }
         Flow flow;
         try {
-            JsonNode jsonFlow = hubConfig.newStagingClient().newJSONDocumentManager().read("/flows/" + flowInputs.getFlowName() + ".flow.json", new JacksonHandle()).get();
+            JsonNode jsonFlow = hubConfig.newStagingClient().newJSONDocumentManager().read("/flows/" + flowName + ".flow.json", new JacksonHandle()).get();
             flow = new FlowImpl().deserialize(jsonFlow);
         } catch (Exception ex) {
             throw new RuntimeException("Unable to retrieve flow with name: " + flowInputs.getFlowName(), ex);

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -100,6 +100,7 @@ import java.util.stream.Stream;
 import static com.marklogic.client.io.DocumentMetadataHandle.Capability.READ;
 import static com.marklogic.client.io.DocumentMetadataHandle.Capability.UPDATE;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 @SuppressWarnings("deprecation")
@@ -1283,5 +1284,17 @@ public class HubTestBase {
                 }
             }
         });
+    }
+
+    /**
+     * These assertions are made in several tests, so this method is in this class to avoid duplicating them.
+     */
+    protected void verifyCollectionCountsFromRunningTestFlow() {
+        assertEquals(1, getDocCount(HubConfig.DEFAULT_STAGING_NAME, "xml-coll"));
+        assertEquals(25, getDocCount(HubConfig.DEFAULT_STAGING_NAME, "csv-coll"));
+        assertEquals(25, getDocCount(HubConfig.DEFAULT_STAGING_NAME, "csv-tab-coll"));
+        assertEquals(1, getDocCount(HubConfig.DEFAULT_STAGING_NAME, "json-coll"));
+        assertEquals(1, getDocCount(HubConfig.DEFAULT_FINAL_NAME, "json-map"));
+        assertEquals(1, getDocCount(HubConfig.DEFAULT_FINAL_NAME, "xml-map"));
     }
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/client/CommandLineFlowInputsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/client/CommandLineFlowInputsTest.java
@@ -1,0 +1,82 @@
+package com.marklogic.hub.cli.client;
+
+import com.marklogic.hub.flow.FlowInputs;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class CommandLineFlowInputsTest {
+
+    @Test
+    public void test() {
+        CommandLineFlowInputs inputs = new CommandLineFlowInputs();
+        inputs.setBatchSize(50);
+        inputs.setFailHard(true);
+        inputs.setFlowName("myFlow");
+        inputs.setInputFilePath("/some/path");
+        inputs.setInputFileType("CSV");
+        inputs.setJobId("myJob");
+        inputs.setOptionsJSON("{\"hello\":\"world\"}");
+        inputs.setOutputURIReplacement(".*data,'/something'");
+        inputs.setSeparator(";");
+        inputs.setShowOptions(true);
+        inputs.setSteps(Arrays.asList("2", "3"));
+        inputs.setThreadCount(3);
+
+        Pair<FlowInputs, String> pair = inputs.buildFlowInputs();
+        assertNotNull(pair.getRight());
+        // Printing the message for manual verification
+        System.out.println(pair.getRight());
+
+        FlowInputs flowInputs = pair.getLeft();
+        assertEquals("myFlow", flowInputs.getFlowName());
+        assertEquals("myJob", flowInputs.getJobId());
+        assertEquals(2, flowInputs.getSteps().size());
+        assertEquals("2", flowInputs.getSteps().get(0));
+        assertEquals("3", flowInputs.getSteps().get(1));
+
+        Map<String, Object> options = flowInputs.getOptions();
+        assertEquals("world", options.get("hello"));
+
+        Map<String, Object> stepConfig = flowInputs.getStepConfig();
+        assertEquals(Boolean.TRUE, stepConfig.get("stopOnFailure"));
+        assertEquals(3, stepConfig.get("threadCount"));
+        assertEquals(50, stepConfig.get("batchSize"));
+
+        Map<String, Object> fileLocations = (Map<String, Object>) stepConfig.get("fileLocations");
+        assertEquals("CSV", fileLocations.get("inputFileType"));
+        assertEquals(";", fileLocations.get("separator"));
+        assertEquals("/some/path", fileLocations.get("inputFilePath"));
+        assertEquals(".*data,'/something'", fileLocations.get("outputURIReplacement"));
+    }
+
+    @Test
+    void readOptionsFromFile() throws IOException {
+        CommandLineFlowInputs inputs = new CommandLineFlowInputs();
+        inputs.setFlowName("someFlow");
+        inputs.setShowOptions(true);
+
+        String filePath = new ClassPathResource("cli-client/test-options.json").getFile().getAbsolutePath();
+        inputs.setOptionsFile(filePath);
+
+        Pair<FlowInputs, String> pair = inputs.buildFlowInputs();
+        // Printing for manual verification
+        System.out.println(pair.getRight());
+
+        Map<String, Object> options = pair.getLeft().getOptions();
+        assertEquals("world", options.get("hello"));
+
+        List<String> values = (List<String>) options.get("values");
+        assertEquals("red", values.get(0));
+        assertEquals("green", values.get(1));
+        assertEquals("blue", values.get(2));
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/client/RunFlowCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/client/RunFlowCommandTest.java
@@ -1,0 +1,29 @@
+package com.marklogic.hub.cli.client;
+
+import com.marklogic.hub.DatabaseKind;
+import com.marklogic.hub.impl.HubConfigImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RunFlowCommandTest {
+
+    @Test
+    public void buildHubConfig() {
+        RunFlowCommand command = new RunFlowCommand();
+        command.setHost("somewhere");
+        command.setUsername("someone");
+        command.setPassword("something");
+        command.getParams().put("mlStagingPort", "8410");
+        command.getParams().put("mlStagingDbName", "my-STAGING");
+
+        HubConfigImpl config = command.buildHubConfig();
+        assertEquals("somewhere", config.getHost());
+        assertEquals("someone", config.getMlUsername());
+        assertEquals("something", config.getMlPassword());
+        assertEquals(8410, config.getPort(DatabaseKind.STAGING));
+        assertEquals("my-STAGING", config.getDbName(DatabaseKind.STAGING));
+        assertEquals("data-hub-FINAL", config.getDbName(DatabaseKind.FINAL), "Smoke-checking that the default properties " +
+            "were set as well");
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/client/RunFlowViaMainTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/client/RunFlowViaMainTest.java
@@ -1,0 +1,47 @@
+package com.marklogic.hub.cli.client;
+
+import com.marklogic.bootstrap.Installer;
+import com.marklogic.hub.ApplicationConfig;
+import com.marklogic.hub.HubTestBase;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ApplicationConfig.class)
+public class RunFlowViaMainTest extends HubTestBase {
+
+    @BeforeAll
+    public static void setup() {
+        XMLUnit.setIgnoreWhitespace(true);
+        new Installer().deleteProjectDir();
+    }
+
+    @AfterAll
+    public static void cleanUp() {
+        new Installer().deleteProjectDir();
+    }
+
+    @Test
+    public void testRunFlow() {
+        setupProjectForRunningTestFlow(adminHubConfig);
+        getHubFlowRunnerConfig();
+
+        final String flowName = "testFlow";
+        makeInputFilePathsAbsoluteInFlow(flowName);
+
+        Main.main(new String[]{
+            "runFlow",
+            "-host", host,
+            "-username", flowRunnerUser,
+            "-password", flowRunnerPassword,
+            "-flow_name", flowName
+        });
+
+        verifyCollectionCountsFromRunningTestFlow();
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunWithDataHubOperatorTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunWithDataHubOperatorTest.java
@@ -169,12 +169,7 @@ public class FlowRunWithDataHubOperatorTest extends HubTestBase {
 
         client.newServerEval().xquery("cts:uris() ! xdmp:document-delete(.)").eval();
 
-        Assertions.assertTrue(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "xml-coll") == 1);
-        Assertions.assertTrue(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "csv-coll") == 25);
-        Assertions.assertTrue(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "csv-tab-coll") == 25);
-        Assertions.assertTrue(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "json-coll") == 1);
-        Assertions.assertTrue(getDocCount(HubConfig.DEFAULT_FINAL_NAME, "json-map") == 1);
-        Assertions.assertTrue(getDocCount(HubConfig.DEFAULT_FINAL_NAME, "xml-map") == 1);
+        verifyCollectionCountsFromRunningTestFlow();
         Assertions.assertTrue(JobStatus.FINISHED.toString().equalsIgnoreCase(resp.getJobStatus()));
         XMLDocumentManager xmlDocMgr = stagingClient.newXMLDocumentManager();
         DocumentMetadataHandle xmlMetadataHandle = new DocumentMetadataHandle();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunnerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunnerTest.java
@@ -70,12 +70,7 @@ public class FlowRunnerTest extends HubTestBase {
         RunFlowResponse resp = runFlow("testFlow", null, null, null, null);
         flowRunner.awaitCompletion();
         System.out.println("Logging response to help with debugging this failure on Jenkins: " + resp);
-        Assertions.assertTrue(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "xml-coll") == 1);
-        Assertions.assertTrue(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "csv-coll") == 25);
-        Assertions.assertTrue(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "csv-tab-coll") == 25);
-        Assertions.assertTrue(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "json-coll") == 1);
-        Assertions.assertTrue(getDocCount(HubConfig.DEFAULT_FINAL_NAME, "json-map") == 1);
-        Assertions.assertTrue(getDocCount(HubConfig.DEFAULT_FINAL_NAME, "xml-map") == 1);
+        verifyCollectionCountsFromRunningTestFlow();
         Assertions.assertTrue(JobStatus.FINISHED.toString().equalsIgnoreCase(resp.getJobStatus()));
         XMLDocumentManager docMgr = stagingClient.newXMLDocumentManager();
         DocumentMetadataHandle metadataHandle = new DocumentMetadataHandle();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubOperatorTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubOperatorTest.java
@@ -50,12 +50,7 @@ public class DataHubOperatorTest extends AbstractSecurityTest {
 
             flowRunner.runFlow("testFlow");
             flowRunner.awaitCompletion();
-            assertEquals(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "xml-coll"), 1);
-            assertEquals(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "csv-coll"), 25);
-            assertEquals(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "csv-tab-coll"), 25);
-            assertEquals(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "json-coll"), 1);
-            assertEquals(getDocCount(HubConfig.DEFAULT_FINAL_NAME, "json-map"), 1);
-            assertEquals(getDocCount(HubConfig.DEFAULT_FINAL_NAME, "xml-map"), 1);
+            verifyCollectionCountsFromRunningTestFlow();
             assertEquals(getDocCount(HubConfig.DEFAULT_JOB_NAME, "Jobs"), 3,
                 "For task 32, data-hub-operator should be able to see documents in the Jobs collection via the " +
                     "data-hub-job-reader role, and there should be 3 documents - 2 in Batch, and 1 in Job");

--- a/marklogic-data-hub/src/test/resources/cli-client/test-options.json
+++ b/marklogic-data-hub/src/test/resources/cli-client/test-options.json
@@ -1,0 +1,8 @@
+{
+  "hello": "world",
+  "values": [
+    "red",
+    "green",
+    "blue"
+  ]
+}


### PR DESCRIPTION
Part of this involves taking the logic in RunFlowTask for processing user inputs and tossing that into the new CommandLineFlowInputs class, where it can be easily reused by the client Main program (and can also be tested easily too). 

Otherwise, this is mostly just some new code - the com.marklogic.hub.cli.client package, and then tests for the new code.