### PR TITLE
DHFPROD-3779: Trying to debug while test failed on Jenkins

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
@@ -614,7 +614,7 @@ public class WriteStepRunner implements StepRunner {
                 jobDoc = jobDocManager.postJobs(jobId, stepStatus, step, stepStatus.equalsIgnoreCase(JobStatus.COMPLETED_PREFIX + step) ? step : null, runStepResponse);
             }
             catch (Exception e) {
-                logger.error(e.getMessage());
+                logger.error("Unable to update job document, cause: " + e.getMessage());
             }
             if(jobDoc != null) {
                 try {
@@ -622,9 +622,8 @@ public class WriteStepRunner implements StepRunner {
                     runStepResponse.setStepStartTime(tempResp.getStepStartTime());
                     runStepResponse.setStepEndTime(tempResp.getStepEndTime());
                 }
-                catch (Exception ex)
-                {
-                    logger.error(ex.getMessage());
+                catch (Exception ex) {
+                    logger.error("Unable to update step response, cause: " + ex.getMessage());
                 }
             }
         });

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunnerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunnerTest.java
@@ -40,6 +40,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.*;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = ApplicationConfig.class)
@@ -388,11 +390,11 @@ public class FlowRunnerTest extends HubTestBase {
         RunFlowResponse resp = runFlow("testFlow", "2", UUID.randomUUID().toString(), opts, stepConfig);
         RunFlowResponse resp1 = runFlow("testFlow", "2", UUID.randomUUID().toString(), opts1, stepConfig1);
         flowRunner.awaitCompletion();
-        Assertions.assertTrue(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "test-collection") == 1);
-        Assertions.assertTrue(getDocCount(HubConfig.DEFAULT_STAGING_NAME, "test-collection1") == 1);
-        System.out.println(resp.getJobStatus());
-        System.out.println(resp1.getJobStatus());
-        Assertions.assertTrue(JobStatus.FINISHED.toString().equalsIgnoreCase(resp.getJobStatus()));
-        Assertions.assertTrue(JobStatus.FINISHED.toString().equalsIgnoreCase(resp1.getJobStatus()));
+        assertEquals(1, getDocCount(HubConfig.DEFAULT_STAGING_NAME, "test-collection"));
+        assertEquals(1, getDocCount(HubConfig.DEFAULT_STAGING_NAME, "test-collection1"));
+        Assertions.assertTrue(JobStatus.FINISHED.toString().equalsIgnoreCase(resp.getJobStatus()),
+            "Expected job status of first response to be 'finished', but was: " + resp.getJobStatus());
+        Assertions.assertTrue(JobStatus.FINISHED.toString().equalsIgnoreCase(resp1.getJobStatus()),
+            "Expected job status of second response to be 'finished', but was: " + resp1.getJobStatus());
     }
 }


### PR DESCRIPTION
I noticed in the logging for FlowRunnerTest that there were some "ERROR" messages from WriteStepRunner with "null" as the message. I added a little context to both log messages, as "null" by itself of course doesn't say much.