### PR TITLE
DHFPROD-4073: dhsVerify now correctly verifies roles

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/AbstractVerifyCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/AbstractVerifyCommand.java
@@ -17,10 +17,6 @@ import org.springframework.util.Assert;
  */
 public abstract class AbstractVerifyCommand extends AbstractInstallerCommand {
 
-    protected String[] getDhfRoleNames() {
-        return new String[]{"flow-developer-role", "flow-operator-role", "data-hub-admin-role"};
-    }
-
     protected String[] getDhfUserNames() {
         return new String[]{"flow-developer", "flow-operator"};
     }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/InstallIntoDhsCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/command/InstallIntoDhsCommand.java
@@ -52,7 +52,13 @@ public class InstallIntoDhsCommand extends AbstractInstallerCommand {
 
         List<Command> commands = new ArrayList<>();
         commands.add(new DeployPrivilegesCommand());
-        commands.add(new DeployRolesCommand());
+
+        DeployRolesCommand deployRolesCommand = new DeployRolesCommand();
+        deployRolesCommand.setResourceFilenamesExcludePattern(
+            Pattern.compile("(flow-developer-role|flow-operator-role|data-hub-admin-role).*")
+        );
+        commands.add(deployRolesCommand);
+
         commands.add(new DeployAmpsCommand());
         commands.add(dbCommand);
         commands.add(new DhsDeployServersCommand(dataHub));

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/command/InstallIntoDhsCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/command/InstallIntoDhsCommandTest.java
@@ -111,6 +111,15 @@ public class InstallIntoDhsCommandTest extends HubTestBase {
         assertTrue(commands.get(index++) instanceof LoadUserArtifactsCommand);
         assertTrue(commands.get(index++) instanceof LoadHubArtifactsCommand);
         assertTrue(commands.get(index++) instanceof CreateGranularPrivilegesCommand);
+
+        DeployRolesCommand deployRolesCommand = (DeployRolesCommand) commands.get(1);
+        ResourceFilenameFilter filter = (ResourceFilenameFilter) deployRolesCommand.getResourceFilenameFilter();
+        File dir = new File(PROJECT_PATH); // the directory doesn't matter, only the filename
+        assertTrue(filter.accept(dir, "data-hub-entity-model-reader.json"));
+        assertTrue(filter.accept(dir, "data-hub-explorer-architect.json"));
+        assertFalse(filter.accept(dir, "flow-developer-role.json"), "The DHF 'legacy' roles should not be deployed as they grant too many privileges for a DHS user");
+        assertFalse(filter.accept(dir, "flow-operator-role.json"), "The DHF 'legacy' roles should not be deployed as they grant too many privileges for a DHS user");
+        assertFalse(filter.accept(dir, "data-hub-admin-role.json"), "The DHF 'legacy' roles should not be deployed as they grant too many privileges for a DHS user");
     }
 
     private void verifyDefaultProperties(Properties props) {


### PR DESCRIPTION
I also realized that we still don't want flow-developer-role, flow-operator-role, or data-hub-admin-role deployed to DHS, as those grant too many privileges and thus shouldn't be present.