### PR TITLE
DHFPROD-4072: ML 10 rewriter now uses OOTB module for GET document

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/rest-api/rewriter/10-rewriter.xml
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/rest-api/rewriter/10-rewriter.xml
@@ -302,7 +302,7 @@
                 <match-header name="range">
                   <dispatch>/data-hub/5/rest-api/endpoints/document-item-query.xqy</dispatch>
                 </match-header>
-                <dispatch>/data-hub/5/rest-api/endpoints/document-item-query-get.xqy</dispatch>
+                <dispatch>/MarkLogic/rest-api/endpoints/document-item-query-get.xqy</dispatch>
             </match-method>
             <match-method any-of="HEAD">
                 <match-query-param name="txid">


### PR DESCRIPTION
These seemingly was just an oversight, and the rewriter should have been using the OOTB module, just like the ML 9 rewriter is. 