### PR TITLE
DHFPROD-3935: Fixing ValidateMappingTest

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -1217,7 +1217,7 @@ public class HubTestBase {
         }
     }
 
-    protected void setupProjectForRunningTestFlow(HubConfig config) {
+    protected void setupProjectForRunningTestFlow() {
         basicSetup();
         getDataHubAdminConfig();
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME, HubConfig.DEFAULT_JOB_NAME);

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/ConstrainSourceQueryToJobTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/ConstrainSourceQueryToJobTest.java
@@ -6,10 +6,7 @@ import com.marklogic.hub.HubTestBase;
 import com.marklogic.hub.flow.impl.FlowRunnerImpl;
 import com.marklogic.hub.step.RunStepResponse;
 import org.custommonkey.xmlunit.XMLUnit;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
@@ -41,7 +38,7 @@ public class ConstrainSourceQueryToJobTest extends HubTestBase {
 
     @BeforeEach
     public void setupEach() {
-        setupProjectForRunningTestFlow(getDataHubAdminConfig());
+        setupProjectForRunningTestFlow();
         getHubFlowRunnerConfig();
     }
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunWithDataHubOperatorTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunWithDataHubOperatorTest.java
@@ -105,7 +105,7 @@ public class FlowRunWithDataHubOperatorTest extends HubTestBase {
         //Copy mapping functions
         FileUtils.copyFileToDirectory(getResourceFile("flow-runner-test/mapping-functions/add-function.xqy"),
             adminHubConfig.getHubProject().getCustomMappingFunctionsDir().toFile());
-        setupProjectForRunningTestFlow(getHubFlowRunnerConfig("test-data-hub-developer", "test-data-hub-developer"));
+        setupProjectForRunningTestFlow();
 
         //Run flow as "data-hub-operator"
         getHubFlowRunnerConfig("test-data-hub-operator", "test-data-hub-operator");

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunnerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunnerTest.java
@@ -63,7 +63,7 @@ public class FlowRunnerTest extends HubTestBase {
 
     @BeforeEach
     public void setupEach() {
-        setupProjectForRunningTestFlow(getDataHubAdminConfig());
+        setupProjectForRunningTestFlow();
         getHubFlowRunnerConfig();
     }
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/mapping/ValidateMappingTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/mapping/ValidateMappingTest.java
@@ -57,6 +57,9 @@ public class ValidateMappingTest extends HubTestBase {
 
     @BeforeEach
     public void setup() {
+        // Need to re-initialize adminHubConfig in case getHubFlowRunnerConfig was called before this test
+        // TODO Arguably HubTestBase should call this before every test??
+        getDataHubAdminConfig();
         client = adminHubConfig.newStagingClient(adminHubConfig.getDbName(DatabaseKind.FINAL));
         client.newJSONDocumentManager().write(
             CUSTOMER_URI,

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubOperatorTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubOperatorTest.java
@@ -43,7 +43,7 @@ public class DataHubOperatorTest extends AbstractSecurityTest {
     @Test
     public void task30RunFlow() {
         Assumptions.assumeTrue(isVersionCompatibleWith520Roles());
-        setupProjectForRunningTestFlow(getDataHubAdminConfig());
+        setupProjectForRunningTestFlow();
 
         try {
             getHubFlowRunnerConfig(userWithRoleBeingTested.getUserName(), userWithRoleBeingTested.getPassword());


### PR DESCRIPTION
It started failing because it was accessing adminHubConfig before ensuring it was initialized to use flow-developer as a user.

Perhaps HubTestBase should be doing this before every test?? Otherwise there's the chance that one test modified adminHubConfig, and that bleeds over into the next test, causing an error.

I also modified setupProjectForRunningTestFlow, as it was ignoring the HubConfig object being passed into it. 