### PR TITLE
DHFPROD-3755: Fixing compilation error

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/client/RunFlowViaMainTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/client/RunFlowViaMainTest.java
@@ -28,7 +28,7 @@ public class RunFlowViaMainTest extends HubTestBase {
 
     @Test
     public void testRunFlow() {
-        setupProjectForRunningTestFlow(adminHubConfig);
+        setupProjectForRunningTestFlow();
         getHubFlowRunnerConfig();
 
         final String flowName = "testFlow";


### PR DESCRIPTION
This occurred due to changes on the develop branch after the original 3755 PR was created and before it was merged. I should have rebased the original 3755 PR again.