### PR TITLE
DHFPROD-3974: HubConfigImpl no longer has to refresh Spring-managed b…

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -32,8 +32,6 @@ import com.marklogic.hub.HubProject;
 import com.marklogic.hub.error.DataHubConfigurationException;
 import com.marklogic.hub.error.DataHubProjectException;
 import com.marklogic.hub.error.InvalidDBOperationError;
-import com.marklogic.hub.job.impl.JobMonitorImpl;
-import com.marklogic.hub.legacy.impl.LegacyFlowManagerImpl;
 import com.marklogic.hub.step.StepDefinition;
 import com.marklogic.mgmt.DefaultManageConfigFactory;
 import com.marklogic.mgmt.ManageClient;
@@ -79,16 +77,6 @@ public class HubConfigImpl implements HubConfig
 
     // a set of properties to use for legacy token replacement.
     Properties projectProperties = null;
-
-    @Autowired
-    LegacyFlowManagerImpl flowManager;
-    @Autowired
-    DataHubImpl dataHub;
-    @Autowired
-    Versions versions;
-    @Autowired
-    JobMonitorImpl jobMonitor;
-
 
     protected String host;
 
@@ -2081,11 +2069,6 @@ public class HubConfigImpl implements HubConfig
     @JsonIgnore
     public void refreshProject(Properties properties, boolean loadGradleProperties) {
         loadConfigurationFromProperties(properties, loadGradleProperties);
-
-        flowManager.setupClient();
-        dataHub.wireClient();
-        versions.setupClient();
-        jobMonitor.setupClient();
     }
 
     /**

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/job/impl/JobMonitorImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/job/impl/JobMonitorImpl.java
@@ -25,33 +25,23 @@ import com.marklogic.client.extensions.ResourceManager;
 import com.marklogic.client.extensions.ResourceServices;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.util.RequestParameters;
-import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.job.JobDocManager;
 import com.marklogic.hub.job.JobMonitor;
 import com.marklogic.hub.job.JobStatus;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@Component
 public class JobMonitorImpl implements JobMonitor {
-
-    private DatabaseClient client;
-
-    @Autowired
-    private HubConfig hubConfig;
 
     private JobDocManager jobDocManager;
     private Batches batches;
 
-    public void setupClient() {
-        this.client = hubConfig.newJobDbClient();
+    public JobMonitorImpl(DatabaseClient client) {
         this.jobDocManager = new JobDocManager(client);
-        batches = new Batches(client);
+        this.batches = new Batches(client);
     }
 
     //obtain the currently running  jobs on the cluster
@@ -77,7 +67,7 @@ public class JobMonitorImpl implements JobMonitor {
             throw new RuntimeException("Unable to get job document");
         }
         String status = null;
-        if(job.get("job") != null){
+        if (job.get("job") != null) {
             status = job.get("job").get("jobStatus").textValue();
         }
         return status;
@@ -85,9 +75,9 @@ public class JobMonitorImpl implements JobMonitor {
 
 
     //status of all batches in a step within a jobID
-    public Map<String,String> getStepBatchStatus(String jobId, String step) {
+    public Map<String, String> getStepBatchStatus(String jobId, String step) {
         JsonNode batch = batches.getBatches(jobId, step, null);
-        Map<String,String> status = new HashMap<>();
+        Map<String, String> status = new HashMap<>();
         if (batch.isArray()) {
             for (final JsonNode objNode : batch) {
                 status.put(objNode.get("batch").get("batchId").textValue(), objNode.get("batch").get("batchStatus").textValue());
@@ -110,8 +100,9 @@ public class JobMonitorImpl implements JobMonitor {
     public List<String> getBatchResponse(String jobId, String batchId) {
         JsonNode batch = batches.getBatches(jobId, null, batchId);
         ObjectMapper mapper = new ObjectMapper();
-        ObjectReader reader = mapper.readerFor(new TypeReference<List<String>>() {});
-        if(batch.get("batch") != null) {
+        ObjectReader reader = mapper.readerFor(new TypeReference<List<String>>() {
+        });
+        if (batch.get("batch") != null) {
             try {
                 return reader.readValue(batch.get("batch").get("uris"));
             } catch (IOException e) {
@@ -134,19 +125,19 @@ public class JobMonitorImpl implements JobMonitor {
 
         private JsonNode getBatches(String jobId, String step, String batchId) {
             params = new RequestParameters();
-            if(jobId == null) {
+            if (jobId == null) {
                 throw new RuntimeException("Cannot get batches without jobId");
             }
             params.add("jobid", jobId);
-            if(batchId != null) {
+            if (batchId != null) {
                 params.add("batchid", batchId);
             }
-            if(step != null) {
+            if (step != null) {
                 params.add("step", step);
             }
 
             ResourceServices.ServiceResultIterator resultItr = this.getServices().get(params);
-            if (resultItr == null || ! resultItr.hasNext()) {
+            if (resultItr == null || !resultItr.hasNext()) {
                 throw new RuntimeException("Unable to get batch document");
             }
             ResourceServices.ServiceResult res = resultItr.next();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -44,7 +44,6 @@ import com.marklogic.client.io.marker.AbstractReadHandle;
 import com.marklogic.hub.deploy.commands.*;
 import com.marklogic.hub.error.DataHubConfigurationException;
 import com.marklogic.hub.impl.*;
-import com.marklogic.hub.job.impl.JobMonitorImpl;
 import com.marklogic.hub.legacy.LegacyDebugging;
 import com.marklogic.hub.legacy.LegacyTracing;
 import com.marklogic.hub.legacy.flow.CodeFormat;
@@ -155,16 +154,6 @@ public class HubTestBase {
 
     @Autowired
     protected LegacyFlowManagerImpl fm;
-
-    @Autowired
-    protected JobMonitorImpl jobMonitor;
-
-    protected JarDocumentFileReader jarDocumentFileReader = null;
-
-    // to speedup dev cycle, you can create a hub and set this to true.
-    // for true setup/teardown, must be 'false'
-    private static boolean isInstalled = false;
-    private static int nInstalls = 0;
 
     static final protected Logger logger = LoggerFactory.getLogger(HubTestBase.class);
 
@@ -442,7 +431,6 @@ public class HubTestBase {
         adminHubConfig.getAppConfig().getCmaConfig().setDeployRoles(false);
         adminHubConfig.getAppConfig().getCmaConfig().setDeployUsers(false);
 
-        wireClients();
         return adminHubConfig;
     }
 
@@ -490,7 +478,6 @@ public class HubTestBase {
         manageClient.setManageConfig(manageConfig);
         adminHubConfig.setManageClient(manageClient);
         adminHubConfig.setAdminConfig(adminConfig);
-        wireClients();
         return adminHubConfig;
     }
 
@@ -590,7 +577,6 @@ public class HubTestBase {
         ((HubConfigImpl)adminHubConfig).setManageClient(manageClient);
 
         ((HubConfigImpl)adminHubConfig).setAdminConfig(adminConfig);
-        wireClients();
     }
 
     public void deleteProjectDir() {
@@ -1167,18 +1153,10 @@ public class HubTestBase {
     }
 
 
-    public void wireClients() {
-        fm.setupClient();
-        dataHub.wireClient();
-        versions.setupClient();
-        jobMonitor.setupClient();
-
-    }
     //Use this method sparingly as it slows down the test
     public void resetProperties() {
         Field[] fields = HubConfigImpl.class.getDeclaredFields();
-        Set<String> s =  Stream.of("hubProject", "environment", "flowManager",
-                "dataHub", "versions", "logger", "objmapper", "projectProperties", "jobMonitor").collect(Collectors.toSet());
+        Set<String> s =  Stream.of("hubProject", "environment", "logger", "objmapper", "projectProperties").collect(Collectors.toSet());
 
         for(Field f : fields){
             if(! s.contains(f.getName())) {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/ConstructServerManagerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/ConstructServerManagerTest.java
@@ -21,7 +21,7 @@ public class ConstructServerManagerTest {
         Assertions.assertNull(hubConfig.getAppConfig(),
             "The AppConfig is expected to be null on a new HubConfigImpl instance");
 
-        ServerManager mgr = dataHub.constructServerManager(manageClient, hubConfig);
+        ServerManager mgr = dataHub.constructServerManager(hubConfig);
         assertEquals("/manage/v2/servers/Admin/properties?group-id=Default", mgr.getPropertiesPath("Admin"),
             "With no AppConfig, the path for an app server should use the Default group");
     }
@@ -30,7 +30,7 @@ public class ConstructServerManagerTest {
     public void appConfigHasNoGroupName() {
         hubConfig.setAppConfig(new AppConfig(), true);
 
-        ServerManager mgr = dataHub.constructServerManager(manageClient, hubConfig);
+        ServerManager mgr = dataHub.constructServerManager(hubConfig);
         assertEquals("/manage/v2/servers/Admin/properties?group-id=Default", mgr.getPropertiesPath("Admin"),
             "If the group name isn't overridden, then the path for an app server should use the Default group");
     }
@@ -41,7 +41,7 @@ public class ConstructServerManagerTest {
         appConfig.setGroupName("CustomGroupName");
         hubConfig.setAppConfig(appConfig, true);
 
-        ServerManager mgr = dataHub.constructServerManager(manageClient, hubConfig);
+        ServerManager mgr = dataHub.constructServerManager(hubConfig);
         assertEquals("/manage/v2/servers/Admin/properties?group-id=CustomGroupName", mgr.getPropertiesPath("Admin"),
             "If group name is overridden on the AppConfig, then its value should be used in the path for an app server");
     }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/DataHubImplTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/DataHubImplTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.hub.core;
+package com.marklogic.hub.impl;
 
 import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.HubTestBase;
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = ApplicationConfig.class)
-public class DataHubTest extends HubTestBase {
+public class DataHubImplTest extends HubTestBase {
 
     private ServerManager serverManager;
 
@@ -71,7 +71,6 @@ public class DataHubTest extends HubTestBase {
         dh = EasyMock.createMockBuilder(DataHubImpl.class)
             .withConstructor()
             .createMock();
-        dh.setServerManager(serverManager);
         dh.setHubConfig(hubConfig);
 
         versions = EasyMock.createMockBuilder(Versions.class)
@@ -218,7 +217,7 @@ public class DataHubTest extends HubTestBase {
         expect(versions.getMarkLogicVersion()).andReturn("9.0-19.1");
         replay(dh, serverManager, versions);
 
-        dh.runPreInstallCheck();
+        dh.runPreInstallCheck(serverManager);
         assertTrue(dh.isServerVersionOk());
         assertFalse(dh.isPortInUse(DatabaseKind.STAGING));
         assertFalse(dh.isPortInUse(DatabaseKind.FINAL));
@@ -241,7 +240,7 @@ public class DataHubTest extends HubTestBase {
         expect(versions.getMarkLogicVersion()).andReturn("9.0-10.10");
         replay(dh, serverManager, versions);
 
-        dh.runPreInstallCheck();
+        dh.runPreInstallCheck(serverManager);
         assertTrue(dh.isServerVersionOk());
         assertFalse(dh.isPortInUse(DatabaseKind.STAGING));
         assertFalse(dh.isPortInUse(DatabaseKind.FINAL));
@@ -262,7 +261,7 @@ public class DataHubTest extends HubTestBase {
         expect(versions.getMarkLogicVersion()).andReturn("10.0-9");
         replay(serverManager, dh, versions);
 
-        dh.runPreInstallCheck();
+        dh.runPreInstallCheck(serverManager);
         assertTrue(dh.isServerVersionOk());
         assertTrue(dh.isPortInUse(DatabaseKind.STAGING));
         assertEquals("port-stealer", dh.getPortInUseBy(DatabaseKind.STAGING));
@@ -284,7 +283,7 @@ public class DataHubTest extends HubTestBase {
         expect(versions.getMarkLogicVersion()).andReturn("9.0-1");
         replay(dh, versions, serverManager);
 
-        dh.runPreInstallCheck();
+        dh.runPreInstallCheck(serverManager);
         assertFalse(dh.isServerVersionOk());
         assertTrue(dh.isPortInUse(DatabaseKind.STAGING));
         assertEquals("port-stealer", dh.getPortInUseBy(DatabaseKind.STAGING));
@@ -306,7 +305,7 @@ public class DataHubTest extends HubTestBase {
         expect(versions.getMarkLogicVersion()).andReturn("9.0-10");
         replay(dh, versions, serverManager);
 
-        dh.runPreInstallCheck();
+        dh.runPreInstallCheck(serverManager);
         assertTrue(dh.isServerVersionOk());
         assertFalse(dh.isPortInUse(DatabaseKind.STAGING));
         assertTrue(dh.isPortInUse(DatabaseKind.FINAL));

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/job/JobMonitorTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/job/JobMonitorTest.java
@@ -8,11 +8,9 @@ import com.marklogic.hub.HubTestBase;
 import com.marklogic.hub.job.impl.JobMonitorImpl;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.io.IOException;
 import java.util.*;
 
 import static com.marklogic.client.io.DocumentMetadataHandle.Capability.*;
@@ -21,7 +19,6 @@ import static com.marklogic.client.io.DocumentMetadataHandle.Capability.*;
 @ContextConfiguration(classes = ApplicationConfig.class)
 class JobMonitorTest extends HubTestBase {
 
-    @Autowired
     private JobMonitorImpl jobMonitor;
 
     @BeforeAll
@@ -30,11 +27,12 @@ class JobMonitorTest extends HubTestBase {
     }
 
     @BeforeEach
-    public void setup() throws IOException {
+    public void setup() {
         basicSetup();
         adminHubConfig.initHubProject();
         clearDatabases(HubConfig.DEFAULT_JOB_NAME);
         addJobDocs();
+        jobMonitor = new JobMonitorImpl(adminHubConfig.newJobDbClient());
     }
 
     @AfterAll
@@ -61,6 +59,7 @@ class JobMonitorTest extends HubTestBase {
     void getBatchStatus() {
         Assertions.assertEquals("started", jobMonitor.getBatchStatus("10584668255644629399", "11368953415268525918"));
     }
+
     @Test
     void getStepBatchStatus() {
         Map<String, String> resp = jobMonitor.getStepBatchStatus("10584668255644629399", "1");
@@ -72,16 +71,15 @@ class JobMonitorTest extends HubTestBase {
         expected.add("failed");
         expected.add("started");
 
-        Assertions.assertEquals(expected, str );
+        Assertions.assertEquals(expected, str);
 
     }
 
     @Test
     void getBatchStatus1() {
-        try{
+        try {
             jobMonitor.getBatchStatus("10584668255644629399", "1136895341526852591");
-        }
-        catch (Exception e){
+        } catch (Exception e) {
             Assertions.assertTrue(e.getMessage().contains("No batch document found"));
         }
     }

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/BaseTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/BaseTest.groovy
@@ -299,8 +299,7 @@ class BaseTest extends Specification {
     //Use this method sparingly as it slows down the test
     public void resetProperties() {
         Field[] fields = HubConfigImpl.class.getDeclaredFields();
-        Set<String> s =  Stream.of("hubProject", "environment", "flowManager",
-            "dataHub", "versions", "logger", "objmapper", "projectProperties", "jobMonitor").collect(Collectors.toSet());
+        Set<String> s =  Stream.of("hubProject", "environment", "logger", "objmapper", "projectProperties").collect(Collectors.toSet());
 
         for(Field f : fields){
             if(! s.contains(f.getName())) {


### PR DESCRIPTION
…eans

This allows for the new UI project to not deal with HubConfigImpl, which won't be a singleton, having dependencies on singletons managed by Spring. 

In addition, the classes that were extending ResourceManager and being managed by Spring no longer extend ResourceManager. Instead, they create a subclass of ResourceManager when needed, based on the current settings of HubConfig.