### PR TITLE
DHFPROD-4142: Ingestion step can now use relative path without HubPro…

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/collector/impl/FileCollectorTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/collector/impl/FileCollectorTest.java
@@ -11,7 +11,7 @@ class FileCollectorTest {
 
     @Test
     void xmlFormat() {
-        collector = new FileCollector(null, "xml");
+        collector = new FileCollector("xml");
         yes("test.xml");
         yes("test.xhtml");
         yes("test.html");
@@ -21,7 +21,7 @@ class FileCollectorTest {
 
     @Test
     void jsonFormat() {
-        collector = new FileCollector(null, "json");
+        collector = new FileCollector("json");
         yes("test.json");
         yes("test");
         no("test.xml");
@@ -29,7 +29,7 @@ class FileCollectorTest {
 
     @Test
     void textFormat() {
-        collector = new FileCollector(null, "text");
+        collector = new FileCollector("text");
         yes("test.txt");
         no("test");
         no("test.xml");
@@ -38,7 +38,7 @@ class FileCollectorTest {
 
     @Test
     void csvFormat() {
-        collector = new FileCollector(null, "csv");
+        collector = new FileCollector("csv");
         yes("test.csv");
         yes("test.psv");
         yes("test.tsv");
@@ -50,7 +50,7 @@ class FileCollectorTest {
 
     @Test
     void binaryFormat() {
-        collector = new FileCollector(null, "binary");
+        collector = new FileCollector("binary");
         yes("test");
         no("test.xml");
         no("test.xhtml");

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/step/impl/DetermineInputFilePathTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/step/impl/DetermineInputFilePathTest.java
@@ -1,0 +1,43 @@
+package com.marklogic.hub.step.impl;
+
+import com.marklogic.hub.HubTestBase;
+import com.marklogic.hub.impl.HubConfigImpl;
+import com.marklogic.hub.impl.HubProjectImpl;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DetermineInputFilePathTest {
+
+    @Test
+    void absolutePath() {
+        HubProjectImpl project = new HubProjectImpl();
+        project.createProject(HubTestBase.PROJECT_PATH);
+
+        Path path = new WriteStepRunner(new HubConfigImpl(project, null)).determineInputFilePath("/absolute/path");
+        assertEquals("/absolute/path", path.toString());
+    }
+
+    @Test
+    void relativePathWithHubProject() {
+        HubProjectImpl project = new HubProjectImpl();
+        project.createProject(HubTestBase.PROJECT_PATH);
+
+        Path path = new WriteStepRunner(new HubConfigImpl(project, null)).determineInputFilePath("relativePath");
+
+        final String expectedDir = project.getProjectDir().resolve("relativePath").toString();
+        assertEquals(expectedDir, path.toString());
+    }
+
+    @Test
+    void relativePathWithNoHubProject() {
+        Path path = new WriteStepRunner(new HubConfigImpl()).determineInputFilePath("relativePath");
+
+        final String expectedDir = Paths.get("relativePath").toAbsolutePath().toString();
+        assertEquals(expectedDir, path.toString(),
+            "When no HubProject is available, the inputFilePath should be resolved based on the current working directory");
+    }
+}


### PR DESCRIPTION
…ject

Removed FileCollector's dependency on HubConfig - it didn't need an entire HubConfig, it just needed an already-resolved inputFilePath. WriteStepRunner now has the logic for resolving the inputFilePath. 

And to make it easier to unit test WriteStepRunner, moved the instantiation of a DatabaseClient to right where it's needed, if it's not null already.