### PR TITLE
DHFPROD-3555: Update mapping layout and tables to address wrapping

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/entity-table-ui.component.scss
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/entity-table-ui.component.scss
@@ -42,21 +42,20 @@
 	}
 
 	.mat-column-name {
-		width: 20% !important;
-		min-width: 20% !important;
+		width: 27% !important;
+		min-width: 27% !important;
 		padding-left: 2%;
 	}    
 	.mat-column-datatype {
-		width: 15% !important;
-		min-width: 15% !important;
+		width: 18% !important;
+		min-width: 18% !important;
 	}
 	.mat-column-expression {
-	    width: 50% !important;
-	    min-width: 50% !important;
+	    width: 375px !important;
+	    min-width: 375px !important;
 	}   
 	.mat-column-value {
 	    width: 15% !important;
-	    min-width: 15% !important;
 	}
 
 	.prop-toggle {
@@ -93,7 +92,7 @@
 	}
 
 	.contextField {
-		width: 252px;
+		width: 254px;
 	}
 
 	.context-label {
@@ -133,7 +132,7 @@
 
 .spacer {
 	display: inline-block;
-	width: 20px;
+	width: 12px;
 }
 
 .hide {

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/mapping-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/mapping-ui.component.html
@@ -78,7 +78,7 @@
         {{ targetEntity?.info.title }}
       </div>
       <div id="table-and-buttons">
-      <span class="btn-icons">
+      <div class="btn-icons">
         <button id="Test-btn" mat-raised-button color="primary" (click)="getMapValidationResp()">
           Test
         </button>
@@ -97,7 +97,7 @@
         >
           <i class="fa fa-columns"></i>
         </mat-icon>
-      </span>
+      </div>
 
       <div id="entity-table-container">
         <app-entity-table-ui

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/mapping-ui.component.scss
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/mapping-ui.component.scss
@@ -51,7 +51,7 @@ div.item-identifying-info {
 
 div.target-entity-title {
   font-weight: normal;
-  margin: 2px 0 29px 0;
+  margin: 2px 0 33px 0;
   font-size: 20px;
 }
 
@@ -276,16 +276,17 @@ div.target-entity-title {
 
 .source-prop-container-map-exp {
   padding: 20px 28px 400px 28px;
-  //height: auto;
-
-  overflow: auto;
-  overflow-x: hidden;
-  overflow-y: hidden;
+  overflow: scroll;
+  display: flex;
 }
 
 .Source_Tbl { 
-  float: left;
-  padding-right: 35px;
+  width: 100% !important;
+  min-width: 405px;
+  flex: 4;
+  display: flex;
+  flex-direction: column;
+  padding-right: 20px;
   word-break: break-all;
 
   >#hideShowTable #source-new-table {
@@ -449,10 +450,12 @@ div.target-entity-title {
 }
 
 .Entities_Tbl {
-  float: left;
+  flex: 9;
+  display: flex;
+  flex-direction: column;
   word-break: break-all;
-  width: auto !important;
-  min-width: 50% !important;
+  width: 100% !important;
+  padding-left: 20px;
 }
 
 mat-icon {
@@ -502,35 +505,19 @@ mat-icon {
   align-self: center;
 }
 
-span.btn-icons{
+div.btn-icons{
   width: 100%;
   display: flex;
-  //flex: 0 1 auto;
-  //overflow: auto;
+  justify-content: flex-end; 
   padding-bottom: 6px;
-     align-content: flex-end ; 
-  text-align: center;
-  margin: 0px;
-  padding-right: 0px;
-  white-space: nowrap;
 }
 #Test-btn {
-  position: relative;
-
-    //padding-right: 4px;
-    display: block;
-    text-align: center;
-    outline: none;
-    top: 50%;
-    left: 78.5%;
+  margin-right: 8px;
+  outline: none;
 }
 #Clear-btn{
-  position: relative;
-  align-content: flex-end ; 
-  align-items:  center ;
-  align-self: center;
-  top: 50%;
-  left: 79.5%;
+  margin-right: 8px;
+  outline: none;
 }
 
 // #lookup-icon {
@@ -541,9 +528,6 @@ span.btn-icons{
 // }
 
 #filter-icon {
-  display: inline-block;
-  position: relative;
-  left: 80.4%;
   padding-right: 2px;
 }
 
@@ -554,7 +538,7 @@ span.btn-icons{
 }
 
 #entity-table-container {
-  width: 800px;
+  width: 100%;
 }
 
 #source-field-container{
@@ -580,6 +564,7 @@ span.btn-icons{
 
 #table-and-buttons{
   display: inline-block;
+  min-width: 860px;
 }
 
 #doc {

--- a/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/mapping-ui.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mapping/ui/mapping-ui.component.ts
@@ -539,7 +539,7 @@ export class MappingUiComponent implements OnChanges {
   //Indenting the nested levels
   IndentCondition(prop) {
     let count = prop.split('/').length - 1;
-    let indentSize = 20*count;
+    let indentSize = 12*count;
   
     let style = {'text-indent': indentSize+'px'}
   return style


### PR DESCRIPTION
- Increase table widths and give additional width to property name columns
- Decrease padding to maximize usable screen real estate
- Decrease indent width to give more space to subproperties
- Set reasonable min-width settings to keep tables from breaking when the browser is shrunk
- Use flexbox more instead of floats for better layout control