### PR TITLE
DHFPROD-4158: Can now deploy to DHS via multiple roles

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,9 @@ in an example project directory.
 
 1. [dh5-custom-hook](https://github.com/marklogic/marklogic-data-hub/tree/master/examples/dh5-custom-hook) - an example of a simple flow with one ingestion step that utilizes a custom hook
 
+1. [dhs-example](https://github.com/marklogic/marklogic-data-hub/tree/master/examples/dhs-example) - demonstrates where to store 
+  resources that can be deployed to a DHS instance. 
+
 1. [mapping-example](https://github.com/marklogic/marklogic-data-hub/tree/master/examples/mapping-example) - demonstrates the new mapping features in Data Hub 5.1.0
 
 1. [smart-mastering-complete](https://github.com/marklogic/marklogic-data-hub/tree/master/examples/smart-mastering-complete) - demonstrates various features of the mastering step

--- a/examples/dhs-example/.gitignore
+++ b/examples/dhs-example/.gitignore
@@ -1,0 +1,2 @@
+src/main/entity-config
+

--- a/examples/dhs-example/README.md
+++ b/examples/dhs-example/README.md
@@ -1,0 +1,103 @@
+This example project demonstrates where to store resources that can be deployed to a DHS instance using a user with the 
+data-hub-developer role, or the data-hub-security-admin role, or both. 
+
+This project is not meant to be deployed. It is intended only to serve as a reference for where resource files
+should be stored. Because of this, it also does not define any Data Hub artifacts, such as flows or entities.
+
+## General deployment guidelines
+
+The tasks for deploying resources to DHS will never read from the src/main/hub-internal-config directory. The 
+resources in that directory are deployed automatically within DHS. For example, if you have defined your configuration
+directories via the following property:
+
+    mlConfigPaths=src/main/hub-internal-config,src/main/ml-config,src/main/other-config
+    
+The ml-config and other-config directories will still be processed, but hub-internal-config will not be.
+
+## Deploying resources as a data-hub-security-admin user
+
+As of 5.2.0, a user with the data-hub-security-admin role is permitted to deploy roles that grant privileges that are
+inherited by the user performing the deployment. As an example of this, the 
+src/main/ml-config/security/roles/custom-role1.json file defines a new role with the "manage" privilege, which is 
+inherited by the data-hub-security-admin role. 
+
+Permitted resources can be deployed via the following task (assuming that gradle-dhs.properties defines the host and
+credentials for the DHS instance):
+
+    ./gradlew -PenvironmentName=dhs hubDeployAsSecurityAdmin
+    
+## Deploying resources as a data-hub-developer user
+
+As of 5.2.0, a user with the data-hub-developer is permitted to deploy the following resources:
+
+- Indexes to the data-hub-STAGING, data-hub-FINAL, and data-hub-JOBS databases
+- Artifacts (entities, flows, mappings, and step definitions)
+- Modules
+- Alert configs, rules, and actions
+- Scheduled tasks
+- Schemas
+- Temporal axes and collections
+- Triggers
+
+Permitted resources can be deployed via the following task (assuming that gradle-dhs.properties defines the host and
+credentials for the DHS instance):
+
+    ./gradlew -PenvironmentName=dhs hubDeployAsDeveloper
+    
+Additionally, if your user has both the data-hub-developer and data-hub-security-admin roles, then you can run the 
+following task, which simply invokes both of the above tasks:
+
+    ./gradlew -PenvironmentName=dhs hubDeploy
+
+Each of the permitted resources is described below in more detail.
+
+### Database indexes
+
+Each database file that references data-hub-STAGING, data-hub-FINAL, and data-hub-JOBS will be processed. Database files
+are located in the "./databases" directory in a configuration directory. In this example project, the "test-database.json"
+file will not be processed since it does not reference one of those 3 databases. Also see 
+[the ml-gradle docs](https://github.com/marklogic-community/ml-gradle/wiki/Resource-reference#databases) for more information.
+
+## Artifacts
+
+Equivalent to on-premise deployment, all Data Hub artifacts in the ./entities, ./flows, ./mappings, and 
+./step-definitions directories will be deployed.
+
+## Modules
+
+All user modules in any directory specified by mlModulePaths (defaults to src/main/ml-modules) will be deployed. Contrary
+to an on-premise deployment, the Data Hub modules themselves are not deployed. These are instead deployed automatically
+within the DHS instance. Also see [the ml-gradle docs](https://github.com/marklogic-community/ml-gradle/wiki/How-modules-are-loaded) for more information. 
+
+## Alert resources
+
+Alert resource files - configs, alerts, and rules - are stored in the directory "./databases/(name of content database)/alerts". 
+See src/main/ml-config/databases/data-hub-FINAL/alert for an example in this project. Also see 
+[the ml-gradle docs](https://github.com/marklogic-community/ml-gradle/wiki/Resource-reference#alerting) for more information.
+
+## Schemas 
+
+Schema files are stored in the directory "./databases/(name of schema database)/schemas". See 
+src/main/ml-config/databases/data-hub-staging-SCHEMAS/schemas for an example in this project. Also see 
+[the ml-gradle docs](https://github.com/marklogic-community/ml-gradle/wiki/Loading-schemas) for more information. 
+
+## Scheduled tasks
+
+Because a DHS instance uses multiple groups for application servers, and because a scheduled task is associated with a
+group, scheduled task files are stored in the directory "./tasks/(name of group)". See 
+src/main/ml-config/tasks for an example in this project. Also see
+[the ml-gradle docs](https://github.com/marklogic-community/ml-gradle/wiki/Resource-reference#scheduled-tasks) for more information.
+
+## Temporal axes and collections
+
+Temporal axes and collections files are stored in the directory "./databases/(name of content database)/temporal". 
+See src/main/ml-config/databases/data-hub-FINAL/temporal for an example in this project. Also see
+[the ml-gradle docs](https://github.com/marklogic-community/ml-gradle/wiki/Resource-reference#temporal) for more information. 
+Note too that LSQT collections are not yet supported.
+
+## Triggers
+
+Trigger files are stored in the directory "./databases/(name of triggers database)/triggers". See 
+src/main/ml-config/databases/data-hub-final-TRIGGERS/triggers for an example in this project. Also see 
+[the ml-gradle docs](https://github.com/marklogic-community/ml-gradle/wiki/Resource-reference#triggers) for more information.
+

--- a/examples/dhs-example/build.gradle
+++ b/examples/dhs-example/build.gradle
@@ -1,0 +1,19 @@
+buildscript {
+    repositories {
+        mavenLocal()
+        maven { url "https://plugins.gradle.org/m2/" }
+        jcenter()
+    }
+    dependencies {
+        if (project.hasProperty("testing")) {
+            classpath "com.marklogic:ml-data-hub:5.2-SNAPSHOT"
+        } else {
+            classpath "gradle.plugin.com.marklogic:ml-data-hub:5.2.0"
+        }
+    }
+}
+
+plugins {
+    id "net.saliman.properties" version "1.5.1"
+}
+apply plugin: "com.marklogic.ml-data-hub"

--- a/examples/dhs-example/src/main/ml-config/databases/data-hub-FINAL/alert/configs/sample-alert-config-actions/log-alert.xml
+++ b/examples/dhs-example/src/main/ml-config/databases/data-hub-FINAL/alert/configs/sample-alert-config-actions/log-alert.xml
@@ -1,0 +1,8 @@
+<alert-action-properties xmlns="http://marklogic.com/manage/alert-action/properties">
+  <name>log-alert</name>
+  <description>log to ErrorLog.txt</description>
+  <module-db>%%MODULES_DATABASE%%</module-db>
+  <module-root>/</module-root>
+  <module>/ext/my-alert.xqy</module>
+  <options />
+</alert-action-properties>

--- a/examples/dhs-example/src/main/ml-config/databases/data-hub-FINAL/alert/configs/sample-alert-config-rules/sample-rule.xml
+++ b/examples/dhs-example/src/main/ml-config/databases/data-hub-FINAL/alert/configs/sample-alert-config-rules/sample-rule.xml
@@ -1,0 +1,12 @@
+<alert-rule-properties xmlns="http://marklogic.com/manage/alert-rule/properties">
+  <name>sample-rule</name>
+  <description>Triggered when the document contains the word "hello"</description>
+  <query>
+    <cts:word-query xmlns:cts="http://marklogic.com/cts">
+      <cts:text xml:lang="en">hello</cts:text>
+    </cts:word-query>
+  </query>
+  <external-security-id>0</external-security-id>
+  <action-name>log-alert</action-name>
+  <options />
+</alert-rule-properties>

--- a/examples/dhs-example/src/main/ml-config/databases/data-hub-FINAL/alert/configs/sample-alert-config.xml
+++ b/examples/dhs-example/src/main/ml-config/databases/data-hub-FINAL/alert/configs/sample-alert-config.xml
@@ -1,0 +1,7 @@
+<alert-config-properties xmlns="http://marklogic.com/manage/alert-config/properties">
+  <uri>sample-alert-config</uri>
+  <name>Sample Alerting App</name>
+  <description>Alerting config for this sample application</description>
+  <triggers />
+  <options />
+</alert-config-properties>

--- a/examples/dhs-example/src/main/ml-config/databases/data-hub-FINAL/temporal/axes/temporal-system-axis.json
+++ b/examples/dhs-example/src/main/ml-config/databases/data-hub-FINAL/temporal/axes/temporal-system-axis.json
@@ -1,0 +1,15 @@
+{
+	"axis-name": "system",
+	"axis-start": {
+		"element-reference": {
+			"namespace-uri": "",
+			"localname": "systemStart"
+		}
+	},
+	"axis-end": {
+		"element-reference": {
+			"namespace-uri": "",
+			"localname": "systemEnd"
+		}
+	}
+}

--- a/examples/dhs-example/src/main/ml-config/databases/data-hub-FINAL/temporal/axes/temporal-valid-axis.json
+++ b/examples/dhs-example/src/main/ml-config/databases/data-hub-FINAL/temporal/axes/temporal-valid-axis.json
@@ -1,0 +1,15 @@
+{
+	"axis-name": "valid",
+	"axis-start": {
+		"element-reference": {
+			"namespace-uri": "",
+			"localname": "validStart"
+		}
+	},
+	"axis-end": {
+		"element-reference": {
+			"namespace-uri": "",
+			"localname": "validEnd"
+		}
+	}
+}

--- a/examples/dhs-example/src/main/ml-config/databases/data-hub-FINAL/temporal/collections/temporal-collection.json
+++ b/examples/dhs-example/src/main/ml-config/databases/data-hub-FINAL/temporal/collections/temporal-collection.json
@@ -1,0 +1,6 @@
+{
+	"collection-name": "temporal-collection",
+	"system-axis": "system",
+	"valid-axis": "valid",
+	"option": ["updates-safe"]
+}

--- a/examples/dhs-example/src/main/ml-config/databases/data-hub-final-TRIGGERS/triggers/sample-trigger.json
+++ b/examples/dhs-example/src/main/ml-config/databases/data-hub-final-TRIGGERS/triggers/sample-trigger.json
@@ -1,0 +1,21 @@
+{
+  "name": "sample-trigger",
+  "description": "sample trigger",
+  "event": {
+    "data-event": {
+      "collection-scope": {
+        "uri": "sample"
+      },
+      "document-content": {
+        "update-kind": "create"
+      },
+      "when": "post-commit"
+    }
+  },
+  "module": "ext/sample-trigger.xqy",
+  "module-db": "%%MODULES_DATABASE%%",
+  "module-root": "/",
+  "enabled": true,
+  "recursive": true,
+  "task-priority": "normal"
+}

--- a/examples/dhs-example/src/main/ml-config/databases/data-hub-staging-SCHEMAS/schemas/permissions.properties
+++ b/examples/dhs-example/src/main/ml-config/databases/data-hub-staging-SCHEMAS/schemas/permissions.properties
@@ -1,0 +1,2 @@
+# This is used to set properties on the schema document, in case the user loading them does not have any default permissions
+sample-schema.xsd=data-hub-developer,read,data-hub-developer,update

--- a/examples/dhs-example/src/main/ml-config/databases/data-hub-staging-SCHEMAS/schemas/sample-schema.xsd
+++ b/examples/dhs-example/src/main/ml-config/databases/data-hub-staging-SCHEMAS/schemas/sample-schema.xsd
@@ -1,0 +1,55 @@
+<xs:schema elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:sem="http://marklogic.com/semantics" xmlns:es="http://marklogic.com/entity-services">
+    <xs:element name="name" type="xs:string"/>
+    <xs:element name="comprisedOfRuns" type="RunContainerType"/>
+    <xs:element name="wonByRunner" type="RunnerContainerType"/>
+    <xs:element name="courseLength" type="xs:decimal"/>
+    <xs:complexType name="RunContainerType">
+        <xs:sequence>
+            <xs:element ref="Run"/>
+        </xs:sequence>
+        <xs:attribute name="datatype"/>
+    </xs:complexType>
+    <xs:complexType name="RunnerContainerType">
+        <xs:sequence>
+            <xs:element ref="Runner"/>
+        </xs:sequence>
+        <xs:attribute name="datatype"/>
+    </xs:complexType>
+    <xs:complexType name="RaceType" mixed="true">
+        <xs:sequence minOccurs="0">
+            <xs:element ref="name"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="comprisedOfRuns"/>
+            <xs:element minOccurs="0" ref="wonByRunner"/>
+            <xs:element minOccurs="0" ref="courseLength"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="Race" type="RaceType"/>
+    <xs:element name="id" type="xs:string"/>
+    <xs:element name="date" type="xs:date"/>
+    <xs:element name="distance" type="xs:decimal"/>
+    <xs:element name="distanceLabel" type="xs:string"/>
+    <xs:element name="duration" type="xs:dayTimeDuration"/>
+    <xs:element name="runByRunner" type="RunnerContainerType"/>
+    <xs:complexType name="RunType" mixed="true">
+        <xs:sequence minOccurs="0">
+            <xs:element ref="id"/>
+            <xs:element ref="date"/>
+            <xs:element ref="distance"/>
+            <xs:element minOccurs="0" ref="distanceLabel"/>
+            <xs:element ref="duration"/>
+            <xs:element ref="runByRunner"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="Run" type="RunType"/>
+    <xs:element name="age" type="xs:int"/>
+    <xs:element name="gender" type="xs:string"/>
+    <xs:complexType name="RunnerType" mixed="true">
+        <xs:sequence minOccurs="0">
+            <xs:element ref="name"/>
+            <xs:element ref="age"/>
+            <xs:element minOccurs="0" ref="gender"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="Runner" type="RunnerType"/>
+</xs:schema>

--- a/examples/dhs-example/src/main/ml-config/databases/final-database.json
+++ b/examples/dhs-example/src/main/ml-config/databases/final-database.json
@@ -1,0 +1,8 @@
+{
+  "database-name": "%%mlFinalDbName%%",
+  "schema-database": "%%mlFinalSchemasDbName%%",
+  "triggers-database": "%%mlFinalTriggersDbName%%",
+  "triple-index": true,
+  "collection-lexicon": true,
+  "uri-lexicon": true
+}

--- a/examples/dhs-example/src/main/ml-config/databases/final-schemas-database.json
+++ b/examples/dhs-example/src/main/ml-config/databases/final-schemas-database.json
@@ -1,0 +1,3 @@
+{
+  "database-name": "%%mlFinalSchemasDbName%%"
+}

--- a/examples/dhs-example/src/main/ml-config/databases/final-triggers-database.json
+++ b/examples/dhs-example/src/main/ml-config/databases/final-triggers-database.json
@@ -1,0 +1,3 @@
+{
+  "database-name": "%%mlFinalTriggersDbName%%"
+}

--- a/examples/dhs-example/src/main/ml-config/databases/modules-database.json
+++ b/examples/dhs-example/src/main/ml-config/databases/modules-database.json
@@ -1,0 +1,5 @@
+{
+  "database-name": "%%mlModulesDbName%%",
+  "collection-lexicon": true,
+  "uri-lexicon": true
+}

--- a/examples/dhs-example/src/main/ml-config/databases/test-database.json
+++ b/examples/dhs-example/src/main/ml-config/databases/test-database.json
@@ -1,0 +1,3 @@
+{
+  "database-name": "test-db"
+}

--- a/examples/dhs-example/src/main/ml-config/security/roles/custom-role1.json
+++ b/examples/dhs-example/src/main/ml-config/security/roles/custom-role1.json
@@ -1,0 +1,11 @@
+{
+  "role-name": "test-custom-role1",
+  "description": "Because data-hub-security-admin has the grant-my-privileges privilege, it can create roles that inherit privileges inherited by data-hub-security-admin",
+  "privilege": [
+    {
+      "privilege-name": "manage",
+      "kind": "execute",
+      "action": "http://marklogic.com/xdmp/privileges/manage"
+    }
+  ]
+}

--- a/examples/dhs-example/src/main/ml-config/servers/final-server.json
+++ b/examples/dhs-example/src/main/ml-config/servers/final-server.json
@@ -1,0 +1,14 @@
+{
+  "server-name": "%%mlFinalAppserverName%%",
+  "server-type": "http",
+  "root": "/",
+  "group-name": "%%GROUP%%",
+  "port": "%%mlFinalPort%%",
+  "modules-database": "%%mlModulesDbName%%",
+  "content-database": "%%mlFinalDbName%%",
+  "authentication": "%%mlFinalAuth%%",
+  "default-error-format": "json",
+  "error-handler": "/MarkLogic/rest-api/error-handler.xqy",
+  "url-rewriter": "/MarkLogic/rest-api/rewriter.xml",
+  "rewrite-resolves-globally": true
+}

--- a/examples/dhs-example/src/main/ml-config/tasks/Curator/task-curator.json
+++ b/examples/dhs-example/src/main/ml-config/tasks/Curator/task-curator.json
@@ -1,0 +1,12 @@
+{
+   "task-enabled": true,
+   "task-path": "/ext/sample-project/task/sample-task.xqy",
+   "task-root": "/",
+   "task-type": "weekly",
+   "task-period": 2,
+   "task-day": ["thursday"],
+   "task-start-time": "13:00:00",
+   "task-database": "%%DATABASE%%",
+   "task-modules": "%%MODULES_DATABASE%%",
+   "task-user": "nobody"
+}

--- a/examples/dhs-example/src/main/ml-config/tasks/Evaluator/task-1.json
+++ b/examples/dhs-example/src/main/ml-config/tasks/Evaluator/task-1.json
@@ -1,0 +1,12 @@
+{
+   "task-enabled": true, 
+   "task-path": "/ext/sample-project/task/sample-task.xqy", 
+   "task-root": "/", 
+   "task-type": "weekly", 
+   "task-period": 2, 
+   "task-day": ["tuesday"], 
+   "task-start-time": "12:00:00", 
+   "task-database": "%%DATABASE%%", 
+   "task-modules": "%%MODULES_DATABASE%%", 
+   "task-user": "nobody"
+}

--- a/examples/dhs-example/src/main/ml-modules/services/exampleResource.sjs
+++ b/examples/dhs-example/src/main/ml-modules/services/exampleResource.sjs
@@ -1,0 +1,20 @@
+function get(context, params) {
+  // return zero or more document nodes
+};
+
+function post(context, params, input) {
+  // return zero or more document nodes
+};
+
+function put(context, params, input) {
+  // return at most one document node
+};
+
+function deleteFunction(context, params) {
+  // return at most one document node
+};
+
+exports.GET = get;
+exports.POST = post;
+exports.PUT = put;
+exports.DELETE = deleteFunction;

--- a/examples/dhs-example/src/main/ml-modules/services/metadata/exampleResource.xml
+++ b/examples/dhs-example/src/main/ml-modules/services/metadata/exampleResource.xml
@@ -1,0 +1,14 @@
+<metadata>
+  <title>exampleResource</title>
+  <description>
+    <div>
+      Use HTML content to provide a description of this resource. The GET method shows an example of how to define the parameters for a method.
+    </div>
+  </description>
+  <method name="GET">
+    <param name="id" />
+  </method>
+  <method name="POST"/>
+  <method name="PUT"/>
+  <method name="DELETE"/>
+</metadata>

--- a/examples/dhs-example/src/main/ml-modules/transforms/exampleTransform.sjs
+++ b/examples/dhs-example/src/main/ml-modules/transforms/exampleTransform.sjs
@@ -1,0 +1,5 @@
+function transform(context, params, content)
+{
+  // Must return the result of the transform 
+};
+exports.transform = transform;

--- a/examples/dhs-example/src/main/ml-modules/transforms/metadata/exampleTransform.xml
+++ b/examples/dhs-example/src/main/ml-modules/transforms/metadata/exampleTransform.xml
@@ -1,0 +1,8 @@
+<metadata>
+  <title>exampleTransform</title>
+  <description>
+    <div>
+      Use HTML content to provide a description of this template.
+    </div>
+  </description>
+</metadata>

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dhs/installer/command/AbstractInstallerCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dhs/installer/command/AbstractInstallerCommand.java
@@ -55,7 +55,7 @@ public abstract class AbstractInstallerCommand extends LoggingObject implements 
 
         logger.info(format("Will connect to host '%s' as user '%s'", options.getHost(), options.getUsername()));
 
-        hubConfig.refreshProject(props, true);
+        hubConfig.loadConfigurationFromProperties(props, true);
 
         verifyUserCanAuthenticate();
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dhs/installer/command/InstallIntoDhsCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dhs/installer/command/InstallIntoDhsCommand.java
@@ -110,21 +110,6 @@ public class InstallIntoDhsCommand extends AbstractInstallerCommand {
             props.put(key, System.getProperties().getProperty(key));
         }
 
-        applyDhsSpecificProperties(props, options.isDisableSsl());
-        return props;
-    }
-
-    /**
-     * Public so that it can be reused by DHF Gradle plugin. Assumes that SSL should be used for connecting to
-     * MarkLogic.
-     *
-     * @param props
-     */
-    public void applyDhsSpecificProperties(Properties props) {
-        applyDhsSpecificProperties(props, false);
-    }
-
-    public void applyDhsSpecificProperties(Properties props, boolean disableSsl) {
         props.setProperty("mlIsHostLoadBalancer", "true");
         props.setProperty("mlIsProvisionedEnvironment", "true");
         props.setProperty("mlAppServicesPort", "8010");
@@ -139,11 +124,13 @@ public class InstallIntoDhsCommand extends AbstractInstallerCommand {
         props.setProperty("mlJobAuth", "basic");
         props.setProperty("mlStagingAuth", "basic");
 
-        if (!disableSsl) {
-            setDefaultPropertiesForSecureConnections(props);
-        } else {
+        if (options.isDisableSsl()) {
             logger.info("Not setting default property values for secure connections to MarkLogic");
+        } else {
+            setDefaultPropertiesForSecureConnections(props);
         }
+
+        return props;
     }
 
     /**

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -1084,6 +1084,11 @@ public class HubConfigImpl implements HubConfig
         }
     }
 
+    @JsonIgnore
+    public void refreshProject() {
+        loadConfigurationFromProperties(null, true);
+    }
+
     /**
      * Expected to be used when an instance of this class is managed by a Spring container, as it depends on a Spring
      * environment object being set.
@@ -1522,46 +1527,33 @@ public class HubConfigImpl implements HubConfig
         else {
             projectProperties.setProperty("mlIsProvisionedEnvironment", isProvisionedEnvironment.toString());
         }
+
         // Need to do this first so that objects like the final SSL objects are set before hydrating AppConfig
         hydrateConfigs();
 
         hydrateAppConfigs(projectProperties);
     }
 
-    private void hydrateAppConfigs(Properties properties) {
+    protected void hydrateAppConfigs(Properties properties) {
         com.marklogic.mgmt.util.PropertySource propertySource = properties::getProperty;
+
         if (appConfig != null) {
+            // Still need to call this since the setter also "updates" appConfig with DHF-specific values
             setAppConfig(appConfig);
-        }
-        else {
+        } else {
             setAppConfig(new DefaultAppConfigFactory(propertySource).newAppConfig());
         }
 
-        if (adminConfig != null) {
-            setAdminConfig(adminConfig);
-        }
-        else {
+        if (adminConfig == null) {
             setAdminConfig(new DefaultAdminConfigFactory(propertySource).newAdminConfig());
         }
-
-        if (adminManager != null) {
-            setAdminManager(adminManager);
-        }
-        else {
+        if (adminManager == null) {
             setAdminManager(new AdminManager(getAdminConfig()));
         }
-
-        if (manageConfig != null) {
-            setManageConfig(manageConfig);
-        }
-        else {
+        if (manageConfig == null) {
             setManageConfig(new DefaultManageConfigFactory(propertySource).newManageConfig());
         }
-
-        if (manageClient != null) {
-            setManageClient(manageClient);
-        }
-        else {
+        if (manageClient == null) {
             setManageClient(new ManageClient(getManageConfig()));
         }
     }
@@ -2072,16 +2064,6 @@ public class HubConfigImpl implements HubConfig
 
         }
 
-    }
-
-    @JsonIgnore
-    public void refreshProject() {
-        refreshProject(null, true);
-    }
-
-    @JsonIgnore
-    public void refreshProject(Properties properties, boolean loadGradleProperties) {
-        loadConfigurationFromProperties(properties, loadGradleProperties);
     }
 
     /**

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/core/HubConfigTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/core/HubConfigTest.java
@@ -80,7 +80,7 @@ public class HubConfigTest extends HubTestBase {
         props.put("mlFinalSimpleSsl", "true");
 
         resetProperties();
-        adminHubConfig.refreshProject(props, true);
+        adminHubConfig.loadConfigurationFromProperties(props, true);
 
         config = adminHubConfig.getAppConfig();
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/DeployAsDeveloperTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/DeployAsDeveloperTest.java
@@ -18,7 +18,6 @@ import com.marklogic.hub.ApplicationConfig;
 import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.HubTestBase;
-import com.marklogic.hub.deploy.commands.DeployDatabaseFieldCommand;
 import com.marklogic.hub.deploy.commands.LoadUserArtifactsCommand;
 import com.marklogic.hub.deploy.commands.LoadUserModulesCommand;
 import com.marklogic.hub.impl.HubConfigImpl;
@@ -41,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = ApplicationConfig.class)
-public class DeployToDhsTest extends HubTestBase {
+public class DeployAsDeveloperTest extends HubTestBase {
 
     private AppConfig originalAppConfig;
 
@@ -168,13 +167,11 @@ public class DeployToDhsTest extends HubTestBase {
 
     @Test
     public void buildCommandList() {
-        List<Command> commands = new DhsDeployer().buildCommandListForDeployingToDhs(adminHubConfig);
+        List<Command> commands = new DhsDeployer().buildCommandsForDeveloper(adminHubConfig);
         Collections.sort(commands, Comparator.comparing(Command::getExecuteSortOrder));
         System.out.println(commands);
-        assertEquals(12, commands.size());
         int index = 0;
         assertTrue(commands.get(index++) instanceof DeployOtherDatabasesCommand);
-        assertTrue(commands.get(index++) instanceof DeployDatabaseFieldCommand);
         assertTrue(commands.get(index++) instanceof LoadSchemasCommand);
         assertTrue(commands.get(index++) instanceof LoadUserModulesCommand);
         assertTrue(commands.get(index++) instanceof DeployTriggersCommand);
@@ -185,6 +182,11 @@ public class DeployToDhsTest extends HubTestBase {
         assertTrue(commands.get(index++) instanceof DeployAlertConfigsCommand);
         assertTrue(commands.get(index++) instanceof DeployAlertActionsCommand);
         assertTrue(commands.get(index++) instanceof DeployAlertRulesCommand);
+        assertEquals(11, commands.size(),
+            "As of ML 10.0-3, the granular privilege for indexes doesn't seem to work with XML payloads. " +
+                "Bug https://bugtrack.marklogic.com/54231 has been created to track that. Thus, " +
+                "DeployDatabaseFieldCommand cannot be included and ml-config/database-fields/final-database.xml " +
+                "cannot be processed.");
 
         DeployOtherDatabasesCommand dodc = (DeployOtherDatabasesCommand) commands.get(0);
         ResourceFilenameFilter filter = (ResourceFilenameFilter) dodc.getResourceFilenameFilter();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/DeployAsSecurityAdminTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/DeployAsSecurityAdminTest.java
@@ -1,0 +1,21 @@
+package com.marklogic.hub.dhs;
+
+import com.marklogic.appdeployer.command.Command;
+import com.marklogic.appdeployer.command.security.DeployRolesCommand;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DeployAsSecurityAdminTest {
+
+    @Test
+    void buildCommands() {
+        List<Command> commands = new DhsDeployer().buildCommandsForSecurityAdmin();
+        assertEquals(1, commands.size());
+        assertTrue(commands.get(0) instanceof DeployRolesCommand,
+            "As of 5.2.0, a data-hub-security-admin can only deploy roles");
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/HubConfigImplTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/HubConfigImplTest.java
@@ -51,7 +51,7 @@ public class HubConfigImplTest {
         env.setProperty("mlHost", "somehost");
 
         HubConfigImpl config = new HubConfigImpl(project, env);
-        config.refreshProject(new Properties(), false);
+        config.loadConfigurationFromProperties(new Properties(), false);
         assertEquals("somehost", config.getHost());
         assertEquals("somehost", config.getAppConfig().getHost());
     }

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -25,16 +25,10 @@ import com.marklogic.gradle.task.client.WatchTask
 import com.marklogic.gradle.task.command.HubUpdateIndexesCommand
 import com.marklogic.gradle.task.databases.ClearModulesDatabaseTask
 import com.marklogic.gradle.task.databases.UpdateIndexesTask
-import com.marklogic.gradle.task.dhs.DhsDeployTask
+import com.marklogic.gradle.task.deploy.DeployAsDeveloperTask
+import com.marklogic.gradle.task.deploy.DeployAsSecurityAdminTask
 import com.marklogic.hub.ApplicationConfig
-import com.marklogic.hub.dhs.installer.command.InstallIntoDhsCommand
-import com.marklogic.hub.deploy.commands.ClearDHFModulesCommand
-import com.marklogic.hub.deploy.commands.GenerateFunctionMetadataCommand
-import com.marklogic.hub.deploy.commands.GeneratePiiCommand
-import com.marklogic.hub.deploy.commands.LoadHubArtifactsCommand
-import com.marklogic.hub.deploy.commands.LoadHubModulesCommand
-import com.marklogic.hub.deploy.commands.LoadUserArtifactsCommand
-import com.marklogic.hub.deploy.commands.LoadUserModulesCommand
+import com.marklogic.hub.deploy.commands.*
 import com.marklogic.hub.deploy.util.ModuleWatchingConsumer
 import com.marklogic.hub.impl.*
 import com.marklogic.hub.legacy.impl.LegacyFlowManagerImpl
@@ -83,7 +77,7 @@ class DataHubPlugin implements Plugin<Project> {
 
         project.plugins.apply(MarkLogicPlugin.class)
 
-        logger.info("\nInitializing data-hub-gradle")
+        logger.info("\nInitializing ml-data-hub Gradle plugin")
         setupHub(project)
 
         String deployGroup = "MarkLogic Data Hub Setup"
@@ -190,10 +184,18 @@ class DataHubPlugin implements Plugin<Project> {
         String flowGroup = "MarkLogic Data Hub Flow Management"
         project.task("hubRunFlow", group: flowGroup, type: RunFlowTask)
 
-        String dhsGroup = "DHS"
-        project.task("dhsDeploy", group: dhsGroup, type: DhsDeployTask,
-            description: "Deploy project resources and modules into a DHS instance"
-        ).finalizedBy(["hubGenerateExplorerOptions"])
+        project.task("hubDeployAsSecurityAdmin", group: deployGroup, type: DeployAsSecurityAdminTask,
+            description: "Deploy roles as a user with the data-hub-security-admin role")
+
+        project.task("hubDeployAsDeveloper", group: deployGroup, type: DeployAsDeveloperTask,
+            description: "Deploy project configuration as a user with the data-hub-developer role"
+        ).finalizedBy(["hubGenerateExplorerOptions"]).mustRunAfter("hubDeployAsSecurityAdmin")
+
+        project.task("hubDeploy", group: deployGroup, dependsOn: ["hubDeployAsDeveloper", "hubDeployAsSecurityAdmin"],
+            description: "Deploy project configuration as a user with the data-hub-security-admin and data-hub-developer roles")
+
+        project.task("dhsDeploy", dependsOn: ["hubDeploy"],
+            description: "dhsDeploy has been replaced in 5.2.0 by hubDeploy and similar tasks. It is now simply an alias for hubDeploy.")
 
         logger.info("Finished initializing ml-data-hub\n")
     }
@@ -231,42 +233,38 @@ class DataHubPlugin implements Plugin<Project> {
 
         hubConfig.createProject(project.getProjectDir().getAbsolutePath())
 
-        boolean calledHubInit = this.userCalledTask(project, "hubinit")
-        boolean calledHubUpdate = this.userCalledTask(project, "hubupdate")
-        boolean calledHubInitOrUpdate = calledHubInit || calledHubUpdate
-
+        boolean calledHubInitOrUpdate = userCalledTask(project, "hubinit") || userCalledTask(project, "hubupdate")
         if (!calledHubInitOrUpdate && !hubProject.isInitialized()) {
             throw new GradleException("Please initialize your project first by running the 'hubInit' Gradle task, or update it by running the 'hubUpdate' Gradle task")
         }
 
         else {
 
-            // If the user called hubInit, only load the configuration. Refreshing the project will fail because
-            // gradle.properties doesn't exist yet.
-            if (calledHubInit) {
-                hubConfig.loadConfigurationFromProperties(new ProjectPropertySource(project).getProperties(), false)
-            }
-             else {
-                Properties props = new ProjectPropertySource(project).getProperties()
-
-                if (userCalledTask(project, "dhsdeploy")) {
-                    new InstallIntoDhsCommand().applyDhsSpecificProperties(props)
-                }
-
-                hubConfig.refreshProject(props, false)
-            }
-
             // By default, DHF uses gradle-local.properties for your local environment.
             def envNameProp = project.hasProperty("environmentName") ? project.property("environmentName") : "local"
             hubConfig.withPropertiesFromEnvironment(envNameProp.toString())
 
-            hubConfig.setAppConfig(extensions.getByName("mlAppConfig"))
+            // Assign the AppConfig created by ml-gradle to hubConfig so that when it updates its instance of AppConfig
+            // with DHF-specific values, it's updating the instance that's used by all the ml-gradle tasks as well.
+            // Can skip updating the AppConfig as it will be updated via the call to loadConfigurationFromProperties.
+            hubConfig.setAppConfig(extensions.getByName("mlAppConfig"), true)
+
+            // Create a Properties object containing all of the properties loaded by Gradle
+            Properties projectProperties = new ProjectPropertySource(project).getProperties()
+            // Populate hubConfig properties, telling hubConfig not to load from gradle.properties as that's already happened
+            hubConfig.loadConfigurationFromProperties(projectProperties, false)
+
+            // Ensure that hubConfig is using the same admin/manage objects that ml-gradle created. DHF doesn't have
+            // any additional properties for customizing these objects, so whatever was created by ml-gradle is what
+            // DHF should use as well.
             hubConfig.setAdminConfig(extensions.getByName("mlAdminConfig"))
             hubConfig.setAdminManager(extensions.getByName("mlAdminManager"))
             hubConfig.setManageConfig(extensions.getByName("mlManageConfig"))
             hubConfig.setManageClient(extensions.getByName("mlManageClient"))
 
             // Turning off CMA for resources that have bugs in ML 9.0-7/8
+            // TODO This can likely be removed now that DHF requires a version higher than those, but will need to test
+            // to confirm.
             hubConfig.getAppConfig().getCmaConfig().setCombineRequests(false);
             hubConfig.getAppConfig().getCmaConfig().setDeployDatabases(false);
             hubConfig.getAppConfig().getCmaConfig().setDeployRoles(false);
@@ -295,6 +293,15 @@ class DataHubPlugin implements Plugin<Project> {
     boolean userCalledTask(Project project, String lowerCaseTaskName) {
         for (String taskName : project.getGradle().getStartParameter().getTaskNames()) {
             if (taskName.toLowerCase().equals(lowerCaseTaskName)) {
+                return true
+            }
+        }
+        return false
+    }
+
+    boolean userCalledDhsDeployTask(Project project) {
+        for (String taskName : project.getGradle().getStartParameter().getTaskNames()) {
+            if (taskName.toLowerCase().startsWith("dhsdeploy")) {
                 return true
             }
         }

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/deploy/DeployAsDeveloperTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/deploy/DeployAsDeveloperTask.groovy
@@ -1,0 +1,13 @@
+package com.marklogic.gradle.task.deploy
+
+import com.marklogic.gradle.task.HubTask
+import com.marklogic.hub.dhs.DhsDeployer
+import org.gradle.api.tasks.TaskAction
+
+class DeployAsDeveloperTask extends HubTask {
+
+    @TaskAction
+    void deployToDhs() {
+        new DhsDeployer().deployAsDeveloper(getHubConfig())
+    }
+}

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/deploy/DeployAsSecurityAdminTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/deploy/DeployAsSecurityAdminTask.groovy
@@ -1,13 +1,14 @@
-package com.marklogic.gradle.task.dhs
+package com.marklogic.gradle.task.deploy
 
 import com.marklogic.gradle.task.HubTask
 import com.marklogic.hub.dhs.DhsDeployer
 import org.gradle.api.tasks.TaskAction
 
-class DhsDeployTask extends HubTask {
+class DeployAsSecurityAdminTask extends HubTask {
 
     @TaskAction
     void deployToDhs() {
-        new DhsDeployer().deployToDhs(getHubConfig())
+        new DhsDeployer().deployAsSecurityAdmin(getHubConfig())
     }
+
 }

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/HubUpdateTaskTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/HubUpdateTaskTest.groovy
@@ -31,7 +31,7 @@ class HubUpdateTaskTest extends BaseTest {
         println(runTask('hubInstallModules', '-i').getOutput())
         println(runTask('mlLoadModules', '-i').getOutput())
     }
-    
+
     //if 4.0 project is upgraded, remove the backed up directories
     def setup() {
         File hubConfigDir = hubConfig().hubProject.projectDir.resolve("src/main/hub-internal-config-" + hubConfig().getDHFVersion()).toFile()
@@ -46,7 +46,7 @@ class HubUpdateTaskTest extends BaseTest {
         given:
         def gradlePropsFile = testProjectDir.getRoot().toPath().resolve("gradle.properties")
         gradlePropsFile.toFile().append("\nmlDHFVersion=4.2.2");
-        hubConfig().refreshProject(null, true)
+        hubConfig().loadConfigurationFromProperties(null, true)
         when:
         def result = runFailTask("hubUpdate")
 


### PR DESCRIPTION
Most of the files in here are for a new example project - dhs-example. 

This is now simpler as we're no longer in the business of eagerly setting DHS-specific properties, like basic auth and SSL. It'll still be up to the user to set those in their gradle-dhs.properties file. 