### PR TITLE
DHFPROD-4154: Developer no longer inherits rest-admin

### DIFF
--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-developer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-developer.json
@@ -5,16 +5,19 @@
     "data-hub-operator",
     "manage-user",
     "ps-user",
-    "rest-admin",
     "tde-admin",
     "data-hub-module-writer",
     "data-hub-flow-writer",
     "data-hub-mapping-writer",
     "data-hub-step-definition-writer",
     "data-hub-entity-model-writer"
-
   ],
   "privilege": [
+    {
+      "privilege-name": "any-uri",
+      "action": "http://marklogic.com/xdmp/privileges/any-uri",
+      "kind": "execute"
+    },
     {
       "privilege-name": "create-trigger",
       "action": "http://marklogic.com/xdmp/privileges/create-trigger",
@@ -36,8 +39,8 @@
       "kind": "execute"
     },
     {
-      "privilege-name": "any-uri",
-      "action": "http://marklogic.com/xdmp/privileges/any-uri",
+      "privilege-name": "rest-admin",
+      "action": "http://marklogic.com/xdmp/privileges/rest-admin",
       "kind": "execute"
     },
     {

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-operator.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-operator.json
@@ -9,7 +9,8 @@
     "data-hub-flow-reader",
     "data-hub-mapping-reader",
     "data-hub-entity-model-reader",
-    "data-hub-step-definition-reader"
+    "data-hub-step-definition-reader",
+    "tde-view"
   ],
   "privilege": [
     {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/AbstractSecurityTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/AbstractSecurityTest.java
@@ -42,8 +42,6 @@ public abstract class AbstractSecurityTest extends HubTestBase {
     protected ManageClient userWithRoleBeingTestedClient;
     protected API userWithRoleBeingTestedApi;
 
-    private List<String> customPrivilegeNames = new ArrayList<>();
-
     @BeforeEach
     public void setupFlowDeveloperApi() {
         // It's assumed that the "admin" user is the default user for talking to the Manage API

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubDeveloperTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubDeveloperTest.java
@@ -203,10 +203,9 @@ public class DataHubDeveloperTest extends AbstractSecurityTest {
         Assumptions.assumeTrue(isVersionCompatibleWith520Roles());
         Task task = new Task(userWithRoleBeingTestedApi, null);
         task.setTaskPath("/MarkLogic/flexrep/tasks/push-local-forests.xqy");
-        if(adminHubConfig.getIsProvisionedEnvironment()) {
+        if (adminHubConfig.getIsProvisionedEnvironment()) {
             task.setGroupName("Curator");
-        }
-        else {
+        } else {
             task.setGroupName("Default");
         }
         task.setTaskEnabled(false);
@@ -276,8 +275,15 @@ public class DataHubDeveloperTest extends AbstractSecurityTest {
      */
     @Test
     public void tasks19And20And22And23And24And26And27And29And30And31And37And38() {
-        assertTrue(roleBeingTested.getRole().contains("rest-admin"),
-            "Task 19: rest-admin allows the user to insert documents via /v1/documents");
+        assertFalse(roleBeingTested.getRole().contains("rest-admin"),
+            "The role should have the rest-admin privilege, but not the rest-admin role; this prevents several " +
+                "default permissions from being added to the role which users may not want");
+        assertFalse(roleBeingTested.getRole().contains("rest-writer"),
+            "The role should not have the rest-writer role; this prevents several " +
+                "default permissions from being added to the role which users may not want");
+
+        assertTrue(roleBeingTested.getRole().contains("data-hub-operator"),
+            "Task 19: data-hub-operator inherits the rest-writer privilege, which allows the user to write documents via /v1/documents");
 
         assertTrue(roleBeingTested.getRole().contains("tde-admin"),
             "Task 19 and 24: tde-admin allows the user to insert TDE schemas into the TDE protected collection");
@@ -285,8 +291,8 @@ public class DataHubDeveloperTest extends AbstractSecurityTest {
         assertTrue(roleBeingTested.getRole().contains("data-hub-flow-writer"),
             "Tasks 20 : data-hub-flow-writer is required for allowing the user to perform CRUD operations on flows");
 
-        assertTrue(roleBeingTested.getRole().contains("rest-admin"),
-            "Tasks 22: rest-admin is sufficient for allowing the user to perform CRUD operations on  " +
+        assertTrue(roleBeingTested.getRole().contains("data-hub-operator"),
+            "Tasks 22: data-hub-operator has the rest-writer privilege, which is sufficient for allowing the user to perform CRUD operations on  " +
                 "schemas, as it defaults to being inserted with rest-reader/rest-writer permissions via " +
                 "flow-developer/ data-hub-developer roles");
 
@@ -294,9 +300,9 @@ public class DataHubDeveloperTest extends AbstractSecurityTest {
             "Task 23: The ML provenance functions add ps-user/read and ps-internal/update permissions by default on " +
                 "provenance documents; thus, a user needs ps-user to read these documents");
 
-        assertTrue(roleBeingTested.getRole().contains("rest-admin"),
+        assertTrue(roleBeingTested.getRole().contains("data-hub-operator"),
             "Tasks 26 and 27: Artifacts get rest-reader and rest-writer by default via " +
-                "mlEntityModelPermissions, and thus rest-admin provides access to reading these documents");
+                "mlEntityModelPermissions, and thus data-hub-operator, which inherits rest-reader, provides access to reading these documents");
 
         assertTrue(roleBeingTested.getRole().contains("manage-user"),
             "Tasks 29 and 30: manage-user grants access to app-server logs, but not system logs");
@@ -304,10 +310,8 @@ public class DataHubDeveloperTest extends AbstractSecurityTest {
         assertTrue(roleBeingTested.getRole().contains("manage-user"),
             "Task 31: manage-user grants read access to documents in the Meters database");
 
-        assertTrue(roleBeingTested.getRole().contains("rest-admin"),
-            "Tasks 37 and 38: these tasks are redundant with task 19; rest-admin allows a user to write these documents");
-
-
+        assertTrue(roleBeingTested.getRole().contains("data-hub-operator"),
+            "Tasks 37 and 38: these tasks are redundant with task 19; data-hub-operator allows a user to write these documents");
     }
 
     private GeospatialElementIndex buildGeoIndex() {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubOperatorTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubOperatorTest.java
@@ -1,9 +1,5 @@
 package com.marklogic.hub.security;
 
-import com.marklogic.bootstrap.Installer;
-import org.custommonkey.xmlunit.XMLUnit;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -23,20 +19,17 @@ public class DataHubOperatorTest extends AbstractSecurityTest {
         return "data-hub-operator";
     }
 
-    @BeforeAll
-    public static void setup() {
-        XMLUnit.setIgnoreWhitespace(true);
-        new Installer().deleteProjectDir();
-    }
-
-    @AfterAll
-    public static void cleanUp() {
-        new Installer().deleteProjectDir();
-    }
-
     @Test
     public void task32ReadJobDocuments() {
         assertTrue(roleBeingTested.getRole().contains("data-hub-job-reader"),
             "The data-hub-job-reader role grants access to Job and Batch documents in the jobs database");
+    }
+
+    @Test
+    void readSchemas() {
+        assertTrue(roleBeingTested.getRole().contains("tde-view"),
+            "The entity models and generated artifacts in the schema databases are known to have a tde-view/read " +
+                "permissions on them. Since they may have no other read permissions, the operator requires this so that " +
+                "it can read entity models.");
     }
 }


### PR DESCRIPTION
This avoids rest-reader/rest-writer default permissions from being added to every document inserted by this user (which was courtesy of the rest-writer role, which is inherited by rest-admin). 

Had to add tde-view to the operator to ensure that user can see TDE stuff in the schemas database.