### PR TITLE
WIP DHFPROD-4152: Matching and merging steps now support permissions

### DIFF
--- a/examples/dh-5-example/flows/ingestion_mapping_mastering-flow.flow.json
+++ b/examples/dh-5-example/flows/ingestion_mapping_mastering-flow.flow.json
@@ -17,7 +17,7 @@
         "collections": [
           "mastering-flow-ingest-json"
         ],
-        "permissions": "rest-reader,read,rest-writer,update",
+        "permissions": "data-hub-operator,read,data-hub-operator,update",
         "outputFormat": "json",
         "targetDatabase": "data-hub-STAGING"
       },
@@ -64,6 +64,7 @@
         "acceptsBatch": true,
         "targetEntity": "Order",
         "sourceDatabase": "data-hub-FINAL",
+        "permissions": "data-hub-operator,read,data-hub-operator,update",
         "collections": [
           "json-matching-step-json"
         ],
@@ -147,6 +148,7 @@
         "sourceQuery": "cts.collectionQuery('json-matching-step-json')",
         "targetEntity": "Order",
         "sourceDatabase": "data-hub-FINAL",
+        "permissions": "data-hub-operator,read,data-hub-operator,update",
         "collections": [
           "mastered1"
         ],

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/auditing/base.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/auditing/base.xqy
@@ -33,6 +33,11 @@ declare variable $rdfs-prefix := fn:namespace-uri-from-QName(xs:QName("rdfs:docu
 declare variable $RDF-TYPE-IRI := sem:iri($rdf-prefix || "type");
 declare variable $RDFS-LABEL-IRI := sem:iri($rdfs-prefix || "label");
 
+declare private variable $AUDIT-PERMISSIONS := (
+  xdmp:permission("data-hub-operator", "read"),
+  xdmp:permission("data-hub-operator", "update")
+);
+
 declare private variable $ps-collection as xs:string :=
  "http://marklogic.com/provenance-services/record";
 
@@ -60,7 +65,7 @@ declare function auditing:audit-trace(
     xdmp:document-insert(
       $audit-trace-def => map:get("uri"),
       $audit-trace-def => map:get("value"),
-      xdmp:default-permissions(),
+      (xdmp:default-permissions(), $AUDIT-PERMISSIONS),
       $audit-trace-def => map:get("context") => map:get("collections")
     )
 };
@@ -194,7 +199,10 @@ declare function auditing:build-audit-trace(
     map:map()
       => map:with("uri", "/com.marklogic.smart-mastering/auditing/"|| $action ||"/"||sem:uuid-string()||".xml")
       => map:with("value", $prov-xml)
-      => map:with("context", map:entry("collections",coll:auditing-collections($options)))
+      => map:with("context", map:new((
+        map:entry("collections",coll:auditing-collections($options)),
+        map:entry("permissions", $AUDIT-PERMISSIONS)
+      )))
 };
 
 (:

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mastering/default/matching.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mastering/default/matching.sjs
@@ -51,15 +51,27 @@ function main(content, options) {
     options.filterQuery ? cts.query(options.filterQuery) : cts.trueQuery(),
     datahub.prov.granularityLevel() === datahub.prov.FINE_LEVEL
   );
-  return {
+
+  return buildResult(matchSummaryJson, options, collections);
+}
+
+function buildResult(matchSummaryJson, options, collections) {
+  let result = {
     uri: `/datahub/5/mastering/match-summary/${sem.uuidString()}.json`,
     value: matchSummaryJson,
     context: {
       collections
     }
   };
+
+  if (options.permissions) {
+    result.context.permissions = datahub.hubUtils.parsePermissions(options.permissions);
+  }
+
+  return result;
 }
 
 module.exports = {
-  main
+  main,
+  buildResult
 };

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mastering/default/merging.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mastering/default/merging.sjs
@@ -50,14 +50,14 @@ function main(content, options) {
       collectionQuery
     ];
     const otherMergesForURI = cts.search(
-        cts.andNotQuery(
-          cts.andQuery(postiveQuery),
-          uriRangeQuery
-        ),
-        ['unfiltered',cts.indexOrder(datahubCreatedOnRef, 'descending')]
-      ).toArray().map(
-        (result) => result.xpath(`/matchSummary/actionDetails/*[action = 'merge']`).toArray()
-          .filter((actionNode) => cts.contains(actionNode, urisQuery))[0].toObject()
+      cts.andNotQuery(
+        cts.andQuery(postiveQuery),
+        uriRangeQuery
+      ),
+      ['unfiltered',cts.indexOrder(datahubCreatedOnRef, 'descending')]
+    ).toArray().map(
+      (result) => result.xpath(`/matchSummary/actionDetails/*[action = 'merge']`).toArray()
+        .filter((actionNode) => cts.contains(actionNode, urisQuery))[0].toObject()
     );
     if (otherMergesForURI.some((otherMerge) => otherMerge.uris.length > uriActionDetails.uris.length)) {
       return Sequence.from([]);
@@ -94,7 +94,33 @@ function main(content, options) {
       });
     }
   }
+
+  applyPermissionsFromOptions(results, options);
+
   return results;
+}
+
+function applyPermissionsFromOptions(results, options) {
+  if (options.permissions) {
+    const parsedPermissions = datahub.hubUtils.parsePermissions(options.permissions);
+    for (var result of results) {
+      if (result['$delete'] == true) {
+        continue;
+      }
+      if (result.context) {
+        const existingPerms = result.context.permissions;
+        if (existingPerms) {
+          result.context.permissions = parsedPermissions.concat(existingPerms);
+        } else {
+          result.context.permissions = parsedPermissions;
+        }
+      } else {
+        result.context = {
+          permissions: parsedPermissions
+        };
+      }
+    }
+  }
 }
 
 function jobReport(jobID, stepResponse, options) {
@@ -120,5 +146,6 @@ function jobReport(jobID, stepResponse, options) {
 
 module.exports = {
   main,
-  jobReport
+  jobReport,
+  applyPermissionsFromOptions
 };

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/master/MasterTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/master/MasterTest.java
@@ -88,7 +88,7 @@ public class MasterTest extends HubTestBase {
         installHubArtifacts(adminHubConfig, true);
         installUserModules(adminHubConfig, true);
 
-        runAsFlowOperator();
+        runAsDataHubOperator();
     }
 
 

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mastering/default/applyPermissionsInMatchingStep.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mastering/default/applyPermissionsInMatchingStep.sjs
@@ -1,0 +1,32 @@
+const matching = require("/data-hub/5/builtins/steps/mastering/default/matching.sjs");
+const test = require("/test/test-helper.xqy");
+
+let result = matching.buildResult(
+  {"anything": "works here"},
+  {permissions: "data-hub-operator,read,data-hub-developer,update"},
+  ["coll1", "coll2"]
+);
+
+let assertions = [
+  test.assertEqual("works here", result.value.anything),
+  test.assertEqual("coll1", result.context.collections[0]),
+  test.assertEqual("coll2", result.context.collections[1]),
+
+  test.assertEqual("data-hub-operator", xdmp.roleName(result.context.permissions[0].roleId)),
+  test.assertEqual("read", result.context.permissions[0].capability),
+  test.assertEqual("data-hub-developer", xdmp.roleName(result.context.permissions[1].roleId)),
+  test.assertEqual("update", result.context.permissions[1].capability)
+];
+
+result = matching.buildResult(
+  {"anything": "works here"},
+  ["coll1"]
+);
+
+assertions.push(
+  test.assertEqual("works here", result.value.anything),
+  test.assertTrue(result.context.permissions == undefined,
+    "If permissions are not in the step options, then no permissions should be assigned to the context")
+);
+
+assertions;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mastering/default/applyPermissionsInMergingStep.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mastering/default/applyPermissionsInMergingStep.sjs
@@ -1,0 +1,78 @@
+const merging = require("/data-hub/5/builtins/steps/mastering/default/merging.sjs");
+const test = require("/test/test-helper.xqy");
+
+let results = [
+  {
+    uri: "deleteMe",
+    "$delete": true
+  },
+  {
+    uri: "hasPermissions",
+    context: {
+      permissions: [xdmp.permission("manage-user", "read"), xdmp.permission("manage-admin", "update")]
+    }
+  },
+  {
+    uri: "hasContextNoPermissions",
+    context: {}
+  },
+  {
+    uri: "noContext"
+  },
+  {
+    uri: "hasPermissionsObject",
+    context: {
+      permissions: xdmp.permission("manage-user", "read")
+    }
+  }
+];
+
+merging.applyPermissionsFromOptions(results, {permissions: "data-hub-operator,read,data-hub-developer,update"});
+
+let assertions = [
+  test.assertTrue(results[0].context == null, "Permissions aren't deleted for a document that is intended to be deleted")
+];
+
+let perms = results[1].context.permissions;
+assertions.push(
+  test.assertEqual(4, perms.length),
+  test.assertEqual("data-hub-operator", xdmp.roleName(perms[0].roleId)),
+  test.assertEqual("read", perms[0].capability),
+  test.assertEqual("data-hub-developer", xdmp.roleName(perms[1].roleId)),
+  test.assertEqual("update", perms[1].capability),
+  test.assertEqual("manage-user", xdmp.roleName(perms[2].roleId)),
+  test.assertEqual("read", perms[2].capability),
+  test.assertEqual("manage-admin", xdmp.roleName(perms[3].roleId)),
+  test.assertEqual("update", perms[3].capability)
+);
+
+perms = results[2].context.permissions;
+assertions.push(
+  test.assertEqual(2, perms.length),
+  test.assertEqual("data-hub-operator", xdmp.roleName(perms[0].roleId)),
+  test.assertEqual("read", perms[0].capability),
+  test.assertEqual("data-hub-developer", xdmp.roleName(perms[1].roleId)),
+  test.assertEqual("update", perms[1].capability)
+);
+
+perms = results[3].context.permissions;
+assertions.push(
+  test.assertEqual(2, perms.length),
+  test.assertEqual("data-hub-operator", xdmp.roleName(perms[0].roleId)),
+  test.assertEqual("read", perms[0].capability),
+  test.assertEqual("data-hub-developer", xdmp.roleName(perms[1].roleId)),
+  test.assertEqual("update", perms[1].capability)
+);
+
+perms = results[4].context.permissions;
+assertions.push(
+  test.assertEqual(3, perms.length),
+  test.assertEqual("data-hub-operator", xdmp.roleName(perms[0].roleId)),
+  test.assertEqual("read", perms[0].capability),
+  test.assertEqual("data-hub-developer", xdmp.roleName(perms[1].roleId)),
+  test.assertEqual("update", perms[1].capability),
+  test.assertEqual("manage-user", xdmp.roleName(perms[2].roleId)),
+  test.assertEqual("read", perms[2].capability)
+);
+
+assertions;

--- a/marklogic-data-hub/src/test/resources/master-test/flows/myMatchMergeFlow.flow.json
+++ b/marklogic-data-hub/src/test/resources/master-test/flows/myMatchMergeFlow.flow.json
@@ -18,7 +18,8 @@
         "targetDatabase": "data-hub-STAGING",
         "sourceQuery": null,
         "outputFormat": "json",
-        "collections": ["default-ingestion"]
+        "collections": ["default-ingestion"],
+        "permissions": "data-hub-operator,read,data-hub-operator,update"
       }
     },
     "2": {
@@ -26,7 +27,8 @@
       "stepDefinitionType": "MAPPING",
       "options": {
         "sourceDatabase": "data-hub-STAGING",
-        "targetDatabase": "data-hub-FINAL"
+        "targetDatabase": "data-hub-FINAL",
+        "permissions": "data-hub-operator,read,data-hub-operator,update"
       }
     },
     "3": {
@@ -36,6 +38,7 @@
         "targetEntity": "person",
         "sourceQuery": "cts.collectionQuery('mapping')",
         "collections": ["myMatchingCollection"],
+        "permissions": "data-hub-operator,read,data-hub-operator,update",
         "provenanceGranularityLevel": "fine",
         "sourceDatabase": "data-hub-FINAL",
         "targetDatabase": "data-hub-FINAL",
@@ -123,6 +126,7 @@
         "sourceQuery": "cts.collectionQuery('myMatchingCollection')",
         "sourceDatabase": "data-hub-FINAL",
         "targetDatabase": "data-hub-FINAL",
+        "permissions": "data-hub-operator,read,data-hub-operator,update",
         "mergeOptions": {
           "propertyDefs": {
             "properties": [

--- a/marklogic-data-hub/src/test/resources/master-test/flows/myNewFlow.flow.json
+++ b/marklogic-data-hub/src/test/resources/master-test/flows/myNewFlow.flow.json
@@ -18,7 +18,8 @@
         "targetDatabase": "data-hub-STAGING",
         "sourceQuery": null,
         "outputFormat": "json",
-        "collections": ["default-ingestion"]
+        "collections": ["default-ingestion"],
+        "permissions": "data-hub-operator,read,data-hub-operator,update"
       }
     },
     "2": {
@@ -26,7 +27,8 @@
       "stepDefinitionType": "MAPPING",
       "options": {
         "sourceDatabase": "data-hub-STAGING",
-        "targetDatabase": "data-hub-FINAL"
+        "targetDatabase": "data-hub-FINAL",
+        "permissions": "data-hub-operator,read,data-hub-operator,update"
       }
     },
     "3": {
@@ -35,7 +37,8 @@
       "options": {
         "provenanceGranularityLevel": "fine",
         "sourceDatabase": "data-hub-FINAL",
-        "targetDatabase": "data-hub-FINAL"
+        "targetDatabase": "data-hub-FINAL",
+        "permissions": "data-hub-operator,read,data-hub-operator,update"
       }
     }
   }


### PR DESCRIPTION
@ryanjdew The initial scope of this was to ensure that the options.permissions property is honored by the matching/merging steps. I believe that's fixed.

Then I tried to run MasterTest as a data-hub-operator - i.e. someone without any default permissions. I ran into a number of problems where the SM code is inserting a document and only calling "xdmp:default-permissions()". 

I started to add a hack of "default" perms of data-hub-operator read/update, but I wanted to get your thoughts first. 

Is it correct that SM requires a user to have default permissions? In my experience, that's not common for users to have - normally the application code determines what permissions to add. That would leave two options:

1. Use a "default" set of perms in addition to default permissions (easy enough to do)
1. Add support for configuring the perms for various documents inserted by SM (a lot more effort)

Thoughts?