### PR TITLE
DHFPROD-4245: Applying default permissions in QS for every step type

### DIFF
--- a/web/src/main/ui/app/components/flows-new/models/mapping-options.model.ts
+++ b/web/src/main/ui/app/components/flows-new/models/mapping-options.model.ts
@@ -8,4 +8,5 @@ export class MappingOptions {
   public mapping: any;
   public targetEntity: string;
   public outputFormat: string;
+  public permissions: string;
 }

--- a/web/src/main/ui/app/components/flows-new/models/mastering-options.model.ts
+++ b/web/src/main/ui/app/components/flows-new/models/mastering-options.model.ts
@@ -9,6 +9,7 @@ export class MasteringOptions {
   public sourceDatabase: string = '';
   public targetDatabase: string;
   public outputFormat: string;
+  public permissions: string;
   public matchOptions: Matching;
   public mergeOptions: Merging;
   constructor() {

--- a/web/src/main/ui/app/components/flows-new/models/step.model.ts
+++ b/web/src/main/ui/app/components/flows-new/models/step.model.ts
@@ -76,6 +76,7 @@ export class Step {
   static createMappingStep(): Step {
     const step = new Step();
     step.options = new MappingOptions();
+    step.options.permissions = 'data-hub-operator,read,data-hub-operator,update';
     step.options.outputFormat = 'json';
     step.customHook = {"module" : "",
     "parameters" : {},
@@ -90,6 +91,7 @@ export class Step {
   static createMatchingStep(): Step {
     const step = new Step();
     step.options = new MatchingOptions();
+    step.options.permissions = 'data-hub-operator,read,data-hub-operator,update';
     step.options.outputFormat = 'json';
     step.customHook = {"module" : "",
     "parameters" : {},
@@ -104,6 +106,7 @@ export class Step {
   static createMergingStep(): Step {
     const step = new Step();
     step.options = new MergingOptions();
+    step.options.permissions = 'data-hub-operator,read,data-hub-operator,update';
     step.options.outputFormat = 'json';
     step.customHook = {"module" : "",
     "parameters" : {},
@@ -118,6 +121,7 @@ export class Step {
   static createMasteringStep(): Step {
     const step = new Step();
     step.options = new MasteringOptions();
+    step.options.permissions = 'data-hub-operator,read,data-hub-operator,update';
     step.options.outputFormat = 'json';
     step.customHook = {"module" : "",
     "parameters" : {},


### PR DESCRIPTION
I'm not sure why these steps didn't gain default permissions the first time around, but I think we're better off doing it for all step types.