### PR TITLE
DHFPROD-4158: hubDeploy tasks now work on-premise

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/HubConfig.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/HubConfig.java
@@ -337,6 +337,8 @@ public interface HubConfig {
      */
     Boolean getIsProvisionedEnvironment();
 
+    void setIsProvisionedEnvironment(boolean isProvisionedEnvironment);
+
     /**
      * Returns the path for the custom forests definition
      * @return path where the custom forests are as string

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dhs/DhsDeployer.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dhs/DhsDeployer.java
@@ -57,6 +57,14 @@ public class DhsDeployer extends LoggingObject {
      * @param hubConfig
      */
     protected void prepareAppConfigForDeployingToDhs(HubConfig hubConfig) {
+        /**
+         * It's likely the user has this set for deploying to DHS. But in case the user wants to test this on an
+         * on-premise installation, it may not seem intuitive to set it to true. But it needs to be set to true so that
+         * DHF knows to e.g. remove certain properties when updating databases to avoid privilege errors. The property
+         * should arguably be interpreted as "is the user restricted" as opposed to "is the environment provisioned".
+         */
+        hubConfig.setIsProvisionedEnvironment(true);
+
         setKnownValuesForDhsDeployment(hubConfig);
 
         AppConfig appConfig = hubConfig.getAppConfig();

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -929,6 +929,11 @@ public class HubConfigImpl implements HubConfig
         return isProvisionedEnvironment;
     }
 
+    @Override
+    public void setIsProvisionedEnvironment(boolean isProvisionedEnvironment) {
+        this.isProvisionedEnvironment = isProvisionedEnvironment;
+    }
+
     public void setLoadBalancerHost(String loadBalancerHost) {
         this.loadBalancerHost = loadBalancerHost;
     }


### PR DESCRIPTION
It's necessary for these tasks to set "is provisioned environment" to true so that DHF excludes certain properties from database files.