### PR TITLE
DHFPROD-4257: QS should consider mapping name from the flow file as well

### DIFF
--- a/web/src/main/ui/app/components/flows-new/edit-flow/mapping/mapping.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/mapping/mapping.component.ts
@@ -107,7 +107,7 @@ export class MappingComponent implements OnInit {
   ) {}
 
   getMapName(): string {
-    return this.flow.name + '-' + this.step.name;
+    return this.step.options.mapping.name || this.flow.name + '-' + this.step.name;
   }
 
   ngOnInit() {


### PR DESCRIPTION
Without this, a flow configured outside of QS, shows up empty mapping configuration although mapping config is available.