### PR TITLE
DHFPROD-4207: Field range indexes now use root instead of en collation

### DIFF
--- a/marklogic-data-hub/src/main/resources/hub-internal-config/database-fields/staging-database.xml
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/database-fields/staging-database.xml
@@ -86,21 +86,21 @@
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>datahubCreatedByJob</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>datahubCreatedByStep</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>datahubCreatedInFlow</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>

--- a/marklogic-data-hub/src/main/resources/ml-config/database-fields/final-database.xml
+++ b/marklogic-data-hub/src/main/resources/ml-config/database-fields/final-database.xml
@@ -86,21 +86,21 @@
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>datahubCreatedByJob</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>datahubCreatedByStep</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>datahubCreatedInFlow</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>

--- a/marklogic-data-hub/src/test/resources/upgrade-projects/dhf43x/key/final-database.xml
+++ b/marklogic-data-hub/src/test/resources/upgrade-projects/dhf43x/key/final-database.xml
@@ -86,28 +86,28 @@
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>datahubCreatedByJob</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>someField</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>datahubCreatedByStep</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>datahubCreatedInFlow</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>

--- a/marklogic-data-hub/src/test/resources/upgrade-projects/dhf43x/src/main/ml-config/database-fields/final-database.xml
+++ b/marklogic-data-hub/src/test/resources/upgrade-projects/dhf43x/src/main/ml-config/database-fields/final-database.xml
@@ -86,28 +86,28 @@
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>datahubCreatedByJob</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>someField</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>datahubCreatedByStep</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>datahubCreatedInFlow</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>

--- a/ml-data-hub-plugin/src/test/resources/update-indexes/final-database.xml
+++ b/ml-data-hub-plugin/src/test/resources/update-indexes/final-database.xml
@@ -101,21 +101,21 @@
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>datahubCreatedByJob</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>datahubCreatedByStep</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>datahubCreatedInFlow</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>

--- a/ml-data-hub-plugin/src/test/resources/update-indexes/staging-database.xml
+++ b/ml-data-hub-plugin/src/test/resources/update-indexes/staging-database.xml
@@ -101,21 +101,21 @@
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>datahubCreatedByJob</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>datahubCreatedByStep</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>
     </range-field-index>
     <range-field-index>
       <scalar-type>string</scalar-type>
-      <collation>http://marklogic.com/collation/en</collation>
+      <collation>http://marklogic.com/collation/</collation>
       <field-name>datahubCreatedInFlow</field-name>
       <range-value-positions>true</range-value-positions>
       <invalid-values>reject</invalid-values>


### PR DESCRIPTION
Verified that the Explorer search options - exp-default.xml - all work fine on the dh-5-example project.