### PR TITLE
DHFPROD-3916: Adding load data roles

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
@@ -362,6 +362,11 @@ public class HubProjectImpl implements HubProject {
             IOUtils.closeQuietly(is);
         }
 
+        //New 5.3.0 roles
+        writeRoleFile(rolesDir, "data-hub-load-data-reader.json");
+        writeRoleFile(rolesDir, "data-hub-load-data-writer.json");
+
+
         // New 5.2.0 roles
         writeRoleFile(rolesDir, "data-hub-admin.json");
         writeRoleFile(rolesDir, "data-hub-developer.json");

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-developer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-developer.json
@@ -10,7 +10,8 @@
     "data-hub-flow-writer",
     "data-hub-mapping-writer",
     "data-hub-step-definition-writer",
-    "data-hub-entity-model-writer"
+    "data-hub-entity-model-writer",
+    "data-hub-load-data-writer"
   ],
   "privilege": [
     {

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-load-data-reader.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-load-data-reader.json
@@ -1,0 +1,4 @@
+{
+  "role-name": "data-hub-load-data-reader",
+  "description": "Permits reading a load data configuration"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-load-data-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-load-data-writer.json
@@ -1,0 +1,4 @@
+{
+  "role-name": "data-hub-load-data-writer",
+  "description": "Permits reading a load data configuration"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-operator.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-operator.json
@@ -10,6 +10,7 @@
     "data-hub-mapping-reader",
     "data-hub-entity-model-reader",
     "data-hub-step-definition-reader",
+    "data-hub-load-data-reader",
     "tde-view"
   ],
   "privilege": [

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/loadData.mjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/loadData.mjs
@@ -22,7 +22,7 @@ const dataHub = DataHubSingleton.instance();
 
 const collections = ['http://marklogic.com/data-hub/load-data-artifact'];
 const databases = [dataHub.config.STAGINGDATABASE, dataHub.config.FINALDATABASE];
-const permissions = [xdmp.permission(dataHub.consts.DATA_HUB_DEVELOPER_ROLE, 'update'), xdmp.permission(dataHub.consts.DATA_HUB_OPERATOR_ROLE, 'read')];
+const permissions = [xdmp.permission(dataHub.consts.DATA_HUB_LOAD_DATA_WRITE_ROLE, 'update'), xdmp.permission(dataHub.consts.DATA_HUB_LOAD_DATA_READ_ROLE, 'read')];
 const requiredProperties = ['name', 'sourceFormat', 'targetFormat'];
 
 export function getNameProperty() {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/consts.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/consts.sjs
@@ -46,5 +46,9 @@ module.exports = {
   ]),
 
   DATA_HUB_OPERATOR_ROLE: "data-hub-operator",
-  DATA_HUB_DEVELOPER_ROLE: "data-hub-developer"
+  DATA_HUB_DEVELOPER_ROLE: "data-hub-developer",
+  DATA_HUB_LOAD_DATA_READ_ROLE: "data-hub-load-data-reader",
+  DATA_HUB_LOAD_DATA_WRITE_ROLE: "data-hub-load-data-writer",
+  DATA_HUB_MAPPING_READ_ROLE: "data-hub-mapping-reader",
+  DATA_HUB_MAPPING_WRITE_ROLE: "data-hub-mapping-writer"
 };


### PR DESCRIPTION
DHFPROD-3916 talks about data-hub-load-data-reader and data-hub-load-data-writer roles to be able to update/view the load configuration in one-ui.
This PR is an attempt to create these new 5.3 roles.