### PR TITLE
DHFPROD-4123: DHF installer no longer assumes group or server names

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dhs/installer/Options.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dhs/installer/Options.java
@@ -45,6 +45,20 @@ public class Options {
     )
     private boolean disableSsl;
 
+    @Parameter(
+        names = {"--groups"},
+        description = "Comma-delimited list of group names that REST options should be copied to, and for which granular " +
+            "privileges should be created for scheduled tasks"
+    )
+    private String groupNames = "Evaluator,Curator,Analyzer,Operator";
+
+    @Parameter(
+        names = {"--servers"},
+        description = "Comma-delimited list of server names. Search options are expected to be loaded into the first server, and then they " +
+            "will be copied to the appropriate locations for each of the other servers combined with each of the groups defined by --groups."
+    )
+    private String serverNames = "data-hub-STAGING,data-hub-FINAL,data-hub-ANALYTICS,data-hub-ANALYTICS-REST,data-hub-OPERATION,data-hub-OPERATION-REST";
+
     @DynamicParameter(
         names = "-P",
         description = "Use this argument to include any property supported by DHF; e.g. -PmlHost=somehost"
@@ -97,5 +111,21 @@ public class Options {
 
     public void setDisableSsl(boolean disableSsl) {
         this.disableSsl = disableSsl;
+    }
+
+    public String getGroupNames() {
+        return groupNames;
+    }
+
+    public void setGroupNames(String groupNames) {
+        this.groupNames = groupNames;
+    }
+
+    public String getServerNames() {
+        return serverNames;
+    }
+
+    public void setServerNames(String serverNames) {
+        this.serverNames = serverNames;
     }
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/Installer.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/Installer.java
@@ -51,6 +51,13 @@ public class Installer extends HubTestBase {
             dataHubOperator.setPassword("password");
             dataHubOperator.addRole("data-hub-operator");
             dataHubOperator.save();
+
+            User testAdmin = new User(new API(adminHubConfig.getManageClient()), "test-admin-for-data-hub-tests");
+            testAdmin.setDescription("This user is intended to be used by DHF tests that require admin or " +
+                "admin-like capabilities, such as being able to deploy a DHF application");
+            testAdmin.setPassword("password");
+            testAdmin.addRole("admin");
+            testAdmin.save();
         }
 
         if (getDataHubAdminConfig().getIsProvisionedEnvironment()) {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -459,6 +459,10 @@ public class HubTestBase {
         return runAsFlowOperator();
     }
 
+    protected HubConfigImpl runAsAdmin() {
+        return runAsUser("test-admin-for-data-hub-tests", "password");
+    }
+    
     protected HubConfigImpl runAsUser(String mlUsername, String mlPassword) {
         adminHubConfig.setMlUsername(mlUsername);
         adminHubConfig.setMlPassword(mlPassword);

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/installer/deploy/CopyQueryOptionsCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/installer/deploy/CopyQueryOptionsCommandTest.java
@@ -1,0 +1,74 @@
+package com.marklogic.hub.dhs.installer.deploy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.marklogic.appdeployer.command.CommandContext;
+import com.marklogic.hub.ApplicationConfig;
+import com.marklogic.hub.DatabaseKind;
+import com.marklogic.hub.HubTestBase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ApplicationConfig.class)
+public class CopyQueryOptionsCommandTest extends HubTestBase {
+
+    @Test
+    void test() throws Exception {
+        runAsAdmin();
+        try {
+            final String groupName = adminHubConfig.getAppConfig().getGroupName();
+            final String stagingServerName = adminHubConfig.getHttpName(DatabaseKind.STAGING);
+            final String jobsServerName = adminHubConfig.getHttpName(DatabaseKind.JOB);
+
+            CopyQueryOptionsCommand command = new CopyQueryOptionsCommand(adminHubConfig,
+                Arrays.asList(groupName, "testGroup-B", "testGroup-C"),
+                Arrays.asList(stagingServerName, "testServer-B", "testServer-C"),
+                jobsServerName
+            );
+
+            command.execute(new CommandContext(adminHubConfig.getAppConfig(), null, null));
+            ArrayNode uris = (ArrayNode) new ObjectMapper().readTree(command.getScriptResponse());
+
+            int index = 0;
+            assertEquals("/testGroup-B/data-hub-STAGING/rest-api/options/default.xml", uris.get(index++).asText());
+            assertEquals("/testGroup-C/data-hub-STAGING/rest-api/options/default.xml", uris.get(index++).asText());
+            assertEquals("/" + groupName + "/testServer-B/rest-api/options/default.xml", uris.get(index++).asText());
+            assertEquals("/" + groupName + "/testServer-C/rest-api/options/default.xml", uris.get(index++).asText());
+            assertEquals("/testGroup-B/testServer-B/rest-api/options/default.xml", uris.get(index++).asText());
+            assertEquals("/testGroup-B/testServer-C/rest-api/options/default.xml", uris.get(index++).asText());
+            assertEquals("/testGroup-C/testServer-B/rest-api/options/default.xml", uris.get(index++).asText());
+            assertEquals("/testGroup-C/testServer-C/rest-api/options/default.xml", uris.get(index++).asText());
+
+            assertEquals("/testGroup-B/data-hub-STAGING/rest-api/options/exp-default.xml", uris.get(index++).asText());
+            assertEquals("/testGroup-C/data-hub-STAGING/rest-api/options/exp-default.xml", uris.get(index++).asText());
+            assertEquals("/" + groupName + "/testServer-B/rest-api/options/exp-default.xml", uris.get(index++).asText());
+            assertEquals("/" + groupName + "/testServer-C/rest-api/options/exp-default.xml", uris.get(index++).asText());
+            assertEquals("/testGroup-B/testServer-B/rest-api/options/exp-default.xml", uris.get(index++).asText());
+            assertEquals("/testGroup-B/testServer-C/rest-api/options/exp-default.xml", uris.get(index++).asText());
+            assertEquals("/testGroup-C/testServer-B/rest-api/options/exp-default.xml", uris.get(index++).asText());
+            assertEquals("/testGroup-C/testServer-C/rest-api/options/exp-default.xml", uris.get(index++).asText());
+
+            assertEquals("/testGroup-B/data-hub-JOBS/rest-api/options/jobs.xml", uris.get(index++).asText());
+            assertEquals("/testGroup-C/data-hub-JOBS/rest-api/options/jobs.xml", uris.get(index++).asText());
+            assertEquals("/testGroup-B/data-hub-JOBS/rest-api/options/traces.xml", uris.get(index++).asText());
+            assertEquals("/testGroup-C/data-hub-JOBS/rest-api/options/traces.xml", uris.get(index++).asText());
+
+            assertEquals(20, uris.size(),
+                "20 URIs are expected. " +
+                    "2 URIs are for copying default.xml to data-hub-STAGING in the other 2 groups. " +
+                    "6 URIs are for copying default.xml to the other 2 servers in all 3 groups. " +
+                    "8 URIs are for copying exp-default.xml in the same fashion as default.xml. " +
+                    "2 URIs are for copying jobs.xml to data-hub-JOBS in the other 2 groups. " +
+                    "2 URIs are for copying traces.xml to data-hub-JOBS in the other 2 groups.");
+        } finally {
+            getDataHubAdminConfig();
+        }
+    }
+}


### PR DESCRIPTION
The group and server names can now be defined via the command line. The server names are used for copying REST options around. Group names are also used for copying REST options around, and also for granular scheduled task privileges.