### PR TITLE
DHFPROD-4158: Updated example to use a different privilege

### DIFF
--- a/examples/dhs-example/README.md
+++ b/examples/dhs-example/README.md
@@ -18,7 +18,7 @@ The ml-config and other-config directories will still be processed, but hub-inte
 
 As of 5.2.0, a user with the data-hub-security-admin role is permitted to deploy roles that grant privileges that are
 inherited by the user performing the deployment. As an example of this, the 
-src/main/ml-config/security/roles/custom-role1.json file defines a new role with the "manage" privilege, which is 
+src/main/ml-config/security/roles/custom-role1.json file defines a new role with the "role-set-external-names" privilege, which is 
 inherited by the data-hub-security-admin role. 
 
 Permitted resources can be deployed via the following task (assuming that gradle-dhs.properties defines the host and

--- a/examples/dhs-example/src/main/ml-config/security/roles/custom-role1.json
+++ b/examples/dhs-example/src/main/ml-config/security/roles/custom-role1.json
@@ -3,9 +3,9 @@
   "description": "Because data-hub-security-admin has the grant-my-privileges privilege, it can create roles that inherit privileges inherited by data-hub-security-admin",
   "privilege": [
     {
-      "privilege-name": "manage",
+      "privilege-name": "role-set-external-names",
       "kind": "execute",
-      "action": "http://marklogic.com/xdmp/privileges/manage"
+      "action": "http://marklogic.com/xdmp/privileges/role-set-external-names"
     }
   ]
 }


### PR DESCRIPTION
"manage" apparently doesn't work because it's not directly inherited by data-hub-security-admin.