### PR TITLE
DHFPROD-3865: Can now run a step via a Data Services endpoint

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -3,11 +3,11 @@ plugins {
     id 'java'
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.7.2'
-    id 'com.marklogic.ml-gradle' version '3.16.2'
+    id 'com.marklogic.ml-gradle' version '4.0.0'
     id 'com.moowork.node' version '1.1.1'
     id 'org.springframework.boot' version '2.1.3.RELEASE'
     id "io.spring.dependency-management" version "1.0.7.RELEASE"
-    id 'com.marklogic.ml-development-tools' version '4.2.0'
+    id 'com.marklogic.ml-development-tools' version '5.1.0'
 }
 
 mainClassName='com.marklogic.hub.ApplicationConfig'
@@ -31,8 +31,8 @@ ext.junitPlatformVersion = '1.4.0'
 ext.junitJupiterVersion  = '5.4.0'
 
 dependencies {
-    compile 'com.marklogic:marklogic-client-api:5.0.1'
-    compile('com.marklogic:ml-app-deployer:3.16.3'){
+    compile 'com.marklogic:marklogic-client-api:5.1.0'
+    compile('com.marklogic:ml-app-deployer:4.0.0'){
         exclude group: 'org.springframework', module: 'http'
     }
 
@@ -57,8 +57,6 @@ dependencies {
     testCompile "org.junit.jupiter:junit-jupiter-params:${junitJupiterVersion}"
     testCompile "org.junit.platform:junit-platform-commons:${junitPlatformVersion}"
     testRuntime "org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}"
-
-    //testCompile "org.junit.platform:junit-platform-runner:${junitPlatformVersion}"
 
     // Only needed to run tests in an (IntelliJ) IDE(A) that bundles an older version
     testRuntime "org.junit.platform:junit-platform-launcher:${junitPlatformVersion}"
@@ -341,7 +339,10 @@ ext {
         customTokens.put("%%mlStagingTriggersDbName%%", mlStagingTriggersDbName)
         customTokens.put("%%mlStagingSchemasDbName%%", mlStagingSchemasDbName)
 
-        modulePaths = ["marklogic-data-hub/src/main/resources/ml-modules", "marklogic-data-hub/src/test/ml-modules"]
+        modulePaths = [
+            new File(getProjectDir(), "src/main/resources/ml-modules").getAbsolutePath(),
+            new File(getProjectDir(), "src/test/ml-modules").getAbsolutePath()
+        ]
     }
 }
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateHubTDETemplateCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateHubTDETemplateCommand.java
@@ -73,8 +73,8 @@ public class GenerateHubTDETemplateCommand extends GenerateModelArtifactsCommand
             //filterEntities(entityNameFileMap);
 
             if (!entityNameFileMap.isEmpty()) {
-                logger.warn("About to generate a template for the following entities: {} into directory {} ",
-                    this.entityNamesList.isEmpty() ? entityNameFileMap.keySet() : this.entityNamesList, hubConfig.getAppConfig().getSchemasPath());
+                logger.warn("About to generate a template for the following entities: {}",
+                    this.entityNamesList.isEmpty() ? entityNameFileMap.keySet() : this.entityNamesList);
                 List<GeneratedCode> generatedCodes = new ArrayList<>();
                 for (File f : entityNameFileMap.values()) {
                     File esModel;

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -1947,8 +1947,6 @@ public class HubConfigImpl implements HubConfig
 
         initializeModulePaths(config);
 
-        config.setSchemasPath(getUserSchemasDir().toString());
-
         addDhfPropertiesToCustomTokens(config);
 
         String version = getJarVersion();

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepRunner/runSteps.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepRunner/runSteps.api
@@ -1,0 +1,28 @@
+{
+    "endpoint": "/data-hub/5/data-services/stepRunner/runSteps.sjs",
+    "params": [
+        {
+            "name": "endpointState",
+            "datatype": "jsonDocument",
+            "multiple": false,
+            "nullable": true
+        },
+        {
+            "name": "session",
+            "datatype": "session",
+            "multiple": false,
+            "nullable": true
+        },
+        {
+            "name": "workUnit",
+            "datatype": "jsonDocument",
+            "multiple": false,
+            "nullable": false
+        }
+    ],
+    "return": {
+        "datatype": "jsonDocument",
+        "multiple": true,
+        "nullable": true
+    }
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepRunner/runSteps.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepRunner/runSteps.sjs
@@ -1,0 +1,15 @@
+'use strict';
+
+const StepRunner = require("/data-hub/5/impl/step-runner.sjs");
+
+var endpointState;
+if (!endpointState) {
+  endpointState = {};
+} else {
+  endpointState = fn.head(xdmp.fromJSON(endpointState));
+}
+
+new StepRunner().runSteps(
+  fn.head(xdmp.fromJSON(workUnit)),
+  endpointState
+);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils.sjs
@@ -82,6 +82,13 @@ class HubUtils {
     let content = [];
     this.queryLatest(function () {
       let results = cts.search(query, cts.indexOrder(cts.uriReference()));
+
+      // Option for limiting the number of results that are processed. Needed for the Data Services
+      // endpoint, but could be used by the REST endpoint as well.
+      if (options.contentDescriptorLimit) {
+        results = fn.subsequence(results, 1, options.contentDescriptorLimit);
+      }
+
       for (let doc of results) {
         content.push({
           uri: xdmp.nodeUri(doc),

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/step-runner.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/step-runner.sjs
@@ -1,0 +1,37 @@
+'use strict';
+
+const DataHubSingleton = require("/data-hub/5/datahub-singleton.sjs");
+
+class StepRunner {
+
+  runSteps(workUnit, endpointState) {
+    const flowName = workUnit.flowName;
+    const stepNumber = workUnit.steps[0];
+    const options = workUnit.options ? workUnit.options : {};
+    const jobId = workUnit.jobId ? workUnit.jobId : endpointState.jobId;
+
+    const datahub = DataHubSingleton.instance({
+      performanceMetrics: !!options.performanceMetrics
+    });
+
+    const filterQuery = endpointState.lastProcessedItem ?
+      cts.rangeQuery(cts.uriReference(), ">", endpointState.lastProcessedItem) :
+      null;
+
+    options.contentDescriptorLimit = workUnit.batchSize ? workUnit.batchSize : 100;
+
+    const content = datahub.flow.findMatchingContent(flowName, stepNumber, options, filterQuery);
+
+    if (content == null || content.length < 1) {
+      // Returning null indicates that there are no items left to be processed by this step
+      null;
+    } else {
+      endpointState.lastProcessedItem = content[content.length - 1].uri;
+      const batchResponse = datahub.flow.runFlow(flowName, jobId, content, options, stepNumber);
+      endpointState.jobId = batchResponse.jobId;
+      return Sequence.from([endpointState, batchResponse]);
+    }
+  }
+}
+
+module.exports = StepRunner;

--- a/marklogic-data-hub/src/main/resources/ml-modules/services/mlRunFlow.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/services/mlRunFlow.sjs
@@ -22,40 +22,17 @@ function get(context, params) {
 
 function post(context, params, input) {
   let flowName = params["flow-name"];
-  let stepNumber = params.step;
   if (!fn.exists(flowName)) {
     fn.error(null, "RESTAPI-SRVEXERR", Sequence.from([400, "Bad Request", "Invalid request - must specify a flowName"]));
   } else {
-    let options = params["options"] ? JSON.parse(params["options"]) : {};
+    const stepNumber = params.step;
+    const options = params["options"] ? JSON.parse(params["options"]) : {};
     const datahub = DataHubSingleton.instance({
       performanceMetrics: !!options.performanceMetrics
     });
-    let jobId = params["job-id"];
-    let flow = datahub.flow.getFlow(flowName);
-    let stepRef = flow.steps[stepNumber];
-    let stepDetails = datahub.flow.step.getStepByNameAndType(stepRef.stepDefinitionName, stepRef.stepDefinitionType);
-    let flowOptions = flow.options || {};
-    let stepRefOptions = stepRef.options || {};
-    let stepDetailsOptions = stepDetails.options || {};
-    // build combined options
-    let combinedOptions = Object.assign({}, stepDetailsOptions, flowOptions, stepRefOptions, options);
-    let sourceDatabase = combinedOptions.sourceDatabase || datahub.flow.globalContext.sourceDatabase;
-    let query = null;
-    let uris = null;
-    if (options.uris) {
-      uris = datahub.hubUtils.normalizeToArray(options.uris);
-      query = cts.documentQuery(uris);
-    } else {
-      let sourceQuery = combinedOptions.sourceQuery || flow.sourceQuery;
-      query = sourceQuery ? cts.query(sourceQuery) : null;
-    }
-    let content;
-    if (stepDetails.name === 'default-merging' && stepDetails.type === 'merging' && uris) {
-      content = uris.map((uri) => { return { uri }; });
-    } else {
-      content = datahub.hubUtils.queryToContentDescriptorArray(query, combinedOptions, sourceDatabase);
-    }
-    return datahub.flow.runFlow(flowName, jobId, content, options, stepNumber);
+
+    const content = datahub.flow.findMatchingContent(flowName, stepNumber, options, null);
+    return datahub.flow.runFlow(flowName, params["job-id"], content, options, stepNumber);
   }
 }
 

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/stepRunner/runSingleStep.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/stepRunner/runSingleStep.sjs
@@ -1,0 +1,48 @@
+const StepRunner = require("/data-hub/5/impl/step-runner.sjs");
+const test = require("/test/test-helper.xqy");
+
+const stepRunner = new StepRunner();
+
+const workUnit = {
+  flowName: "PersonFlow",
+  steps: ["1"],
+  batchSize: 2,
+  jobId: "job123"
+};
+let endpointState = {};
+
+let results = stepRunner.runSteps(workUnit, endpointState).toArray();
+endpointState = results[0];
+let batchResponse = results[1];
+
+let assertions = [
+  test.assertEqual("/content/person2.json", endpointState.lastProcessedItem),
+  test.assertEqual("job123", endpointState.jobId),
+
+  test.assertEqual("job123", batchResponse.jobId),
+  test.assertEqual(2, batchResponse.totalCount),
+  test.assertEqual(0, batchResponse.errorCount),
+  test.assertEqual("/content/person1.json", batchResponse.completedItems[0]),
+  test.assertEqual("/content/person2.json", batchResponse.completedItems[1])
+];
+
+results = stepRunner.runSteps(workUnit, endpointState).toArray();
+endpointState = results[0];
+batchResponse = results[1];
+
+assertions.push(
+  test.assertEqual("/content/person3.json", endpointState.lastProcessedItem),
+  test.assertEqual("job123", endpointState.jobId),
+
+  test.assertEqual("job123", batchResponse.jobId),
+  test.assertEqual(1, batchResponse.totalCount),
+  test.assertEqual(0, batchResponse.errorCount),
+  test.assertEqual("/content/person3.json", batchResponse.completedItems[0])
+);
+
+results = stepRunner.runSteps(workUnit, endpointState);
+
+assertions.concat(
+  test.assertEqual(undefined, results,
+    "Since all the items have been processed, the endpoint should not return anything, indicating that the step is complete")
+);

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/stepRunner/suite-setup.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/stepRunner/suite-setup.xqy
@@ -1,0 +1,15 @@
+xquery version "1.0-ml";
+
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+import module namespace test = "http://marklogic.com/test" at "/test/test-helper.xqy";
+
+hub-test:load-entities($test:__CALLER_FILE__)
+;
+
+xquery version "1.0-ml";
+
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+import module namespace test = "http://marklogic.com/test" at "/test/test-helper.xqy";
+
+hub-test:load-non-entities($test:__CALLER_FILE__),
+hub-test:clear-jobs-database()

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/stepRunner/suite-teardown.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/stepRunner/suite-teardown.xqy
@@ -1,0 +1,6 @@
+xquery version "1.0-ml";
+
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+import module namespace test = "http://marklogic.com/test" at "/test/test-helper.xqy";
+
+hub-test:delete-artifacts($test:__CALLER_FILE__)

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/stepRunner/test-data/content/person1.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/stepRunner/test-data/content/person1.json
@@ -1,0 +1,8 @@
+{
+  "envelope": {
+    "instance": {
+      "personId": "111",
+      "theNickname": "Nicky"
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/stepRunner/test-data/content/person2.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/stepRunner/test-data/content/person2.json
@@ -1,0 +1,16 @@
+{
+  "envelope": {
+    "instance": {
+      "personId": "222",
+      "theNickname": "Nicky",
+      "theName": {
+        "middleName": "Middle",
+        "lastName": "Last",
+        "firstName": {
+          "theValue": "First",
+          "thePrefix": "SomePrefix"
+        }
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/stepRunner/test-data/content/person3.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/stepRunner/test-data/content/person3.json
@@ -1,0 +1,16 @@
+{
+  "envelope": {
+    "instance": {
+      "personId": "333",
+      "theNickname": "MyNickname",
+      "theName": {
+        "middleName": "Middle",
+        "lastName": "Last",
+        "firstName": {
+          "theValue": "First",
+          "thePrefix": "SomePrefix"
+        }
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/stepRunner/test-data/entities/Person.entity.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/stepRunner/test-data/entities/Person.entity.json
@@ -1,0 +1,45 @@
+{
+  "info": {
+    "title": "Person",
+    "version": "1.0.0",
+    "baseUri": "http://marklogic.com/data-hub/example/"
+  },
+  "definitions": {
+    "FirstName": {
+      "properties": {
+        "value": {
+          "datatype": "string"
+        },
+        "prefix": {
+          "datatype": "string"
+        }
+      }
+    },
+    "Name": {
+      "properties": {
+        "first": {
+          "$ref": "#/definitions/FirstName"
+        },
+        "middle": {
+          "datatype": "string"
+        },
+        "last": {
+          "datatype": "string"
+        }
+      }
+    },
+    "Person": {
+      "properties": {
+        "id": {
+          "datatype": "int"
+        },
+        "name": {
+          "$ref": "#/definitions/Name"
+        },
+        "nickname": {
+          "datatype": "string"
+        }
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/stepRunner/test-data/flows/PersonFlow.flow.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/stepRunner/test-data/flows/PersonFlow.flow.json
@@ -1,0 +1,19 @@
+{
+  "name": "PersonFlow",
+  "steps": {
+    "1": {
+      "stepDefinitionName": "entity-services-mapping",
+      "stepDefinitionType": "MAPPING",
+      "options": {
+        "sourceDatabase": "data-hub-FINAL",
+        "targetDatabase": "data-hub-FINAL",
+        "mapping" : {
+          "name" : "PersonMapping",
+          "version" : 1
+        },
+        "sourceQuery": "cts.collectionQuery('raw-content')",
+        "outputFormat": "json"
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/stepRunner/test-data/mappings/PersonMapping/PersonMapping-1.mapping.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/stepRunner/test-data/mappings/PersonMapping/PersonMapping-1.mapping.json
@@ -1,0 +1,37 @@
+{
+  "lang": "zxx",
+  "name": "PersonMapping",
+  "description": "TBD",
+  "version": 1,
+  "sourceContext": "/",
+  "targetEntityType": "http://marklogic.com/data-hub/example/Person-1.0.0/Person",
+  "properties": {
+    "id": {
+      "sourcedFrom": "personId"
+    },
+    "name": {
+      "sourcedFrom": "theName",
+      "targetEntityType": "http://marklogic.com/data-hub/example/Person-1.0.0/Name",
+      "properties": {
+        "middle" : {
+          "sourcedFrom": "middleName"
+        },
+        "last" : {
+          "sourcedFrom": "lastName"
+        },
+        "first": {
+          "sourcedFrom": "firstName",
+          "targetEntityType": "http://marklogic.com/data-hub/example/Person-1.0.0/FirstName",
+          "properties": {
+            "value": {
+              "sourcedFrom": "theValue"
+            },
+            "prefix": {
+              "sourcedFrom": "thePrefix"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/ml-data-hub-plugin/build.gradle
+++ b/ml-data-hub-plugin/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     compile (project(':marklogic-data-hub')) {
         exclude group: 'ch.qos.logback'
     }
-    compile ('com.marklogic:ml-gradle:3.16.3') {
+    compile ('com.marklogic:ml-gradle:4.0.0') {
         exclude group: 'ch.qos.logback'
     }
 

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -48,8 +48,8 @@ repositories {
     maven {url 'http://developer.marklogic.com/maven2/'}
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = "1.9"
+targetCompatibility = "1.9"
 
 ext.junit4Version        = '4.12'
 ext.junitVintageVersion  = '4.12.0-RC3'


### PR DESCRIPTION
Upgraded to Java Client 5.1.0 to use the Bulk IO API for testing. This required upgrading to ml-gradle 4.0, which supports Java Client 5.1 (3.x does not). 

Extracted reusable code from mlRunFlow.sjs into flow.sjs/findMatchingContent. This helps minimize the code in mlRunFlow.sjs (REST) and runSteps.sjs (DS).