### PR TITLE
DHFPROD-4483: Fixing custom rewriter for ML 10

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/rest-api/rewriter/10-rewriter.xml
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/rest-api/rewriter/10-rewriter.xml
@@ -333,7 +333,7 @@
                 <match-header name="range">
                     <dispatch>/data-hub/5/rest-api/endpoints/document-item-query.xqy</dispatch>
                 </match-header>
-                <dispatch>/data-hub/5/rest-api/endpoints/document-item-query-head.xqy</dispatch>
+                <dispatch>/MarkLogic/rest-api/endpoints/document-item-query-head.xqy</dispatch>
             </match-method>
             <match-method any-of="OPTIONS">
                 <match-query-param name="txid">
@@ -374,7 +374,7 @@
                 <match-query-param name="transform">
                     <dispatch>/data-hub/5/rest-api/endpoints/document-item-update.xqy</dispatch>
                 </match-query-param>
-                <dispatch>/data-hub/5/rest-api/endpoints/document-item-update-put.xqy</dispatch>
+                <dispatch>/MarkLogic/rest-api/endpoints/document-item-update-put.xqy</dispatch>
             </match-method>
             <match-method any-of="DELETE">
                 <match-query-param name="txid">
@@ -390,7 +390,7 @@
                 <match-query-param name="category" repeated="true">
                   <dispatch>/data-hub/5/rest-api/endpoints/document-item-update.xqy</dispatch>
                 </match-query-param>
-                <dispatch>/data-hub/5/rest-api/endpoints/document-item-update-delete.xqy</dispatch>
+                <dispatch>/MarkLogic/rest-api/endpoints/document-item-update-delete.xqy</dispatch>
              </match-method>
             <match-method any-of="POST">
                 <match-query-param name="txid">

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/rewriter/StagingRewriterTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/rewriter/StagingRewriterTest.java
@@ -1,0 +1,45 @@
+package com.marklogic.hub.rewriter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.document.JSONDocumentManager;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.hub.ApplicationConfig;
+import com.marklogic.hub.HubTestBase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ApplicationConfig.class)
+public class StagingRewriterTest extends HubTestBase {
+
+    /**
+     * This is simply to verify that the custom rewriter for ML doesn't cause basic functions to fail. This was the
+     * case prior to 5.2.0, as 10-rewriter.xml referred to some non-existent modules.
+     */
+    @Test
+    void test() {
+        DatabaseClient client = adminHubConfig.newStagingClient();
+        JSONDocumentManager mgr = client.newJSONDocumentManager();
+
+        final String uri = "/test.json";
+        ObjectNode node = new ObjectMapper().createObjectNode();
+        node.put("hello", "world");
+
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        metadata.getPermissions().add("data-hub-operator", DocumentMetadataHandle.Capability.READ, DocumentMetadataHandle.Capability.UPDATE);
+        mgr.write(uri, metadata, new JacksonHandle(node));
+
+        assertEquals(uri, mgr.exists(uri).getUri());
+        assertNotNull(mgr.read(uri, new JacksonHandle()).get());
+
+        mgr.delete(uri);
+        assertNull(mgr.exists(uri));
+    }
+}


### PR DESCRIPTION
The HEAD/PUT/DELETE dispatchers were referring to non-existent modules. They now refer to the OOTB ML modules.