### PR TITLE
DHFPROD-4492: Renamed runFlowWithoutProject to runFlow

### DIFF
--- a/examples/dh-5-example/src/main/java/org/example/RunFlowWithoutProject.java
+++ b/examples/dh-5-example/src/main/java/org/example/RunFlowWithoutProject.java
@@ -33,7 +33,7 @@ public class RunFlowWithoutProject {
         inputs.setInputFilePath(inputFilePath);
 
         System.out.println("Running flow: " + flowName);
-        RunFlowResponse response = flowRunner.runFlowWithoutProject(inputs);
+        RunFlowResponse response = flowRunner.runFlow(inputs);
         flowRunner.awaitCompletion();
         System.out.println("Response: " + response);
     }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/client/RunFlowCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/cli/client/RunFlowCommand.java
@@ -48,7 +48,7 @@ public class RunFlowCommand extends CommandLineFlowInputs implements Runnable {
         Pair<FlowInputs, String> pair = super.buildFlowInputs();
         System.out.println(pair.getRight());
 
-        RunFlowResponse response = flowRunner.runFlowWithoutProject(pair.getLeft());
+        RunFlowResponse response = flowRunner.runFlow(pair.getLeft());
         flowRunner.awaitCompletion();
         System.out.println("\nOutput:");
         System.out.println(response.toJson());

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/FlowRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/FlowRunner.java
@@ -21,51 +21,60 @@ public interface FlowRunner {
      * @param flowInputs
      * @return
      */
-    RunFlowResponse runFlowWithoutProject(FlowInputs flowInputs);
+    RunFlowResponse runFlow(FlowInputs flowInputs);
 
     /**
      * Runs the flow, with a specific set of steps, with all custom settings
      *
+     * @deprecated Starting in 5.2.0, prefer runFlow(FlowInputs), which does not depend on Spring or project files on the filesystem
      * @param flow the flow to run
      * @param jobId the jobid to be used for the flow
      * @return a response object
      */
+    @Deprecated
     RunFlowResponse runFlow(String flow, String jobId);
 
     /**
      * Runs the flow, with a specific set of steps, with all custom settings
      *
+     * @deprecated Starting in 5.2.0, prefer runFlow(FlowInputs), which does not depend on Spring or project files on the filesystem
      * @param flow the flow to run
      * @param steps the steps in the flow to run
      * @param jobId the jobid to be used for the flow
      * @return a response object
      */
+    @Deprecated
     RunFlowResponse runFlow(String flow, List<String> steps, String jobId);
 
     /**
      * Runs the flow, with a specific set of steps, with all custom settings
      *
+     * @deprecated Starting in 5.2.0, prefer runFlow(FlowInputs), which does not depend on Spring or project files on the filesystem
      * @param flow the flow to run
      * @param jobId the jobid to be used for the flow
      * @param options the key/value options to be passed
      * @return a response object
      */
+    @Deprecated
     RunFlowResponse runFlow(String flow, String jobId, Map<String, Object> options);
 
     /**
      * Runs the flow, with a specific set of steps, with all custom settings
      *
+     * @deprecated Starting in 5.2.0, prefer runFlow(FlowInputs), which does not depend on Spring or project files on the filesystem
      * @param flow the flow to run
      * @param steps the steps in the flow to run
      * @param jobId the jobid to be used for the flow
      * @param options the key/value options to be passed
      * @return a response object
      */
+    @Deprecated
     RunFlowResponse runFlow(String flow, List<String> steps, String jobId, Map<String, Object> options);
 
     /**
      * Runs the flow, with a specific set of steps, with all custom settings
      *
+     * @deprecated Starting in 5.2.0, prefer runFlow(FlowInputs), which does not depend on Spring or project files on the filesystem
      * @param flow the flow to run
      * @param steps the steps in the flow to run
      * @param jobId the jobid to be used for the flow
@@ -73,23 +82,28 @@ public interface FlowRunner {
      * @param stepConfig the key/value config to override the running of the step
      * @return a response object
      */
+    @Deprecated
     RunFlowResponse runFlow(String flow, List<String> steps, String jobId, Map<String, Object> options, Map<String, Object> stepConfig);
 
     /**
      * Runs the flow, with a specific set of steps, with all defaults from step
      *
+     * @deprecated Starting in 5.2.0, prefer runFlow(FlowInputs), which does not depend on Spring or project files on the filesystem
      * @param flow the flow to run
      * @param steps the steps in the flow to run
      * @return a response object
      */
+    @Deprecated
     RunFlowResponse runFlow(String flow, List<String> steps);
 
     /**
      * Runs the entire flow, with full defaults
      *
+     * @deprecated Starting in 5.2.0, prefer runFlow(FlowInputs), which does not depend on Spring or project files on the filesystem
      * @param flow the flow to run
      * @return a response object
      */
+    @Deprecated
     RunFlowResponse runFlow(String flow);
 
     /**

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/impl/FlowRunnerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/impl/FlowRunnerImpl.java
@@ -84,7 +84,7 @@ public class FlowRunnerImpl implements FlowRunner{
      * project files from the filesystem.
      *
      * This constructor handles ensuring that step definitions are retrieved from MarkLogic as opposed to from the
-     * filesystem. It is expected that the "runFlowWithoutProject" method will then be used, which ensures that flow
+     * filesystem. It is expected that the "runFlow(FlowInputs)" method will then be used, which ensures that flow
      * artifacts are also retrieved from MarkLogic as opposed to from the filesystem.
      *
      * @param hubConfig
@@ -101,30 +101,37 @@ public class FlowRunnerImpl implements FlowRunner{
         return this;
     }
 
+    @Deprecated
     public RunFlowResponse runFlow(String flowName) {
         return runFlow(flowName, null, null, new HashMap<>(), new HashMap<>());
     }
 
+    @Deprecated
     public RunFlowResponse runFlow(String flowName, List<String> stepNums) {
         return runFlow(flowName, stepNums, null, new HashMap<>(), new HashMap<>());
     }
 
+    @Deprecated
     public RunFlowResponse runFlow(String flowName, String jobId) {
         return runFlow(flowName, null, jobId, new HashMap<>(), new HashMap<>());
     }
 
+    @Deprecated
     public RunFlowResponse runFlow(String flowName, List<String> stepNums, String jobId) {
         return runFlow(flowName, stepNums, jobId, new HashMap<>(), new HashMap<>());
     }
 
+    @Deprecated
     public RunFlowResponse runFlow(String flowName, String jobId, Map<String, Object> options) {
         return runFlow(flowName, null, jobId, options, new HashMap<>());
     }
 
+    @Deprecated
     public RunFlowResponse runFlow(String flowName, List<String> stepNums,  String jobId, Map<String, Object> options) {
         return runFlow(flowName, stepNums, jobId, options, new HashMap<>());
     }
 
+    @Deprecated
     public RunFlowResponse runFlow(String flowName, List<String> stepNums, String jobId, Map<String, Object> options, Map<String, Object> stepConfig) {
         Flow flow = flowManager.getFlow(flowName);
         if (flow == null) {
@@ -141,7 +148,7 @@ public class FlowRunnerImpl implements FlowRunner{
      * @return
      */
     @Override
-    public RunFlowResponse runFlowWithoutProject(FlowInputs flowInputs) {
+    public RunFlowResponse runFlow(FlowInputs flowInputs) {
         final String flowName = flowInputs.getFlowName();
         if (StringUtils.isEmpty(flowName)) {
             throw new IllegalArgumentException("Cannot run flow; no flow name provided");
@@ -156,7 +163,7 @@ public class FlowRunnerImpl implements FlowRunner{
         return runFlow(flow, flowInputs.getSteps(), flowInputs.getJobId(), flowInputs.getOptions(), flowInputs.getStepConfig());
     }
 
-    public RunFlowResponse runFlow(Flow flow, List<String> stepNums, String jobId, Map<String, Object> options, Map<String, Object> stepConfig) {
+    protected RunFlowResponse runFlow(Flow flow, List<String> stepNums, String jobId, Map<String, Object> options, Map<String, Object> stepConfig) {
         if (options != null && options.containsKey("disableJobOutput")) {
             disableJobOutput = Boolean.parseBoolean(options.get("disableJobOutput").toString());
         } else {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/RunFlowRunnerTestsWithoutProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/RunFlowRunnerTestsWithoutProjectTest.java
@@ -4,7 +4,6 @@ import com.marklogic.hub.flow.impl.FlowRunnerImpl;
 import com.marklogic.hub.step.MarkLogicStepDefinitionProvider;
 import com.marklogic.hub.step.StepDefinition;
 import com.marklogic.hub.step.StepDefinitionProvider;
-import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -38,7 +37,7 @@ public class RunFlowRunnerTestsWithoutProjectTest extends FlowRunnerTest {
         makeInputFilePathsAbsoluteInFlow(flowName);
         verifyStepDefinitionsCanBeFound(flowRunner);
 
-        return flowRunner.runFlowWithoutProject(inputs);
+        return flowRunner.runFlow(inputs);
     }
 
     /**

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/mapping/RunMappingTestsWithoutProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/mapping/RunMappingTestsWithoutProjectTest.java
@@ -6,7 +6,7 @@ import com.marklogic.hub.flow.RunFlowResponse;
 import com.marklogic.hub.flow.impl.FlowRunnerImpl;
 
 /**
- * Extends MappingTest so that each of its tests can be run via the runFlowWithoutProject method.
+ * Extends MappingTest so that each of its tests can be run via the runFlow(FlowInputs) method.
  */
 public class RunMappingTestsWithoutProjectTest extends MappingTest {
 
@@ -15,7 +15,7 @@ public class RunMappingTestsWithoutProjectTest extends MappingTest {
         makeInputFilePathsAbsoluteInFlow(flowName);
         FlowRunner flowRunner = new FlowRunnerImpl(host, flowRunnerUser, flowRunnerPassword);
         FlowInputs inputs = new FlowInputs(flowName, stepIds);
-        RunFlowResponse response = flowRunner.runFlowWithoutProject(inputs);
+        RunFlowResponse response = flowRunner.runFlow(inputs);
         flowRunner.awaitCompletion();
         return response;
     }


### PR DESCRIPTION
And deprecated existing runFlow methods.

This is based on beta and tech summit feedback. 