### PR TITLE
DHFPROD-4025: Unwrap array retrieving the lastest job for a single flow

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/services/mlJobs.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/services/mlJobs.sjs
@@ -1,18 +1,18 @@
 /**
-  Copyright 2012-2019 MarkLogic Corporation
+ Copyright 2012-2019 MarkLogic Corporation
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+ http://www.apache.org/licenses/LICENSE-2.0
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-*/
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
 'use strict';
 const DataHub = require("/data-hub/5/datahub.sjs");
 const datahub = new DataHub();
@@ -36,18 +36,21 @@ function get(context, params) {
   else if(fn.exists(status)) {
     resp = datahub.jobs.getJobDocs(status);
   }
+  else if (fn.exists(latest)) {
+    flowNames = (fn.exists(flowNames)) ? datahub.hubUtils.normalizeToSequence(flowNames) : datahub.hubUtils.normalizeToSequence([flow]);
+    if (fn.empty(flowNames)) {
+      flowNames = null;
+    }
+    resp = datahub.jobs.getLatestJobDocPerFlow(flowNames);
+    if (fn.count(flowNames) === 1) {
+      resp = resp[0];
+    }
+  }
   else if (fn.exists(flowNames)) {
     resp = datahub.jobs.getJobDocsForFlows(flowNames);
   }
   else if (fn.exists(flow)) {
     resp = datahub.jobs.getJobDocsByFlow(flow);
-  }
-  else if (fn.exists(latest)) {
-    flowNames = (fn.exists(flowNames)) ? datahub.hubUtils.normalizeToSequence(flowNames) : flowNames;
-    resp = datahub.jobs.getLatestJobDocPerFlow(flowNames);
-    if (fn.count(flowNames) === 1) {
-      resp = resp[0];
-    }
   }
   else{
     fn.error(null,"RESTAPI-SRVEXERR",  Sequence.from([400, "Bad Request", "Incorrect options"]));


### PR DESCRIPTION
Adjusting the Jobs API to match the documentation for the latest job for a single flow endpoint. That API was described in QuiskStart Documentation, but wasn't used due to timing of the 5.0 release.