### PR TITLE
DHFPROD-4568: Increase antd version to 3.26.13

### DIFF
--- a/one-ui/ui/package.json
+++ b/one-ui/ui/package.json
@@ -15,7 +15,7 @@
     "@types/react-dom": "16.9.4",
     "@types/react-router": "^5.1.3",
     "@types/react-router-dom": "^5.1.2",
-    "antd": "^3.25.2",
+    "antd": "^3.26.13",
     "axios": "^0.19.0",
     "babel-plugin-import": "^1.13.0",
     "enzyme": "^3.10.0",


### PR DESCRIPTION
This antd version fixes the string/number typing issue for the Result component.

Details:
https://github.com/ant-design/ant-design/issues/21592
https://github.com/ant-design/ant-design/pull/21691

Thanks, @bsrikan, for discovering this fix. 