### PR TITLE
DHFPROD-4558: Modified test for deploying query rolesets

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/installer/deploy/DeployHubQueryRolesetsCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/installer/deploy/DeployHubQueryRolesetsCommandTest.java
@@ -7,7 +7,8 @@ import com.marklogic.mgmt.SaveReceipt;
 import com.marklogic.mgmt.resource.security.QueryRolesetManager;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class DeployHubQueryRolesetsCommandTest extends AbstractSecurityTest {
 
@@ -38,8 +39,9 @@ public class DeployHubQueryRolesetsCommandTest extends AbstractSecurityTest {
             assertEquals(201, receipt.getResponse().getStatusCodeValue(), "The query roleset should have been created " +
                 "successfully because data-hub-developer has the add-query-rolesets privilege");
 
-            receipt = command.saveResource(mgr, new CommandContext(new AppConfig(), userWithRoleBeingTestedClient, null), payload);
-            assertNull(receipt, "The receipt object will be null because the Manage API threw an exception, since a " +
+            command.saveResource(mgr, new CommandContext(new AppConfig(), userWithRoleBeingTestedClient, null), payload);
+            logger.info("In ML 10.0-3 and earlier, the above command should succeed but with an error logged. This is " +
+                "because the Manage API threw an exception, since a " +
                 "user without the security role can't call POST again on a query roleset, and the data-hub-developer " +
                 "user doesn't have the security role. And a PUT call can't be made because the GET endpoint for a " +
                 "roleset doesn't support passing in the role names that constitute a roleset, so there's no way to " +
@@ -47,7 +49,9 @@ public class DeployHubQueryRolesetsCommandTest extends AbstractSecurityTest {
                 "" +
                 "So instead of an exception being thrown, check the logging to verify that a message was logged " +
                 "indicating that the SEC-PERMDENIED exception can be safely ignored if the query roleset has already " +
-                "been deployed. This is the best we can do in DHF based on ML 10.0-3.");
+                "been deployed. This is the best we can do in DHF based on ML 10.0-3." +
+                "" +
+                "Starting in ML 10.0-4, due to https://bugtrack.marklogic.com/54501, no error will be thrown.");
         } finally {
             // The lack of an exception from this verifies that the roleset was deleted successfully
             userWithRoleBeingTestedClient.delete(rolesetPath);


### PR DESCRIPTION
The SaveReceipt is not null when run against the trunk build, which has a fix for this scenario. So just logging a message to explain what's expected.