### PR TITLE
DHFPROD-4361: Roles information gets reset when Load Data route is refreshed

### DIFF
--- a/one-ui/ui/src/components/login-form/login-form.tsx
+++ b/one-ui/ui/src/components/login-form/login-form.tsx
@@ -44,6 +44,7 @@ const LoginForm: React.FC = () => {
         setMessage({show: false, text: ''});
         setIsLoading(false);
         console.log(response);
+        localStorage.setItem('loginResp',JSON.stringify(response.data));
         loginAuthenticated(username, response.data);
       } 
     } catch (error) {

--- a/one-ui/ui/src/util/auth-context.tsx
+++ b/one-ui/ui/src/util/auth-context.tsx
@@ -75,6 +75,7 @@ const AuthProvider: React.FC<{ children: any }> = ({children}) => {
     localStorage.setItem('dhIsInstalled', '');
     localStorage.setItem('dhUserHasManagePrivileges', '');
     localStorage.setItem('projectName', '');
+    localStorage.setItem('loginResp','');
     rolesService.setRoles([]);
     resetEnvironment();
     setUser({ ...user,name: '', authenticated: false, redirect: true });
@@ -175,6 +176,10 @@ const AuthProvider: React.FC<{ children: any }> = ({children}) => {
   useEffect(() => {
     if (sessionUser) {
       sessionAuthenticated(sessionUser);
+      let loginResponse = JSON.parse(localStorage.getItem('loginResp') || '{}')
+      if(JSON.stringify(loginResponse) !== JSON.stringify({})){
+        loginAuthenticated(sessionUser,loginResponse);
+      }
     }
   }, []);
 


### PR DESCRIPTION
This PR fixes the issue mentioned in the TITLE and makes sure that the user maintains the required roles throughout the session.