### PR TITLE
DHFPROD-3854: sourceQuery can now be a script

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow.sjs
@@ -150,6 +150,10 @@ class Flow {
     let uris = null;
     if (options.uris) {
       uris = this.datahub.hubUtils.normalizeToArray(options.uris);
+      if (options.sourceQueryIsScript) {
+        // When the source query is a script, map each item to a content object with the "uri" property containing the item value
+        return uris.map(uri => {return {uri}});
+      }
       query = cts.documentQuery(uris);
     } else {
       let sourceQuery = combinedOptions.sourceQuery || flow.sourceQuery;
@@ -173,18 +177,19 @@ class Flow {
    *
    * @param flowName Required name of the flow to run
    * @param jobId Required ID of the job associated with the execution of the given step and flow
-   * @param content Array of content "descriptors", where each descriptor is expected to at least have a "uri" property
+   * @param content Array of content "descriptors", where each descriptor is expected to at least have a "uri" property.
+   * The value of the "uri" property is not necessarily a URI; if sourceQueryIsScript is true for the step, then
+   * the value of the "uri" property can be any string.
    * @param options Optional map of options that are used to override the flow and step configuration
    * @param stepNumber The number of the step within the given flow to run
    */
   runFlow(flowName, jobId, content = [], options, stepNumber) {
-    let uris = content.map((contentItem) => contentItem.uri);
+    let items = content.map((contentItem) => contentItem.uri);
     let flow = this.getFlow(flowName);
     if(!flow) {
       this.datahub.debug.log({message: 'The flow with the name '+flowName+' could not be found.', type: 'error'});
       throw Error('The flow with the name '+flowName+' could not be found.')
     }
-    //set the flow in the context
     this.globalContext.flow = flow;
 
     let jobDoc = this.datahub.jobs.getJobDocWithId(jobId);
@@ -244,11 +249,11 @@ class Flow {
     let flowInstance = this;
 
     if (this.isContextDB(this.globalContext.sourceDatabase) && !combinedOptions.stepUpdate) {
-      this.runStep(uris, content, combinedOptions, flowName, stepNumber, stepRef);
+      this.runStep(items, content, combinedOptions, flowName, stepNumber, stepRef);
     } else {
       xdmp.invoke(
         '/data-hub/5/impl/invoke-step.sjs',
-        {flow: flowInstance, uris, content, options: combinedOptions, flowName, step: stepRef, stepNumber},
+        {flow: flowInstance, items, content, options: combinedOptions, flowName, step: stepRef, stepNumber},
         {
           database: this.globalContext.sourceDatabase ? xdmp.database(this.globalContext.sourceDatabase) : xdmp.database(),
           update: combinedOptions.stepUpdate ? 'true': 'false',
@@ -310,7 +315,7 @@ class Flow {
         }
       }
       if (!combinedOptions.disableJobOutput) {
-        jobsMod.updateBatch(this.datahub,this.globalContext.jobId, this.globalContext.batchId, batchStatus, uris, writeTransactionInfo, this.globalContext.batchErrors[0]);
+        jobsMod.updateBatch(this.datahub,this.globalContext.jobId, this.globalContext.batchId, batchStatus, items, writeTransactionInfo, this.globalContext.batchErrors[0]);
       }
     }
 
@@ -333,8 +338,17 @@ class Flow {
     return resp;
   }
 
-  runStep(uris, content, options, flowName, stepNumber, step) {
-    // declareUpdate({explicitCommit: true});
+  /**
+   * @param items the batch of items being processed by the current transaction for the given flow and step. Will be a
+   * set of URIs, unless sourceQueryIsScript is set to true for the step, in which case the items can be any set
+   * of strings.
+   * @param content
+   * @param options
+   * @param flowName
+   * @param stepNumber
+   * @param step
+   */
+  runStep(items, content, options, flowName, stepNumber, step) {
     let flowInstance = this;
     let processor = flowInstance.step.getStepProcessor(flowInstance, step.stepDefinitionName, step.stepDefinitionType);
     if (!(processor && processor.run)) {
@@ -350,7 +364,7 @@ class Flow {
     }
     if (hook && hook.module) {
       // Include all of the step context in the parameters for the custom hook to make use of
-      let parameters = Object.assign({uris, content, options, flowName, stepNumber, step}, hook.parameters);
+      let parameters = Object.assign({uris: items, content, options, flowName, stepNumber, step}, hook.parameters);
       hookOperation = function () {
         flowInstance.datahub.hubUtils.invoke(
           hook.module,
@@ -368,9 +382,9 @@ class Flow {
       try {
         let results = normalizeToSequence(flowInstance.runMain(normalizeToSequence(content), options, processor.run));
         flowInstance.processResults(results, options, flowName, step);
-        flowInstance.globalContext.completedItems = flowInstance.globalContext.completedItems.concat(uris);
+        flowInstance.globalContext.completedItems = flowInstance.globalContext.completedItems.concat(items);
       } catch (e) {
-        this.handleStepError(flowInstance, e, uris);
+        this.handleStepError(flowInstance, e, items);
       }
     } else {
       for (let contentItem of content) {
@@ -391,10 +405,10 @@ class Flow {
     }
   }
 
-  handleStepError(flowInstance, error, uris) {
+  handleStepError(flowInstance, error, items) {
     flowInstance.addBatchError(flowInstance, error, flowInstance.globalContext.uri);
-    if (!flowInstance.globalContext.uri && uris) {
-      flowInstance.globalContext.failedItems = flowInstance.globalContext.failedItems.concat(uris);
+    if (!flowInstance.globalContext.uri && items) {
+      flowInstance.globalContext.failedItems = flowInstance.globalContext.failedItems.concat(items);
     } else if (flowInstance.globalContext.uri) {
       flowInstance.globalContext.failedItems.push(flowInstance.globalContext.uri);
     }

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/invoke-step.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/invoke-step.sjs
@@ -1,5 +1,5 @@
 'use strict';
 
-var flow, uris, content, options, flowName, stepNumber, step;
+var flow, items, content, options, flowName, stepNumber, step;
 
-flow.runStep(uris, content, options, flowName, stepNumber, step);
+flow.runStep(items, content, options, flowName, stepNumber, step);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/jobs.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/jobs.sjs
@@ -361,13 +361,13 @@ module.exports.updateJob = module.amp(
   });
 
 module.exports.updateBatch = module.amp(
-  function updateBatch(datahub, jobId, batchId, batchStatus, uris, writeTransactionInfo, error) {
+  function updateBatch(datahub, jobId, batchId, batchStatus, items, writeTransactionInfo, error) {
     let docObj = datahub.jobs.getBatchDoc(jobId, batchId);
     if(!docObj) {
       throw new Error("Unable to find batch document: "+ batchId);
     }
     docObj.batch.batchStatus = batchStatus;
-    docObj.batch.uris = uris;
+    docObj.batch.uris = items;
     if (batchStatus === "finished" || batchStatus === "finished_with_errors" || batchStatus === "failed") {
       docObj.batch.timeEnded = fn.currentDateTime();
     }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -1271,8 +1271,12 @@ public class HubTestBase implements InitializingBean {
                 adminHubConfig.getStepsDirByType(StepDefinition.StepDefinitionType.INGESTION).resolve("json-ingestion").toFile());
             FileUtils.copyFileToDirectory(getResourceFile("flow-runner-test/step-definitions/json-mapping.step.json"),
                 adminHubConfig.getStepsDirByType(StepDefinition.StepDefinitionType.MAPPING).resolve("json-mapping").toFile());
+            FileUtils.copyFileToDirectory(getResourceFile("flow-runner-test/step-definitions/value-step.step.json"),
+                adminHubConfig.getStepsDirByType(StepDefinition.StepDefinitionType.CUSTOM).resolve("value-step").toFile());
             FileUtils.copyDirectory(getResourceFile("flow-runner-test/mappings"),
                 adminHubConfig.getHubMappingsDir().resolve("e2e-mapping").toFile());
+            FileUtils.copyFileToDirectory(getResourceFile("flow-runner-test/custom-modules/custom/value-step/main.sjs"),
+                adminHubConfig.getModulesDir().resolve("root/custom-modules/custom/value-step").toFile());
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub_unit_test/RunMarkLogicUnitTestsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub_unit_test/RunMarkLogicUnitTestsTest.java
@@ -1,6 +1,7 @@
 package com.marklogic.hub_unit_test;
 
 import com.marklogic.appdeployer.impl.SimpleAppDeployer;
+import com.marklogic.bootstrap.Installer;
 import com.marklogic.hub.ApplicationConfig;
 import com.marklogic.hub.HubTestBase;
 import com.marklogic.junit5.MarkLogicUnitTestArgumentsProvider;
@@ -8,7 +9,6 @@ import com.marklogic.test.unit.TestManager;
 import com.marklogic.test.unit.TestModule;
 import com.marklogic.test.unit.TestResult;
 import com.marklogic.test.unit.TestSuiteResult;
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,10 +19,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Runs all marklogic-unit-test tests located under src/test/ml-modules/root/test.
@@ -59,15 +55,9 @@ public class RunMarkLogicUnitTestsTest extends HubTestBase {
 
     @BeforeAll
     public void setupIndexes() {
-        try {
-            Path srcDir = Paths.get("src", "test", "ml-config", "databases","final-database.json");
-            Path dstDir = Paths.get(adminHubConfig.getUserDatabaseDir().toString(), "test-final-database.json");
-            FileUtils.copyFile(srcDir.toAbsolutePath().toFile(), dstDir.toAbsolutePath().toFile());
-        } catch (IOException ioe) {
-            throw new RuntimeException("Unable to copy test indexes file to project", ioe);
-        }
-        dataHub.updateIndexes();
+        Installer.applyDatabasePropertiesForTests(dataHub, adminHubConfig);
     }
+
     /**
      * This is overridden so that the test class is only initialized once, which is sufficient. Otherwise, it's invoked
      * for every unit test module, which is unnecessary.

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/endpoints/collectorLib/prepareSourceQuery.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/endpoints/collectorLib/prepareSourceQuery.sjs
@@ -33,7 +33,7 @@ sourceQuery = lib.prepareSourceQuery(
 );
 assertions.push(
   test.assertEqual(
-    "cts.andQuery([cts.fieldWordQuery('datahubCreatedByJob', 'job123'), cts.collectionQuery('test')])",
+    "cts.uris(null, null, cts.andQuery([cts.fieldWordQuery('datahubCreatedByJob', 'job123'), cts.collectionQuery('test')]))",
     sourceQuery,
     "When constrainSourceQueryToJob is set to true, and a jobId is set, then the sourceQuery is and'ed with a " +
     "query on datahubCreatedByJob (the contents of the step definition don't matter)"
@@ -49,7 +49,7 @@ options.sourceQuery = 'cts.collectionQuery("test")';
 sourceQuery = lib.prepareSourceQuery(options, {});
 assertions.push(
   test.assertEqual(
-    "cts.andQuery([cts.fieldWordQuery('datahubCreatedByJob', 'job123'), cts.collectionQuery(\"test\")])",
+    "cts.uris(null, null, cts.andQuery([cts.fieldWordQuery('datahubCreatedByJob', 'job123'), cts.collectionQuery(\"test\")]))",
     sourceQuery,
     "Just verifying that if the user's query has double quotes on it, things still work"
   )
@@ -64,7 +64,7 @@ sourceQuery = lib.prepareSourceQuery(
 );
 assertions.push(
   test.assertEqual(
-    "cts.collectionQuery('test')",
+    "cts.uris(null, null, cts.collectionQuery('test'))",
     sourceQuery,
     "If no jobId is provided in the options, then the query won't be constrained by a job"
   )

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/flowWithValues.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/flowWithValues.sjs
@@ -1,0 +1,32 @@
+const test = require("/test/test-helper.xqy");
+const DataHubSingleton = require("/data-hub/5/datahub-singleton.sjs");
+const datahub = DataHubSingleton.instance();
+
+function flowWorksWithValues() {
+  const assertions = [];
+
+  const flowName = "CustomerByValue";
+  const options = {
+    sourceQueryIsScript: true,
+    provenanceGranularityLevel: 'off',
+    uris: "test-data"
+  };
+
+  const content = datahub.flow.findMatchingContent(flowName, "1", options, null);
+  assertions.push(
+    test.assertEqual(1, content.length),
+    test.assertEqual("test-data", content[0].uri,
+      "Each value is stored in a separate content item under the 'uri' property so that we can maintain the convention " +
+      "that every content item has a 'uri' property.")
+  );
+
+  const response = datahub.flow.runFlow(flowName, 'value-test-job', content, options, 1);
+  return assertions.concat(
+    test.assertEqual(0, response.errors.length),
+    test.assertEqual(1, response.totalCount),
+    test.assertEqual("test-data", response.completedItems[0])
+  );
+}
+
+[]
+  .concat(flowWorksWithValues());

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/suite-setup.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/suite-setup.xqy
@@ -27,6 +27,12 @@ xdmp:invoke-function(function() {
     test:get-test-file("nullStep.sjs"),
     (xdmp:default-permissions(), xdmp:permission("rest-extension-user", "execute"), xdmp:permission("data-hub-module-reader", "read"), xdmp:permission("data-hub-module-writer", "update")),
     ()
+  ),
+  xdmp:document-insert(
+    "/test/custom-by-value-step/main.sjs",
+    test:get-test-file("valueStep.sjs"),
+    (xdmp:default-permissions(), xdmp:permission("rest-extension-user", "execute"), xdmp:permission("data-hub-module-reader", "read"), xdmp:permission("data-hub-module-writer", "update")),
+    ()
   )
 },
   map:entry("database", xdmp:modules-database())

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/suite-teardown.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/suite-teardown.xqy
@@ -6,6 +6,9 @@ import module namespace test = "http://marklogic.com/test" at "/test/test-helper
 xdmp:invoke-function(function() {
   xdmp:document-delete(
     "/test/custom-null-step/main.sjs"
+  ),
+    xdmp:document-delete(
+    "/test/custom-by-value-step/main.sjs"
   )
 },
   map:entry("database", xdmp:modules-database())

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/test-data/flows/CustomerByValue.flow.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/test-data/flows/CustomerByValue.flow.json
@@ -1,0 +1,23 @@
+{
+  "name": "CustomerByValue",
+  "options": {
+    "collections": [
+      "CustomerByValue"
+    ],
+    "targetEntity": "Customer",
+    "sourceQuery": "cts.values(cts.uriReference())",
+    "sourceQueryIsScript": true,
+    "noWrite": true
+  },
+  "description": "flow description",
+  "steps": {
+    "1": {
+      "stepDefinitionName": "CustomerByValue",
+      "stepDefinitionType": "CUSTOM",
+      "options": {
+        "sourceDatabase": "data-hub-FINAL",
+        "targetDatabase": "data-hub-FINAL"
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/test-data/step-definitions/CustomerByValue.step.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/test-data/step-definitions/CustomerByValue.step.json
@@ -1,0 +1,19 @@
+{
+  "name": "CustomerByValue",
+  "type": "CUSTOM",
+  "version": 1,
+  "options": {
+    "collections": [
+      "value-collection"
+    ],
+    "sourceDatabase": "data-hub-FINAL",
+    "targetDatabase": "data-hub-FINAL",
+    "targetEntity": "Customer",
+    "sourceQuery": "cts.values(cts.uriReference())",
+    "sourceQueryIsScript": true,
+    "noWrite": true
+  },
+  "customHook": {},
+  "lang": "zxx",
+  "modulePath": "/test/custom-by-value-step/main.sjs"
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/test-data/valueStep.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/test-data/valueStep.sjs
@@ -1,0 +1,21 @@
+const DataHubSingleton = require("/data-hub/5/datahub-singleton.sjs");
+const datahub = DataHubSingleton.instance();
+
+function main(contentItem, options) {
+  const collectionValue = contentItem.uri;
+  const instance = {
+    collection: collectionValue
+  };
+  return {
+    uri: "/processed/customer1.json",
+    value: datahub.flow.flowUtils.makeEnvelope(instance, {}, [], "json"),
+    context: {
+      collections: ["test-data"],
+      permissions: datahub.hubUtils.parsePermissions("data-hub-operator,read,data-hub-operator,update")
+    }
+  };
+}
+
+module.exports = {
+  main: main
+};

--- a/marklogic-data-hub/src/test/resources/flow-runner-test/custom-modules/custom/value-step/main.sjs
+++ b/marklogic-data-hub/src/test/resources/flow-runner-test/custom-modules/custom/value-step/main.sjs
@@ -1,0 +1,22 @@
+const DataHubSingleton = require("/data-hub/5/datahub-singleton.sjs");
+const datahub = DataHubSingleton.instance();
+
+/**
+ * Trivial example of a custom step for testing a collector that returns values.
+ */
+function main(contentItem, options) {
+  const instance = {
+    contentValue: contentItem.uri
+  };
+  return {
+    uri: "/processed/" + sem.uuidString() + ".json",
+    value: datahub.flow.flowUtils.makeEnvelope(instance, {}, [], "json"),
+    context: {
+      permissions: datahub.hubUtils.parsePermissions("data-hub-operator,read,data-hub-operator,update")
+    }
+  };
+}
+
+module.exports = {
+  main: main
+};

--- a/marklogic-data-hub/src/test/resources/flow-runner-test/flows/testValuesFlow.flow.json
+++ b/marklogic-data-hub/src/test/resources/flow-runner-test/flows/testValuesFlow.flow.json
@@ -1,0 +1,15 @@
+{
+  "name": "testValuesFlow",
+  "steps": {
+    "1": {
+      "name": "valueFlow",
+      "stepDefinitionName": "value-step",
+      "stepDefinitionType": "CUSTOM",
+      "options": {
+        "sourceDatabase": "data-hub-FINAL",
+        "targetDatabase": "data-hub-FINAL",
+        "sourceQueryIsScript": true
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/resources/flow-runner-test/step-definitions/value-step.step.json
+++ b/marklogic-data-hub/src/test/resources/flow-runner-test/step-definitions/value-step.step.json
@@ -1,0 +1,9 @@
+{
+  "lang": "zxx",
+  "name": "value-step",
+  "type": "CUSTOM",
+  "options": {
+    "outputFormat": "json"
+  },
+  "modulePath": "/custom-modules/custom/value-step/main.sjs"
+}


### PR DESCRIPTION
Step option "sourceQueryIsScript:true" can be added so that the collector knows to evaluate the sourceQuery as a script instead of tossing it into a cts.uris call. 

Did some renaming of "uris" as a variable to "items". Unfortunately can't change e.g. "uris" in a Batch document, as that'd be a breaking change. 

FlowRunnerTest now depends on the indexes in the test final-database.json file, so I moved the setup of those indexes from RunMarkLogicUnitTestsTest into Installer.