### PR TITLE
DHFPROD-4568: Adding working dir for npm

### DIFF
--- a/one-ui/build.gradle
+++ b/one-ui/build.gradle
@@ -77,6 +77,9 @@ node {
     // Set the work directory for unpacking node
     workDir = file("${project.buildDir}/nodejs")
 
+    // Set the work directory for NPM
+    npmWorkDir = file("${project.buildDir}/npm")
+
     // Set the work directory where node_modules should be located
     nodeModulesDir = file("${project.projectDir}/ui")
 }


### PR DESCRIPTION
There were conflicts due to different npm versions on marklogic-datahub and one-ui modules. I added a working directory for npm in one-ui and it fixed the build issue(could download node 12.16.1) on develop