### PR TITLE
DHFPROD-4568:Changing the node-gradle plugin

### DIFF
--- a/one-ui/build.gradle
+++ b/one-ui/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 	}
 	dependencies {
 		classpath "org.springframework.boot:spring-boot-gradle-plugin:2.2.1.RELEASE"
-		classpath "com.moowork.gradle:gradle-node-plugin:1.3.1"
+		classpath "com.github.node-gradle:gradle-node-plugin:2.2.3"
 	}
 }
 
@@ -14,7 +14,7 @@ apply plugin: "org.springframework.boot"
 apply plugin: 'maven-publish'
 apply plugin: "io.spring.dependency-management"
 apply plugin: 'war'
-apply plugin: "com.moowork.node"
+apply plugin: "com.github.node-gradle.node"
 
 mainClassName = "com.marklogic.hub.oneui.Application"
 


### PR DESCRIPTION
There were build issues as the plugin fails to download node.js intermittently.

The below suggests that changing the plugin resolves the issue.
https://github.com/srs/gradle-node-plugin/issues/301
