### PR TITLE
DHFPROD-4568: Adding base dist url for node js

### DIFF
--- a/one-ui/build.gradle
+++ b/one-ui/build.gradle
@@ -73,7 +73,8 @@ node {
     npmVersion = '6.13.4'
 
     download = true
-
+    distBaseUrl = 'http://nodejs.org/dist'
+    
     // Set the work directory for unpacking node
     workDir = file("${project.buildDir}/nodejs")
 
@@ -82,6 +83,8 @@ node {
 
     // Set the work directory where node_modules should be located
     nodeModulesDir = file("${project.projectDir}/ui")
+
+
 }
 task installDependencies(type: NpmTask, group: taskGroup) {
 	description = "Install UI dependencies before building the UI files"


### PR DESCRIPTION
This should resolve all the build issues while downloading node js.