### PR TITLE
DHFPROD-4025: Display step errors in post-run dialog

### DIFF
--- a/one-ui/ui/src/App.css
+++ b/one-ui/ui/src/App.css
@@ -54,7 +54,7 @@ ul#global-icons.ant-menu .ant-dropdown-trigger .anticon.anticon-user {
     font-size: 24px;
 }
 
-/* Tool Bench Flows view */
+/* Tool Bench Flows */
 div#flows-container div.ant-collapse-content-box {
     padding: 4px 16px 16px;
 }
@@ -70,4 +70,15 @@ div#flows-container div.ant-card-head {
 div#flows-container div.ant-card-body {
     border-top: white;
     padding: 4px 12px 12px;
+}
+/* Tool Bench Flow Errors */
+div#error-list div.ant-collapse {
+    position: relative;
+    left: -16px;
+}
+div#error-list div.ant-collapse div.ant-collapse-item {
+    border-bottom: white;
+}
+div#error-list div.ant-collapse div.ant-collapse-item div.ant-collapse-content div.ant-collapse-content-box {
+    padding: 0 16px;
 }

--- a/one-ui/ui/src/pages/Bench.module.scss
+++ b/one-ui/ui/src/pages/Bench.module.scss
@@ -2,3 +2,16 @@
     padding: 40px 80px 150px 80px;
     background-color: rgb(255, 255, 255);
 }
+
+.errorHeader, .errorLabel {
+    color: rgba(0, 0, 0, 0.85);
+    font-weight: bold;
+}
+
+.errorSummary {
+    font-weight: normal;
+}
+
+.errorVal {
+    font-weight: bold;
+}

--- a/one-ui/ui/src/pages/Bench.tsx
+++ b/one-ui/ui/src/pages/Bench.tsx
@@ -271,7 +271,7 @@ const Bench: React.FC = () => {
                         } else if (response['jobStatus'] === Statuses.FAILED) {
                             console.log('Flow failed: ' + flowId);
                             let errors = getErrors(response);
-                            showFailed(stepName, stepType, errors);
+                            showFailed(stepName, stepType, errors.slice(0,1));
                         }
                         setIsLoading(false);
                     }).catch(function(error) {


### PR DESCRIPTION
This commit displays an error dialog box at end the of a run and handles:
- Failed run with no batches processed (shows single error)
- Completed run with one or more errors across batches (shows up to 10 errors realized)

Screencast of UI functionality:
https://drive.google.com/file/d/1znqu7xPXKQYKhR_XeIN7lYAnq9pXdBj3/view

How to set up system so that a run will fail:
https://project.marklogic.com/jira/browse/DHFPROD-4025?focusedCommentId=170498&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-170498
https://project.marklogic.com/jira/browse/DHFPROD-4025?focusedCommentId=170654&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-170654

This work depends on the following functionality being in place:
https://project.marklogic.com/jira/browse/DHFPROD-3922
(This has already been merged: https://github.com/marklogic/marklogic-data-hub/pull/3674)