### PR TITLE
DHFPROD-4603:Set absolute schema path in 'AppConfig'

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -1947,6 +1947,8 @@ public class HubConfigImpl implements HubConfig
 
         initializeModulePaths(config);
 
+        config.setSchemaPaths(List.of(getUserSchemasDir().toString()));
+
         addDhfPropertiesToCustomTokens(config);
 
         String version = getJarVersion();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/HubConfigImplTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/HubConfigImplTest.java
@@ -6,9 +6,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.mock.env.MockEnvironment;
 
+import java.io.File;
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HubConfigImplTest {
 
@@ -54,6 +58,9 @@ public class HubConfigImplTest {
         config.loadConfigurationFromProperties(new Properties(), false);
         assertEquals("somehost", config.getHost());
         assertEquals("somehost", config.getAppConfig().getHost());
+        assertTrue(new File(config.getAppConfig().getSchemaPaths().get(0)).isAbsolute(),
+            "LoadSchemasCommand requires that the schemas path be absolute ");
+
     }
 
     private void verifyDefaultValues(HubConfigImpl config) {


### PR DESCRIPTION
Set absolute schema path in 'AppConfig'. There is a test already for this running in regression, its failure resulted in this issue
https://jenkins.marklogic.com/blue/organizations/jenkins/Datahub_CI/detail/develop/759/tests