### PR TITLE
DHFPROD-3647: Save personal search query and its associated filters

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -200,6 +200,10 @@ task generateEntitySearchInterface(type: com.marklogic.client.tools.gradle.Endpo
     serviceDeclarationFile = dataServicesPath + "/entitySearch/service.json"
 }
 
+task generateSavedQueriesInterface(type: com.marklogic.client.tools.gradle.EndpointProxiesGenTask, group: dataServicesGroup) {
+    serviceDeclarationFile = dataServicesPath + "/savedQueries/service.json"
+}
+
 task generateDataServiceInterfaces {
     description = "Generate Java interfaces for all Data Services. Must run this from the ./marklogic-data-hub directory"
     dependsOn {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/SavedQueriesService.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/SavedQueriesService.java
@@ -1,0 +1,87 @@
+package com.marklogic.hub.dataservices;
+
+// IMPORTANT: Do not edit. This file is generated.
+
+import com.marklogic.client.io.Format;
+
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.io.marker.JSONWriteHandle;
+
+import com.marklogic.client.impl.BaseProxy;
+
+/**
+ * Provides a set of operations on the database server
+ */
+public interface SavedQueriesService {
+    /**
+     * Creates a SavedQueriesService object for executing operations on the database server.
+     *
+     * The DatabaseClientFactory class can create the DatabaseClient parameter. A single
+     * client object can be used for any number of requests and in multiple threads.
+     *
+     * @param db	provides a client for communicating with the database server
+     * @return	an object for executing database operations
+     */
+    static SavedQueriesService on(DatabaseClient db) {
+      return on(db, null);
+    }
+    /**
+     * Creates a SavedQueriesService object for executing operations on the database server.
+     *
+     * The DatabaseClientFactory class can create the DatabaseClient parameter. A single
+     * client object can be used for any number of requests and in multiple threads.
+     *
+     * The service declaration uses a custom implementation of the same service instead
+     * of the default implementation of the service by specifying an endpoint directory
+     * in the modules database with the implementation. A service.json file with the
+     * declaration can be read with FileHandle or a string serialization of the JSON
+     * declaration with StringHandle.
+     *
+     * @param db	provides a client for communicating with the database server
+     * @param serviceDeclaration	substitutes a custom implementation of the service
+     * @return	an object for executing database operations
+     */
+    static SavedQueriesService on(DatabaseClient db, JSONWriteHandle serviceDeclaration) {
+        final class SavedQueriesServiceImpl implements SavedQueriesService {
+            private DatabaseClient dbClient;
+            private BaseProxy baseProxy;
+
+            private BaseProxy.DBFunctionRequest req_saveSavedQuery;
+
+            private SavedQueriesServiceImpl(DatabaseClient dbClient, JSONWriteHandle servDecl) {
+                this.dbClient  = dbClient;
+                this.baseProxy = new BaseProxy("/data-hub/5/data-services/savedQueries/", servDecl);
+
+                this.req_saveSavedQuery = this.baseProxy.request(
+                    "saveSavedQuery.sjs", BaseProxy.ParameterValuesKind.SINGLE_NODE);
+            }
+
+            @Override
+            public com.fasterxml.jackson.databind.JsonNode saveSavedQuery(com.fasterxml.jackson.databind.JsonNode saveQuery) {
+                return saveSavedQuery(
+                    this.req_saveSavedQuery.on(this.dbClient), saveQuery
+                    );
+            }
+            private com.fasterxml.jackson.databind.JsonNode saveSavedQuery(BaseProxy.DBFunctionRequest request, com.fasterxml.jackson.databind.JsonNode saveQuery) {
+              return BaseProxy.JsonDocumentType.toJsonNode(
+                request
+                      .withParams(
+                          BaseProxy.documentParam("saveQuery", false, BaseProxy.JsonDocumentType.fromJsonNode(saveQuery))
+                          ).responseSingle(false, Format.JSON)
+                );
+            }
+        }
+
+        return new SavedQueriesServiceImpl(db, serviceDeclaration);
+    }
+
+  /**
+   * Invokes the saveSavedQuery operation on the database server
+   *
+   * @param saveQuery	provides input
+   * @return	as output
+   */
+    com.fasterxml.jackson.databind.JsonNode saveSavedQuery(com.fasterxml.jackson.databind.JsonNode saveQuery);
+
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
@@ -368,6 +368,8 @@ public class HubProjectImpl implements HubProject {
         //New 5.3.0 roles
         writeRoleFile(rolesDir, "data-hub-load-data-reader.json");
         writeRoleFile(rolesDir, "data-hub-load-data-writer.json");
+        writeRoleFile(rolesDir, "data-hub-saved-query-reader.json");
+        writeRoleFile(rolesDir, "data-hub-saved-query-writer.json");
 
 
         // New 5.2.0 roles

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-operator.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-operator.json
@@ -12,7 +12,9 @@
     "data-hub-step-definition-reader",
     "data-hub-load-data-reader",
     "data-hub-match-merge-reader",
-    "tde-view"
+    "tde-view",
+    "data-hub-saved-query-reader",
+    "data-hub-saved-query-writer"
   ],
   "privilege": [
     {

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-saved-query-reader.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-saved-query-reader.json
@@ -1,0 +1,4 @@
+{
+  "role-name": "data-hub-saved-query-reader",
+  "description": "Permits reading saved query documents"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-saved-query-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-saved-query-writer.json
@@ -1,0 +1,4 @@
+{
+  "role-name": "data-hub-saved-query-writer",
+  "description": "Permits updating saved query documents"
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/savedQueries/saveSavedQuery.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/savedQueries/saveSavedQuery.api
@@ -1,0 +1,15 @@
+{
+  "functionName": "saveSavedQuery",
+  "params": [
+    {
+      "name": "saveQuery",
+      "datatype": "jsonDocument",
+      "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+    }
+  ],
+  "return": {
+    "datatype": "jsonDocument",
+    "$javaClass": "com.fasterxml.jackson.databind.JsonNode",
+    "description": "Returns the savedQuery with the 'id' property populated"
+  }
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/savedQueries/saveSavedQuery.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/savedQueries/saveSavedQuery.sjs
@@ -1,0 +1,52 @@
+'use strict';
+declareUpdate();
+
+var saveQuery;
+var userCollections = ["http://marklogic.com/data-hub/saved-query"];
+var queryDocument = JSON.parse(saveQuery);
+
+if (queryDocument == null || queryDocument.savedQuery == null) {
+    throw Error("The request is empty or malformed");
+}
+
+if (queryDocument.savedQuery.name == null || !queryDocument.savedQuery.name) {
+    throw Error("Query name is missing");
+}
+
+if (queryDocument.savedQuery.query == null || Object.keys(queryDocument.savedQuery.query) == 0) {
+    throw Error("Query to be saved cannot be empty");
+}
+
+if (queryDocument.savedQuery.propertiesToDisplay == null || queryDocument.savedQuery.propertiesToDisplay.length == 0) {
+    throw Error("Entity type properties to be displayed cannot be empty");
+}
+
+let id = queryDocument.savedQuery.id;
+if (cts.doc("/saved-queries/" + id + ".json")) {
+    queryDocument.savedQuery.systemMetadata.lastUpdatedBy = xdmp.getCurrentUser();
+    queryDocument.savedQuery.systemMetadata.lastUpdatedDateTime = fn.currentDateTime();
+    xdmp.nodeReplace(cts.doc("/saved-queries/" + id + ".json"), queryDocument);
+} else {
+    queryDocument.savedQuery.id = sem.uuidString();
+    queryDocument.savedQuery.owner = xdmp.getCurrentUser();
+    queryDocument.savedQuery.systemMetadata = {
+        "createdBy": xdmp.getCurrentUser(),
+        "createdDateTime": fn.currentDateTime(),
+        "lastUpdatedBy": xdmp.getCurrentUser(),
+        "lastUpdatedDateTime": fn.currentDateTime()
+    };
+    insertDocument(queryDocument);
+}
+
+function insertDocument(queryDocument) {
+    let docUri = "/saved-queries/" + queryDocument.savedQuery.id + ".json";
+    let permissions = [xdmp.permission('data-hub-saved-query-reader', 'read'),
+        xdmp.permission('data-hub-saved-query-writer', 'update'),
+        xdmp.defaultPermissions()];
+    xdmp.documentInsert(docUri, queryDocument, {
+        permissions: permissions,
+        collections: userCollections
+    });
+}
+
+queryDocument;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/savedQueries/service.json
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/savedQueries/service.json
@@ -1,0 +1,4 @@
+{
+  "endpointDirectory": "/data-hub/5/data-services/savedQueries/",
+  "$javaClass": "com.marklogic.hub.dataservices.SavedQueriesService"
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/savedQueries/saveSavedQueryTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/savedQueries/saveSavedQueryTest.sjs
@@ -1,0 +1,82 @@
+const test = require("/test/test-helper.xqy");
+
+var saveQuery = JSON.stringify({
+  "savedQuery": {
+    "id": "",
+    "name": "some-query",
+    "description": "some-query-description",
+    "query": {
+      "searchText": "some-string",
+      "entityTypeIds": [
+        "Entity1"
+      ],
+      "selectedFacets": {
+        "Collection": {
+          "dataType": "string",
+          "stringValues": [
+            "Entity1",
+            "Collection1"
+          ]
+        },
+        "facet1": {
+          "dataType": "decimal",
+          "rangeValues": {
+            "lowerBound": "2.5",
+            "upperBound": "15"
+          }
+        },
+        "facet2": {
+          "dataType": "dateTime",
+          "rangeValues": {
+            "lowerBound": "2020-01-01T13:06:17",
+            "upperBound": "2020-01-22T13:06:17"
+          }
+        }
+      }
+    },
+    "propertiesToDisplay": ["facet1", "EntityTypeProperty1"]
+  }
+});
+
+function invokeService(saveQuery) {
+  return fn.head(xdmp.invoke(
+      "/data-hub/5/data-services/savedQueries/saveSavedQuery.sjs",
+      {
+        "saveQuery": saveQuery
+      }
+  ));
+}
+
+
+function testSaveNewQuery() {
+  const result = invokeService(saveQuery);
+  return [
+    test.assertNotEqual(null, result),
+    test.assertNotEqual(null, result.savedQuery),
+    test.assertNotEqual(null, result.savedQuery.systemMetadata),
+    test.assertNotEqual(null, result.savedQuery.id),
+    test.assertEqual("some-query", result.savedQuery.name),
+    test.assertEqual(4, Object.keys(result.savedQuery.systemMetadata).length),
+    test.assertEqual("flow-developer", result.savedQuery.owner)
+  ];
+}
+
+function testModifyQuery() {
+  let insertedQuery = invokeService(saveQuery);
+  const id = insertedQuery.savedQuery.id;
+  insertedQuery.savedQuery.name = "modified-query";
+  const result = invokeService(JSON.stringify(insertedQuery));
+  return [
+    test.assertNotEqual(null, result),
+    test.assertNotEqual(null, result.savedQuery),
+    test.assertNotEqual(null, result.savedQuery.systemMetadata),
+    test.assertEqual(id, result.savedQuery.id),
+    test.assertEqual("modified-query", result.savedQuery.name),
+    test.assertEqual(4, Object.keys(result.savedQuery.systemMetadata).length),
+    test.assertEqual("flow-developer", result.savedQuery.owner)
+  ];
+}
+
+[]
+    .concat(testSaveNewQuery())
+    .concat(testModifyQuery());

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/security/getAuthoritiesTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/security/getAuthoritiesTest.sjs
@@ -8,17 +8,18 @@ function invokeService() {
 }
 
 const response = invokeService();
+const minExpectedAuthorities = ["canReadLoadData", "canReadFlows", "canReadStepDefinitions", "canReadMappings", "canReadMatching"];
+const minExpectedRoles = ["data-hub-operator", "data-hub-entity-model-reader", "data-hub-job-reader", "data-hub-flow-reader",
+    "data-hub-step-definition-reader", "data-hub-load-data-reader", "data-hub-match-merge-reader", "data-hub-mapping-reader",
+    "data-hub-saved-query-reader", "data-hub-saved-query-writer", "data-hub-module-reader"];
 
-[
+const result = [
+    // The inequality references are assuming that the least priveleged role used to run the tests is data-hub-operator
     test.assertEqual("flow-developer", xdmp.getCurrentUser()),
-    test.assertEqual(10, response.authorities.length),
-    test.assertEqual("canWriteLoadData,canReadLoadData,canWriteFlows,canReadFlows," +
-        "canWriteStepDefinitions,canReadStepDefinitions,canWriteMappings,canReadMappings,canWriteMatching,canReadMatching",
-        response.authorities.toString()),
-    test.assertEqual(17, response.roles.length),
-    test.assertEqual("data-hub-operator,data-hub-entity-model-reader,data-hub-mapping-writer,data-hub-mapping-reader,"+
-    "data-hub-match-merge-writer,data-hub-load-data-writer,data-hub-module-writer,data-hub-load-data-reader,"+
-    "data-hub-job-reader,data-hub-flow-reader,data-hub-step-definition-reader,data-hub-match-merge-reader,data-hub-step-definition-writer,"+
-    "data-hub-flow-writer,data-hub-developer,data-hub-entity-model-writer,data-hub-module-reader",
-        response.roles.toString())
-]
+    test.assertTrue(response.authorities.length >= 5, "The minimum number of authorities any user has"),
+    test.assertTrue(minExpectedAuthorities.every(authority => response.authorities.includes(authority))),
+    test.assertTrue(response.roles.length >= 11, "The minimum number of roles any user has"),
+    test.assertTrue(minExpectedRoles.every(role => response.roles.includes(role)))
+];
+
+result;

--- a/one-ui/src/main/java/com/marklogic/hub/oneui/controllers/SavedQueriesController.java
+++ b/one-ui/src/main/java/com/marklogic/hub/oneui/controllers/SavedQueriesController.java
@@ -1,0 +1,37 @@
+package com.marklogic.hub.oneui.controllers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.hub.dataservices.SavedQueriesService;
+import com.marklogic.hub.oneui.models.HubConfigSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@RequestMapping(value = "/api/savedQueries")
+public class SavedQueriesController {
+
+    @Autowired
+    private HubConfigSession hubConfig;
+
+    @RequestMapping(method = RequestMethod.POST)
+    @ResponseBody
+    public ResponseEntity<JsonNode> saveQueryDocument(@RequestBody JsonNode queryDocument) {
+        return new ResponseEntity<>(getSavedQueriesService().saveSavedQuery(queryDocument), HttpStatus.CREATED);
+    }
+
+    @RequestMapping(method = RequestMethod.PUT)
+    @ResponseBody
+    public ResponseEntity<JsonNode> updateQueryDocument(@RequestBody JsonNode queryDocument) {
+        return new ResponseEntity<>(getSavedQueriesService().saveSavedQuery(queryDocument), HttpStatus.OK);
+    }
+
+    private SavedQueriesService getSavedQueriesService() {
+        return SavedQueriesService.on(hubConfig.newFinalClient());
+    }
+}

--- a/one-ui/src/test/java/com/marklogic/hub/oneui/TestHelper.java
+++ b/one-ui/src/test/java/com/marklogic/hub/oneui/TestHelper.java
@@ -3,10 +3,13 @@ package com.marklogic.hub.oneui;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.document.GenericDocumentManager;
 import com.marklogic.client.eval.EvalResultIterator;
 import com.marklogic.client.eval.ServerEvaluationCall;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.FileHandle;
+import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.deploy.commands.LoadHubArtifactsCommand;
 import com.marklogic.hub.impl.ArtifactManagerImpl;
 import com.marklogic.hub.oneui.auth.LoginInfo;
@@ -183,5 +186,13 @@ public class TestHelper {
         user = new User(adminAPI, username);
         user.setRole(Stream.of(role).collect(Collectors.toList()));
         user.save();
+    }
+
+    protected GenericDocumentManager getFinalGenericDocumentManager(DatabaseKind databaseKind) {
+        return getFinalClient(databaseKind).newDocumentManager();
+    }
+
+    protected DatabaseClient getFinalClient(DatabaseKind databaseKind) {
+        return hubConfig.newFinalClient(hubConfig.getDbName(databaseKind));
     }
 }

--- a/one-ui/ui/api/swagger/mocks.json
+++ b/one-ui/ui/api/swagger/mocks.json
@@ -3768,6 +3768,128 @@
         "x-swagger-router-controller": "facetValue"
       }
     },
+    "/savedQueries":{
+      "post":{
+        "tags":[
+          "Saved Queries"
+        ],
+        "summary":"Save user search query into database",
+        "description":"....",
+        "operationId":"saveQuery",
+        "produces":[
+          "application/json"
+        ],
+        "parameters":[
+          {
+            "in":"body",
+            "name":"body",
+            "required":true,
+            "schema":{
+              "$ref":"#/definitions/savedQueryRequest"
+            }
+          }
+        ],
+        "responses":{
+          "200":{
+            "description":"Successful Operation",
+            "schema":{
+              "$ref":"#/definitions/savedQuery"
+            }
+          },
+          "400":{
+            "description":"Bad Request",
+            "schema":{
+              "$ref":"#/definitions/error"
+            }
+          },
+          "401":{
+            "description":"Unauthorized",
+            "schema":{
+              "$ref":"#/definitions/error"
+            }
+          },
+          "403":{
+            "description":"Forbidden",
+            "schema":{
+              "$ref":"#/definitions/error"
+            }
+          },
+          "404":{
+            "description":"Not Found",
+            "schema":{
+              "$ref":"#/definitions/error"
+            }
+          },
+          "500":{
+            "description":"Internal Server Error",
+            "schema":{
+              "$ref":"#/definitions/error"
+            }
+          }
+        },
+        "x-swagger-router-controller":"savedQuery"
+      },
+      "put":{
+        "tags":[
+          "Saved Queries"
+        ],
+        "summary":"Update saved user search query into database",
+        "description":"....",
+        "operationId":"updateQuery",
+        "produces":[
+          "application/json"
+        ],
+        "parameters":[
+          {
+            "in":"body",
+            "name":"body",
+            "required":true,
+            "schema":{
+              "$ref":"#/definitions/updateQueryRequest"
+            }
+          }
+        ],
+        "responses":{
+          "200":{
+            "description":"Successful Operation",
+            "schema":{
+              "$ref":"#/definitions/savedQuery"
+            }
+          },
+          "400":{
+            "description":"Bad Request",
+            "schema":{
+              "$ref":"#/definitions/error"
+            }
+          },
+          "401":{
+            "description":"Unauthorized",
+            "schema":{
+              "$ref":"#/definitions/error"
+            }
+          },
+          "403":{
+            "description":"Forbidden",
+            "schema":{
+              "$ref":"#/definitions/error"
+            }
+          },
+          "404":{
+            "description":"Not Found",
+            "schema":{
+              "$ref":"#/definitions/error"
+            }
+          },
+          "500":{
+            "description":"Internal Server Error",
+            "schema":{
+              "$ref":"#/definitions/error"
+            }
+          }
+        },
+        "x-swagger-router-controller":"savedQuery"
+      }
+    },
     "/environment/reset": {
       "post": {
         "tags": [
@@ -4884,6 +5006,232 @@
         "flowId": "flow-id",
         "endTime": "2000-01-23T04:56:07.000+00:00",
         "status": "canceled"
+      }
+    },
+    "savedQueryRequest": {
+      "type":"object",
+      "description":"Save user search query request",
+      "properties":{
+        "id":{
+          "type":"string",
+          "description":"Identifier for a saved query"
+        },
+        "name":{
+          "type":"string",
+          "description":"Name of the saved query"
+        },
+        "description":{
+          "type":"string",
+          "description":"Description about the saved query"
+        },
+        "query": {
+          "type": "object",
+          "description": "Data related to the last job run for this Flow",
+          "properties": {
+
+          }
+        },
+        "propertiesToDisplay": {
+          "type":"array",
+          "description":"Array of properties to display in tabular view or during export",
+          "items":{
+            "type":"string"
+          }
+        }
+      },
+      "example":{
+        "savedQuery": {
+          "id": "",
+          "name": "some-query",
+          "description": "some-query-description",
+          "query": {
+            "searchText": "some-string",
+            "entityTypeIds": [
+              "Entity1"
+            ],
+            "selectedFacets": {
+              "Collection": {
+                "dataType": "string",
+                "stringValues": [
+                  "Entity1",
+                  "Collection1"
+                ]
+              },
+              "facet1": {
+                "dataType": "decimal",
+                "rangeValues": {
+                  "lowerBound": "2.5",
+                  "upperBound": "15"
+                }
+              },
+              "facet2": {
+                "dataType": "dateTime",
+                "rangeValues": {
+                  "lowerBound": "2020-01-01T13:06:17",
+                  "upperBound": "2020-01-22T13:06:17"
+                }
+              }
+            }
+          },
+          "propertiesToDisplay": ["facet1", "EntityTypeProperty1"]
+        }
+      }
+    },
+    "updateQueryRequest": {
+      "type":"object",
+      "description":"Update user search query request",
+      "properties":{
+        "id":{
+          "type":"string",
+          "description":"Identifier for a saved query"
+        },
+        "name":{
+          "type":"string",
+          "description":"Name of the saved query"
+        },
+        "description":{
+          "type":"string",
+          "description":"Description about the saved query"
+        },
+        "query": {
+          "type": "object",
+          "description": "Data related to the last job run for this Flow",
+          "properties": {
+
+          }
+        },
+        "propertiesToDisplay": {
+          "type":"array",
+          "description":"Array of properties to display in tabular view or during export",
+          "items":{
+            "type":"string"
+          }
+        }
+      },
+      "example":{
+        "savedQuery": {
+          "id": "a986e6f1-e20d-4cce-bd75-5a5806cb9712",
+          "name": "some-query",
+          "description": "some-query-description",
+          "query": {
+            "searchText": "some-string",
+            "entityTypeIds": [
+              "Entity1"
+            ],
+            "selectedFacets": {
+              "Collection": {
+                "dataType": "string",
+                "stringValues": [
+                  "Entity1",
+                  "Collection1"
+                ]
+              },
+              "facet1": {
+                "dataType": "decimal",
+                "rangeValues": {
+                  "lowerBound": "2.5",
+                  "upperBound": "15"
+                }
+              },
+              "facet2": {
+                "dataType": "dateTime",
+                "rangeValues": {
+                  "lowerBound": "2020-01-01T13:06:17",
+                  "upperBound": "2020-01-22T13:06:17"
+                }
+              }
+            }
+          },
+          "propertiesToDisplay": ["facet1", "EntityTypeProperty1"]
+        }
+      }
+    },
+    "savedQuery":{
+      "type":"object",
+      "description":"Saved user search query",
+      "properties":{
+        "id":{
+          "type":"string",
+          "description":"Identifier for a saved query"
+        },
+        "name":{
+          "type":"string",
+          "description":"Name of the saved query"
+        },
+        "description":{
+          "type":"string",
+          "description":"Description about the saved query"
+        },
+        "query": {
+          "type": "object",
+          "description": "Data related to the last job run for this Flow",
+          "properties": {
+
+          }
+        },
+        "propertiesToDisplay": {
+          "type":"array",
+          "description":"Array of properties to display in tabular view or during export",
+          "items":{
+            "type":"string"
+          }
+        },
+        "owner": {
+          "type":"string",
+          "description":"defines the user who owns the query"
+        },
+        "systemMetadata": {
+          "type":"object",
+          "description":"contains user created or updated and the time stamps when updated",
+          "properties": {
+
+          }
+        }
+      },
+      "example":{
+        "id": "a986e6f1-e20d-4cce-bd75-5a5806cb9712",
+        "name": "some-query",
+        "description": "some-query-description",
+        "query": {
+          "searchText": "some-string",
+          "entityTypeIds": [
+            "Entity1"
+          ],
+          "selectedFacets": {
+            "Collection": {
+              "dataType": "string",
+              "stringValues": [
+                "Entity1",
+                "Collection1"
+              ]
+            },
+            "facet1": {
+              "dataType": "decimal",
+              "rangeValues": {
+                "lowerBound": "2.5",
+                "upperBound": "15"
+              }
+            },
+            "facet2": {
+              "dataType": "dateTime",
+              "rangeValues": {
+                "lowerBound": "2020-01-01T13:06:17",
+                "upperBound": "2020-01-22T13:06:17"
+              }
+            }
+          }
+        },
+        "propertiesToDisplay": [
+          "facet1",
+          "EntityTypeProperty1"
+        ],
+        "owner": "data-hub-user",
+        "systemMetadata": {
+          "createdBy": "data-hub-user",
+          "createdDateTime": "2020-03-17T13:09:55.458979-07:00",
+          "lastUpdatedBy": "data-hub-user",
+          "lastUpdatedDateTime": "2020-03-17T13:09:55.458979-07:00"
+        }
       }
     },
     "error": {

--- a/one-ui/ui/api/swagger/mocks.yaml
+++ b/one-ui/ui/api/swagger/mocks.yaml
@@ -2546,6 +2546,87 @@ paths:
                     schema:
                         $ref: '#/definitions/error'
             x-swagger-router-controller: facetValue
+    /savedQueries:
+        post:
+            tags:
+                - Saved Queries
+            summary: Save user search query into database
+            description: ....
+            operationId: saveQuery
+            produces:
+                - application/json
+            parameters:
+                - in: body
+                  name: body
+                  required: true
+                  schema:
+                      $ref: '#/definitions/savedQueryRequest'
+            responses:
+                '200':
+                    description: Successful Operation
+                    schema:
+                        $ref: '#/definitions/savedQuery'
+                '400':
+                    description: Bad Request
+                    schema:
+                        $ref: '#/definitions/error'
+                '401':
+                    description: Unauthorized
+                    schema:
+                        $ref: '#/definitions/error'
+                '403':
+                    description: Forbidden
+                    schema:
+                        $ref: '#/definitions/error'
+                '404':
+                    description: Not Found
+                    schema:
+                        $ref: '#/definitions/error'
+                '500':
+                    description: Internal Server Error
+                    schema:
+                        $ref: '#/definitions/error'
+            x-swagger-router-controller: savedQuery
+        put:
+            tags:
+                - Saved Queries
+            summary: Update saved user search query into database
+            description: ....
+            operationId: updateQuery
+            produces:
+                - application/json
+            parameters:
+                - in: body
+                  name: body
+                  required: true
+                  schema:
+                      $ref: '#/definitions/updateQueryRequest'
+            responses:
+                '200':
+                    description: Successful Operation
+                    schema:
+                        $ref: '#/definitions/savedQuery'
+                '400':
+                    description: Bad Request
+                    schema:
+                        $ref: '#/definitions/error'
+                '401':
+                    description: Unauthorized
+                    schema:
+                        $ref: '#/definitions/error'
+                '403':
+                    description: Forbidden
+                    schema:
+                        $ref: '#/definitions/error'
+                '404':
+                    description: Not Found
+                    schema:
+                        $ref: '#/definitions/error'
+                '500':
+                    description: Internal Server Error
+                    schema:
+                        $ref: '#/definitions/error'
+            x-swagger-router-controller: savedQuery
     /environment/reset:
         post:
             tags:
@@ -3398,6 +3479,168 @@ definitions:
             flowId: flow-id
             endTime: '2000-01-23T04:56:07.000+00:00'
             status: canceled
+    savedQueryRequest:
+        type: object
+        description: Save user search query request
+        properties:
+            id:
+                type: string
+                description: Identifier for a saved query
+            name:
+                type: string
+                description: Name of the saved query
+            description:
+                type: string
+                description: Description about the saved query
+            query:
+                type: object
+                description: Data related to the last job run for this Flow
+                properties: {}
+            propertiesToDisplay:
+                type: array
+                description: Array of properties to display in tabular view or during export
+                items:
+                    type: string
+        example:
+            savedQuery:
+                id: ''
+                name: some-query
+                description: some-query-description
+                query:
+                    searchText: some-string
+                    entityTypeIds:
+                        - Entity1
+                    selectedFacets:
+                        Collection:
+                            dataType: string
+                            stringValues:
+                                - Entity1
+                                - Collection1
+                        facet1:
+                            dataType: decimal
+                            rangeValues:
+                                lowerBound: '2.5'
+                                upperBound: '15'
+                        facet2:
+                            dataType: dateTime
+                            rangeValues:
+                                lowerBound: '2020-01-01T13:06:17'
+                                upperBound: '2020-01-22T13:06:17'
+                propertiesToDisplay:
+                    - facet1
+                    - EntityTypeProperty1
+    updateQueryRequest:
+        type: object
+        description: Update user search query request
+        properties:
+            id:
+                type: string
+                description: Identifier for a saved query
+            name:
+                type: string
+                description: Name of the saved query
+            description:
+                type: string
+                description: Description about the saved query
+            query:
+                type: object
+                description: Data related to the last job run for this Flow
+                properties: {}
+            propertiesToDisplay:
+                type: array
+                description: Array of properties to display in tabular view or during export
+                items:
+                    type: string
+        example:
+            savedQuery:
+                id: a986e6f1-e20d-4cce-bd75-5a5806cb9712
+                name: some-query
+                description: some-query-description
+                query:
+                    searchText: some-string
+                    entityTypeIds:
+                        - Entity1
+                    selectedFacets:
+                        Collection:
+                            dataType: string
+                            stringValues:
+                                - Entity1
+                                - Collection1
+                        facet1:
+                            dataType: decimal
+                            rangeValues:
+                                lowerBound: '2.5'
+                                upperBound: '15'
+                        facet2:
+                            dataType: dateTime
+                            rangeValues:
+                                lowerBound: '2020-01-01T13:06:17'
+                                upperBound: '2020-01-22T13:06:17'
+                propertiesToDisplay:
+                    - facet1
+                    - EntityTypeProperty1
+    savedQuery:
+        type: object
+        description: Saved user search query
+        properties:
+            id:
+                type: string
+                description: Identifier for a saved query
+            name:
+                type: string
+                description: Name of the saved query
+            description:
+                type: string
+                description: Description about the saved query
+            query:
+                type: object
+                description: Data related to the last job run for this Flow
+                properties: {}
+            propertiesToDisplay:
+                type: array
+                description: Array of properties to display in tabular view or during export
+                items:
+                    type: string
+            owner:
+                type: string
+                description: defines the user who owns the query
+            systemMetadata:
+                type: object
+                description: contains user created or updated and the time stamps when updated
+                properties: {}
+        example:
+            id: a986e6f1-e20d-4cce-bd75-5a5806cb9712
+            name: some-query
+            description: some-query-description
+            query:
+                searchText: some-string
+                entityTypeIds:
+                    - Entity1
+                selectedFacets:
+                    Collection:
+                        dataType: string
+                        stringValues:
+                            - Entity1
+                            - Collection1
+                    facet1:
+                        dataType: decimal
+                        rangeValues:
+                            lowerBound: '2.5'
+                            upperBound: '15'
+                    facet2:
+                        dataType: dateTime
+                        rangeValues:
+                            lowerBound: '2020-01-01T13:06:17'
+                            upperBound: '2020-01-22T13:06:17'
+            propertiesToDisplay:
+                - facet1
+                - EntityTypeProperty1
+            owner: data-hub-user
+            systemMetadata:
+                createdBy: data-hub-user
+                createdDateTime: '2020-03-17T13:09:55.458979-07:00'
+                lastUpdatedBy: data-hub-user
+                lastUpdatedDateTime: '2020-03-17T13:09:55.458979-07:00'
     error:
         type: object
         properties:


### PR DESCRIPTION
DHFPROD-3647: Save Query endpoint implementation
DHFPROD-3647: Adding reader and writer roles for saved query documents
DHFPROD-3647: Save Query dataservice modules

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests


- ##### Reviewer:

- [x] Reviewed Tests
