### PR TITLE
DHFPROD-4665: sourceQuery can now be a cts.uris script again

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/endpoints/collectorLib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/endpoints/collectorLib.sjs
@@ -50,6 +50,13 @@ class CollectorLib {
       }
     }
 
+    // This is retained only for backwards compatibility, though its existence is neither documented nor tested
+    // prior to DHFPROD-4665. Prior to DHFPROD-3854, this did support cts.values, though it would not have worked had
+    // someone tried to use that, since the rest of DHF was still expecting URIs to be returned, not values.
+    if (/^\s*cts\.uris\(.*\)\s*$/.test(sourceQuery)) {
+      return sourceQuery;
+    }
+
     return `cts.uris(null, null, ${sourceQuery})`;
   }
 }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/endpoints/collectorLib/prepareSourceQuery.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/endpoints/collectorLib/prepareSourceQuery.sjs
@@ -70,5 +70,15 @@ assertions.push(
   )
 );
 
+sourceQuery = lib.prepareSourceQuery(
+  {
+    sourceQuery: "cts.uris(null, null, cts.trueQuery())"
+  }, {}
+);
+assertions.push(
+  test.assertEqual("cts.uris(null, null, cts.trueQuery())", sourceQuery,
+    "For backwards compatibility (even though it's not documented or tested anywhere), a user can pass in cts.uris " +
+    "without having to set sourceQueryIsScript")
+);
 
 assertions;


### PR DESCRIPTION
This is an undocumented, untested feature that was uncovered by someone making use of it. So ensuring it still is supported.
