### PR TITLE
DHFPROD-4531: Handle runFlow exception to return a proper message to the caller

### DIFF
--- a/azure/flow-runner-function/README.md
+++ b/azure/flow-runner-function/README.md
@@ -18,7 +18,7 @@ Then run the function locally: (note: make sure to have JAVA_HOME env variable i
 
 You can then test it by running the following:
 
-    curl -w "\n" http://localhost:7071/api/HttpExampleDhfFlow --data flowNameDoesntMatterYet
+    curl -w "\n" http://localhost:7071/api/HttpExampleDataHubFlow --data flowNameDoesntMatterYet
 
 ## Testing on Azure
 
@@ -34,7 +34,7 @@ Then deploy your function (this can take many seconds to finish):
 
 Then get your HTTP trigger URL and test the endpoint - your URL should be similar to what's shown below:
 
-    curl -w "\n" https://az-functions-20200227122602814.azurewebsites.net/api/HttpExampleDhfFlow --data flowNameDoesntMatterYet
+    curl -w "\n" https://az-functions-data-hub-sample-v1.azurewebsites.net/api/HttpExampleDataHubFlow --data flowNameDoesntMatterYet
 
 
 You can also follow the instructions at https://docs.microsoft.com/en-us/azure/azure-functions/functions-add-output-binding-storage-queue-java to connect the function to Azure storage. If you do that, then after running the test, 

--- a/azure/flow-runner-function/pom.xml
+++ b/azure/flow-runner-function/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <azure.functions.maven.plugin.version>1.4.1</azure.functions.maven.plugin.version>
         <azure.functions.java.library.version>1.3.1</azure.functions.java.library.version>
-        <functionAppName>az-functions-20200227122602814</functionAppName>
+        <functionAppName>az-functions-data-hub-sample-v1</functionAppName>
         <stagingDirectory>${project.build.directory}/azure-functions/${functionAppName}</stagingDirectory>
     </properties>
 

--- a/azure/flow-runner-function/src/test/java/com/marklogic/dhf/azure/FunctionDataHubFlowTest.java
+++ b/azure/flow-runner-function/src/test/java/com/marklogic/dhf/azure/FunctionDataHubFlowTest.java
@@ -18,9 +18,9 @@ import static org.mockito.Mockito.*;
 /**
  * Unit test for Function class.
  */
-public class FunctionDhfFlowTest {
+public class FunctionDataHubFlowTest {
     /**
-     * Unit test for HttpTriggerJava method.
+     * Unit test for HttpExampleDataHubFlow method.
      */
     @Test
     public void testHttpTriggerJava() throws Exception {
@@ -52,7 +52,7 @@ public class FunctionDhfFlowTest {
         // Invoke
         // Running invalid flow throws Exception. The test fails without the try/catch block.
         try {
-            final HttpResponseMessage ret = new FunctionDhfFlow().run(req, msg, context);
+            final HttpResponseMessage ret = new FunctionDataHubFlow().run(req, msg, context);
         } catch (java.lang.RuntimeException ex) {
             System.out.println (ex.getMessage());
         }


### PR DESCRIPTION
Sometimes, noticing inconsistent behavior when the Function App is throwing exception and is not being handled properly by the Logic App. This PR is to return an appropriate message to the caller - either successful or exception message.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests


- ##### Reviewer:

- [x] Reviewed Tests
