### PR TITLE
DHFPROD-4656: Added models service and controller

### DIFF
--- a/marklogic-data-hub/gradle.properties
+++ b/marklogic-data-hub/gradle.properties
@@ -66,5 +66,6 @@ mlHubLogLevel=default
 # Ensure modules are loaded with the correct permissions when running "gradle mlWatch" during testing
 mlModulePermissions=data-hub-module-reader,read,data-hub-module-reader,execute,data-hub-module-writer,update,rest-extension-user,execute
 
-# Needs to be here so that tokens in config.sjs/config.xqy are replaced
+# Needs to be here so that tokens in config.sjs/config.xqy are replaced when loading modules into the test app
 mlJobPermissions=data-hub-job-reader,read,data-hub-job-internal,update
+mlEntityModelPermissions=data-hub-entity-model-reader,read,data-hub-entity-model-writer,update

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/EntityManager.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/EntityManager.java
@@ -77,6 +77,7 @@ public interface EntityManager {
 
     List<HubEntity> getEntities(Boolean extendSubEntities);
 
+    @Deprecated(since = "DHF 5.3.0; use ModelsService instead")
     HubEntity saveEntity(HubEntity entity, Boolean rename) throws IOException;
 
     void deleteEntity(String entity) throws IOException;

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/ModelsService.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/ModelsService.java
@@ -1,0 +1,190 @@
+package com.marklogic.hub.dataservices;
+
+// IMPORTANT: Do not edit. This file is generated.
+
+import com.marklogic.client.io.Format;
+
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.io.marker.JSONWriteHandle;
+
+import com.marklogic.client.impl.BaseProxy;
+
+/**
+ * Provides a set of operations on the database server
+ */
+public interface ModelsService {
+    /**
+     * Creates a ModelsService object for executing operations on the database server.
+     *
+     * The DatabaseClientFactory class can create the DatabaseClient parameter. A single
+     * client object can be used for any number of requests and in multiple threads.
+     *
+     * @param db	provides a client for communicating with the database server
+     * @return	an object for executing database operations
+     */
+    static ModelsService on(DatabaseClient db) {
+      return on(db, null);
+    }
+    /**
+     * Creates a ModelsService object for executing operations on the database server.
+     *
+     * The DatabaseClientFactory class can create the DatabaseClient parameter. A single
+     * client object can be used for any number of requests and in multiple threads.
+     *
+     * The service declaration uses a custom implementation of the same service instead
+     * of the default implementation of the service by specifying an endpoint directory
+     * in the modules database with the implementation. A service.json file with the
+     * declaration can be read with FileHandle or a string serialization of the JSON
+     * declaration with StringHandle.
+     *
+     * @param db	provides a client for communicating with the database server
+     * @param serviceDeclaration	substitutes a custom implementation of the service
+     * @return	an object for executing database operations
+     */
+    static ModelsService on(DatabaseClient db, JSONWriteHandle serviceDeclaration) {
+        final class ModelsServiceImpl implements ModelsService {
+            private DatabaseClient dbClient;
+            private BaseProxy baseProxy;
+
+            private BaseProxy.DBFunctionRequest req_updateModelInfo;
+            private BaseProxy.DBFunctionRequest req_saveModel;
+            private BaseProxy.DBFunctionRequest req_getPrimaryEntityTypes;
+            private BaseProxy.DBFunctionRequest req_createModel;
+            private BaseProxy.DBFunctionRequest req_updateModelEntityTypes;
+
+            private ModelsServiceImpl(DatabaseClient dbClient, JSONWriteHandle servDecl) {
+                this.dbClient  = dbClient;
+                this.baseProxy = new BaseProxy("/data-hub/5/data-services/models/", servDecl);
+
+                this.req_updateModelInfo = this.baseProxy.request(
+                    "updateModelInfo.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_ATOMICS);
+                this.req_saveModel = this.baseProxy.request(
+                    "saveModel.sjs", BaseProxy.ParameterValuesKind.SINGLE_NODE);
+                this.req_getPrimaryEntityTypes = this.baseProxy.request(
+                    "getPrimaryEntityTypes.sjs", BaseProxy.ParameterValuesKind.NONE);
+                this.req_createModel = this.baseProxy.request(
+                    "createModel.sjs", BaseProxy.ParameterValuesKind.SINGLE_NODE);
+                this.req_updateModelEntityTypes = this.baseProxy.request(
+                    "updateModelEntityTypes.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_MIXED);
+            }
+
+            @Override
+            public com.fasterxml.jackson.databind.JsonNode updateModelInfo(String name, String description) {
+                return updateModelInfo(
+                    this.req_updateModelInfo.on(this.dbClient), name, description
+                    );
+            }
+            private com.fasterxml.jackson.databind.JsonNode updateModelInfo(BaseProxy.DBFunctionRequest request, String name, String description) {
+              return BaseProxy.JsonDocumentType.toJsonNode(
+                request
+                      .withParams(
+                          BaseProxy.atomicParam("name", false, BaseProxy.StringType.fromString(name)),
+                          BaseProxy.atomicParam("description", false, BaseProxy.StringType.fromString(description))
+                          ).responseSingle(false, Format.JSON)
+                );
+            }
+
+            @Override
+            public void saveModel(com.fasterxml.jackson.databind.JsonNode model) {
+                saveModel(
+                    this.req_saveModel.on(this.dbClient), model
+                    );
+            }
+            private void saveModel(BaseProxy.DBFunctionRequest request, com.fasterxml.jackson.databind.JsonNode model) {
+              request
+                      .withParams(
+                          BaseProxy.documentParam("model", false, BaseProxy.JsonDocumentType.fromJsonNode(model))
+                          ).responseNone();
+            }
+
+            @Override
+            public com.fasterxml.jackson.databind.JsonNode getPrimaryEntityTypes() {
+                return getPrimaryEntityTypes(
+                    this.req_getPrimaryEntityTypes.on(this.dbClient)
+                    );
+            }
+            private com.fasterxml.jackson.databind.JsonNode getPrimaryEntityTypes(BaseProxy.DBFunctionRequest request) {
+              return BaseProxy.JsonDocumentType.toJsonNode(
+                request.responseSingle(false, Format.JSON)
+                );
+            }
+
+            @Override
+            public com.fasterxml.jackson.databind.JsonNode createModel(com.fasterxml.jackson.databind.JsonNode input) {
+                return createModel(
+                    this.req_createModel.on(this.dbClient), input
+                    );
+            }
+            private com.fasterxml.jackson.databind.JsonNode createModel(BaseProxy.DBFunctionRequest request, com.fasterxml.jackson.databind.JsonNode input) {
+              return BaseProxy.JsonDocumentType.toJsonNode(
+                request
+                      .withParams(
+                          BaseProxy.documentParam("input", false, BaseProxy.JsonDocumentType.fromJsonNode(input))
+                          ).responseSingle(false, Format.JSON)
+                );
+            }
+
+            @Override
+            public com.fasterxml.jackson.databind.JsonNode updateModelEntityTypes(String name, com.fasterxml.jackson.databind.JsonNode input) {
+                return updateModelEntityTypes(
+                    this.req_updateModelEntityTypes.on(this.dbClient), name, input
+                    );
+            }
+            private com.fasterxml.jackson.databind.JsonNode updateModelEntityTypes(BaseProxy.DBFunctionRequest request, String name, com.fasterxml.jackson.databind.JsonNode input) {
+              return BaseProxy.JsonDocumentType.toJsonNode(
+                request
+                      .withParams(
+                          BaseProxy.atomicParam("name", false, BaseProxy.StringType.fromString(name)),
+                          BaseProxy.documentParam("input", false, BaseProxy.JsonDocumentType.fromJsonNode(input))
+                          ).responseSingle(false, Format.JSON)
+                );
+            }
+        }
+
+        return new ModelsServiceImpl(db, serviceDeclaration);
+    }
+
+  /**
+   * Update the description of an existing model. Model title and version cannot yet be edited because doing so would break existing mapping and mastering configurations.
+   *
+   * @param name	The name of the model
+   * @param description	provides input
+   * @return	as output
+   */
+    com.fasterxml.jackson.databind.JsonNode updateModelInfo(String name, String description);
+
+  /**
+   * Save a model, where the input is a JSON model
+   *
+   * @param model	provides input
+   * 
+   */
+    void saveModel(com.fasterxml.jackson.databind.JsonNode model);
+
+  /**
+   * Returns an array of primary entity types. A primary entity type is the entity type in a model descriptor with a name equal to the title of the model descriptor.
+   *
+   * 
+   * @return	as output
+   */
+    com.fasterxml.jackson.databind.JsonNode getPrimaryEntityTypes();
+
+  /**
+   * Create a new model, resulting in a new entity descriptor with a primary entity type in it.
+   *
+   * @param input	provides input
+   * @return	as output
+   */
+    com.fasterxml.jackson.databind.JsonNode createModel(com.fasterxml.jackson.databind.JsonNode input);
+
+  /**
+   * Invokes the updateModelEntityTypes operation on the database server
+   *
+   * @param name	The name of the model
+   * @param input	provides input
+   * @return	as output
+   */
+    com.fasterxml.jackson.databind.JsonNode updateModelEntityTypes(String name, com.fasterxml.jackson.databind.JsonNode input);
+
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/EntityManagerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/EntityManagerImpl.java
@@ -69,8 +69,6 @@ public class EntityManagerImpl extends LoggingObject implements EntityManager {
     @Autowired
     private HubConfig hubConfig;
 
-    private ObjectMapper mapper;
-
     public EntityManagerImpl() {
     }
 
@@ -103,16 +101,16 @@ public class EntityManagerImpl extends LoggingObject implements EntityManager {
                 String options = generator.generateOptions(entities, false);
                 if (options != null) {
                     FileUtils.writeStringToFile(stagingFile, options);
-                    logger.info("Wrote entity-specific search options to: " + stagingFile.getAbsolutePath());
+                    logger.debug("Wrote entity-specific search options to: " + stagingFile.getAbsolutePath());
                     FileUtils.writeStringToFile(finalFile, options);
-                    logger.info("Wrote entity-specific search options to: " + finalFile.getAbsolutePath());
+                    logger.debug("Wrote entity-specific search options to: " + finalFile.getAbsolutePath());
                 }
                 String expOptions = generator.generateOptions(entities, true);
                 if (expOptions != null) {
                     FileUtils.writeStringToFile(expStagingFile, expOptions);
-                    logger.info("Wrote entity-specific search options for Explorer to: " + stagingFile.getAbsolutePath());
+                    logger.debug("Wrote entity-specific search options for Explorer to: " + stagingFile.getAbsolutePath());
                     FileUtils.writeStringToFile(expFinalFile, expOptions);
-                    logger.info("Wrote entity-specific search options for Explorer to: " + finalFile.getAbsolutePath());
+                    logger.debug("Wrote entity-specific search options for Explorer to: " + finalFile.getAbsolutePath());
                 }
                 return true;
             }
@@ -137,9 +135,9 @@ public class EntityManagerImpl extends LoggingObject implements EntityManager {
                 String options = generator.generateOptions(entities, true);
                 if (options != null) {
                     FileUtils.writeStringToFile(expStagingFile, options);
-                    logger.info("Wrote entity-specific search options for Explorer to: " + expStagingFile.getAbsolutePath());
+                    logger.debug("Wrote entity-specific search options for Explorer to: " + expStagingFile.getAbsolutePath());
                     FileUtils.writeStringToFile(expFinalFile, options);
-                    logger.info("Wrote entity-specific search options for Explorer to: " + expFinalFile.getAbsolutePath());
+                    logger.debug("Wrote entity-specific search options for Explorer to: " + expFinalFile.getAbsolutePath());
                 }
             }
         } catch (IOException e) {
@@ -515,6 +513,7 @@ public class EntityManagerImpl extends LoggingObject implements EntityManager {
         return entities;
     }
 
+    @Deprecated(since = "DHF 5.3.0; use ModelsService instead")
     public HubEntity saveEntity(HubEntity entity, Boolean rename) throws IOException {
         JsonNode node = entity.toJson();
         ObjectMapper objectMapper = new ObjectMapper();

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
@@ -478,7 +478,9 @@ public class HubProjectImpl implements HubProject {
 
     private void writeResourceFile(String srcFile, Path dstFile, boolean overwrite) {
         if (overwrite || !dstFile.toFile().exists()) {
-            logger.info("Getting file: " + srcFile);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Getting file: " + srcFile);
+            }
             InputStream inputStream = null;
             try {
                 inputStream = HubProject.class.getClassLoader().getResourceAsStream(srcFile);

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/ModelManagerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/ModelManagerImpl.java
@@ -1,0 +1,73 @@
+package com.marklogic.hub.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.hub.HubConfig;
+import com.marklogic.hub.dataservices.ModelsService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.FileCopyUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * This is implementing ModelsService instead of defining a new ModelManager interface, which would just duplicate the
+ * ModelsService interface.
+ */
+public class ModelManagerImpl implements ModelsService {
+
+    private final static Logger logger = LoggerFactory.getLogger(ModelManagerImpl.class);
+
+    private HubConfig hubConfig;
+    private ModelsService modelsService;
+
+    public ModelManagerImpl(HubConfig hubConfig) {
+        this.hubConfig = hubConfig;
+        this.modelsService = ModelsService.on(hubConfig.newFinalClient(null));
+    }
+
+    @Override
+    public JsonNode getPrimaryEntityTypes() {
+        return modelsService.getPrimaryEntityTypes();
+    }
+
+    @Override
+    public JsonNode createModel(JsonNode input) {
+        return saveModelToFilesystem(modelsService.createModel(input));
+    }
+
+    @Override
+    public JsonNode updateModelInfo(String name, String description) {
+        return saveModelToFilesystem(modelsService.updateModelInfo(name, description));
+    }
+
+    @Override
+    public JsonNode updateModelEntityTypes(String name, JsonNode input) {
+        return saveModelToFilesystem(modelsService.updateModelEntityTypes(name, input));
+    }
+
+    /**
+     * This does not write to the filesystem, as the only use case for this so far is for loading the model after it's
+     * been read from the filesystem.
+     *
+     * @param model	provides input
+     */
+    @Override
+    public void saveModel(JsonNode model) {
+        modelsService.saveModel(model);
+    }
+
+    protected JsonNode saveModelToFilesystem(JsonNode model) {
+        final String name = model.get("info").get("title").asText();
+        File dir = hubConfig.getHubProject().getHubEntitiesDir().toFile();
+        dir.mkdirs();
+        File file = new File(dir, name + ".entity.json");
+        try {
+            FileCopyUtils.copy(model.toString().getBytes(), file);
+            logger.info(String.format("Wrote %s model to %s", name, file.getAbsolutePath()));
+        } catch (IOException e) {
+            throw new RuntimeException("Model was saved to MarkLogic, but could not be written to the project filesystem; cause: " + e.getMessage(), e);
+        }
+        return model;
+    }
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.hub/config.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.hub/config.sjs
@@ -8,5 +8,6 @@ module.exports = {
   HUBLOGLEVEL: "%%mlHubLogLevel%%",
   FLOWOPERATORROLE: "%%mlFlowOperatorRole%%",
   FLOWDEVELOPERROLE: "%%mlFlowDeveloperRole%%",
-  JOBPERMISSIONS: "%%mlJobPermissions%%"
+  JOBPERMISSIONS: "%%mlJobPermissions%%",
+  MODELPERMISSIONS: "%%mlEntityModelPermissions%%"
 };

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/core.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/core.sjs
@@ -146,6 +146,7 @@ function setArtifact(artifactType, artifactName, artifact) {
     const artifactPermissions = artifactLibrary.getPermissions();
     const artifactCollections = artifactLibrary.getCollections();
     artifact.lastUpdated = fn.string(fn.currentDateTime());
+    dataHub.hubUtils.replaceLangWithLanguage(artifact);
     for (const db of artifactDatabases) {
         dataHub.hubUtils.writeDocument(`${artifactDirectory}${xdmp.urlEncode(artifactName)}${artifactFileExtension}`, artifact, artifactPermissions, artifactCollections, db);
     }

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/createModel.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/createModel.api
@@ -13,9 +13,6 @@
         },
         "description" : {
           "type" : "string"
-        },
-        "baseUri" : {
-          "type" : "string"
         }
       },
       "required" : [ "name" ]

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/createModel.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/createModel.sjs
@@ -17,16 +17,30 @@
 
 const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
 
-var entityCollection;
+var input = fn.head(xdmp.fromJSON(input));
 
-let res = {
-  "entityCollection": entityCollection,
-  "latestJobId": null,
-  "latestJobDateTime": null
+const name = input.name;
+const description = input.description;
+
+if (name == null) {
+  new Error("The model must have an info object with a title property");
+}
+
+const model = {
+  info: {
+    title: name
+  },
+  definitions: {}
 };
 
-const latestJobData = entityLib.getLatestJobData(entityCollection);
-if (latestJobData) {
-  res = Object.assign(res, latestJobData);
+model.definitions[name] = {
+  properties: {}
+};
+
+if (input.description) {
+  model.definitions[name].description = description;
 }
-res;
+
+entityLib.writeModel(name, model);
+
+model;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/getPrimaryEntityTypes.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/getPrimaryEntityTypes.sjs
@@ -17,16 +17,13 @@
 
 const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
 
-var entityCollection;
-
-let res = {
-  "entityCollection": entityCollection,
-  "latestJobId": null,
-  "latestJobDateTime": null
-};
-
-const latestJobData = entityLib.getLatestJobData(entityCollection);
-if (latestJobData) {
-  res = Object.assign(res, latestJobData);
-}
-res;
+fn.collection(entityLib.getModelCollection()).toArray().map(model => {
+  const entityName = model.toObject().info.title;
+  const jobData = entityLib.getLatestJobData(entityName);
+  const response = {
+    entityName: entityName,
+    entityInstanceCount: cts.estimate(cts.collectionQuery(entityName)),
+    model: model
+  };
+  return Object.assign(response, jobData);
+})

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/saveModel.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/saveModel.api
@@ -1,0 +1,11 @@
+{
+    "functionName": "saveModel",
+    "desc": "Save a model, where the input is a JSON model",
+    "params": [
+        {
+            "name": "model",
+            "datatype": "jsonDocument",
+            "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+        }
+    ]
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/saveModel.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/saveModel.sjs
@@ -17,16 +17,11 @@
 
 const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
 
-var entityCollection;
+var model = fn.head(xdmp.fromJSON(model));
 
-let res = {
-  "entityCollection": entityCollection,
-  "latestJobId": null,
-  "latestJobDateTime": null
-};
-
-const latestJobData = entityLib.getLatestJobData(entityCollection);
-if (latestJobData) {
-  res = Object.assign(res, latestJobData);
+const name = model.info.title;
+if (name == null) {
+  new Error("The model must have an info object with a title property");
 }
-res;
+
+entityLib.writeModel(name, model);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelEntityTypes.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelEntityTypes.api
@@ -11,5 +11,9 @@
     "schema" : {
       "$ref" : "../../models/ModelDefinitions.v1.json"
     }
-  } ]
+  } ],
+  "return" : {
+    "datatype" : "jsonDocument",
+    "$javaClass" : "com.fasterxml.jackson.databind.JsonNode"
+  }
 }

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelEntityTypes.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelEntityTypes.sjs
@@ -17,16 +17,16 @@
 
 const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
 
-var entityCollection;
+var name;
+var input = fn.head(xdmp.fromJSON(input));
 
-let res = {
-  "entityCollection": entityCollection,
-  "latestJobId": null,
-  "latestJobDateTime": null
-};
-
-const latestJobData = entityLib.getLatestJobData(entityCollection);
-if (latestJobData) {
-  res = Object.assign(res, latestJobData);
+const uri = entityLib.getModelUri(name);
+if (!fn.docAvailable(uri)) {
+  new Error("Could not find model with name: " + name);
 }
-res;
+
+const model = cts.doc(uri).toObject();
+model.definitions = input;
+entityLib.writeModel(name, model);
+
+model;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelInfo.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelInfo.api
@@ -8,5 +8,9 @@
   }, {
     "name" : "description",
     "datatype" : "string"
-  } ]
+  } ],
+  "return" : {
+    "datatype" : "jsonDocument",
+    "$javaClass" : "com.fasterxml.jackson.databind.JsonNode"
+  }
 }

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelInfo.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelInfo.sjs
@@ -17,16 +17,21 @@
 
 const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
 
-var entityCollection;
+var name;
+var description;
 
-let res = {
-  "entityCollection": entityCollection,
-  "latestJobId": null,
-  "latestJobDateTime": null
-};
-
-const latestJobData = entityLib.getLatestJobData(entityCollection);
-if (latestJobData) {
-  res = Object.assign(res, latestJobData);
+const uri = entityLib.getModelUri(name);
+if (!fn.docAvailable(uri)) {
+  new Error("Could not find model with name: " + name);
 }
-res;
+
+const model = cts.doc(uri).toObject();
+
+if (!model.definitions[name]) {
+  new Error("Could not find model with an entity type with name: " + name);
+}
+
+model.definitions[name].description = description;
+entityLib.writeModel(name, model);
+
+model;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils.sjs
@@ -231,7 +231,20 @@ class HubUtils {
       }
     }
     return parts.join('');
-  };
+  }
+
+  /**
+   * This was originally addressed via DHFPROD-3193 - based on an update to ML 10.0-2, "lang" must now be used instead
+   * of "language".
+   *
+   * @param artifact
+   */
+  replaceLangWithLanguage(artifact) {
+    if (artifact.language) {
+      artifact.lang = artifact.language;
+      delete artifact.language;
+    }
+  }
 }
 
 module.exports = HubUtils;

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/AbstractHubTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/AbstractHubTest.java
@@ -1,0 +1,16 @@
+package com.marklogic.hub;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Adding this so that a class can subclass HubTestBase without having to define the same two Spring annotations
+ * over and over. Plan is to move a lot of classes to under this so they don't duplicate the annotations.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ApplicationConfig.class)
+public abstract class AbstractHubTest extends HubTestBase {
+
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.appdeployer.AppConfig;
 import com.marklogic.appdeployer.command.Command;
-import com.marklogic.appdeployer.command.modules.LoadModulesCommand;
 import com.marklogic.appdeployer.impl.SimpleAppDeployer;
+import com.marklogic.bootstrap.Installer;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.DatabaseClientFactory.Authentication;
@@ -81,6 +81,7 @@ import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ReflectionUtils;
 import org.w3c.dom.Document;
@@ -143,11 +144,13 @@ public class HubTestBase implements InitializingBean {
     @Autowired
     protected ApplicationContext context;
 
+    /**
+     * This is a misleading name; it's really "the current HubConfig being used by tests". It's actually rarely a user
+     * with the admin role; it's most often a user with the flow-developer-role role, which has the manage-admin role.
+     * But it can be changed at any point by any test.
+     */
     @Autowired
     protected HubConfigImpl adminHubConfig;
-
-    //@Autowired
-    //protected HubConfigImpl hubConfig;
 
     @Autowired
     protected DataHubImpl dataHub;
@@ -157,21 +160,6 @@ public class HubTestBase implements InitializingBean {
 
     @Autowired
     protected Versions versions;
-
-    @Autowired
-    protected LoadHubModulesCommand loadHubModulesCommand;
-
-    @Autowired
-    protected LoadHubArtifactsCommand loadHubArtifactsCommand;
-
-    @Autowired
-    protected LoadUserModulesCommand loadUserModulesCommand;
-
-    @Autowired
-    protected LoadUserArtifactsCommand loadUserArtifactsCommand;
-
-    @Autowired
-    protected GenerateFunctionMetadataCommand generateFunctionMetadataCommand;
 
     @Autowired
     protected Scaffolding scaffolding;
@@ -232,7 +220,6 @@ public class HubTestBase implements InitializingBean {
     public  GenericDocumentManager finalDocMgr;
     public  JSONDocumentManager jobDocMgr;
     public  GenericDocumentManager modMgr;
-    public  String bootStrapHost = null;
     static TrustManagerFactory tmf;
 
     static {
@@ -1028,55 +1015,96 @@ public class HubTestBase implements InitializingBean {
         }
     }
 
-    //installHubModules(), installUserModules() and clearUserModules() must be run as 'flow-developer'.
     protected void installHubModules() {
         logger.debug("Installing Data Hub modules into MarkLogic");
         List<Command> commands = new ArrayList<>();
-        commands.add(loadHubModulesCommand);
+        commands.add(new LoadHubModulesCommand(adminHubConfig));
 
         SimpleAppDeployer deployer = new SimpleAppDeployer(adminHubConfig.getManageClient(), adminHubConfig.getAdminManager());
         deployer.setCommands(commands);
         deployer.deploy(adminHubConfig.getAppConfig());
     }
 
+
+    /**
+     * Use this anytime a test needs to wait for things that run on the ML task server - generally, post-commit triggers
+     * - to finish, without resorting to arbitrary Thread.sleep calls that don't always work and often require more
+     * waiting than necessary.
+     */
+    protected void waitForTasksToFinish() {
+        String query = "xquery version '1.0-ml';" +
+            "\n declare namespace ss = 'http://marklogic.com/xdmp/status/server';" +
+            "\n declare namespace hs = 'http://marklogic.com/xdmp/status/host';" +
+            "\n let $task-server-id as xs:unsignedLong := xdmp:host-status(xdmp:host())//hs:task-server-id" +
+            "\n return fn:count(xdmp:server-status(xdmp:host(), $task-server-id)/ss:request-statuses/*)";
+
+        final int maxTries = 100;
+        final long sleepPeriod = 200;
+
+        int taskCount = Integer.parseInt(getServerEval(HubConfig.DEFAULT_STAGING_NAME).xquery(query).evalAs(String.class));
+        int tries = 0;
+        logger.debug("Waiting for task server tasks to finish, count: " + taskCount);
+        while (taskCount > 0 && tries < maxTries) {
+            tries++;
+            try {
+                Thread.sleep(sleepPeriod);
+            } catch (Exception ex) {
+                // ignore
+            }
+            taskCount = Integer.parseInt(getServerEval(HubConfig.DEFAULT_STAGING_NAME).xquery(query).evalAs(String.class));
+            logger.debug("Waiting for task server tasks to finish, count: " + taskCount);
+        }
+    }
+
+    protected void installUserModulesAndArtifacts() {
+        installUserModules(adminHubConfig, true);
+    }
+
+    /**
+     * This loads user artifacts as well, despite the name.
+     *
+     * @param hubConfig
+     * @param force
+     */
     protected void installUserModules(HubConfig hubConfig, boolean force) {
         logger.debug("Installing user modules into MarkLogic");
         List<Command> commands = new ArrayList<>();
+
+        LoadUserModulesCommand loadUserModulesCommand = new LoadUserModulesCommand(adminHubConfig);
         loadUserModulesCommand.setForceLoad(force);
         commands.add(loadUserModulesCommand);
 
-        LoadModulesCommand loadModulesCommand = new LoadModulesCommand();
-        commands.add(loadModulesCommand);
-        //'generateFunctionMetadataCommand' must be called before deploying mappings. If mapping is deployed first
-        // and it references custom functions, mapping xslt will not have reference to custom functions and tests
-        // would fail with XDMP-UNDFUN: (err:XPST0017) Undefined function customDateTime().
-        commands.add(generateFunctionMetadataCommand);
+        commands.add(new GenerateFunctionMetadataCommand(adminHubConfig));
 
+        LoadUserArtifactsCommand loadUserArtifactsCommand = new LoadUserArtifactsCommand(adminHubConfig);
         loadUserArtifactsCommand.setForceLoad(force);
         commands.add(loadUserArtifactsCommand);
 
-        SimpleAppDeployer deployer = new SimpleAppDeployer(((HubConfigImpl)hubConfig).getManageClient(), ((HubConfigImpl)hubConfig).getAdminManager());
+        SimpleAppDeployer deployer = new SimpleAppDeployer(hubConfig.getManageClient(), hubConfig.getAdminManager());
         deployer.setCommands(commands);
         deployer.deploy(hubConfig.getAppConfig());
+
+        waitForTasksToFinish();
+    }
+
+    protected void installUserArtifacts() {
+        LoadUserArtifactsCommand command = new LoadUserArtifactsCommand(adminHubConfig);
+        command.setForceLoad(true);
+        new SimpleAppDeployer(adminHubConfig.getManageClient(), adminHubConfig.getAdminManager(), command).deploy(adminHubConfig.getAppConfig());
+        waitForTasksToFinish();
     }
 
     protected void installHubArtifacts(HubConfig hubConfig, boolean force) {
         logger.debug("Installing hub artifacts into MarkLogic");
         List<Command> commands = new ArrayList<>();
 
-        loadHubArtifactsCommand.setForceLoad(force);
-        commands.add(loadHubArtifactsCommand);
+        LoadHubArtifactsCommand command = new LoadHubArtifactsCommand(adminHubConfig);
+        command.setForceLoad(force);
+        commands.add(command);
 
-        SimpleAppDeployer deployer = new SimpleAppDeployer(((HubConfigImpl)hubConfig).getManageClient(), ((HubConfigImpl)hubConfig).getAdminManager());
+        SimpleAppDeployer deployer = new SimpleAppDeployer(hubConfig.getManageClient(), hubConfig.getAdminManager());
         deployer.setCommands(commands);
         deployer.deploy(hubConfig.getAppConfig());
-
-        // Provides some time for post-commit triggers to complete
-        try {
-            Thread.sleep(1500);
-        } catch (InterruptedException e) {
-            logger.warn("Unexpected error while trying to sleep: " + e.getMessage(), e);
-        }
     }
 
     public void clearUserModules() {
@@ -1255,13 +1283,22 @@ public class HubTestBase implements InitializingBean {
         }
     }
 
-    protected void setupProjectForRunningTestFlow() {
+    /**
+     * Resets the project by clearing the 3 databases and then installing the OOTB artifacts (flows and step definitions)
+     * into the DHF instance.
+     */
+    protected void resetProject() {
+        new Installer().deleteProjectDir();
         basicSetup();
         getDataHubAdminConfig();
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME, HubConfig.DEFAULT_JOB_NAME);
+        installHubArtifacts(getDataHubAdminConfig(), true);
+    }
+
+    protected void setupProjectForRunningTestFlow() {
+        resetProject();
         copyFlowArtifactsToProject();
         installUserModules(getDataHubAdminConfig(), true);
-        installHubArtifacts(getDataHubAdminConfig(), true);
     }
 
     protected void copyFlowArtifactsToProject() {
@@ -1385,5 +1422,55 @@ public class HubTestBase implements InitializingBean {
     @Override
     public void afterPropertiesSet() throws Exception {
         init();
+    }
+
+    /**
+     * Load the files associated with the entity reference model.
+     */
+    protected void loadReferenceModelProject() {
+        loadProjectFiles("entity-reference-model");
+    }
+
+    /**
+     * Intended to make it easy to specify a set of project files to load for a particular test. You likely will want to
+     * call "resetProject" before calling this.
+     *
+     * @param folderInClasspath
+     */
+    protected void loadProjectFiles(String folderInClasspath) {
+        boolean loadModules = false;
+
+        try {
+            File testProjectDir = new ClassPathResource(folderInClasspath).getFile();
+            File entitiesDir = new File(testProjectDir, "entities");
+            if (entitiesDir.exists()) {
+                FileUtils.copyDirectory(entitiesDir, adminHubConfig.getHubEntitiesDir().toFile());
+            }
+
+            File flowsDir = new File(testProjectDir, "flows");
+            if (flowsDir.exists()) {
+                FileUtils.copyDirectory(flowsDir, adminHubConfig.getFlowsDir().toFile());
+            }
+
+            File stepDefinitionsDir = new File(testProjectDir, "step-definitions");
+            if (stepDefinitionsDir.exists()) {
+                FileUtils.copyDirectory(stepDefinitionsDir, adminHubConfig.getStepDefinitionsDir().toFile());
+            }
+
+            File modulesDir = new File(testProjectDir, "modules");
+            if (modulesDir.exists()) {
+                FileUtils.copyDirectory(modulesDir, adminHubConfig.getModulesDir().toFile());
+                loadModules = true;
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to load project files: " + e.getMessage(), e);
+        }
+
+        if (loadModules) {
+            installUserModulesAndArtifacts();
+        } else {
+            installUserArtifacts();
+        }
     }
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/models/CreateAndUpdateModelTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/models/CreateAndUpdateModelTest.java
@@ -1,0 +1,146 @@
+package com.marklogic.hub.dataservices.models;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.document.JSONDocumentManager;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.hub.AbstractHubTest;
+import com.marklogic.hub.dataservices.ModelsService;
+import com.marklogic.hub.impl.ModelManagerImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CreateAndUpdateModelTest extends AbstractHubTest {
+
+    private final static String MODEL_NAME = "CreateModelTestEntity";
+    private final static String EXPECTED_URI = "/entities/" + MODEL_NAME + ".entity.json";
+
+    private ModelsService service;
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void beforeEach() {
+        resetProject();
+        service = new ModelManagerImpl(adminHubConfig);
+    }
+
+    @Test
+    void createAndUpdateInfoThenUpdateEntityTypes() throws IOException {
+        ObjectNode input = mapper.createObjectNode();
+        input.put("name", MODEL_NAME);
+        input.put("description", "Initial description");
+        JsonNode model = service.createModel(input);
+        verifyModelContents(model, "Initial description");
+        verifyPersistedModels("Initial description");
+
+        service.updateModelInfo(MODEL_NAME, "Modified description");
+        verifyPersistedModels("Modified description");
+
+        updateEntityTypes();
+        updateEntityTypesWithInvalidData();
+    }
+
+    /**
+     * validateModelDefinitions.sjs covers all validation rules.
+     */
+    @Test
+    void invalidEntityName() {
+        ObjectNode input = mapper.createObjectNode();
+        input.put("name", "Spaces not allowed");
+        try {
+            service.createModel(input);
+            fail("Expected error because spaces are not allowed in an entity name");
+        } catch (Exception ex) {
+            logger.info("Caught expected exception: " + ex.getMessage());
+            assertTrue(ex.getMessage().contains("must start with a letter"));
+        }
+    }
+
+    private void verifyModelContents(JsonNode model, String expectedDescription) {
+        assertEquals(MODEL_NAME, model.get("info").get("title").asText());
+        assertEquals("1.0.0", model.get("info").get("version").asText());
+        assertEquals("http://example.org/", model.get("info").get("baseUri").asText(),
+            "Until a user can enter a baseUri via the GUI, the service will use a default value");
+
+        assertEquals(expectedDescription, model.get("definitions").get(MODEL_NAME).get("description").asText());
+    }
+
+    /**
+     * Verify the model in the ML databases and in the project filesystem.
+     *
+     * @param expectedDescription
+     * @throws IOException
+     */
+    private void verifyPersistedModels(String expectedDescription) throws IOException {
+        File file = new File(adminHubConfig.getHubProject().getHubEntitiesDir().toFile(), MODEL_NAME + ".entity.json");
+        assertTrue(file.exists(), "Expected model file to exist: " + file.getAbsolutePath());
+        verifyModelContents(mapper.readTree(file), expectedDescription);
+
+        JSONDocumentManager stagingMgr = adminHubConfig.newStagingClient().newJSONDocumentManager();
+        JSONDocumentManager finalMgr = adminHubConfig.newFinalClient().newJSONDocumentManager();
+
+        verifyModelContents(stagingMgr.read(EXPECTED_URI, new JacksonHandle()).get(), expectedDescription);
+        verifyModelContents(finalMgr.read(EXPECTED_URI, new JacksonHandle()).get(), expectedDescription);
+
+        verifyModelMetadata(stagingMgr.readMetadata(EXPECTED_URI, new DocumentMetadataHandle()));
+        verifyModelMetadata(finalMgr.readMetadata(EXPECTED_URI, new DocumentMetadataHandle()));
+    }
+
+    private void verifyModelMetadata(DocumentMetadataHandle metadata) {
+        assertEquals("http://marklogic.com/entity-services/models", metadata.getCollections().iterator().next());
+        DocumentMetadataHandle.DocumentPermissions perms = metadata.getPermissions();
+        assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("data-hub-entity-model-reader").iterator().next());
+        assertEquals(DocumentMetadataHandle.Capability.UPDATE, perms.get("data-hub-entity-model-writer").iterator().next());
+    }
+
+    private void updateEntityTypes() throws IOException {
+        String entityTypes = "{\"" + MODEL_NAME + "\" : {\n" +
+            "      \"required\" : [ ],\n" +
+            "      \"properties\" : {\n" +
+            "        \"someProperty\" : {\n" +
+            "          \"datatype\" : \"string\",\n" +
+            "          \"collation\" : \"http://marklogic.com/collation/codepoint\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    }}";
+        service.updateModelEntityTypes(MODEL_NAME, mapper.readTree(entityTypes));
+
+        JSONDocumentManager stagingMgr = adminHubConfig.newStagingClient().newJSONDocumentManager();
+        JSONDocumentManager finalMgr = adminHubConfig.newFinalClient().newJSONDocumentManager();
+
+        JsonNode model = stagingMgr.read(EXPECTED_URI, new JacksonHandle()).get();
+        assertEquals("string", model.get("definitions").get(MODEL_NAME).get("properties").get("someProperty").get("datatype").asText());
+        model = finalMgr.read(EXPECTED_URI, new JacksonHandle()).get();
+        assertEquals("string", model.get("definitions").get(MODEL_NAME).get("properties").get("someProperty").get("datatype").asText());
+
+        verifyModelMetadata(stagingMgr.readMetadata(EXPECTED_URI, new DocumentMetadataHandle()));
+        verifyModelMetadata(finalMgr.readMetadata(EXPECTED_URI, new DocumentMetadataHandle()));
+    }
+
+    private void updateEntityTypesWithInvalidData() throws IOException {
+        String entityTypes = "{\"" + MODEL_NAME + "\" : {\n" +
+            "      \"required\" : [ ],\n" +
+            "      \"properties\" : {\n" +
+            "        \"1cantStartWithANumber\" : {\n" +
+            "          \"datatype\" : \"string\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    }}";
+        JsonNode input = mapper.readTree(entityTypes);
+
+        try {
+            service.updateModelEntityTypes(MODEL_NAME, input);
+            fail("Expected an error because of an invalid property name");
+        } catch (Exception ex) {
+            logger.info("Caught expected error: " + ex.getMessage());
+            assertTrue(ex.getMessage().contains("must start with a letter"));
+        }
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/models/GetPrimaryEntityTypesTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/models/GetPrimaryEntityTypesTest.java
@@ -1,0 +1,80 @@
+package com.marklogic.hub.dataservices.models;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.document.JSONDocumentManager;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.hub.AbstractHubTest;
+import com.marklogic.hub.dataservices.ModelsService;
+import com.marklogic.hub.flow.FlowInputs;
+import com.marklogic.hub.flow.FlowRunner;
+import com.marklogic.hub.flow.impl.FlowRunnerImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GetPrimaryEntityTypesTest extends AbstractHubTest {
+
+    @Test
+    void referenceModelWithOneCustomerLoaded() {
+        givenTheReferenceModelProjectIsLoaded();
+        givenASingleCustomerDocument();
+        givenACustomerFlowHasBeenRun();
+
+        ArrayNode entityTypes = (ArrayNode) ModelsService.on(adminHubConfig.newFinalClient(null)).getPrimaryEntityTypes();
+        assertEquals(2, entityTypes.size(), "Expecting an entry for Customer and for Order");
+        // The order of types isn't guaranteed here
+        entityTypes.forEach(entityType -> {
+            String name = entityType.get("entityName").asText();
+            if ("Order".equals(name)) {
+                assertEquals("0", entityType.get("entityInstanceCount").asText());
+                assertFalse(entityType.has("latestJobId"), "Job data shouldn't exist since no flows have been run for this entity");
+                assertFalse(entityType.has("latestJobDateTime"));
+                assertEquals("Order", entityType.get("model").get("info").get("title").asText(), "Verifying that the model is included");
+            } else {
+                assertEquals("Customer", name);
+                assertEquals("1", entityType.get("entityInstanceCount").asText());
+                assertEquals("echoFlow-test", entityType.get("latestJobId").asText());
+                assertTrue(entityType.has("latestJobDateTime"));
+                assertEquals("Customer", entityType.get("model").get("info").get("title").asText());
+            }
+        });
+    }
+
+    @Test
+    void noEntityModelsExist() {
+        resetProject();
+        ArrayNode entityTypes = (ArrayNode) ModelsService.on(adminHubConfig.newFinalClient(null)).getPrimaryEntityTypes();
+        assertNotNull(entityTypes);
+        assertEquals(0, entityTypes.size());
+    }
+
+    private void givenTheReferenceModelProjectIsLoaded() {
+        resetProject();
+        loadReferenceModelProject();
+    }
+
+    private void givenASingleCustomerDocument() {
+        JSONDocumentManager mgr = adminHubConfig.newFinalClient().newJSONDocumentManager();
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode customer1 = mapper.createObjectNode();
+        customer1.put("name", "Customer One");
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle()
+            .withCollections("customer-input")
+            .withPermission("data-hub-operator", DocumentMetadataHandle.Capability.READ, DocumentMetadataHandle.Capability.UPDATE);
+        mgr.write("/customer/customer-1.json", metadata, new JacksonHandle(customer1));
+    }
+
+    private void givenACustomerFlowHasBeenRun() {
+        runAsDataHubOperator();
+
+        FlowInputs inputs = new FlowInputs("echoFlow");
+        inputs.setJobId("echoFlow-test");
+
+        FlowRunner flowRunner = new FlowRunnerImpl(host, adminHubConfig.getMlUsername(), adminHubConfig.getMlPassword());
+        flowRunner.runFlow(inputs);
+        flowRunner.awaitCompletion();
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/models/SaveModelTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/models/SaveModelTest.java
@@ -1,0 +1,51 @@
+package com.marklogic.hub.dataservices.models;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.hub.AbstractHubTest;
+import com.marklogic.hub.dataservices.ModelsService;
+import com.marklogic.hub.impl.ModelManagerImpl;
+import com.marklogic.mgmt.util.ObjectMapperFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class SaveModelTest extends AbstractHubTest {
+
+    private ModelsService service;
+
+    @BeforeEach
+    void beforeEach() {
+        resetProject();
+        service = new ModelManagerImpl(adminHubConfig);
+    }
+
+    @Test
+    void modelHasLanguageInIt() throws Exception {
+        final String json = "{\n" +
+            "  \"info\" : {\n" +
+            "    \"title\" : \"LanguageTest\"\n" +
+            "  },\n" +
+            " \"language\": \"zxx\",\n" +
+            "  \"definitions\" : {\n" +
+            "    \"LanguageTest\" : {\n" +
+            "      \"properties\" : {\n" +
+            "        \"street\" : {\n" +
+            "          \"datatype\" : \"string\",\n" +
+            "          \"collation\" : \"http://marklogic.com/collation/codepoint\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
+        service.saveModel(ObjectMapperFactory.getObjectMapper().readTree(json));
+
+        JsonNode type = service.getPrimaryEntityTypes().get(0);
+        JsonNode model = type.get("model");
+        assertEquals("zxx", model.get("lang").asText(), " Per DHFPROD-3193 and an update to MarkLogic 10.0-2, 'lang' " +
+            "must now be used instead of 'language'.");
+        assertFalse(model.has("language"));
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/GenerateFunctionMetadataCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/GenerateFunctionMetadataCommandTest.java
@@ -75,8 +75,8 @@ public class GenerateFunctionMetadataCommandTest extends HubTestBase {
 
     @Test
     public void sortOrder() {
-        int metadataOrder = generateFunctionMetadataCommand.getExecuteSortOrder();
-        int userModulesOrder = loadUserModulesCommand.getExecuteSortOrder();
+        int metadataOrder = new GenerateFunctionMetadataCommand().getExecuteSortOrder();
+        int userModulesOrder = new LoadUserModulesCommand().getExecuteSortOrder();
         assertTrue(metadataOrder > userModulesOrder,
             "Function metadata should be generated after user modules are loaded");
     }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadHubArtifactsCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadHubArtifactsCommandTest.java
@@ -36,6 +36,7 @@ public class LoadHubArtifactsCommandTest extends HubTestBase {
 
     @Test
     public void verifyDefaultPermissions() {
+        LoadHubArtifactsCommand loadHubArtifactsCommand = new LoadHubArtifactsCommand(adminHubConfig);
         DocumentMetadataHandle h = loadHubArtifactsCommand.buildMetadata(adminHubConfig.getFlowPermissions(),"http://marklogic.com/data-hub/flow");
         assertEquals(2, h.getCollections().size());
         Iterator<String> collections = h.getCollections().iterator();
@@ -77,6 +78,8 @@ public class LoadHubArtifactsCommandTest extends HubTestBase {
         config.setFlowPermissions("manage-user,read,manage-admin,update");
         config.setStepDefinitionPermissions("manage-user,read,manage-admin,update");
         config.setModulePermissions("manage-user,read,manage-admin,update");
+
+        LoadUserArtifactsCommand loadUserArtifactsCommand = new LoadUserArtifactsCommand(adminHubConfig);
 
         DocumentMetadataHandle.DocumentPermissions perms = loadUserArtifactsCommand.buildMetadata(config.getStepDefinitionPermissions(),"http://marklogic.com/data-hub/step-definition").getPermissions();
         assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("manage-user").iterator().next());

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommandTest.java
@@ -24,6 +24,7 @@ import com.marklogic.mgmt.util.ObjectMapperFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -37,9 +38,11 @@ import static org.junit.jupiter.api.Assertions.*;
 @ContextConfiguration(classes = ApplicationConfig.class)
 public class LoadUserArtifactsCommandTest extends HubTestBase {
 
+    private LoadUserArtifactsCommand loadUserArtifactsCommand;
+
     @BeforeEach
     public void setup() {
-        loadUserArtifactsCommand.setHubConfig(getDataHubAdminConfig());
+        loadUserArtifactsCommand = new LoadUserArtifactsCommand(adminHubConfig);
     }
 
     @Test

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/entity/EntityServicesAlignmentTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/entity/EntityServicesAlignmentTest.java
@@ -21,7 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.io.File;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -34,8 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = ApplicationConfig.class)
 public class EntityServicesAlignmentTest extends HubTestBase {
-    static Path projectPath = Paths.get(PROJECT_PATH).toAbsolutePath();
-    private static File projectDir = projectPath.toFile();
 
     @Autowired
     HubProject project;
@@ -94,8 +91,7 @@ public class EntityServicesAlignmentTest extends HubTestBase {
 
         installUserModules(getDataHubAdminConfig(), true);
 
-        // Adding sleep to give the server enough time to act on triggers in both staging and final databases.
-        Thread.sleep(1000);
+        waitForTasksToFinish();
 
         assertEquals(1, getDocCount(HubConfig.DEFAULT_FINAL_SCHEMAS_DB_NAME, "http://marklogic.com/xdmp/tde"));
         assertEquals(1, getDocCount(HubConfig.DEFAULT_STAGING_SCHEMAS_DB_NAME, "http://marklogic.com/xdmp/tde"));

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/mapping/MappingManagerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/mapping/MappingManagerTest.java
@@ -22,7 +22,6 @@ import com.marklogic.hub.HubTestBase;
 import com.marklogic.hub.MappingManager;
 import com.marklogic.hub.ApplicationConfig;
 import com.marklogic.hub.util.FileUtil;
-import com.marklogic.hub.util.HubModuleManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,9 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -44,8 +41,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = ApplicationConfig.class)
 public class MappingManagerTest extends HubTestBase {
-    static Path projectPath = Paths.get(PROJECT_PATH).toAbsolutePath();
-    private static File projectDir = projectPath.toFile();
 
     private        String mappingName = "my-fun-test";
 
@@ -215,39 +210,4 @@ public class MappingManagerTest extends HubTestBase {
     private void copySecondTestMap() {
         FileUtil.copy(getResourceStream("scaffolding-test/"+mappingName+"-2"+MappingManager.MAPPING_FILE_EXTENSION), getDataHubAdminConfig().getHubMappingsDir().resolve(mappingName+"/"+mappingName+"-2"+MappingManager.MAPPING_FILE_EXTENSION).toFile());
     }
-
-    private void installMappings() {
-        Path employeeDir = project.getEntityDir("employee");
-        employeeDir.toFile().mkdirs();
-        assertTrue(employeeDir.toFile().exists());
-        FileUtil.copy(getResourceStream("scaffolding-test/employee.entity.json"),
-            employeeDir.resolve("employee.entity.json").toFile());
-
-        Path managerDir = project.getEntityDir("manager");
-        managerDir.toFile().mkdirs();
-        assertTrue(managerDir.toFile().exists());
-        FileUtil.copy(getResourceStream("scaffolding-test/manager.entity.json"), managerDir.resolve("manager.entity.json").toFile());
-    }
-
-    private void updateManagerEntity() {
-        Path managerDir = project.getEntityDir("manager");
-        assertTrue(managerDir.toFile().exists());
-        File targetFile = managerDir.resolve("manager.entity.json").toFile();
-        FileUtil.copy(getResourceStream("scaffolding-test/manager2.entity.json"), targetFile);
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-        targetFile.setLastModified(System.currentTimeMillis());
-    }
-
-    private HubModuleManager getPropsMgr() {
-        String timestampFile = getDataHubAdminConfig().getHubProject().getUserModulesDeployTimestampFile();
-        HubModuleManager propertiesModuleManager = new HubModuleManager(timestampFile);
-        return propertiesModuleManager;
-    }
-
-
-
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/mapping/MappingTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/mapping/MappingTest.java
@@ -15,7 +15,6 @@ import com.marklogic.hub.HubTestBase;
 import com.marklogic.hub.flow.FlowRunner;
 import com.marklogic.hub.flow.RunFlowResponse;
 import com.marklogic.hub.step.RunStepResponse;
-import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,14 +39,9 @@ public class MappingTest extends HubTestBase {
     @Autowired
     FlowRunner flowRunner;
 
-    @BeforeAll
-    public static void setup() {
-        XMLUnit.setIgnoreWhitespace(true);
-        new Installer().setupProject();
-    }
-
     @BeforeEach
     public void setupTest() {
+        resetProject();
         runAsDataHubOperator();
     }
 
@@ -388,10 +382,11 @@ public class MappingTest extends HubTestBase {
     }
 
     private void installProject() throws IOException {
+        projectPath.toFile().mkdirs();
         String[] directoriesToCopy = new String[]{"input", "flows", "entities", "mappings", "src/main/ml-modules/root/custom-modules"};
         for (final String subDirectory: directoriesToCopy) {
             final Path subProjectPath = projectPath.resolve(subDirectory);
-            subProjectPath.toFile().mkdir();
+            subProjectPath.toFile().mkdirs();
             Path subResourcePath = Paths.get("mapping-test", subDirectory);
             copyFileStructure(subResourcePath, subProjectPath);
         }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/master/MasterTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/master/MasterTest.java
@@ -97,7 +97,7 @@ public class MasterTest extends HubTestBase {
         String[] directoriesToCopy = new String[]{"input", "flows", "step-definitions", "entities", "mappings"};
         for (final String subDirectory : directoriesToCopy) {
             final Path subProjectPath = projectPath.resolve(subDirectory);
-            subProjectPath.toFile().mkdir();
+            subProjectPath.toFile().mkdirs();
             Path subResourcePath = Paths.get("master-test", subDirectory);
             copyFileStructure(subResourcePath, subProjectPath);
         }
@@ -144,7 +144,7 @@ public class MasterTest extends HubTestBase {
         // that it fails sometimes is being ignored enough that there's no value in having Jenkins test runs fail solely
         // because this returns 205 instead of 208. The ideal solution is likely to narrow down the set of documents
         // that are expected to be merged together, as it's very difficult right now to know why only 205 are in the
-        // collection and which 3 are "missing". 
+        // collection and which 3 are "missing".
         int masteredCount = getFinalDocCount("sm-person-mastered");
         assertTrue(masteredCount >= 205, "Expecting at least 205 documents to be in the 'sm-person-mastered' collection, but only found: "+ masteredCount);
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub_unit_test/RunMarkLogicUnitTestsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub_unit_test/RunMarkLogicUnitTestsTest.java
@@ -4,6 +4,7 @@ import com.marklogic.appdeployer.impl.SimpleAppDeployer;
 import com.marklogic.bootstrap.Installer;
 import com.marklogic.hub.ApplicationConfig;
 import com.marklogic.hub.HubTestBase;
+import com.marklogic.hub.deploy.commands.LoadHubArtifactsCommand;
 import com.marklogic.junit5.MarkLogicUnitTestArgumentsProvider;
 import com.marklogic.test.unit.TestManager;
 import com.marklogic.test.unit.TestModule;
@@ -48,7 +49,7 @@ public class RunMarkLogicUnitTestsTest extends HubTestBase {
     public void setup() {
         if (!loadedHubArtifacts) {
             clearStagingFinalAndJobDatabases();
-            new SimpleAppDeployer(loadHubArtifactsCommand).deploy(adminHubConfig.getAppConfig());
+            new SimpleAppDeployer(new LoadHubArtifactsCommand(adminHubConfig)).deploy(adminHubConfig.getAppConfig());
             loadedHubArtifacts = true;
         }
     }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/models/validateModelDefinitions.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/models/validateModelDefinitions.sjs
@@ -1,0 +1,60 @@
+const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
+const test = require("/test/test-helper.xqy");
+
+const assertions = [];
+
+function assertThrowsEntityNameError(model, badEntityName) {
+  try {
+    entityLib.validateModelDefinitions(model);
+    throw new Error("Expected model to fail validation: " + xdmp.toJsonString(model));
+  } catch (e) {
+    assertions.push(test.assertEqual("Invalid entity name: " + badEntityName + "; must start with a letter and can only contain letters, numbers, hyphens, and underscores.", e.message));
+  }
+}
+
+function assertThrowsPropertyNameError(model, badPropertyName) {
+  try {
+    entityLib.validateModelDefinitions(model);
+    throw new Error("Expected model to fail validation: " + xdmp.toJsonString(model));
+  } catch (e) {
+    assertions.push(test.assertEqual("Invalid property name: " + badPropertyName + "; must start with a letter and can only contain letters, numbers, hyphens, and underscores.", e.message));
+  }
+}
+
+entityLib.validateModelDefinitions({
+  "CanHaveNumbersNotAtBeginning123": {
+    "properties": {
+      "ThisIsFine111": {
+        "type": "string"
+      }
+    }
+  }
+});
+
+assertions.push(
+  assertThrowsEntityNameError({
+    "2CannotHaveNumberAtBeginning": {}
+  }, "2CannotHaveNumberAtBeginning"),
+
+  assertThrowsEntityNameError({
+    "Cannot have spaces": {}
+  }, "Cannot have spaces"),
+
+  assertThrowsPropertyNameError({
+    "ThisIsFine": {
+      "properties": {
+        "1CannotStartWithNumber": {}
+      }
+    }
+  }, "1CannotStartWithNumber"),
+
+  assertThrowsPropertyNameError({
+    "ThisIsFine": {
+      "properties": {
+        "Cannot have spaces": {}
+      }
+    }
+  }, "Cannot have spaces")
+);
+
+assertions;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-utils/replaceLangWithLanguage.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-utils/replaceLangWithLanguage.sjs
@@ -1,0 +1,26 @@
+const HubUtils = require("/data-hub/5/impl/hub-utils.sjs");
+const test = require("/test/test-helper.xqy");
+const hubUtils = new HubUtils();
+
+const assertions = [];
+
+let artifact = {
+  "info": {},
+  "definitions": {},
+  "language": "zxx"
+};
+hubUtils.replaceLangWithLanguage(artifact);
+assertions.push(
+  test.assertEqual("zxx", artifact.lang),
+  test.assertTrue(artifact.language === undefined)
+);
+
+artifact = {
+  "langNotHere": "hello"
+};
+hubUtils.replaceLangWithLanguage(artifact);
+assertions.push(
+  test.assertEqual("hello", fn.string(artifact.langNotHere)),
+  test.assertEqual(1, Object.keys(artifact).length)
+);
+assertions;

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/entities/Customer.entity.json
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/entities/Customer.entity.json
@@ -1,0 +1,75 @@
+{
+  "info": {
+    "title": "Customer",
+    "version": "0.0.1",
+    "baseUri": "http://example.org/"
+  },
+  "definitions": {
+    "Customer": {
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "datatype": "string",
+          "collation": "http://marklogic.com/collation/codepoint"
+        },
+        "shipping": {
+          "$ref": "#/definitions/Address"
+        },
+        "billing": {
+          "$ref": "#/definitions/Address"
+        },
+        "customerNumber": {
+          "datatype": "integer"
+        },
+        "customerSince": {
+          "datatype": "date"
+        },
+        "orders": {
+          "datatype": "array",
+          "items": {
+            "$ref": "http://example.org/Order-0.0.1/Order"
+          }
+        }
+      }
+    },
+    "Address": {
+      "required": [],
+      "pii": [],
+      "elementRangeIndex": [],
+      "rangeIndex": [],
+      "wordLexicon": [],
+      "properties": {
+        "street": {
+          "datatype": "string",
+          "collation": "http://marklogic.com/collation/codepoint"
+        },
+        "city": {
+          "datatype": "string",
+          "collation": "http://marklogic.com/collation/codepoint"
+        },
+        "state": {
+          "datatype": "string",
+          "collation": "http://marklogic.com/collation/codepoint"
+        },
+        "zip": {
+          "$ref": "#/definitions/Zip"
+        }
+      }
+    },
+    "Zip": {
+      "required": [],
+      "properties": {
+        "fiveDigit": {
+          "datatype": "string",
+          "collation": "http://marklogic.com/collation/codepoint"
+        },
+        "plusFour": {
+          "datatype": "string",
+          "collation": "http://marklogic.com/collation/codepoint"
+        }
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/entities/Order.entity.json
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/entities/Order.entity.json
@@ -1,0 +1,30 @@
+{
+  "info": {
+    "title": "Order",
+    "version": "0.0.1",
+    "baseUri": "http://marklogic.com/example/"
+  },
+  "definitions": {
+    "Order": {
+      "required": [],
+      "properties": {
+        "orderID": {
+          "datatype": "string"
+        },
+        "address": {
+          "$ref": "#/definitions/Address"
+        }
+      }
+    },
+    "Address": {
+      "properties": {
+        "city": {
+          "datatype": "string"
+        },
+        "state": {
+          "datatype": "string"
+        }
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/flows/echoFlow.flow.json
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/flows/echoFlow.flow.json
@@ -1,0 +1,16 @@
+{
+  "name": "echoFlow",
+  "steps": {
+    "1": {
+      "name": "echoStep",
+      "stepDefinitionName": "echoStep",
+      "stepDefinitionType": "CUSTOM",
+      "options": {
+        "sourceQuery": "cts.collectionQuery('customer-input')",
+        "sourceDatabase": "data-hub-FINAL",
+        "targetDatabase": "data-hub-FINAL",
+        "collections": ["Customer"]
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/modules/root/custom-modules/custom/echoStep/echoStep.sjs
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/modules/root/custom-modules/custom/echoStep/echoStep.sjs
@@ -1,0 +1,20 @@
+const DataHubSingleton = require("/data-hub/5/datahub-singleton.sjs");
+const datahub = DataHubSingleton.instance();
+
+/**
+ * Simple custom step that just marks the content as processed via a URI alteration.
+ */
+function main(contentItem, options) {
+  const instance = cts.doc(contentItem.uri);
+  return {
+    uri: "/echo" + contentItem.uri,
+    value: datahub.flow.flowUtils.makeEnvelope(instance, {}, [], "json"),
+    context: {
+      permissions: datahub.hubUtils.parsePermissions("data-hub-operator,read,data-hub-operator,update")
+    }
+  };
+}
+
+module.exports = {
+  main: main
+};

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/step-definitions/custom/echoStep/echoStep.step.json
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/step-definitions/custom/echoStep/echoStep.step.json
@@ -1,0 +1,9 @@
+{
+  "lang": "zxx",
+  "name": "echoStep",
+  "type": "CUSTOM",
+  "options": {
+    "outputFormat": "json"
+  },
+  "modulePath": "/custom-modules/custom/echoStep/echoStep.sjs"
+}

--- a/marklogic-data-hub/src/test/resources/logback.xml
+++ b/marklogic-data-hub/src/test/resources/logback.xml
@@ -28,6 +28,11 @@
     <appender-ref ref="STDOUT" />
   </logger>
 
+  <!-- Shut this thing up unless there's a real problem, otherwise pollutes the logs -->
+  <logger name="com.marklogic.client.ext.modulesloader.impl.PropertiesModuleManager" level="ERROR" additivity="false">
+    <appender-ref ref="STDOUT" />
+  </logger>
+
   <logger name="com.marklogic.mgmt" level="WARN" additivity="false">
     <appender-ref ref="STDOUT" />
   </logger>

--- a/one-ui/src/test/java/com/marklogic/hub/oneui/controllers/ModelControllerTest.java
+++ b/one-ui/src/test/java/com/marklogic/hub/oneui/controllers/ModelControllerTest.java
@@ -1,0 +1,84 @@
+package com.marklogic.hub.oneui.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.hub.DatabaseKind;
+import com.marklogic.hub.oneui.TestHelper;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ModelControllerTest extends TestHelper {
+
+    private final static String MODEL_NAME = "UiTestEntity";
+
+    private ModelController controller;
+
+    @Test
+    void testModelsServicesEndpoints() {
+        authenticateSession();
+        clearDatabases(hubConfig.getDbName(DatabaseKind.STAGING), hubConfig.getDbName(DatabaseKind.FINAL));
+        controller = new ModelController();
+        controller.hubConfig = hubConfig;
+
+        createModel();
+        updateModelInfo();
+        updateModelEntityTypes();
+    }
+
+    private void createModel() {
+        ArrayNode existingEntityTypes = (ArrayNode) controller.getPrimaryEntityTypes().getBody();
+        assertEquals(0, existingEntityTypes.size(), "Any existing models should have been deleted when this test started");
+
+        ObjectNode input = objectMapper.createObjectNode();
+        input.put("name", MODEL_NAME);
+        JsonNode model = controller.createModel(input).getBody();
+        assertEquals(MODEL_NAME, model.get("info").get("title").asText());
+
+        ArrayNode entityTypes = (ArrayNode) controller.getPrimaryEntityTypes().getBody();
+        assertEquals(1, entityTypes.size(), "A new model should have been created " +
+            "and thus there should be one primary entity type");
+
+        File file = new File(hubConfig.getHubProject().getHubEntitiesDir().toFile(), MODEL_NAME + ".entity.json");
+        assertTrue(file.exists(), "Expected model file to have been written to: " + file.getAbsolutePath());
+    }
+
+    private void updateModelInfo() {
+        ObjectNode input = objectMapper.createObjectNode();
+        input.put("description", "Updated description");
+        controller.updateModelInfo(MODEL_NAME, input);
+
+        assertEquals("Updated description", loadModel(hubConfig.newFinalClient()).get("definitions").get(MODEL_NAME).get("description").asText());
+    }
+
+    private void updateModelEntityTypes() {
+        String entityTypes = "{\"" + MODEL_NAME + "\" : {\n" +
+            "      \"required\" : [ ],\n" +
+            "      \"properties\" : {\n" +
+            "        \"someProperty\" : {\n" +
+            "          \"datatype\" : \"string\",\n" +
+            "          \"collation\" : \"http://marklogic.com/collation/codepoint\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    }}";
+
+        try {
+            controller.updateModelEntityTypes(MODEL_NAME, objectMapper.readTree(entityTypes));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        assertEquals("string", loadModel(hubConfig.newFinalClient()).get("definitions").get(MODEL_NAME).get("properties").get("someProperty").get("datatype").asText());
+    }
+
+    private JsonNode loadModel(DatabaseClient client) {
+        return client.newJSONDocumentManager().read("/entities/" + MODEL_NAME + ".entity.json", new JacksonHandle()).get();
+    }
+}

--- a/specs/models/PrimaryEntityTypes.v1.json
+++ b/specs/models/PrimaryEntityTypes.v1.json
@@ -12,9 +12,13 @@
       "entityInstanceCount": {
         "type": "number"
       },
-      "lastHarmonizedDateTime": {
+      "latestJobId": {
         "type": "string",
-        "description": "Included if the user can read instances of this type, and at least one instance has been processed by a step. Likely should use \"processed\" instead of \"harmonized\" here.",
+        "description": "If at least one instance of this type has been processed by a job, then this will contain the ID of the most recent such job."
+      },
+      "latestJobDateTime": {
+        "type": "string",
+        "description": "If latestJobId is populated, then this will contain the dateTime of the most entity instance of this type most recently processed.",
         "format": "date-time"
       },
       "model": {

--- a/specs/reference/data-services/models.v1.json
+++ b/specs/reference/data-services/models.v1.json
@@ -78,7 +78,14 @@
         "tags": [],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../../models/ModelDescriptor.v1.json"
+                }
+              }
+            }
           }
         },
         "operationId": "get-updateModelInfo.sjs",
@@ -123,6 +130,18 @@
             "description": "The name of the model"
           }
         ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../../models/ModelDescriptor.v1.json"
+                }
+              }
+            }
+          }
+        },
         "requestBody": {
           "content": {
             "application/json": {

--- a/specs/reference/rest-endpoints/models.v1.json
+++ b/specs/reference/rest-endpoints/models.v1.json
@@ -31,7 +31,7 @@
       "parameters": []
     },
     "/api/models/${name}/info": {
-      "post": {
+      "put": {
         "summary": "Edit model info",
         "operationId": "post-api-models-info",
         "responses": {

--- a/web/src/main/java/com/marklogic/hub/web/service/EntityManagerService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/EntityManagerService.java
@@ -111,6 +111,7 @@ public class EntityManagerService {
         return getEntity(newEntity.getName());
     }
 
+    @Deprecated(since = "DHF 5.3.0; use ModelsService instead")
     public EntityModel saveEntity(EntityModel entity) throws IOException {
         JsonNode node = entity.toJson();
         String fullpath = entity.getFilename();


### PR DESCRIPTION
Much of this is updates to existing tests and test plumbing:

- Also added more reliable way of waiting for post-commit triggers to finish - waitForTasksToFinish. This required a new privilege to be added to data-hub-developer in the test app. 
- Tweaked test logging in core so it's not so verbose 
- The Load*Command objects are no longer autowired in HubTestBase - they're just manually constructed when needed now

```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests


- ##### Reviewer:

- [x] Reviewed Tests

