### PR TITLE
DHFPROD-2693:Linking to new docs site in Javadocs

### DIFF
--- a/marklogic-data-hub/src/main/resources/overview.html
+++ b/marklogic-data-hub/src/main/resources/overview.html
@@ -5,7 +5,7 @@
 <p>Entry point to DHF Java API is package {@link com.marklogic.hub}</p>
 <h3>Before Starting</h3>
 <p>
-  Read through our <a target="_blank" href="https://marklogic.github.io/marklogic-data-hub/">Main Documentation page</a>.
+  Read through our <a target="_blank" href="http://docs.marklogic.com/datahub">Main Documentation page</a>.
 </p>
 </body>
 </html>


### PR DESCRIPTION
### Description
Linking the new docs website on every javadocs page.
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

