### PR TITLE
DHFPROD-4119: hubDeploy now deploys lsqt configuration

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dhs/DhsDeployer.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dhs/DhsDeployer.java
@@ -14,6 +14,7 @@ import com.marklogic.appdeployer.command.security.DeployRolesCommand;
 import com.marklogic.appdeployer.command.tasks.DeployScheduledTasksCommand;
 import com.marklogic.appdeployer.command.temporal.DeployTemporalAxesCommand;
 import com.marklogic.appdeployer.command.temporal.DeployTemporalCollectionsCommand;
+import com.marklogic.appdeployer.command.temporal.DeployTemporalCollectionsLSQTCommand;
 import com.marklogic.appdeployer.command.triggers.DeployTriggersCommand;
 import com.marklogic.client.ext.SecurityContextType;
 import com.marklogic.client.ext.helper.LoggingObject;
@@ -183,6 +184,7 @@ public class DhsDeployer extends LoggingObject {
 
         commands.add(new DeployTemporalAxesCommand());
         commands.add(new DeployTemporalCollectionsCommand());
+        commands.add(new DeployTemporalCollectionsLSQTCommand());
         commands.add(new DeployTriggersCommand());
         commands.add(new LoadSchemasCommand());
         commands.add(new DeployScheduledTasksCommand());

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/DeployAsDeveloperTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/DeployAsDeveloperTest.java
@@ -13,6 +13,7 @@ import com.marklogic.appdeployer.command.security.DeployProtectedPathsCommand;
 import com.marklogic.appdeployer.command.tasks.DeployScheduledTasksCommand;
 import com.marklogic.appdeployer.command.temporal.DeployTemporalAxesCommand;
 import com.marklogic.appdeployer.command.temporal.DeployTemporalCollectionsCommand;
+import com.marklogic.appdeployer.command.temporal.DeployTemporalCollectionsLSQTCommand;
 import com.marklogic.appdeployer.command.triggers.DeployTriggersCommand;
 import com.marklogic.client.ext.SecurityContextType;
 import com.marklogic.hub.DatabaseKind;
@@ -182,6 +183,7 @@ public class DeployAsDeveloperTest {
         assertTrue(commands.get(index++) instanceof LoadUserArtifactsCommand);
         assertTrue(commands.get(index++) instanceof DeployTemporalAxesCommand);
         assertTrue(commands.get(index++) instanceof DeployTemporalCollectionsCommand);
+        assertTrue(commands.get(index++) instanceof DeployTemporalCollectionsLSQTCommand);
         assertTrue(commands.get(index++) instanceof DeployScheduledTasksCommand);
         assertTrue(commands.get(index++) instanceof DeployAlertConfigsCommand);
         assertTrue(commands.get(index++) instanceof DeployAlertActionsCommand);
@@ -189,7 +191,7 @@ public class DeployAsDeveloperTest {
         assertTrue(commands.get(index++) instanceof GenerateFunctionMetadataCommand);
         assertTrue(commands.get(index++) instanceof DeployProtectedPathsCommand);
 
-        assertEquals(14, commands.size(),
+        assertEquals(15, commands.size(),
             "As of ML 10.0-3, the granular privilege for indexes doesn't seem to work with XML payloads. " +
                 "Bug https://bugtrack.marklogic.com/54231 has been created to track that. Thus, " +
                 "DeployDatabaseFieldCommand cannot be included and ml-config/database-fields/final-database.xml " +


### PR DESCRIPTION
### Description
hubDeploy and hubDeployAsDeveloper task now deploy lsqt configuration in develop.
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

