### PR TITLE
DHFPROD-3841: Can now reference $URI in mappings

### DIFF
--- a/marklogic-data-hub/gradle.properties
+++ b/marklogic-data-hub/gradle.properties
@@ -63,5 +63,8 @@ mlIsProvisionedEnvironment=false
 
 mlHubLogLevel=default
 
+# Ensure modules are loaded with the correct permissions when running "gradle mlWatch" during testing
+mlModulePermissions=data-hub-module-reader,read,data-hub-module-reader,execute,data-hub-module-writer,update,rest-extension-user,execute
+
 # Needs to be here so that tokens in config.sjs/config.xqy are replaced
 mlJobPermissions=data-hub-job-reader,read,data-hub-job-internal,update

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/main.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/main.sjs
@@ -4,13 +4,13 @@ const defaultLib = require('/data-hub/5/builtins/steps/mapping/default/lib.sjs')
 const lib = require('/data-hub/5/builtins/steps/mapping/entity-services/lib.sjs');
 const es = require('/MarkLogic/entity-services/entity-services');
 const entityValidationLib = require('entity-validation-lib.sjs');
+const xqueryLib = require('xquery-lib.xqy')
 
 // caching mappings in key to object since tests can have multiple mappings run in same transaction
 var mappings = {};
 var entityModel = null;
 
 function main(content, options) {
-  let id = content.uri;
   //let's set our output format, so we know what we're exporting
   let inputFormat = options.inputFormat ? options.inputFormat.toLowerCase() : datahub.flow.consts.DEFAULT_FORMAT;
   let outputFormat = options.outputFormat ? options.outputFormat.toLowerCase() : datahub.flow.consts.DEFAULT_FORMAT;
@@ -62,10 +62,12 @@ function main(content, options) {
   let entity = lib.getTargetEntity(targetEntityType);
   let instance = lib.extractInstance(doc);
   let provenance = {};
-  //Then we obtain the newInstance and process it from the source context
+
+  const userParams = {"URI":content.uri};
+
   let newInstance;
   try {
-    newInstance = es.mapToCanonical(instance, mappingURIforXML, {'format':outputFormat});
+    newInstance = xqueryLib.dataHubMapToCanonical(instance, mappingURIforXML, userParams, {"format":outputFormat});
   } catch (e) {
     datahub.debug.log({message: e, type: 'error'});
     throw Error(e);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/xquery-lib.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/xquery-lib.xqy
@@ -18,8 +18,51 @@ xquery version "1.0-ml";
 (: This library is for operations for mapping that are more dificult to accomplish in JavaScript :)
 module namespace xquery-lib = "http://marklogic.com/mapping/es/xquery";
 
+import module namespace inst="http://marklogic.com/entity-services-instance" at "/MarkLogic/entity-services/entity-services-instance.xqy";
+
 declare function document-with-nodes($nodes as node()*) {
-    document {
-      $nodes
-    }
+  document {
+    $nodes
+  }
+};
+
+(:
+Copy of this function from ML 10.0-3. The only change is the addition of user-params.
+Note that "parms" in the code below should really be "options", which would then match the signature of xslt-eval.
+
+I opened bug 54632 to improve the ES functions so that a map of params will be accepted. Then we can get rid of this
+hack.
+:)
+declare function data-hub-map-to-canonical(
+  $source-instance as node(),
+  $mapping-uri as xs:string,
+  $user-params as map:map?,
+  $options as map:map
+) as node()
+{
+  let $target-entity-name := $options=>map:get("entity")
+  let $format := $options=>map:get("format")
+  let $format :=
+    if (empty($format)) then
+      typeswitch ($source-instance)
+        case document-node() return
+          if ($source-instance/element()) then "xml"
+          else "json"
+        case element() return "xml"
+        default return "json"
+    else $format
+  let $input :=
+    typeswitch ($source-instance)
+      case document-node() return $source-instance
+      case element() return document { $source-instance }
+      default return document { $source-instance }
+  let $parms :=
+    if (empty($target-entity-name)) then ()
+    else map:map()=>map:with("template", $target-entity-name)
+  let $results :=
+    xdmp:xslt-invoke($mapping-uri||".xslt", $input, $user-params, $parms)
+  return
+    if ($format="xml")
+    then inst:canonical-xml($results)
+    else inst:canonical-json($results)
 };

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/triggers/mapping/mappingJSONtoXML.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/triggers/mapping/mappingJSONtoXML.sjs
@@ -24,7 +24,6 @@ if (esMappingLib.versionIsCompatibleWithES()) {
   xdmp.invokeFunction(function () {
       const es = require('/MarkLogic/entity-services/entity-services');
       es.mappingPut(xmlURI);
-      xdmp.nodeDelete(cts.doc(xmlURI+'.xslt').xpath('//xdmp:import-module[@href="/MarkLogic/entity-services/standard-library.xqy"]'));
     },
     {database: xdmp.modulesDatabase(), update: "true", commit: "auto"}
   );

--- a/marklogic-data-hub/src/main/resources/ml-modules/transforms/mlGenerateFunctionMetadata.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/transforms/mlGenerateFunctionMetadata.sjs
@@ -22,14 +22,19 @@ function mlGenerateFunctionMetadata(context, params, content) {
       metadataXml = addMapNamespaceToMetadata(metadataXml);
       let collection = 'http://marklogic.com/entity-services/function-metadata';
       let permissions = xdmp.defaultPermissions().concat([
-      xdmp.permission(datahub.config.FLOWOPERATORROLE,'execute'),
-      xdmp.permission(datahub.config.FLOWDEVELOPERROLE,'execute'),
-      xdmp.permission(datahub.config.FLOWDEVELOPERROLE,'update'),
-      xdmp.permission(datahub.config.FLOWOPERATORROLE,'read'),
-      xdmp.permission(datahub.config.FLOWDEVELOPERROLE,'read'),
-      xdmp.permission(datahub.consts.DATA_HUB_OPERATOR_ROLE,'execute'),
-      xdmp.permission(datahub.consts.DATA_HUB_DEVELOPER_ROLE,'update'),
-      xdmp.permission(datahub.consts.DATA_HUB_OPERATOR_ROLE,'read')
+        xdmp.permission(datahub.config.FLOWOPERATORROLE, 'execute'),
+        xdmp.permission(datahub.config.FLOWDEVELOPERROLE, 'execute'),
+        xdmp.permission(datahub.config.FLOWDEVELOPERROLE, 'update'),
+        xdmp.permission(datahub.config.FLOWOPERATORROLE, 'read'),
+        xdmp.permission(datahub.config.FLOWDEVELOPERROLE, 'read'),
+        xdmp.permission(datahub.consts.DATA_HUB_OPERATOR_ROLE, 'execute'),
+        xdmp.permission(datahub.consts.DATA_HUB_DEVELOPER_ROLE, 'update'),
+        xdmp.permission(datahub.consts.DATA_HUB_OPERATOR_ROLE, 'read'),
+        xdmp.permission("data-hub-module-reader", "execute"),
+        // In the absence of this, ML will report an error about standard-library.xqy not being found. This is misleading; the
+        // actual problem is that a mapping will fail if the XML or XSLT representation of a custom mapping function library
+        // does not have this permission on it, which is expected to be on every other DHF module.
+        xdmp.permission("rest-extension-user", "execute")
       ]);
       let writeInfo = datahub.hubUtils.writeDocument(uriVal + ".xml", metadataXml, permissions, [collection], datahub.config.MODULESDATABASE);
       if (writeInfo && fn.exists(writeInfo.transaction)) {

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/createEntityServicesMapping.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/createEntityServicesMapping.sjs
@@ -224,6 +224,7 @@ assertions.push(
 expectedTemplate = tidyXML(`
   <m:mapping xmlns:m="http://marklogic.com/entity-services/mapping" xmlns:map="http://marklogic.com/xdmp/map" xmlns:ns1="http://ns1" xmlns:ns2="http://ns2">
     ${mappingLib.retrieveFunctionImports()}
+    <m:param name="URI"/>
     <m:entity name="Customer" xmlns:m="http://marklogic.com/entity-services/mapping">
       <Customer xmlns="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
         <m:optional><ID xsi:type="xs:string"><m:val>string(@CustomerID)</m:val></ID></m:optional>

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/runMappingWithUriReference.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/runMappingWithUriReference.sjs
@@ -1,0 +1,45 @@
+const esMappingLib = require("/data-hub/5/builtins/steps/mapping/entity-services/lib.sjs");
+const hubTest = require("/test/data-hub-test-helper.xqy");
+const lib = require("lib/lib.sjs");
+const mappingLib = require("/data-hub/5/builtins/steps/mapping/entity-services/lib.sjs");
+const test = require("/test/test-helper.xqy");
+
+const contentUri = "/content/person2.json";
+
+function verifyUriIsResolvedByMappingStep() {
+  const person = lib.invokeTestMapping(contentUri, "PersonMapping", "7").Person;
+  return [
+    test.assertEqual(contentUri, fn.string(person.nickname),
+      "The nickname is mapped to the $URI variable which is expected to be populated by the mapper")
+  ];
+}
+
+function verifyUriResolvedWhenTestingMapping() {
+  const result = esMappingLib.validateAndRunMapping({
+    targetEntityType: "http://marklogic.com/data-hub/example/Person-1.0.0/Person",
+    properties: {
+      nickname: {sourcedFrom: "$URI"}
+    }
+  }, contentUri);
+
+  return [
+    test.assertEqual("$URI", result.properties.nickname.sourcedFrom),
+    test.assertEqual(contentUri, result.properties.nickname.output)
+  ];
+}
+
+function verifyMappingContainsUriParam() {
+  const xmlMapping = hubTest.getModulesDocument("/mappings/PersonMapping/PersonMapping-7.mapping.xml");
+  const stylesheet = hubTest.getModulesDocument("/mappings/PersonMapping/PersonMapping-7.mapping.xml.xslt");
+  return [
+    test.assertTrue(fn.head(xmlMapping.xpath("/*:mapping/*:param[@name = 'URI']")) != null),
+    test.assertTrue(fn.head(stylesheet.xpath("/*:stylesheet/*:param[@name = 'URI']")) != null)
+  ]
+}
+
+if (mappingLib.versionIsCompatibleWithES()) {
+  []
+    .concat(verifyUriIsResolvedByMappingStep())
+    .concat(verifyUriResolvedWhenTestingMapping())
+    .concat(verifyMappingContainsUriParam());
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/test-data/mappings/PersonMapping/PersonMapping-7.mapping.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/test-data/mappings/PersonMapping/PersonMapping-7.mapping.json
@@ -1,0 +1,24 @@
+{
+  "lang": "zxx",
+  "name": "PersonMapping",
+  "version": 7,
+  "sourceContext": "/",
+  "targetEntityType": "http://marklogic.com/data-hub/example/Person-1.0.0/Person",
+  "properties": {
+    "id": {
+      "sourcedFrom": "personId"
+    },
+    "nickname": {
+      "sourcedFrom": "$URI"
+    },
+    "name": {
+      "sourcedFrom": "theName",
+      "targetEntityType": "http://marklogic.com/data-hub/example/Person-1.0.0/Name",
+      "properties": {
+        "last" : {
+          "sourcedFrom": "lastName"
+        }
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/testCleanMapping.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/testCleanMapping.sjs
@@ -13,11 +13,6 @@ if (mappingLib.versionIsCompatibleWithES()) {
     "  fn.docAvailable('/mappings/OrdersMapping/OrdersMapping-1.mapping.xml.xslt') ",
     {}, {database: xdmp.modulesDatabase()}
   ))));
-  //Test to ensure standard-library.xqy is removed from inserted xslt
-  assertions.push(test.assertFalse(fn.head(xdmp.eval(
-    "  String(fn.doc('/mappings/OrdersMapping/OrdersMapping-1.mapping.xml.xslt')).includes('/MarkLogic/entity-services/standard-library.xqy') ",
-    {}, {database: xdmp.modulesDatabase()}
-  ))));
 
   xdmp.eval('xdmp.documentDelete("/mappings/OrdersMapping/OrdersMapping-1.mapping.json")',
     {},

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/validateMapping.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mapping/entity-services/validateMapping.sjs
@@ -13,28 +13,6 @@ function validateGenderMapping(sourcedFrom) {
   });
 }
 
-function generateMappingStyleSheet() {
-  let mapping =
-    {
-        targetEntityType: entityType,
-        properties: {
-          id: {sourcedFrom: "id"}
-        }
-    }
-  let xmlMapping = esMappingLib.buildMappingXML(fn.head(xdmp.unquote(xdmp.quote(mapping))));
-  let stylesheet = fn.head(xdmp.xsltInvoke("/MarkLogic/entity-services/mapping-compile.xsl", xmlMapping));
-  return stylesheet;
-}
-
-function testRemoveStandardFunction() {
-  let stylesheet = generateMappingStyleSheet();
-  let removedStdFn = String(esMappingLib.removeStandardFunction(stylesheet));
-  return [
-    test.assertFalse(removedStdFn.includes("/MarkLogic/entity-services/standard-library.xqy"),"standard-library should be removed"),
-    test.assertEqual(removedStdFn, String(esMappingLib.removeStandardFunction(xdmp.unquote(removedStdFn)))
-    ,"if input doesn't have standard-library the input xslt should bee returned")];
-}
-
 function validMapping() {
   let sourcedFrom = "memoryLookup(gender, '{\"m\": \"Male\", \"f\": \"Female\", \"nb\": \"Non-Binary\"}')";
   let result = validateGenderMapping(sourcedFrom);
@@ -134,7 +112,6 @@ if (esMappingLib.versionIsCompatibleWithES()) {
     .concat(mixOfValidAndInvalidExpressions())
     .concat(validUseOfCustomFunction())
     .concat(invalidUseOfCustomFunction())
-    .concat(testRemoveStandardFunction())
   ;
 }
 else {

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/testMappingTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/testMappingTest.sjs
@@ -58,11 +58,10 @@ function invokeService(jsonMapping, uri, database) {
 }
 
 function testMappings() {
-    dataHub.hubUtils.writeDocument("/test/entities/Customer.entity.json", testEntityModel , [xdmp.permission('rest-reader', 'read'),
-        xdmp.permission('rest-writer', 'update')], ['http://marklogic.com/entity-services/models'], dataHub.config.FINALDATABASE);
+  const perms = [xdmp.permission("data-hub-operator", "read"), xdmp.permission("data-hub-operator", "update")];
 
-    dataHub.hubUtils.writeDocument("/test/customer100.json", testEntityInstance , [xdmp.permission('rest-reader', 'read'),
-        xdmp.permission('rest-writer', 'update')], ['Customer'], dataHub.config.FINALDATABASE);
+    dataHub.hubUtils.writeDocument("/test/entities/Customer.entity.json", testEntityModel , perms, ['http://marklogic.com/entity-services/models'], dataHub.config.FINALDATABASE);
+    dataHub.hubUtils.writeDocument("/test/customer100.json", testEntityInstance , perms, ['Customer'], dataHub.config.FINALDATABASE);
 
     const result = invokeService(validMapping,'/test/customer100.json', 'data-hub-FINAL');
     const errorResult = invokeService(invalidMapping,'/test/customer100.json', 'data-hub-FINAL');

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/savedQueries/saveSavedQueryTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/savedQueries/saveSavedQueryTest.sjs
@@ -57,7 +57,7 @@ function testSaveNewQuery() {
     test.assertNotEqual(null, result.savedQuery.id),
     test.assertEqual("some-query", result.savedQuery.name),
     test.assertEqual(4, Object.keys(result.savedQuery.systemMetadata).length),
-    test.assertEqual("flow-developer", result.savedQuery.owner)
+    test.assertEqual(xdmp.getCurrentUser(), result.savedQuery.owner)
   ];
 }
 
@@ -73,7 +73,7 @@ function testModifyQuery() {
     test.assertEqual(id, result.savedQuery.id),
     test.assertEqual("modified-query", result.savedQuery.name),
     test.assertEqual(4, Object.keys(result.savedQuery.systemMetadata).length),
-    test.assertEqual("flow-developer", result.savedQuery.owner)
+    test.assertEqual(xdmp.getCurrentUser(), result.savedQuery.owner)
   ];
 }
 

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/security/getAuthoritiesTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/security/getAuthoritiesTest.sjs
@@ -14,8 +14,7 @@ const minExpectedRoles = ["data-hub-operator", "data-hub-entity-model-reader", "
     "data-hub-saved-query-reader", "data-hub-saved-query-writer", "data-hub-module-reader"];
 
 const result = [
-    // The inequality references are assuming that the least priveleged role used to run the tests is data-hub-operator
-    test.assertEqual("flow-developer", xdmp.getCurrentUser()),
+    // The inequality references are assuming that the least privileged role used to run the tests is data-hub-operator
     test.assertTrue(response.authorities.length >= 5, "The minimum number of authorities any user has"),
     test.assertTrue(minExpectedAuthorities.every(authority => response.authorities.includes(authority))),
     test.assertTrue(response.roles.length >= 11, "The minimum number of roles any user has"),


### PR DESCRIPTION
This opens the door to all sorts of variables in a mapping artifact. However, to achieve this, I had to make a copy of the ES functions map-to-canonical and node-map-to-canonical so that I can pass in a map of params to the underlying xdmp:xslt calls. I opened up bug 54632 so that the ES functions will allow this in a future version.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

