### PR TITLE
DHFPROD-4173: Tests for activity settings

### DIFF
--- a/one-ui/ui/src/components/activity-settings/activity-settings-dialog.test.tsx
+++ b/one-ui/ui/src/components/activity-settings/activity-settings-dialog.test.tsx
@@ -1,72 +1,177 @@
 import React from 'react';
+import axiosMock from 'axios';
+import { fireEvent, render, wait, cleanup } from "@testing-library/react";
 import ActivitySettingsDialog from './activity-settings-dialog';
-import axios, { AxiosRequestConfig, AxiosPromise, AxiosResponse } from 'axios';
-import { shallow } from 'enzyme';
-import {act} from "react-dom/test-utils";
-import { fireEvent, render, waitForElementToBeRemoved } from "@testing-library/react";
 import data from '../../config/data.config';
 
 jest.mock('axios');
 
 describe('Update data load settings component', () => {
-  let wrapper: any;
-  let getSpy: any;
-  let postSpy: any;
 
-
-  beforeEach(() => {
-    getSpy = jest.spyOn(axios, 'get');
-    postSpy = jest.spyOn(axios, 'post');
-    wrapper = shallow(<ActivitySettingsDialog {...data.activitySettings}/>);
+  afterEach(() => {
+    jest.clearAllMocks();
+    cleanup;
   });
 
-  test('Settings Dialog renders ', () => {
-    expect(wrapper.find('#sourceDatabase').length).toEqual(1)
-    expect(wrapper.find('#targetDatabase').length).toEqual(1)
-    expect(wrapper.find('#additionalColl').length).toEqual(1)
-    expect(wrapper.find('#targetPermissions').length).toEqual(1)
-    expect(wrapper.find('#provGranularity').length).toEqual(1)
-    expect(wrapper.find('#additionalColl').length).toEqual(1)
-    expect(wrapper.find('#targetPermissions').props().value).toEqual('data-hub-operator,read,data-hub-operator,update')
-    // Custom hook hasn't been expanded yet
-    expect(wrapper.find('#cHparameters').length).toEqual(0)
-    expect(wrapper.find('#user').length).toEqual(0)
-    expect(wrapper.find('#module').length).toEqual(0)
+  test('Verify settings dialog renders for Mapping', () => {
+    const { getByText, getByPlaceholderText, getByRole } = render(<ActivitySettingsDialog {...data.activitySettings} />);
+    expect(getByText('Activity Settings')).toBeInTheDocument();
+    expect(getByText('Source Database:')).toBeInTheDocument();
+    expect(getByText('data-hub-STAGING')).toBeInTheDocument();
+    expect(getByText('Target Database:')).toBeInTheDocument();
+    expect(getByText('data-hub-FINAL')).toBeInTheDocument();
+    //Add a check for target format once implemented
+    //Should show default collections applied???
+    expect(getByText('Additional Collections:')).toBeInTheDocument();
+    expect(getByText('Please select')).toBeInTheDocument();
+    expect(getByPlaceholderText('Enter targetPermissions')).toHaveValue('data-hub-operator,read,data-hub-operator,update');
+    expect(getByText('Provenance Granularity:')).toBeInTheDocument();
+    expect(getByText('coarse-grained')).toBeInTheDocument();
+    expect(getByText('Custom Hook')).toBeInTheDocument();    
+    fireEvent.click(getByText('Custom Hook'));
+    expect(getByPlaceholderText('Enter module')).toBeInTheDocument();
+    expect(getByPlaceholderText('Enter parameters')).toHaveValue('{}');
+    expect(getByPlaceholderText('Enter user information')).toBeInTheDocument();
+    expect(getByRole('switch')).toBeInTheDocument();
+    expect(getByText('OFF')).toBeInTheDocument();
   });
 
-  test('Load Data Settings Dialog renders without source database ', () => {
-    //Overriding props set in beforeEach, to test for loadData settings
-    wrapper.setProps({activityType:'loadData'});
-    expect(wrapper.find('#sourceDatabase').length).toEqual(0)
-    expect(wrapper.find('#targetDatabase').length).toEqual(1)
-    expect(wrapper.find('#additionalColl').length).toEqual(1)
-    expect(wrapper.find('#targetPermissions').length).toEqual(1)
-    expect(wrapper.find('#provGranularity').length).toEqual(1)
-    expect(wrapper.find('#additionalColl').length).toEqual(1)
-    // Custom hook hasn't been expanded yet
-    expect(wrapper.find('#cHparameters').length).toEqual(0)
-    expect(wrapper.find('#user').length).toEqual(0)
-    expect(wrapper.find('#module').length).toEqual(0)
+  test('Verify settings dialog renders for Load Data', () => {
+    const { queryByText, getByText, getByPlaceholderText, getByRole } = render(<ActivitySettingsDialog {...data.activitySettings} activityType={'loadData'} />);
+    expect(getByText('Activity Settings')).toBeInTheDocument();
+    expect(queryByText('Source Database:')).not.toBeInTheDocument();
+    expect(getByText('Target Database:')).toBeInTheDocument();
+    expect(getByText('data-hub-STAGING')).toBeInTheDocument();
+    expect(getByText('Additional Collections:')).toBeInTheDocument();
+    expect(getByText('Please select')).toBeInTheDocument();
+    expect(getByPlaceholderText('Enter targetPermissions')).toHaveValue('data-hub-operator,read,data-hub-operator,update');
+    expect(getByText('Provenance Granularity:')).toBeInTheDocument();
+    expect(getByText('coarse-grained')).toBeInTheDocument();
+    expect(getByText('Custom Hook')).toBeInTheDocument();    
+    fireEvent.click(getByText('Custom Hook'));
+    expect(getByPlaceholderText('Enter module')).toBeInTheDocument();
+    expect(getByPlaceholderText('Enter parameters')).toHaveValue('{}');
+    expect(getByPlaceholderText('Enter user information')).toBeInTheDocument();
+    expect(getByRole('switch')).toBeInTheDocument();
+    expect(getByText('OFF')).toBeInTheDocument();
   });
 
-  test('Expect post to be called when saved ',  () => {
-      /**
-       * below RTL test passes but it also throws a warning about "not wrapped in act".
-       * This maybe due to setIsLoading() function and its promise needs to be resolved. Should find a way to fix this
-       * Enzyme test throws a promise rejection warning as well. Probably the fix is same
-      **/
+  test('Verify all form fields can be input/selected by user', () => {
+    const { getByText, getByTitle, container, getAllByTestId, getAllByRole, getByPlaceholderText, getByRole } = render(<ActivitySettingsDialog {...data.activitySettings} activityType={'loadData'} />);
+   
+    //Verifying database options select field
+    fireEvent.click(getByText('data-hub-STAGING'));
+    const dbOptions = getAllByTestId('dbOptions').map(li => li);
+    expect(dbOptions.map(li => li.textContent).toString()).toEqual('data-hub-STAGING,data-hub-FINAL');
+    fireEvent.select(dbOptions[1]);
+    expect(getByText('data-hub-FINAL')).toBeInTheDocument();
 
-      /*const { getByText } = render(<ActivitySettingsDialog {...data.activitySettings} />);
-      expect(getByText('Save')).toBeInTheDocument();
+    //Not able to send input to Additional collections. Test via e2e
+    //https://github.com/testing-library/react-testing-library/issues/375
+    //Solution in github wont work because our list for additional collection is empty to start with
+
+    fireEvent.change(getByPlaceholderText('Enter targetPermissions'), { target: { value: 'data-hub-monitor,update' }});
+    expect(getByPlaceholderText('Enter targetPermissions')).toHaveValue('data-hub-monitor,update');
+
+    //Verifying provenance options select field
+    fireEvent.click(getByText('coarse-grained'));
+    const provOptions = getAllByTestId('provOptions').map(li => li);
+    expect(provOptions.map(li => li.textContent).toString()).toEqual('coarse-grained,off');
+    fireEvent.select(provOptions[1]);
+    expect(getByText('off')).toBeInTheDocument();
+
+    fireEvent.click(getByText('Custom Hook'));
+    fireEvent.change(getByPlaceholderText('Enter module'), { target: { value: 'test-module' }});
+    expect(getByPlaceholderText('Enter module')).toHaveValue('test-module');
+    fireEvent.change(getByPlaceholderText('Enter parameters'), { target: { value: '{}' }});
+    expect(getByPlaceholderText('Enter parameters')).toHaveValue('{}');
+    fireEvent.change(getByPlaceholderText('Enter user information'), { target: { value: 'test-user' }});
+    expect(getByPlaceholderText('Enter user information')).toHaveValue('test-user');
+    fireEvent.click(getByRole('switch'));
+    expect(getByText('ON')).toBeInTheDocument();
+  });
+
+  test('Verify read only users cannot edit settings', () => {
+    const { getByText, getByPlaceholderText, getByRole } = render(<ActivitySettingsDialog {...data.activitySettings} canWrite={false} />);
+    expect(document.querySelector('#sourceDatabase')).toHaveClass('ant-select-disabled');
+    expect(document.querySelector('#targetDatabase')).toHaveClass('ant-select-disabled');
+    expect(document.querySelector('#additionalColl')).toHaveClass('ant-select-disabled');
+    expect(getByPlaceholderText('Enter targetPermissions')).toBeDisabled();
+    expect(document.querySelector('#provGranularity')).toHaveClass('ant-select-disabled');
+
+    fireEvent.click(getByText('Custom Hook'));
+    expect(getByPlaceholderText('Enter module')).toBeDisabled();
+    expect(getByPlaceholderText('Enter parameters')).toBeDisabled();
+    expect(getByPlaceholderText('Enter user information')).toBeDisabled();
+    expect(getByRole('switch')).toBeDisabled();
+  });
+
+  test('Verify post is called when Mapping configuration is saved', async () => {
+    //Enhance this test once DHFPROD-4712 is fixed
+    axiosMock.post.mockImplementationOnce(jest.fn(() => Promise.resolve({ status: 200, data: {} })));
+    const { getByText } = render(<ActivitySettingsDialog {...data.activitySettings} />);
+    expect(getByText('Save')).toBeInTheDocument();
+    await wait(() => {
       fireEvent.click(getByText('Save'));
-      expect(postSpy).toBeCalled();*/
-    expect(getSpy).not.toBeCalled();
-    expect(postSpy).not.toBeCalled();
-    act(() => {
-      wrapper.find('#saveButton').props().onClick();
     });
-    expect(postSpy).toBeCalled();
-    expect(getSpy).not.toBeCalled();
+    expect(axiosMock.post).toHaveBeenCalledTimes(1);
+  });
+
+  test('Verify post is called when Load Data configuration is saved', async () => {
+    axiosMock.post.mockImplementationOnce(jest.fn(() => Promise.resolve({ status: 200, data: {} })));
+    const { getByText } = render(<ActivitySettingsDialog {...data.activitySettings} activityType={'loadData'} />);
+    expect(getByText('Save')).toBeInTheDocument();
+    await wait(() => {
+      fireEvent.click(getByText('Save'));
+    });
+    expect(axiosMock.post).toHaveBeenCalledTimes(1);
+  });
+
+  test('Verify discard dialog is not opened when Cancel is clicked with no changes to the Mapping settings', () => {
+    const { getByText, queryByText } = render(<ActivitySettingsDialog {...data.activitySettings} />);
+    expect(getByText('Activity Settings')).toBeInTheDocument();
+    fireEvent.click(getByText('Cancel'));
+    expect(queryByText('Discard changes?')).not.toBeInTheDocument();
+  });
+
+  test('Verify discard dialog is not opened when Cancel is clicked with no changes to the Load Data settings', () => {
+    const { getByText, queryByText } = render(<ActivitySettingsDialog {...data.activitySettings} activityType={'loadData'} />);
+    expect(getByText('Activity Settings')).toBeInTheDocument();
+    fireEvent.click(getByText('Cancel'));
+    expect(queryByText('Discard changes?')).not.toBeInTheDocument();
+  });
+
+  test('Verify discard dialog modal when Cancel is clicked', () => {
+    const { rerender, queryByText, getByPlaceholderText, getByText } = render(<ActivitySettingsDialog {...data.activitySettings} />);
+    //fireEvent.change(getByText('Please select'), { target: { value: 'test-collection' }});
+    fireEvent.click(getByText('Custom Hook'));
+    fireEvent.change(getByPlaceholderText('Enter module'), { target: { value: 'test-module' }});
+    expect(getByPlaceholderText('Enter module')).toHaveValue('test-module');
+    fireEvent.click(getByText('Cancel'));
+    expect(getByText('Discard changes?')).toBeInTheDocument();
+    expect(getByText('Yes')).toBeInTheDocument();
+    expect(getByText('No')).toBeInTheDocument();
+
+    const noButton = getByText('No');
+    noButton.onclick = jest.fn();
+    fireEvent.click(noButton);
+    expect(noButton.onclick).toHaveBeenCalledTimes(1);
+
+    const yesButton = getByText('Yes');
+    yesButton.onclick = jest.fn();
+    fireEvent.click(yesButton);
+    expect(yesButton.onclick).toHaveBeenCalledTimes(1);
+  });
+
+  test('Verify discard dialog modal when "x" is clicked', () => {
+    const { getByPlaceholderText, getByText, getByLabelText } = render(<ActivitySettingsDialog {...data.activitySettings} />);
+    fireEvent.click(getByText('Custom Hook'));
+    fireEvent.change(getByPlaceholderText('Enter module'), { target: { value: 'test-module' }});
+    expect(getByPlaceholderText('Enter module')).toHaveValue('test-module');
+    fireEvent.click(getByLabelText('Close'));
+    expect(getByText('Discard changes?')).toBeInTheDocument();
+    expect(getByText('Yes')).toBeInTheDocument();
+    expect(getByText('No')).toBeInTheDocument();
   });
 
 });

--- a/one-ui/ui/src/components/activity-settings/activity-settings-dialog.tsx
+++ b/one-ui/ui/src/components/activity-settings/activity-settings-dialog.tsx
@@ -9,8 +9,8 @@ const ActivitySettingsDialog = (props) => {
   const activityType = props.activityType;
   const usesSourceDatabase = activityType !== 'loadData';
   //const [settingsArtifact, setSettingsArtifact] = useState({});
-  const defaultTargetDatabase = (activityType === 'loadData') ? 'data-hub-STAGING' : 'data-hub-FINAL';
-  const defaultSourceDatabase = (activityType === 'mapping') ? 'data-hub-STAGING' : 'data-hub-FINAL';
+  const defaultTargetDatabase = !usesSourceDatabase ? 'data-hub-STAGING' : 'data-hub-FINAL';
+  const defaultSourceDatabase = usesSourceDatabase ? 'data-hub-STAGING' : 'data-hub-FINAL';
   const [tgtDatabase, setTgtDatabase] = useState(defaultTargetDatabase);
   const [srcDatabase, setSrcDatabase] = useState(defaultSourceDatabase);
   const[ additionalCollections, setAdditionalCollections ] = useState<any[]>([]);
@@ -359,9 +359,9 @@ const getSettingsArtifact = async () => {
       </Tooltip>
     </Form.Item></div>
 
-  const tgtDbOptions = tgtDatabaseOptions.map(d => <Select.Option key={d}>{d}</Select.Option>);
+  const tgtDbOptions = tgtDatabaseOptions.map(d => <Select.Option data-testid='dbOptions' key={d}>{d}</Select.Option>);
 
-  const provGranOpt = provGranOptions.map(d => <Select.Option key={d}>{d}</Select.Option>);
+  const provGranOpt = provGranOptions.map(d => <Select.Option data-testid='provOptions' key={d}>{d}</Select.Option>);
 
   return (
     <Modal
@@ -458,6 +458,7 @@ const getSettingsArtifact = async () => {
             className={styles.formItem}>
             <Select
               id="provGranularity"
+              placeholder="Select provenance granularity"
               value={provGranularity}
               onChange={handleProvGranularity}
               disabled={!canReadWrite}

--- a/one-ui/ui/src/config/data.config.js
+++ b/one-ui/ui/src/config/data.config.js
@@ -112,7 +112,7 @@ const activitySettings = {
   canWrite: true,
   openActivitySettings: true,
   stepData: {
-    name: 'testLoad'
+    name: 'testActivitySettings'
   },
   setOpenActivitySettings: jest.fn()
 };


### PR DESCRIPTION
### Description
Updated existing Enzyme tests to RTL and added some more unit tests for activity settings.
There is no test plan for this story, this was carried over from previous sprint. It includes all possible tests for the activity settings component.

Added comments for 2-3 scenarios that can be written after bugs are fixed.

Other than tests, added data-testid to select options for testing. 
Reused a boolean variable (usesSourceDatabase) in place of explicit check for acttivityType.
Added placeholder text for provenance granularity Select field.

Reviewers pls let me know if some more scenarios needs to be added.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

