### PR TITLE
DHFPROD-4522: getting the correct commit Id

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -270,13 +270,19 @@ pipeline{
 		count++;
 		    props = readProperties file:'data-hub/pipeline.properties';
 		     def  reviewResponse;
+		     def commitHash;
 		    withCredentials([usernameColonPassword(credentialsId: '550650ab-ee92-4d31-a3f4-91a11d5388a3', variable: 'Credentials')]) {
 		     reviewResponse = sh (returnStdout: true, script:'''
                                curl -u $Credentials  -X GET  '''+githubAPIUrl+'''/pulls/$CHANGE_ID/reviews
                                ''')
+             commitHash = sh (returnStdout: true, script:'''
+                               curl -u $Credentials  -X GET  '''+githubAPIUrl+'''/pulls/$CHANGE_ID
+                               ''')
 		    }
-		    def reviewState=getReviewStateOfPR reviewResponse,2,env.GIT_COMMIT ;
-		    println(env.GIT_COMMIT)
+		    def jsonObj = new JsonSlurperClassic().parseText(commitHash.toString().trim())
+		    def commit_id=jsonObj.head.sha
+		    println(commit_id)
+		    def reviewState=getReviewStateOfPR reviewResponse,2,commit_id ;
 		    println(reviewState)
 			if((env.CHANGE_TITLE.split(':')[1].contains("Automated PR")) || reviewState.equalsIgnoreCase("APPROVED")){
 				println("Automated PR")


### PR DESCRIPTION
### Description
Getting the original commit ID from PR instead of merged commit ID.
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

