### PR TITLE
DHFPROD-4752: Generating a swagger-ui view for the models OpenAPI file

### DIFF
--- a/one-ui/README.md
+++ b/one-ui/README.md
@@ -40,6 +40,13 @@ src/main/resources/application.properties .
 
 See the comments in the AbstractOneUiTest class for information on how to write tests for the Java code in this application.
 
+### Viewing OpenAPI docs
+
+To view the OpenAPI docs for the REST middle tier endpoints in this project, just do the following:
+
+    cd one-ui/ui/mockserver
+    npm install
+    npm start
 
 ## Using this for production 
 

--- a/one-ui/ui/mockserver/index.html
+++ b/one-ui/ui/mockserver/index.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<ul>
+  <li><a href="/models/">Model APIs</a></li>
+  <li><a href="/api/swagger-ui/">View all other APIs</a></li>
+</ul>
+</body>
+</html>

--- a/one-ui/ui/mockserver/package-lock.json
+++ b/one-ui/ui/mockserver/package-lock.json
@@ -150,6 +150,11 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "optional": true
     },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -193,6 +198,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -395,6 +405,11 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formidable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -429,6 +444,14 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "requires": {
+        "lodash": "^4.17.15"
       }
     },
     "har-schema": {
@@ -561,6 +584,28 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-refs": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/json-refs/-/json-refs-3.0.15.tgz",
+      "integrity": "sha512-0vOQd9eLNBL18EGl5yYaO44GhixmImes2wiYn9Z3sag3QnehWrYWlB9AFtMxCL2Bj3fyxgDYkxGFEU/chlYssw==",
+      "requires": {
+        "commander": "~4.1.1",
+        "graphlib": "^2.1.8",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.15",
+        "native-promise-only": "^0.8.1",
+        "path-loader": "^1.0.10",
+        "slash": "^3.0.0",
+        "uri-js": "^4.2.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
+        }
+      }
     },
     "json-schema": {
       "version": "0.2.3",
@@ -726,6 +771,11 @@
         }
       }
     },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -777,6 +827,15 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "path-loader": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/path-loader/-/path-loader-1.0.10.tgz",
+      "integrity": "sha512-CMP0v6S6z8PHeJ6NFVyVJm6WyJjIwFvyz2b0n2/4bKdS/0uZa/9sKUlYZzubrn3zuDRU0zIuEDX9DZYQ2ZI8TA==",
+      "requires": {
+        "native-promise-only": "^0.8.1",
+        "superagent": "^3.8.3"
+      }
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -791,6 +850,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
       "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA=="
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "proxy-addr": {
       "version": "2.0.5",
@@ -943,6 +1007,11 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -978,6 +1047,65 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "superagent": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "swagger-express-middleware": {
       "version": "2.0.4",
@@ -1121,6 +1249,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/one-ui/ui/mockserver/package.json
+++ b/one-ui/ui/mockserver/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "express": "^4.17.1",
     "http-proxy-middleware": "^0.20.0",
+    "json-refs": "^3.0.15",
     "request": "^2.88.0",
     "swagger-express-middleware": "^2.0.4",
     "swagger-ui-express": "^4.1.2"

--- a/one-ui/ui/mockserver/server.js
+++ b/one-ui/ui/mockserver/server.js
@@ -4,84 +4,66 @@
  * such as setting a few options, initializing the mock data store, and adding custom middleware logic.
  **************************************************************************************************/
 
-const util = require('util');
 const path = require('path');
-const proxy = require('http-proxy-middleware')
+const proxy = require('http-proxy-middleware');
 const express = require('express');
-const request = require('request');
+const JsonRefs = require('json-refs');
 const swagger = require('swagger-express-middleware');
 const Middleware = swagger.Middleware;
-const MemoryDataStore = swagger.MemoryDataStore;
-const Resource = swagger.Resource;
-const Collection = swagger.Collection;
 const swaggerUi = require('swagger-ui-express');
 const swaggerMockDocPath = path.join(__dirname, '../api/swagger/mocks.json');
 const swaggerMockDocument = require(swaggerMockDocPath);
-// const swaggerFullDocPath = path.join(__dirname, '/api/swagger/full.json')
-// const swaggerFullDocument = require(swaggerFullDocPath);
 
 // turn off warnings
 process.env.WARN = 'off';
- 
-let app = express();
-let middleware = new Middleware(app);
 
-// Initialize Swagger Express Middleware with our Swagger file
-middleware.init(swaggerMockDocPath, (err) => {
+const app = express();
+const middleware = new Middleware(app);
 
-  // Create a custom data store with some initial mock data
-  // Not currently functioning as expected
-  // let myDB = new MemoryDataStore();
-  // let data = [
-  //   {collection: '/api/samples', name: '/1', data: {id: 1, name: 'aaa', status: 'old'}},
-  //   {collection: '/api/samples', name: '/2', data: {id: 2, name: 'bbb', status: 'something'}},
-  //   {collection: '/api/samples', name: '/3', data: {id: 3, name: 'ccc', status: 'geewiz'}},
-  //   {collection: '/api/samples', name: '/4', data: {id: 4, name: 'ddd', status: 'ohhhh'}},
-  //   {collection: '/api/samples', name: '/5', data: {id: 5, name: 'eee', status: 'wowowow'}}
-  // ];
-  // myDB.save(Resource.parse(data));
+// TODO JsonRefs is able to resolve $ref values from the OpenAPI file to a JSON schema under specs/models, but it's not
+// then able to resolve references between models.
+JsonRefs
+  .resolveRefsAt(path.join(__dirname, '../../../specs/reference/rest-endpoints/models.v1.json'))
+  .then(function (res) {
+    // Initialize Swagger Express Middleware with our Swagger file
+    middleware.init(swaggerMockDocPath, (err) => {
 
-  // Enable Express' case-sensitive and strict options
-  app.enable('case sensitive routing');
-  app.enable('strict routing');
+      // Enable Express' case-sensitive and strict options
+      app.enable('case sensitive routing');
+      app.enable('strict routing');
 
-  app.use(middleware.metadata());
+      app.use(middleware.metadata());
 
-  // http://localhost:4200/api/swagger/doc/ - see Swagger document
-  app.use(middleware.files(
-    {
-      apiPath: '/api/swagger/doc/',
-      rawFilesPath: false
-    }
-  ));
+      app.get('/', function(req, res) {
+        res.sendFile(path.join(__dirname + '/index.html'));
+      });
 
-  // http://localhost:4200/api/swagger-ui/ - see Swagger UI
-  app.use('/api/swagger-ui/', swaggerUi.serve, swaggerUi.setup(swaggerMockDocument));
+      // Found this technique at https://stackoverflow.com/questions/55273857/swagger-ui-express-multiple-routes-for-different-api-documentation
+      app.use('/api/swagger-ui/', swaggerUi.serve, (...args) => swaggerUi.setup(swaggerMockDocument)(...args));
+      app.use("/models/", swaggerUi.serve, (...args) => swaggerUi.setup(res.resolved)(...args));
 
-  // can only serve one Swagger UI, so below code won't work:  https://github.com/swagger-api/swagger-ui/issues/1672
-  // http://localhost:4200/api/swagger/ui/full/ - see Swagger UI
-  // app.use('/api/swagger/ui/full/', swaggerUi.serve, swaggerUi.setup(swaggerFullDocument));
+      app.use(
+        middleware.CORS()
+      );
 
-  app.use(
-    middleware.CORS(),
-    // middleware.validateRequest()  // TODO: requires very thorough Swagger documentation to be in place
-  );
-  
-  // // The mock middleware will use our custom data store,
-  // // which we already pre-populated with mock data
-  // app.use(middleware.mock(myDB));
+      // standard mock use - swagger definitions only
+      app.use(middleware.mock());
 
-  // standard mock use - swagger definitions only
-  app.use(middleware.mock());
+      // Not working - throws TypeError: Converting circular structure to JSON
+      // app.use(middleware.files({
+      //   apiPath: '/api/swagger/doc/',
+      //   rawFilesPath: false
+      // }));
 
-  app.use(proxy({ 
-    target: 'http://localhost:8080', 
-    ws: true, // proxy websockets
-  }))
+      app.use(proxy({
+        target: 'http://localhost:8080',
+        ws: true // proxy websockets
+      }));
 
-  app.listen(8081, () => {
-    console.log('Sample Mock API server is now running at http://localhost:8081');
-    console.log('Swagger JSON Doc: http://localhost:4200/api/swagger/doc/');
-    console.log('Swagger UI: http://localhost:4200/api/swagger-ui/');
+      app.listen(8081, () => {
+        console.log('Swagger UI: http://localhost:8081/');
+      });
+    });
+
   });
-});
+


### PR DESCRIPTION
Using JsonRefs to resolve references to the models directory, but it unfortunately does not yet resolve references between model files.

This adds a new route at "/", which serves up index.html, which provides links to each swagger-ui view. So the existing /api/swagger-ui/ view is not modified in any way.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

