### PR TITLE
DHFPROD-4440: Improving how resetProject works in HubTestBase

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserModulesCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserModulesCommand.java
@@ -213,13 +213,15 @@ public class LoadUserModulesCommand extends LoadModulesCommand {
 
         AllButAssetsModulesFinder allButAssetsModulesFinder = new AllButAssetsModulesFinder();
 
-        Path dir = Paths.get(hubConfig.getHubProject().getProjectDirString(), HubConfig.ENTITY_CONFIG_DIR);
-        if (!dir.toFile().exists()) {
-            dir.toFile().mkdirs();
+        // deploy the auto-generated ES search options, but not if mlWatch is being run, as it will result in the same
+        // options being generated and loaded over and over
+        if (!watchingModules) {
+            Path entityConfigDir = Paths.get(hubConfig.getHubProject().getProjectDirString(), HubConfig.ENTITY_CONFIG_DIR);
+            if (!entityConfigDir.toFile().exists()) {
+                entityConfigDir.toFile().mkdirs();
+            }
+            entityManager.deployQueryOptions();
         }
-
-        // deploy the auto-generated ES search options
-        entityManager.deployQueryOptions();
 
         try {
             if (startPath.toFile().exists()) {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/AbstractHubTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/AbstractHubTest.java
@@ -1,16 +1,20 @@
 package com.marklogic.hub;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
- * Adding this so that a class can subclass HubTestBase without having to define the same two Spring annotations
+ * Adding this so that a class can subclass HubTestBase without hing to define the same two Spring annotations
  * over and over. Plan is to move a lot of classes to under this so they don't duplicate the annotations.
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = ApplicationConfig.class)
 public abstract class AbstractHubTest extends HubTestBase {
 
+    @BeforeEach
+    void beforeEachHubTest() {
+        resetProject();
+    }
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -784,14 +784,16 @@ public class HubTestBase implements InitializingBean {
         return count;
     }
 
-    protected int getMlMajorVersion() {
-        return Integer.parseInt(versions.getMarkLogicVersion().substring(0, 1));
-    }
-
     protected void clearStagingFinalAndJobDatabases() {
         clearDatabases(HubConfig.DEFAULT_FINAL_NAME, HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_JOB_NAME);
     }
-    //not getting uris of prov collection as they cannot be deleted by flow-developer
+
+    /**
+     * Excludes provenance documents, as they cannot be deleted by any of the users that run DHF tests.
+     * Also excluding hub-core-artifact documents so that these do not need to be reloaded.
+     *
+     * @param databases
+     */
     public void clearDatabases(String... databases) {
         ServerEvaluationCall eval = stagingClient.newServerEval();
         String installer =
@@ -799,7 +801,7 @@ public class HubTestBase implements InitializingBean {
             "for $database in fn:tokenize($databases, \",\")\n" +
             "return\n" +
             "  xdmp:eval('\n" +
-            "    cts:uris((),(),cts:not-query(cts:collection-query(\"http://marklogic.com/provenance-services/record\"))) ! xdmp:document-delete(.)\n" +
+            "    cts:uris((),(),cts:not-query(cts:collection-query((\"http://marklogic.com/provenance-services/record\", \"hub-core-artifact\")))) ! xdmp:document-delete(.)\n" +
             "  ',\n" +
             "  (),\n" +
             "  map:entry(\"database\", xdmp:database($database))\n" +
@@ -1072,6 +1074,8 @@ public class HubTestBase implements InitializingBean {
 
         LoadUserModulesCommand loadUserModulesCommand = new LoadUserModulesCommand(adminHubConfig);
         loadUserModulesCommand.setForceLoad(force);
+        // Avoids loading from ml-modules-final; TODO See if any test needs them
+        loadUserModulesCommand.setWatchingModules(true);
         commands.add(loadUserModulesCommand);
 
         commands.add(new GenerateFunctionMetadataCommand(adminHubConfig));
@@ -1292,7 +1296,6 @@ public class HubTestBase implements InitializingBean {
         basicSetup();
         getDataHubAdminConfig();
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME, HubConfig.DEFAULT_JOB_NAME);
-        installHubArtifacts(getDataHubAdminConfig(), true);
     }
 
     protected void setupProjectForRunningTestFlow() {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/PiiE2E.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/PiiE2E.java
@@ -319,9 +319,6 @@ public class PiiE2E extends HubTestBase
 
     private void runInputFLow() throws URISyntaxException
     {
-        int stagingCount = getStagingDocCount();
-        int finalCount = getFinalDocCount();
-
         ServerTransform runFlow = new ServerTransform("mlInputFlow");
         runFlow.addParameter("entity-name", "SupportCall");
         runFlow.addParameter("flow-name", "test-data");
@@ -350,16 +347,6 @@ public class PiiE2E extends HubTestBase
             throw new RuntimeException(e);
         }
         batcher.flushAndWait();
-
-        stagingCount = getStagingDocCount();
-        finalCount = getFinalDocCount();
-
-        assertTrue(
-            "After save, pii, this value is 16, before, it's 15.  Actual is " + stagingCount,
-            stagingCount == 15 || stagingCount == 16);
-        assertTrue(
-            "After save, pii, this value is 4, before, it's 3.  Actual is " + finalCount,
-            finalCount == 3 || finalCount == 4);
     }
 
     private void runHarmonizeFlow(String flowName, DatabaseClient srcClient, String destDb)
@@ -375,12 +362,6 @@ public class PiiE2E extends HubTestBase
 
         flowRunner.run();
         flowRunner.awaitCompletion();
-        int finalCount = getFinalDocCount();
-
-        assertTrue(
-            "After save, pii, this value is 16, before, it's 15.  Actual is " + finalCount,
-            finalCount == 15 || finalCount == 16);
-
     }
 
     private String getCustomerHistory(DatabaseClient client, String name)

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/core/DebugLibTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/core/DebugLibTest.java
@@ -65,7 +65,7 @@ public class DebugLibTest extends HubTestBase {
 
     private void run516() {
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME);
-        assertEquals(0, getStagingDocCount());
+        final int currentCount = getStagingDocCount();
 
         ServerTransform runFlow = new ServerTransform("mlInputFlow");
         runFlow.addParameter("entity-name", entityName);
@@ -91,6 +91,6 @@ public class DebugLibTest extends HubTestBase {
         batcher.flushAndWait();
 
         assertFalse(errorMessage, runFlowFailed);
-        assertEquals(2, getStagingDocCount());
+        assertEquals(currentCount + 2, getStagingDocCount());
     }
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/models/CreateAndUpdateModelTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/models/CreateAndUpdateModelTest.java
@@ -27,7 +27,6 @@ public class CreateAndUpdateModelTest extends AbstractHubTest {
 
     @BeforeEach
     void beforeEach() {
-        resetProject();
         service = new ModelManagerImpl(adminHubConfig);
     }
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/entity/EntityManagerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/entity/EntityManagerTest.java
@@ -40,24 +40,16 @@ import java.util.HashMap;
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.junit.jupiter.api.Assertions.*;
 
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = ApplicationConfig.class)
-public class EntityManagerTest extends HubTestBase {
-    static Path projectPath = Paths.get(PROJECT_PATH).toAbsolutePath();
-    private static File projectDir = projectPath.toFile();
+public class EntityManagerTest extends AbstractHubTest {
 
     @Autowired
-    private EntityManager entityManager;
+    EntityManager entityManager;
 
     @Autowired
     HubProject project;
 
     @BeforeEach
     public void clearDbs() {
-        deleteProjectDir();
-        basicSetup();
-        getDataHubAdminConfig();
-        clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME);
         getDataHub().clearUserModules();
         installHubModules();
         getPropsMgr().deletePropertiesFile();
@@ -104,16 +96,12 @@ public class EntityManagerTest extends HubTestBase {
         assertNull(getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE));
         assertFalse(Paths.get(dir.toString(), HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
         assertFalse(Paths.get(dir.toString(), HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
-        assertEquals(0, getStagingDocCount());
-        assertEquals(0, getFinalDocCount());
 
         HashMap<Enum, Boolean> deployed = entityManager.deployQueryOptions();
 
         assertEquals(0, deployed.size());
         assertFalse(Paths.get(dir.toString(), HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
         assertFalse(Paths.get(dir.toString(), HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
-        assertEquals(0, getStagingDocCount());
-        assertEquals(0, getFinalDocCount());
         assertNull(getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE));
         assertNull(getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE));
     }
@@ -178,8 +166,6 @@ public class EntityManagerTest extends HubTestBase {
         assertNull(getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE));
         assertFalse(Paths.get(dir.toString(), HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
         assertFalse(Paths.get(dir.toString(), HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
-        assertEquals(0, getStagingDocCount());
-        assertEquals(0, getFinalDocCount());
 
         entityManager.deployQueryOptions();
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/legacy/collector/EmptyLegacyCollectorTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/legacy/collector/EmptyLegacyCollectorTest.java
@@ -18,9 +18,9 @@ package com.marklogic.hub.legacy.collector;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.marklogic.client.datamovement.JobTicket;
 import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.hub.ApplicationConfig;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.HubTestBase;
-import com.marklogic.hub.ApplicationConfig;
 import com.marklogic.hub.legacy.flow.*;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,9 +29,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
@@ -41,10 +38,9 @@ import static org.junit.Assert.assertEquals;
 public class EmptyLegacyCollectorTest extends HubTestBase {
 
     private static final String ENTITY = "streamentity";
-    private static Path projectDir = Paths.get(".", "ye-olde-project");
 
     @BeforeEach
-    public void setup() throws IOException {
+    public void setup() {
         // note, not basicSetup
 
         XMLUnit.setIgnoreWhitespace(true);
@@ -65,8 +61,6 @@ public class EmptyLegacyCollectorTest extends HubTestBase {
 
     @Test
     public void runCollector() {
-        assertEquals(0, getStagingDocCount());
-        assertEquals(0, getFinalDocCount());
         LegacyFlow harmonizeFlow = fm.getFlow(ENTITY, "testharmonize",
             FlowType.HARMONIZE);
         HashMap<String, Object> options = new HashMap<>();
@@ -81,7 +75,6 @@ public class EmptyLegacyCollectorTest extends HubTestBase {
             .withStopOnFailure(true);
         JobTicket ticket = flowRunner.run();
         flowRunner.awaitCompletion();
-        assertEquals(0, getFinalDocCount());
 
         JsonNode node = jobDocMgr.read("/jobs/" + ticket.getJobId() + ".json").next().getContent(new JacksonHandle()).get();
         assertEquals(ticket.getJobId(), node.get("jobId").asText());

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/legacy/flow/LegacyFlowManagerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/legacy/flow/LegacyFlowManagerTest.java
@@ -299,11 +299,9 @@ public class LegacyFlowManagerTest extends HubTestBase {
     }
 
     @Test
-    public void testRunFlow() throws SAXException, IOException, ParserConfigurationException, XMLStreamException {
+    public void testRunFlow() {
         addStagingDocs();
         installModules();
-        assertEquals(2, getStagingDocCount());
-        assertEquals(0, getFinalDocCount());
         runAsFlowOperator();
         LegacyFlow flow1 = fm.getFlow("test", "my-test-flow1");
         LegacyFlowRunner flowRunner = fm.newFlowRunner()
@@ -313,8 +311,6 @@ public class LegacyFlowManagerTest extends HubTestBase {
         flowRunner.run();
         flowRunner.awaitCompletion();
         getDataHubAdminConfig();
-        assertEquals(2, getStagingDocCount());
-        assertEquals(2, getFinalDocCount());
         assertXMLEqual(getXmlFromResource("flow-manager-test/harmonized/harmonized1.xml"), finalDocMgr.read("/employee1.xml").next().getContent(new DOMHandle()).get() );
         assertXMLEqual(getXmlFromResource("flow-manager-test/harmonized/harmonized2.xml"), finalDocMgr.read("/employee2.xml").next().getContent(new DOMHandle()).get());
         DocumentMetadataHandle metadata = finalDocMgr.readMetadata("/employee1.xml", new DocumentMetadataHandle());
@@ -327,8 +323,6 @@ public class LegacyFlowManagerTest extends HubTestBase {
     public void testRunFlowWithBackwards() throws SAXException, IOException, ParserConfigurationException, XMLStreamException {
         addFinalDocs();
         installModules();
-        assertEquals(0, getStagingDocCount());
-        assertEquals(2, getFinalDocCount());
         runAsFlowOperator();
         LegacyFlow flow1 = fm.getFlow("test", "my-test-flow1");
         LegacyFlowRunner flowRunner = fm.newFlowRunner()
@@ -340,8 +334,6 @@ public class LegacyFlowManagerTest extends HubTestBase {
         flowRunner.run();
         flowRunner.awaitCompletion();
         getDataHubAdminConfig();
-        assertEquals(2, getStagingDocCount());
-        assertEquals(2, getFinalDocCount());
         assertXMLEqual(getXmlFromResource("flow-manager-test/harmonized/harmonized1.xml"), stagingDocMgr.read("/employee1.xml").next().getContent(new DOMHandle()).get() );
         assertXMLEqual(getXmlFromResource("flow-manager-test/harmonized/harmonized2.xml"), stagingDocMgr.read("/employee2.xml").next().getContent(new DOMHandle()).get());
         DocumentMetadataHandle metadata = stagingDocMgr.readMetadata("/employee1.xml", new DocumentMetadataHandle());
@@ -363,8 +355,6 @@ public class LegacyFlowManagerTest extends HubTestBase {
         modules.put("/entities/test/harmonize/my-test-flow-with-header/main.xqy", "flow-manager-test/my-test-flow-with-header/main.xqy");
         installModules(modules);
 
-        assertEquals(2, getStagingDocCount());
-        assertEquals(0, getFinalDocCount());
         runAsFlowOperator();
         LegacyFlow flow1 = fm.getFlow("test", "my-test-flow-with-header");
         LegacyFlowRunner flowRunner = fm.newFlowRunner()
@@ -374,8 +364,6 @@ public class LegacyFlowManagerTest extends HubTestBase {
         flowRunner.run();
         flowRunner.awaitCompletion();
         getDataHubAdminConfig();
-        assertEquals(2, getStagingDocCount());
-        assertEquals(2, getFinalDocCount());
         assertXMLEqual(getXmlFromResource("flow-manager-test/harmonized-with-header/harmonized1.xml"), finalDocMgr.read("/employee1.xml").next().getContent(new DOMHandle()).get() );
         assertXMLEqual(getXmlFromResource("flow-manager-test/harmonized-with-header/harmonized2.xml"), finalDocMgr.read("/employee2.xml").next().getContent(new DOMHandle()).get());
 
@@ -383,7 +371,7 @@ public class LegacyFlowManagerTest extends HubTestBase {
     }
 
     @Test
-    public void testRunFlowWithAll() throws SAXException, IOException, ParserConfigurationException, XMLStreamException {
+    public void testRunFlowWithAll() {
         addStagingDocs();
         HashMap<String, String> modules = new HashMap<>();
         modules.put("/entities/test/harmonize/my-test-flow-with-all/my-test-flow-with-all.xml", "flow-manager-test/my-test-flow-with-all/my-test-flow-with-all.xml");
@@ -395,8 +383,8 @@ public class LegacyFlowManagerTest extends HubTestBase {
         modules.put("/entities/test/harmonize/my-test-flow-with-all/main.xqy", "flow-manager-test/my-test-flow-with-all/main.xqy");
         installModules(modules);
 
-        assertEquals(2, getStagingDocCount());
-        assertEquals(0, getFinalDocCount());
+        final int stagingCount = getStagingDocCount();
+        final int finalCount = getFinalDocCount();
         runAsFlowOperator();
         LegacyFlow flow1 = fm.getFlow("test", "my-test-flow-with-all");
         LegacyFlowRunner flowRunner = fm.newFlowRunner()
@@ -406,8 +394,8 @@ public class LegacyFlowManagerTest extends HubTestBase {
         flowRunner.run();
         flowRunner.awaitCompletion();
         getDataHubAdminConfig();
-        assertEquals(2, getStagingDocCount());
-        assertEquals(2, getFinalDocCount());
+        assertEquals(stagingCount, getStagingDocCount());
+        assertEquals(2 + finalCount, getFinalDocCount());
         assertXMLEqual(getXmlFromResource("flow-manager-test/harmonized-with-all/harmonized1.xml"), finalDocMgr.read("/employee1.xml").next().getContent(new DOMHandle()).get() );
         assertXMLEqual(getXmlFromResource("flow-manager-test/harmonized-with-all/harmonized2.xml"), finalDocMgr.read("/employee2.xml").next().getContent(new DOMHandle()).get());
 
@@ -415,7 +403,7 @@ public class LegacyFlowManagerTest extends HubTestBase {
     }
 
     @Test
-    public void testRunFlowNamespaceXMLSJS() throws SAXException, IOException, ParserConfigurationException, XMLStreamException {
+    public void testRunFlowNamespaceXMLSJS() {
         addStagingDocs();
         HashMap<String, String> modules = new HashMap<>();
         modules.put("/entities/test/harmonize/my-test-flow-ns-xml-sjs/flow.xml", "flow-manager-test/my-test-flow-ns-xml-sjs/flow.xml");
@@ -427,8 +415,6 @@ public class LegacyFlowManagerTest extends HubTestBase {
         modules.put("/entities/test/harmonize/my-test-flow-ns-xml-sjs/main.sjs", "flow-manager-test/my-test-flow-ns-xml-sjs/main.sjs");
         installModules(modules);
 
-        assertEquals(2, getStagingDocCount());
-        assertEquals(0, getFinalDocCount());
         runAsFlowOperator();
         LegacyFlow flow1 = fm.getFlow("test", "my-test-flow-ns-xml-sjs");
         LegacyFlowRunner flowRunner = fm.newFlowRunner()
@@ -438,8 +424,6 @@ public class LegacyFlowManagerTest extends HubTestBase {
         flowRunner.run();
         flowRunner.awaitCompletion();
         getDataHubAdminConfig();
-        assertEquals(2, getStagingDocCount());
-        assertEquals(2, getFinalDocCount());
         assertXMLEqual(getXmlFromResource("flow-manager-test/harmonized-with-ns-xml/harmonized1.xml"), finalDocMgr.read("/employee1.xml").next().getContent(new DOMHandle()).get() );
         assertXMLEqual(getXmlFromResource("flow-manager-test/harmonized-with-ns-xml/harmonized2.xml"), finalDocMgr.read("/employee2.xml").next().getContent(new DOMHandle()).get());
 
@@ -447,7 +431,7 @@ public class LegacyFlowManagerTest extends HubTestBase {
     }
 
     @Test
-    public void testRunFlowNamespaceXMLXQY() throws SAXException, IOException, ParserConfigurationException, XMLStreamException {
+    public void testRunFlowNamespaceXMLXQY() {
         addStagingDocs();
         HashMap<String, String> modules = new HashMap<>();
         modules.put("/entities/test/harmonize/my-test-flow-ns-xml-xqy/flow.xml", "flow-manager-test/my-test-flow-ns-xml-xqy/flow.xml");
@@ -459,8 +443,6 @@ public class LegacyFlowManagerTest extends HubTestBase {
         modules.put("/entities/test/harmonize/my-test-flow-ns-xml-xqy/main.xqy", "flow-manager-test/my-test-flow-ns-xml-xqy/main.xqy");
         installModules(modules);
 
-        assertEquals(2, getStagingDocCount());
-        assertEquals(0, getFinalDocCount());
         runAsFlowOperator();
         LegacyFlow flow1 = fm.getFlow("test", "my-test-flow-ns-xml-xqy");
         LegacyFlowRunner flowRunner = fm.newFlowRunner()
@@ -470,8 +452,6 @@ public class LegacyFlowManagerTest extends HubTestBase {
         flowRunner.run();
         flowRunner.awaitCompletion();
         getDataHubAdminConfig();
-        assertEquals(2, getStagingDocCount());
-        assertEquals(2, getFinalDocCount());
         assertXMLEqual(getXmlFromResource("flow-manager-test/harmonized-with-ns-xml/harmonized1.xml"), finalDocMgr.read("/employee1.xml").next().getContent(new DOMHandle()).get() );
         assertXMLEqual(getXmlFromResource("flow-manager-test/harmonized-with-ns-xml/harmonized2.xml"), finalDocMgr.read("/employee2.xml").next().getContent(new DOMHandle()).get());
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/legacy/job/LegacyTracingTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/legacy/job/LegacyTracingTest.java
@@ -80,8 +80,7 @@ public class LegacyTracingTest extends HubTestBase {
 
     @Test
     public void runXMLFlowSansTracing() {
-        assertEquals(0, getFinalDocCount());
-        assertEquals(0, getTracingDocCount());
+        int finalCount = getFinalDocCount();
 
         LegacyTracing t = LegacyTracing.create(flowRunnerClient);
         assertFalse(t.isEnabled());
@@ -95,8 +94,7 @@ public class LegacyTracingTest extends HubTestBase {
         flowRunner.run();
         flowRunner.awaitCompletion();
 
-        assertEquals(5, getFinalDocCount());
-        assertEquals(0, getTracingDocCount());
+        assertEquals(finalCount + 5, getFinalDocCount());
 
         // disable must be idempotent
         disableTracing();
@@ -106,8 +104,7 @@ public class LegacyTracingTest extends HubTestBase {
 
     @Test
     public void runJSONFlowSansTracing() {
-        assertEquals(0, getFinalDocCount());
-        assertEquals(0, getTracingDocCount());
+        int finalCount = getFinalDocCount();
 
         LegacyTracing t = LegacyTracing.create(flowRunnerClient);
         assertFalse(t.isEnabled());
@@ -121,14 +118,12 @@ public class LegacyTracingTest extends HubTestBase {
         flowRunner.run();
         flowRunner.awaitCompletion();
 
-        assertEquals(5, getFinalDocCount());
-        assertEquals(0, getTracingDocCount());
+        assertEquals(5 + finalCount, getFinalDocCount());
     }
 
     @Test
     public void runXMLFlowWithTracing() {
-        assertEquals(0, getFinalDocCount());
-        assertEquals(0, getTracingDocCount());
+        int tracingCount = getTracingDocCount();
 
         LegacyTracing t = LegacyTracing.create(flowRunnerClient);
         assertFalse(t.isEnabled());
@@ -145,14 +140,12 @@ public class LegacyTracingTest extends HubTestBase {
         flowRunner.run();
         flowRunner.awaitCompletion();
 
-        assertEquals(5, getFinalDocCount());
-        assertEquals(6, getTracingDocCount());
+        assertEquals(tracingCount + 6, getTracingDocCount());
     }
 
     @Test
     public void runXqyXmlFlowWithBinaryContent() {
-        assertEquals(0, getFinalDocCount());
-        assertEquals(0, getTracingDocCount());
+        int tracingCount = getTracingDocCount();
 
         LegacyTracing t = LegacyTracing.create(flowRunnerClient);
         assertFalse(t.isEnabled());
@@ -169,8 +162,7 @@ public class LegacyTracingTest extends HubTestBase {
         flowRunner.run();
         flowRunner.awaitCompletion();
 
-        assertEquals(5, getFinalDocCount());
-        assertEquals(6, getTracingDocCount());
+        assertEquals(tracingCount + 6, getTracingDocCount());
 
 
         DocumentRecord doc = finalDocMgr.read("/doc/1.xml").next();
@@ -195,8 +187,7 @@ public class LegacyTracingTest extends HubTestBase {
 
     @Test
     public void runXqyJsonFlowWithBinaryContent() {
-        assertEquals(0, getFinalDocCount());
-        assertEquals(0, getTracingDocCount());
+        int tracingCount = getTracingDocCount();
 
         LegacyTracing t = LegacyTracing.create(flowRunnerClient);
         assertFalse(t.isEnabled());
@@ -213,8 +204,7 @@ public class LegacyTracingTest extends HubTestBase {
         flowRunner.run();
         flowRunner.awaitCompletion();
 
-        assertEquals(5, getFinalDocCount());
-        assertEquals(6, getTracingDocCount());
+        assertEquals(tracingCount + 6, getTracingDocCount());
 
         DocumentRecord doc = finalDocMgr.read("/doc/1.json").next();
         String finalDoc= doc.getContent(new StringHandle()).get();
@@ -229,8 +219,7 @@ public class LegacyTracingTest extends HubTestBase {
 
     @Test
     public void runJSONFlowWithTracing() {
-        assertEquals(0, getFinalDocCount());
-        assertEquals(0, getTracingDocCount());
+        int tracingCount = getTracingDocCount();
 
         LegacyTracing t = LegacyTracing.create(flowRunnerClient);
         assertFalse(t.isEnabled());
@@ -247,15 +236,13 @@ public class LegacyTracingTest extends HubTestBase {
         flowRunner.run();
         flowRunner.awaitCompletion();
 
-        assertEquals(5, getFinalDocCount());
-        assertEquals(6, getTracingDocCount());
+        assertEquals(tracingCount + 6, getTracingDocCount());
     }
 
 
     @Test
     public void runSjsJsonFlowWithBinaryContent() {
-        assertEquals(0, getFinalDocCount());
-        assertEquals(0, getTracingDocCount());
+        int tracingCount = getTracingDocCount();
 
         LegacyTracing t = LegacyTracing.create(flowRunnerClient);
         assertFalse(t.isEnabled());
@@ -272,8 +259,7 @@ public class LegacyTracingTest extends HubTestBase {
         flowRunner.run();
         flowRunner.awaitCompletion();
 
-        assertEquals(5, getFinalDocCount());
-        assertEquals(6, getTracingDocCount());
+        assertEquals(tracingCount + 6, getTracingDocCount());
 
         DocumentRecord doc = finalDocMgr.read("1").next();
         String finalDoc= doc.getContent(new StringHandle()).get();
@@ -287,8 +273,7 @@ public class LegacyTracingTest extends HubTestBase {
 
     @Test
     public void runSjsXmlFlowWithBinaryContent() {
-        assertEquals(0, getFinalDocCount());
-        assertEquals(0, getTracingDocCount());
+        int tracingCount = getTracingDocCount();
 
         LegacyTracing t = LegacyTracing.create(flowRunnerClient);
         assertFalse(t.isEnabled());
@@ -305,8 +290,7 @@ public class LegacyTracingTest extends HubTestBase {
         flowRunner.run();
         flowRunner.awaitCompletion();
 
-        assertEquals(5, getFinalDocCount());
-        assertEquals(6, getTracingDocCount());
+        assertEquals(tracingCount + 6, getTracingDocCount());
 
         DocumentRecord doc = finalDocMgr.read("1").next();
         Document finalDoc = doc.getContent(new DOMHandle()).get();
@@ -322,8 +306,7 @@ public class LegacyTracingTest extends HubTestBase {
 
     @Test
     public void runXMLErrorFlowWithoutTracing() {
-        assertEquals(0, getFinalDocCount());
-        assertEquals(0, getTracingDocCount());
+        int tracingCount = getTracingDocCount();
 
         LegacyTracing t = LegacyTracing.create(flowRunnerClient);
         assertFalse(t.isEnabled());
@@ -337,8 +320,7 @@ public class LegacyTracingTest extends HubTestBase {
         flowRunner.run();
         flowRunner.awaitCompletion();
 
-        assertEquals(0, getFinalDocCount());
-        assertEquals(5, getTracingDocCount());
+        assertEquals(tracingCount + 5, getTracingDocCount());
 
         Document node = jobDocMgr.search(allButCollectors(), 1).next().getContent(new DOMHandle()).get();
         assertEquals(1, node.getElementsByTagName("step").getLength());
@@ -347,8 +329,7 @@ public class LegacyTracingTest extends HubTestBase {
 
     @Test
     public void runXMLWriterErrorFlowWithoutTracing() {
-        assertEquals(0, getFinalDocCount());
-        assertEquals(0, getTracingDocCount());
+        int tracingCount = getTracingDocCount();
 
         LegacyTracing t = LegacyTracing.create(flowRunnerClient);
         assertFalse(t.isEnabled());
@@ -362,8 +343,7 @@ public class LegacyTracingTest extends HubTestBase {
         flowRunner.run();
         flowRunner.awaitCompletion();
 
-        assertEquals(0, getFinalDocCount());
-        assertEquals(5, getTracingDocCount());
+        assertEquals(tracingCount + 5, getTracingDocCount());
 
         Document node = jobDocMgr.search(allButCollectors(), 1).next().getContent(new DOMHandle()).get();
         assertEquals(1, node.getElementsByTagName("step").getLength());
@@ -372,8 +352,7 @@ public class LegacyTracingTest extends HubTestBase {
 
     @Test
     public void runJSONErrorFlowWithoutTracing() {
-        assertEquals(0, getFinalDocCount());
-        assertEquals(0, getTracingDocCount());
+        int tracingCount = getTracingDocCount();
 
         LegacyTracing t = LegacyTracing.create(flowRunnerClient);
         assertFalse(t.isEnabled());
@@ -387,8 +366,7 @@ public class LegacyTracingTest extends HubTestBase {
         flowRunner.run();
         flowRunner.awaitCompletion();
 
-        assertEquals(0, getFinalDocCount());
-        assertEquals(5, getTracingDocCount());
+        assertEquals(tracingCount + 5, getTracingDocCount());
 
         JsonNode node = jobDocMgr.search(allButCollectors(), 1).next().getContent(new JacksonHandle()).get();
         System.out.println(node.asText());
@@ -399,8 +377,7 @@ public class LegacyTracingTest extends HubTestBase {
 
     @Test
     public void runJSONWriterErrorFlowWithoutTracing() {
-        assertEquals(0, getFinalDocCount());
-        assertEquals(0, getTracingDocCount());
+        int tracingCount = getTracingDocCount();
 
         LegacyTracing t = LegacyTracing.create(flowRunnerClient);
         assertFalse(t.isEnabled());
@@ -414,8 +391,7 @@ public class LegacyTracingTest extends HubTestBase {
         flowRunner.run();
         flowRunner.awaitCompletion();
 
-        assertEquals(0, getFinalDocCount());
-        assertEquals(5, getTracingDocCount());
+        assertEquals(tracingCount + 5, getTracingDocCount());
 
         JsonNode node = jobDocMgr.search(allButCollectors(), 1).next().getContent(new JacksonHandle()).get();
         assertEquals(1, node.get("trace").get("steps").size());

--- a/web/src/test/java/com/marklogic/hub/web/service/LegacyFlowManagerServiceTest.java
+++ b/web/src/test/java/com/marklogic/hub/web/service/LegacyFlowManagerServiceTest.java
@@ -210,7 +210,7 @@ public class LegacyFlowManagerServiceTest extends AbstractServiceTest {
     public void runHarmonizationFlow() throws InterruptedException {
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME, HubConfig.DEFAULT_JOB_NAME);
 
-        assertEquals(0, getFinalDocCount());
+        int finalCount = getFinalDocCount();
 
         DocumentMetadataHandle meta = new DocumentMetadataHandle();
         meta.getCollections().add(ENTITY);
@@ -243,14 +243,12 @@ public class LegacyFlowManagerServiceTest extends AbstractServiceTest {
             monitor.wait();
         }
 
-        assertEquals(1, getFinalDocCount());
+        assertEquals(finalCount + 1, getFinalDocCount());
     }
 
     @Test
     public void runHarmonizationFlowWithOptions() throws InterruptedException {
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME, HubConfig.DEFAULT_JOB_NAME);
-
-        assertEquals(0, getFinalDocCount());
 
         DocumentMetadataHandle meta = new DocumentMetadataHandle();
         meta.getCollections().add(ENTITY);
@@ -288,8 +286,6 @@ public class LegacyFlowManagerServiceTest extends AbstractServiceTest {
         {
             monitor.wait();
         }
-
-        assertEquals(1, getFinalDocCount());
 
         DocumentRecord doc = finalDocMgr.read("/staged.json").next();
         JsonNode root = doc.getContent(new JacksonHandle()).get();


### PR DESCRIPTION
Submitting this as part of DHFPROD-4440, which involves step processors. I started writing a JUnit test for this and realized that our tests can be sped up by not having to load hub artifacts all the time (because clearDatabases no longer needs them) and by not having to generate and deploy entity-based search options, which are never used. 

Main change is that clearDatabases in HubTestBase no longer deletes the hub-core-artifact collection. That keeps all DH core artifacts present. Had to improve some legacy tests that were assuming that the database was empty after calling clear (making assertions on the number of docs in a database leads to brittle tests).

Also made a tweak to LoadUserModulesCommand that both speeds up tests and fixes a long-standing issue when running "mlWatch", which is - when you run mlWatch, DHF generates and deploys entity-based search options over and over and over. That also adds some time to every test, and none of our tests depend on LoadUserModulesCommand deploying entity-based search options.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

