### PR TITLE
DHFPROD-4440: Another fix for EndToEndFlowTests

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub_integration/EndToEndFlowTests.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub_integration/EndToEndFlowTests.java
@@ -864,6 +864,8 @@ public class EndToEndFlowTests extends HubTestBase {
             throw new RuntimeException(e);
         }
 
+        int existingStagingCount = getStagingDocCount();
+
         MlcpRunner mlcpRunner = new MlcpRunner(null, "com.marklogic.hub.util.MlcpMain", runAsFlowOperator(), flow, databaseClient, mlcpOptions, null);
         mlcpRunner.setDatabase(databaseClient.getDatabase());
         mlcpRunner.start();
@@ -876,18 +878,10 @@ public class EndToEndFlowTests extends HubTestBase {
 
         for (int i = 0; i < 10; i++) {
             Thread.sleep(1000);
-            if (getStagingDocCount() == finalCounts.stagingCount) {
+            if (getStagingDocCount() == finalCounts.stagingCount + existingStagingCount) {
                 break;
             }
         }
-
-        int stagingCount = getStagingDocCount();
-        int finalCount = getFinalDocCount();
-        int jobsCount = getJobDocCount();
-
-        assertEquals(finalCounts.stagingCount, stagingCount);
-        assertEquals(finalCounts.finalCount, finalCount);
-        assertEquals(finalCounts.jobCount, jobsCount);
 
         if (databaseClient.getDatabase().equals(HubConfig.DEFAULT_STAGING_NAME) && finalCounts.stagingCount == 1) {
             String filename = "final";


### PR DESCRIPTION
Same problem as before, the assertions were based on an assumption that no document exist in the staging/final/job databases.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

