### PR TITLE
DHFPROD-4440: Steps now support custom processors

### DIFF
--- a/examples/step-processors/.gitignore
+++ b/examples/step-processors/.gitignore
@@ -1,0 +1,7 @@
+build
+src/main/hub-internal-config
+src/main/ml-config
+src/main/entity-config
+gradle
+gradlew
+gradlew.bat

--- a/examples/step-processors/README.md
+++ b/examples/step-processors/README.md
@@ -1,0 +1,106 @@
+This example project demonstrates how to configure step processors for invoking custom code before content is 
+persisted by a step. 
+
+## How to install
+
+To install via Gradle, start with a clean MarkLogic instance - i.e. without an existing Data hub installation. 
+Then, initialize the project:
+
+    ./gradlew -i hubInit
+    
+Then modify the gradle-local.properties file and either un-comment the mlUsername and mlPassword properties and set the
+password for your admin user, or set the properties to a different MarkLogic user that is able to deploy applications. 
+
+Then deploy the application:
+
+    ./gradlew -i mlDeploy
+
+## Running the test flow
+
+This project contains a simple test flow named "orderFlow". It consists of two steps:
+
+1. An ingestion step that will ingest 2 simple Order documents from the ./data directory in this project
+1. A mapping step that has 2 step processors configured on it
+
+To run the flow so that you can observe the output, run the following Gradle task:
+
+    ./gradlew hubRunFlow -PflowName=orderFlow
+
+## Understanding step processors
+
+The step processors are configured in the ./flows/orderFlow.flow.json file. A step can have zero or many processors. 
+Each processor refers to a module to be invoked via [xdmp.invoke](http://docs.marklogic.com/xdmp.invoke) in the same
+transaction as the content being processed. 
+
+The mapping step in "orderFlow" has the following two processors configured:
+
+```
+"processors": [
+    {
+      "path": "/custom-modules/step-processors/addHeaders.sjs",
+      "when": "beforeContentPersisted",
+      "vars": {
+        "exampleVariable": "testValue"
+      }
+    },
+    {
+      "path": "/org.example/addPermissions.sjs",
+      "when": "beforeContentPersisted"
+    }
+]
+```
+
+The properties of a processor are as follows:
+
+- path = required; defines the path to a module that the user running the step can read and execute
+- when = required; defines when the processor will be invoked. 
+- vars = optional; an object whose key/value pairs will be passed to the processor module. This mirrors the "vars" 
+argument in [xdmp.invoke](http://docs.marklogic.com/xdmp.invoke)
+
+As of 5.3.0, only "beforeContentPersisted" is supported for "when", but this still must be specified. This value of 
+"when" allows you to modify each content object before it is persisted, and thus after Data Hub has determined what 
+its URI, collections, permissions, and metadata should be.
+
+In addition to any variables defined via "vars", Data Hub will pass the following variables to the processor module:
+
+- contentArray = an array of content objects that are about to be persisted
+- options = the combined step configuration options that are derived from the flow, the step, and any options defined at runtime
+
+Each object in the "contentArray" has the following keys:
+
+- uri = the URI at which the document will be persisted
+- value = the document to be persisted. Depending on the step being executed, this may be a node such that you must first
+call toObject() on it to manipulate it. See the addHeaders.sjs processor module for more information.
+- context = an object containing document metadata, including "collections", "permissions", and "metadata"
+
+### A note about ingestion steps
+
+The contents of the "context" object differ based on how you are ingesting data. If you are ingesting data via MLCP, 
+then you will have access to everything that [MLCP provides in the context object](https://docs.marklogic.com/guide/mlcp/import#id_59764), 
+thus allowing you to modify like collections and permissions.
+
+But if you are executing an ingestion step via QuickStart or Gradle, you'll use a REST transform, and REST transforms
+are very limited in what you can modify. The [context object in a REST transform](https://docs.marklogic.com/guide/rest-dev/transforms#id_23889) 
+does not provide access to collections and permissions. And while "uri" is provided, a REST transform does not allow you
+to modify that. 
+
+So while you can apply step processors to ingestion steps, you may not be able to achieve what you want to do if you 
+are using a REST transform.  
+
+## Understanding each step processor in this example
+
+The "addHeaders.sjs" processor demonstrates a common use case for a step processor - mapping data from the source 
+document into the headers of the envelope. This approach is not yet supported by a Data Hub mapping step, but we still 
+want to map everything we can via a mapping step. 
+
+Note that as commented in this module, "content.value" is a node object that cannot be manipulated. So the addHeaders.sjs
+module must first call "toObject()" on it. Then, after that object has been modified, addHeaders.sjs must assign the 
+object back to the value of "content.value". If the step being executed instead sets "content.value" to a mutable 
+object, it is not necessary to perform these actions.
+
+The "addPermissions.sjs" processor then demonstrates another common use case for a step processor - content-driven 
+permissions, where permissions are determined based on the content to be persisted. This example is trivial, but it 
+could of course contain as much custom logic as needed to determine the correct permissions for a document. This 
+example also shows a permission being added to the existing array of permissions, but the processor could instead 
+replace that array with its own array of permissions.
+  

--- a/examples/step-processors/build.gradle
+++ b/examples/step-processors/build.gradle
@@ -1,0 +1,18 @@
+buildscript {
+    repositories {
+        mavenLocal()
+        maven { url "https://plugins.gradle.org/m2/" }
+        jcenter()
+    }
+    dependencies {
+        classpath "net.saliman:gradle-properties-plugin:1.5.1"
+        if (project.hasProperty("testing")) {
+            classpath "com.marklogic:ml-data-hub:5.3-SNAPSHOT"
+        } else {
+            classpath "gradle.plugin.com.marklogic:ml-data-hub:5.3.0"
+        }
+    }
+}
+
+apply plugin: "net.saliman.properties"
+apply plugin: "com.marklogic.ml-data-hub"

--- a/examples/step-processors/data/10248.json
+++ b/examples/step-processors/data/10248.json
@@ -1,0 +1,6 @@
+{
+  "OrderID": "10248",
+  "OrderDate": "1996-07-04T14:25:55",
+  "ShipAddress": "123 Main St",
+  "ShipCity": "Reims"
+}

--- a/examples/step-processors/data/10249.json
+++ b/examples/step-processors/data/10249.json
@@ -1,0 +1,7 @@
+{
+  "OrderID": "10249",
+  "OrderDate": "1996-07-04T14:25:55",
+  "ShipAddress": "456 Broad St",
+  "ShipCity": "Paris"
+}
+

--- a/examples/step-processors/entities/Order.entity.json
+++ b/examples/step-processors/entities/Order.entity.json
@@ -1,0 +1,22 @@
+{
+  "info": {
+    "title": "Order",
+    "version": "0.0.1",
+    "baseUri": "http://marklogic.com/"
+  },
+  "definitions": {
+    "Order": {
+      "properties": {
+        "OrderID": {
+          "datatype": "string"
+        },
+        "ShipCity": {
+          "datatype": "string"
+        },
+        "ShipAddress": {
+          "datatype": "string"
+        }
+      }
+    }
+  }
+}

--- a/examples/step-processors/flows/orderFlow.flow.json
+++ b/examples/step-processors/flows/orderFlow.flow.json
@@ -1,0 +1,54 @@
+{
+  "name": "orderFlow",
+  "steps": {
+    "1": {
+      "name": "ingest-orders",
+      "stepDefinitionName": "default-ingestion",
+      "stepDefinitionType": "INGESTION",
+      "options": {
+        "collections": [
+          "order-input"
+        ],
+        "permissions": "data-hub-operator,read,data-hub-operator,update",
+        "outputFormat": "json",
+        "targetDatabase": "data-hub-STAGING"
+      },
+      "fileLocations": {
+        "inputFilePath": "data",
+        "inputFileType": "json",
+        "outputURIReplacement": ".*data*.,'/order/'"
+      }
+    },
+    "2": {
+      "name": "map-orders",
+      "stepDefinitionName": "entity-services-mapping",
+      "stepDefinitionType": "MAPPING",
+      "processors": [
+        {
+          "path": "/custom-modules/step-processors/addHeaders.sjs",
+          "when": "beforeContentPersisted",
+          "vars": {
+            "exampleVariable": "testValue"
+          }
+        },
+        {
+          "path": "/org.example/addPermissions.sjs",
+          "when": "beforeContentPersisted"
+        }
+      ],
+      "options": {
+        "sourceQuery": "cts.collectionQuery('order-input')",
+        "mapping": {
+          "name": "OrderMappingJson",
+          "version": 1
+        },
+        "sourceDatabase": "data-hub-STAGING",
+        "collections": [
+          "Order"
+        ],
+        "outputFormat": "json",
+        "targetDatabase": "data-hub-FINAL"
+      }
+    }
+  }
+}

--- a/examples/step-processors/mappings/OrderMappingJson/OrderMappingJson-1.mapping.json
+++ b/examples/step-processors/mappings/OrderMappingJson/OrderMappingJson-1.mapping.json
@@ -1,0 +1,18 @@
+{
+  "lang": "zxx",
+  "name": "OrderMappingJson",
+  "version": 1,
+  "targetEntityType": "http://marklogic.com/Order-0.0.1/Order",
+  "sourceContext": "/",
+  "properties": {
+    "OrderID": {
+      "sourcedFrom": "OrderID"
+    },
+    "ShipCity": {
+      "sourcedFrom": "ShipCity"
+    },
+    "ShipAddress": {
+      "sourcedFrom": "ShipAddress"
+    }
+  }
+}

--- a/examples/step-processors/src/main/ml-modules/root/custom-modules/step-processors/addHeaders.sjs
+++ b/examples/step-processors/src/main/ml-modules/root/custom-modules/step-processors/addHeaders.sjs
@@ -1,0 +1,21 @@
+var contentArray;
+var options;
+
+// This is passed in because it's defined in the processors config in the flow file
+var exampleVariable;
+
+contentArray.forEach(content => {
+  // The entity-services-mapping step results in "value" being a node, so must call toObject first
+  const contentValue = content.value.toObject();
+
+  // Variables can be used to affect the behavior of a reusable processor; just logging the value in this example
+  console.log("Received exampleVariable value: " + exampleVariable);
+
+  // Example of mapping data from the source document, located in the attachment, to the header
+  const orderDate = contentValue.envelope.attachments.envelope.instance.OrderDate;
+  contentValue.envelope.headers.mappedOrderDate = orderDate;
+
+  content.value = contentValue;
+});
+
+contentArray;

--- a/examples/step-processors/src/main/ml-modules/root/org.example/addPermissions.sjs
+++ b/examples/step-processors/src/main/ml-modules/root/org.example/addPermissions.sjs
@@ -1,0 +1,17 @@
+var contentArray;
+var options;
+
+contentArray.forEach(content => {
+  // Example of content-driven permissions
+  // Because the addHeaders.sjs processor was run already, and that converted content.value into an object as opposed
+  // to a node, we don't need to call toObject() here on content.value.
+  if (content.value.envelope.instance.Order.ShipCity == "Reims") {
+    content.context.permissions.push(xdmp.permission("qconsole-user", "read"));
+  }
+
+  // Also, note that in order to modify permissions via a step processor during ingestion, you must use MLCP to ingest
+  // the data, as a REST transform does not allow you to modify everything about the data to be ingested, such as URI,
+  // collections, and permissions.
+});
+
+contentArray;

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/FlowInputs.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/FlowInputs.java
@@ -56,12 +56,22 @@ public class FlowInputs {
         this.steps = steps;
     }
 
+    public FlowInputs withSteps(String... steps) {
+        setSteps(Arrays.asList(steps));
+        return this;
+    }
+
     public String getJobId() {
         return jobId;
     }
 
     public void setJobId(String jobId) {
         this.jobId = jobId;
+    }
+
+    public FlowInputs withJobId(String jobId) {
+        setJobId(jobId);
+        return this;
     }
 
     public Map<String, Object> getOptions() {
@@ -72,11 +82,21 @@ public class FlowInputs {
         this.options = options;
     }
 
+    public FlowInputs withOptions(Map<String, Object> options) {
+        setOptions(options);
+        return this;
+    }
+
     public Map<String, Object> getStepConfig() {
         return stepConfig;
     }
 
     public void setStepConfig(Map<String, Object> stepConfig) {
         this.stepConfig = stepConfig;
+    }
+
+    public FlowInputs withStepConfig(Map<String, Object> stepConfig) {
+        setStepConfig(stepConfig);
+        return this;
     }
 }

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils.sjs
@@ -49,6 +49,13 @@ class HubUtils {
     }));
   }
 
+  /**
+   * @param writeQueue
+   * @param permissions
+   * @param collections
+   * @param database
+   * @return An object consisting of two properties - "transaction" and "dateTime"
+   */
   writeDocuments(writeQueue, permissions = xdmp.defaultPermissions(), collections = [], database = xdmp.databaseName(xdmp.database())){
     return fn.head(xdmp.invoke('/data-hub/5/impl/hub-utils/invoke-queue-write.sjs',
       {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/invoke-step.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/invoke-step.sjs
@@ -1,5 +1,5 @@
 'use strict';
 
-var flow, items, content, options, flowName, stepNumber, step;
+var flowInstance, items, content, combinedOptions, flowName, stepNumber, flowStep;
 
-flow.runStep(items, content, options, flowName, stepNumber, step);
+flowInstance.runStep(items, content, combinedOptions, flowName, stepNumber, flowStep);

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/AbstractHubTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/AbstractHubTest.java
@@ -6,7 +6,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
- * Adding this so that a class can subclass HubTestBase without hing to define the same two Spring annotations
+ * Adding this so that a class can subclass HubTestBase without having to define the same two Spring annotations
  * over and over. Plan is to move a lot of classes to under this so they don't duplicate the annotations.
  */
 @ExtendWith(SpringExtension.class)

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -1430,8 +1430,9 @@ public class HubTestBase implements InitializingBean {
     /**
      * Load the files associated with the entity reference model.
      */
-    protected void loadReferenceModelProject() {
+    protected ReferenceModelProject loadReferenceModelProject() {
         loadProjectFiles("entity-reference-model");
+        return new ReferenceModelProject(adminHubConfig);
     }
 
     /**

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/ReferenceModelProject.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/ReferenceModelProject.java
@@ -1,0 +1,41 @@
+package com.marklogic.hub;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.document.JSONDocumentManager;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.hub.flow.FlowInputs;
+import com.marklogic.hub.flow.FlowRunner;
+import com.marklogic.hub.flow.RunFlowResponse;
+import com.marklogic.hub.flow.impl.FlowRunnerImpl;
+import com.marklogic.hub.impl.HubConfigImpl;
+
+public class ReferenceModelProject {
+
+    private HubConfigImpl hubConfig;
+    private ObjectMapper objectMapper;
+
+    public ReferenceModelProject(HubConfigImpl hubConfig) {
+        this.hubConfig = hubConfig;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public void createCustomer(int customerId, String name) {
+        JSONDocumentManager mgr = hubConfig.newStagingClient().newJSONDocumentManager();
+        ObjectNode customer = objectMapper.createObjectNode();
+        customer.put("customerId", customerId);
+        customer.put("name", name);
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle()
+            .withCollections("customer-input")
+            .withPermission("data-hub-operator", DocumentMetadataHandle.Capability.READ, DocumentMetadataHandle.Capability.UPDATE);
+        mgr.write("/customer" + customerId + ".json", metadata, new JacksonHandle(customer));
+    }
+
+    public RunFlowResponse runFlow(FlowInputs flowInputs) {
+        FlowRunner flowRunner = new FlowRunnerImpl(hubConfig.getHost(), hubConfig.getMlUsername(), hubConfig.getMlPassword());
+        RunFlowResponse flowResponse = flowRunner.runFlow(flowInputs);
+        flowRunner.awaitCompletion();
+        return flowResponse;
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/models/GetPrimaryEntityTypesTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/models/GetPrimaryEntityTypesTest.java
@@ -1,16 +1,10 @@
 package com.marklogic.hub.dataservices.models;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.marklogic.client.document.JSONDocumentManager;
-import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.hub.AbstractHubTest;
+import com.marklogic.hub.ReferenceModelProject;
 import com.marklogic.hub.dataservices.ModelsService;
 import com.marklogic.hub.flow.FlowInputs;
-import com.marklogic.hub.flow.FlowRunner;
-import com.marklogic.hub.flow.impl.FlowRunnerImpl;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -19,9 +13,9 @@ public class GetPrimaryEntityTypesTest extends AbstractHubTest {
 
     @Test
     void referenceModelWithOneCustomerLoaded() {
-        givenTheReferenceModelProjectIsLoaded();
-        givenASingleCustomerDocument();
-        givenACustomerFlowHasBeenRun();
+        ReferenceModelProject project = loadReferenceModelProject();
+        project.createCustomer(1, "Customer One");
+        project.runFlow(new FlowInputs("echoFlow").withJobId("echoFlow-test"));
 
         ArrayNode entityTypes = (ArrayNode) ModelsService.on(adminHubConfig.newFinalClient(null)).getPrimaryEntityTypes();
         assertEquals(2, entityTypes.size(), "Expecting an entry for Customer and for Order");
@@ -45,36 +39,8 @@ public class GetPrimaryEntityTypesTest extends AbstractHubTest {
 
     @Test
     void noEntityModelsExist() {
-        resetProject();
         ArrayNode entityTypes = (ArrayNode) ModelsService.on(adminHubConfig.newFinalClient(null)).getPrimaryEntityTypes();
         assertNotNull(entityTypes);
         assertEquals(0, entityTypes.size());
-    }
-
-    private void givenTheReferenceModelProjectIsLoaded() {
-        resetProject();
-        loadReferenceModelProject();
-    }
-
-    private void givenASingleCustomerDocument() {
-        JSONDocumentManager mgr = adminHubConfig.newFinalClient().newJSONDocumentManager();
-        ObjectMapper mapper = new ObjectMapper();
-        ObjectNode customer1 = mapper.createObjectNode();
-        customer1.put("name", "Customer One");
-        DocumentMetadataHandle metadata = new DocumentMetadataHandle()
-            .withCollections("customer-input")
-            .withPermission("data-hub-operator", DocumentMetadataHandle.Capability.READ, DocumentMetadataHandle.Capability.UPDATE);
-        mgr.write("/customer/customer-1.json", metadata, new JacksonHandle(customer1));
-    }
-
-    private void givenACustomerFlowHasBeenRun() {
-        runAsDataHubOperator();
-
-        FlowInputs inputs = new FlowInputs("echoFlow");
-        inputs.setJobId("echoFlow-test");
-
-        FlowRunner flowRunner = new FlowRunnerImpl(host, adminHubConfig.getMlUsername(), adminHubConfig.getMlPassword());
-        flowRunner.runFlow(inputs);
-        flowRunner.awaitCompletion();
     }
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/RunStepWithProcessorsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/RunStepWithProcessorsTest.java
@@ -1,0 +1,80 @@
+package com.marklogic.hub.flow;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.client.document.JSONDocumentManager;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.hub.AbstractHubTest;
+import com.marklogic.hub.ReferenceModelProject;
+import com.marklogic.hub.job.JobStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RunStepWithProcessorsTest extends AbstractHubTest {
+
+    private final static String CUSTOMER1_URI = "/echo/customer1.json";
+    private final static String CUSTOMER2_URI = "/echo/customer2.json";
+
+    ReferenceModelProject project;
+
+    @BeforeEach
+    void beforeEach() {
+        project = loadReferenceModelProject();
+        runAsDataHubOperator();
+        project.createCustomer(1, "Jane");
+        project.createCustomer(2, "John");
+    }
+
+    @Test
+    void test() {
+        RunFlowResponse response = project.runFlow(new FlowInputs("stepProcessors", "1"));
+        assertEquals(JobStatus.FINISHED.toString(), response.getJobStatus());
+
+        JSONDocumentManager mgr = adminHubConfig.newFinalClient().newJSONDocumentManager();
+        Stream.of(CUSTOMER1_URI, CUSTOMER2_URI).forEach(uri -> {
+            JsonNode customer = mgr.read(uri, new JacksonHandle()).get();
+            assertEquals("world", customer.get("envelope").get("headers").get("hello").asText(),
+                "The hello header should have been added by the addHeaders.sjs processor");
+        });
+
+        DocumentMetadataHandle.DocumentPermissions perms = mgr.readMetadata(CUSTOMER1_URI, new DocumentMetadataHandle()).getPermissions();
+        assertEquals(2, perms.get("data-hub-operator").size());
+        assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("qconsole-user").iterator().next(),
+            "The addPermissions.sjs processor should have added qconsole-user/read to the first document since it " +
+                "has a name of 'Jane'");
+
+        perms = mgr.readMetadata(CUSTOMER2_URI, new DocumentMetadataHandle()).getPermissions();
+        assertEquals(2, perms.get("data-hub-operator").size());
+        assertNull(perms.get("qconsole-user"),
+            "The second customer shouldn't have a qconsole-user permission since it doesn't have a name of 'Jane'");
+    }
+
+    @Test
+    void missingProcessorModule() {
+        RunFlowResponse response = project.runFlow(new FlowInputs("stepProcessors", "2"));
+        assertEquals(JobStatus.FAILED.toString(), response.getJobStatus(),
+            "The job should have failed because step 2 references an invalid path");
+
+        String stepOutput = response.getStepResponses().get("2").getStepOutput().get(0);
+        assertTrue(stepOutput.contains("XDMP-MODNOTFOUND"), "The step output should have a single entry with an " +
+            "error message indicating that the module was not found and thus XDMP-MODNOTFOUND should be present; " +
+            "actual step output: " + stepOutput);
+    }
+
+    @Test
+    void missingWhen() {
+        RunFlowResponse response = project.runFlow(new FlowInputs("stepProcessors", "3"));
+        assertEquals(JobStatus.FINISHED.toString(), response.getJobStatus());
+
+        JSONDocumentManager mgr = adminHubConfig.newFinalClient().newJSONDocumentManager();
+        Stream.of(CUSTOMER1_URI, CUSTOMER2_URI).forEach(uri -> {
+            JsonNode customer = mgr.read(uri, new JacksonHandle()).get();
+            assertFalse(customer.get("envelope").get("headers").has("hello"),
+                "Because the processor doesn't have a 'when' property, the processor will be ignored (as opposed to throwing an error).");
+        });
+    }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/flow-utils/getMetadata.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/flow-utils/getMetadata.sjs
@@ -32,7 +32,6 @@ let flowDoc = {
                 }
               };
 
-//metadata is set in processResults method of flow.sjs as below and it gets called for every step in the flowDoc
 //this is to verify that stepDefName corresponding to the stepNumber is the value of metadata datahubCreatedByStep
 for (const stepNum in flowDoc.steps) {
   metadata.push(flowUtils.createMetadata(metadata ? metadata : {}, flowDoc.name, flowDoc.steps[stepNum].stepDefinitionName, jobId).datahubCreatedByStep)

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/entities/Customer.entity.json
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/entities/Customer.entity.json
@@ -9,7 +9,11 @@
       "required": [
         "name"
       ],
+      "primaryKey": "customerId",
       "properties": {
+        "customerId": {
+          "datatype": "integer"
+        },
         "name": {
           "datatype": "string",
           "collation": "http://marklogic.com/collation/codepoint"
@@ -19,9 +23,6 @@
         },
         "billing": {
           "$ref": "#/definitions/Address"
-        },
-        "customerNumber": {
-          "datatype": "integer"
         },
         "customerSince": {
           "datatype": "date"

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/entities/Order.entity.json
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/entities/Order.entity.json
@@ -7,8 +7,9 @@
   "definitions": {
     "Order": {
       "required": [],
+      "primaryKey": "orderId",
       "properties": {
-        "orderID": {
+        "orderId": {
           "datatype": "string"
         },
         "address": {

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/flows/echoFlow.flow.json
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/flows/echoFlow.flow.json
@@ -7,7 +7,7 @@
       "stepDefinitionType": "CUSTOM",
       "options": {
         "sourceQuery": "cts.collectionQuery('customer-input')",
-        "sourceDatabase": "data-hub-FINAL",
+        "sourceDatabase": "data-hub-STAGING",
         "targetDatabase": "data-hub-FINAL",
         "collections": ["Customer"]
       }

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/flows/stepProcessors.flow.json
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/flows/stepProcessors.flow.json
@@ -1,0 +1,56 @@
+{
+  "name": "stepProcessors",
+  "steps": {
+    "1": {
+      "name": "stepOne",
+      "stepDefinitionName": "echoStep",
+      "stepDefinitionType": "CUSTOM",
+      "options": {
+        "sourceQuery": "cts.collectionQuery('customer-input')"
+      },
+      "processors": [
+        {
+          "path": "/custom-modules/step-processors/addHeaders.sjs",
+          "when": "beforeContentPersisted",
+          "vars": {
+            "headerValueToAdd": "world"
+          }
+        },
+        {
+          "path": "/custom-modules/step-processors/addPermissions.sjs",
+          "when": "beforeContentPersisted"
+        }
+      ]
+    },
+    "2": {
+      "name": "missingProcessorModule",
+      "stepDefinitionName": "echoStep",
+      "stepDefinitionType": "CUSTOM",
+      "options": {
+        "sourceQuery": "cts.collectionQuery('customer-input')"
+      },
+      "processors": [
+        {
+          "path": "/missing/module.sjs",
+          "when": "beforeContentPersisted"
+        }
+      ]
+    },
+    "3": {
+      "name": "missingWhen",
+      "stepDefinitionName": "echoStep",
+      "stepDefinitionType": "CUSTOM",
+      "options": {
+        "sourceQuery": "cts.collectionQuery('customer-input')"
+      },
+      "processors": [
+        {
+          "path": "/custom-modules/step-processors/addHeaders.sjs",
+          "vars": {
+            "headerValueToAdd": "world"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/modules/root/custom-modules/custom/echoStep/echoStep.sjs
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/modules/root/custom-modules/custom/echoStep/echoStep.sjs
@@ -5,7 +5,7 @@ const datahub = DataHubSingleton.instance();
  * Simple custom step that just marks the content as processed via a URI alteration.
  */
 function main(contentItem, options) {
-  const instance = cts.doc(contentItem.uri);
+  const instance = cts.doc(contentItem.uri).toObject();
   return {
     uri: "/echo" + contentItem.uri,
     value: datahub.flow.flowUtils.makeEnvelope(instance, {}, [], "json"),

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/modules/root/custom-modules/step-processors/addHeaders.sjs
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/modules/root/custom-modules/step-processors/addHeaders.sjs
@@ -1,0 +1,11 @@
+var contentArray;
+var options;
+
+// This is passed in because it's defined in the processors config in the flow file
+var headerValueToAdd;
+
+contentArray.forEach(content => {
+  content.value.envelope.headers.hello = headerValueToAdd;
+});
+
+contentArray;

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/modules/root/custom-modules/step-processors/addPermissions.sjs
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/modules/root/custom-modules/step-processors/addPermissions.sjs
@@ -1,0 +1,10 @@
+var contentArray;
+var options;
+
+contentArray.forEach(content => {
+  if (fn.string(content.value.envelope.instance.name) == "Jane") {
+    content.context.permissions.push(xdmp.permission("qconsole-user", "read"));
+  }
+});
+
+contentArray;

--- a/specs/models/Flow.schema.json
+++ b/specs/models/Flow.schema.json
@@ -1,0 +1,217 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "http://marklogic.com/data-hub/Flow.schema.json",
+  "title": "Flow",
+  "type": "object",
+  "description": "A Data Hub flow containing zero or many steps",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Unique name for the flow"
+    },
+    "description": {
+      "type": "string",
+      "description": "Optional description of the flow"
+    },
+    "batchSize": {
+      "type": "number",
+      "description": "Default batch size for every step"
+    },
+    "threadCount": {
+      "type": "number",
+      "description": "Default thread count for every step"
+    },
+    "stopOnError": {
+      "type": "boolean",
+      "description": "If true and an error is encountered, the flow run ends, the rest of the source data is ignored, and the remaining steps are not performed. Information about the failure is logged in the job document. Default is false."
+    },
+    "options": {
+      "type": "object",
+      "description": "Default options for every step. Not yet known what is typically defined here; may be rarely used",
+      "properties": {
+      }
+    },
+    "version": {
+      "type": "number",
+      "description": "Does not appear to be used for anything"
+    },
+    "steps": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[0-9]+$": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of step, though the 'step number' is how a step is referred to when running a flow"
+            },
+            "description": {
+              "type": "string",
+              "description": "Optional description fo the step",
+            },
+            "stepDefinitionName": {
+              "type": "string"
+            },
+            "stepDefinitionType": {
+              "type": "string"
+            },
+            "batchSize": {
+              "type": "number",
+              "description": "If set, overrides the batchSize defined at the flow level and in the step definition"
+            },
+            "threadCount": {
+              "type": "number",
+              "description": "If set, overrides the threadCount defined at the flow level and in the step definition"
+            },
+            "retryLimit": {
+              "type": "number",
+              "description": "Unused, has no effect if set"
+            },
+            "customHook": {
+              "type": "object",
+              "properties": {
+                "module": {
+                  "type": "string"
+                },
+                "parameters": {
+                  "type": "object"
+                },
+                "user": {
+                  "type": "string"
+                },
+                "runBefore": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "processors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "description": "Path to a module in the modules database that will be invoked via xdmp.invoke"
+                  },
+                  "when": {
+                    "type": "string",
+                    "description": "When the processor should be invoked. Only 'beforeContentPersisted' is supported."
+                  },
+                  "vars": {
+                    "type": "object",
+                    "description": "Any properties defined in this object are passed to the invoked module"
+                  }
+                }
+              }
+            },
+            "options": {
+              "type": "object",
+              "properties": {
+                "sourceQuery": {
+                  "type": "string",
+                  "description": "Defines the items to be processed by the step; must be a cts.query or cts.uris statement if sourceQueryIsScript is false"
+                },
+                "sourceQueryIsScript": {
+                  "type": "boolean",
+                  "description": "Added in 5.3.0; if true, then sourceQuery can be any JavaScript statement that can be passed into xdmp.eval"
+                },
+                "constrainSourceQueryToJob": {
+                  "type": "boolean",
+                  "description": "If true, the query is applied to the documents that were created or modified in the same job that executes the step"
+                },
+                "provenanceGranularityLevel": {
+                  "type": "string",
+                  "description": "The granularity of the provenance tracking information: coarse (default) to store document-level provenance information only, fine to store document-level and property-level provenance information, or off to disable provenance tracking in future job runs. Applies only to mapping, matching, merging, mastering, and custom steps."
+                },
+                "stepUpdate": {
+                  "type": "boolean",
+                  "description": "If true, custom modules can make changes directly to records in the database"
+                },
+                "acceptsBatch": {
+                  "type": "boolean",
+                  "description": "If true, the step module is invoked once with all records in the batch passed to it"
+                },
+                "collections": {
+                  "type": "array",
+                  "items" : {
+                    "type": "string"
+                  }
+                },
+                "additionalCollections": {
+                  "type": "array",
+                  "items" : {
+                    "type": "string"
+                  }
+                },
+                "permissions": {
+                  "type": "string",
+                  "description": "Comma-delimited string of role,capability,role,capability,etc"
+                },
+                "outputFormat": {
+                  "type": "string"
+                },
+                "sourceDatabase": {
+                  "type": "string"
+                },
+                "targetDatabase": {
+                  "type": "string"
+                },
+                "targetEntity": {
+                  "type": "string",
+                  "description": "Name of the entity type associated with the output of the step"
+                },
+                "validateEntity": {
+                  "type": "boolean",
+                  "description": "Applicable to mapping steps only"
+                },
+                "headers": {
+                  "type": "object",
+                  "description": "Any properties in this object will be copied into the headers of each document processed by the step"
+                },
+                "fileLocations": {
+                  "type": "object",
+                  "description": "Applicable only to ingestion steps run via Gradle or QuickStart; not applicable when using MLCP",
+                  "properties": {
+                    "inputFilePath": {
+                      "type": "string"
+                    },
+                    "inputFileType": {
+                      "type": "string"
+                    },
+                    "outputURIReplacement": {
+                      "type": "string"
+                    },
+                    "separator": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "mapping": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "The name of your mapping that is defined in your-project-root/mappings/your-mapping-name/mapping.version.json"
+                    },
+                    "version": {
+                      "type": "string",
+                      "description": "The version of the mapping to use, as defined in the mapping artifact"
+                    }
+                  }
+                },
+                "matchOptions": {
+                  "type": "object"
+                },
+                "mergeOptions": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [ "name" ]
+}


### PR DESCRIPTION
Included a new "step-processors" example project to document the feature. 

There are a lot of changes in flow.sjs, but much of this was due to 1) renaming variables for consistency, and 2) moving existing code into two new functions - writeProvenanceData and updateBatchDocument - so that "runFlow" isn't quite so big. 

The actual new stuff in flow.sjs is fairly minimal - it's the new applyProcessorsBeforeContentPersisted function, and I had to change the if/else that invokes a step module based on acceptsBatch=true. That block of code no longer adds content objects to the writeQueue, because it first needs to apply processors before adding content to the writeQueue.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

