### PR TITLE
DHFPROD-4795: Creating a model with an existing name now fails

### DIFF
--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/ModelController.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/ModelController.java
@@ -97,4 +97,8 @@ public class ModelController {
     private ModelsService newService() {
         return new ModelManagerImpl(hubConfig);
     }
+
+    public void setHubConfig(HubConfigSession hubConfig) {
+        this.hubConfig = hubConfig;
+    }
 }

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/CreateModelMvcTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/CreateModelMvcTest.java
@@ -1,0 +1,27 @@
+package com.marklogic.hub.central.controllers.model;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.hub.central.AbstractMvcTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class CreateModelMvcTest extends AbstractMvcTest {
+
+    /**
+     * Verifies that CustomExceptionHandler is correctly processing a FailedRequestException from a DS endpoint.
+     *
+     * @throws Exception
+     */
+    @Test
+    void missingName() throws Exception {
+        postJson("/api/models", "{}")
+            .andExpect(status().isBadRequest())
+            .andDo(result -> {
+                ObjectNode error = readJsonObject(result.getResponse().getContentAsString());
+                assertEquals(400, error.get("code").asInt());
+                assertEquals("The model must have an info object with a title property", error.get("message").asText());
+            });
+    }
+}

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/ModelControllerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/ModelControllerTest.java
@@ -1,4 +1,4 @@
-package com.marklogic.hub.central.controllers;
+package com.marklogic.hub.central.controllers.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.hub.central.AbstractHubCentralTest;
+import com.marklogic.hub.central.controllers.ModelController;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -22,7 +23,7 @@ public class ModelControllerTest extends AbstractHubCentralTest {
 
     @Test
     void testModelsServicesEndpoints() { controller = new ModelController();
-        controller.hubConfig = hubConfig;
+        controller.setHubConfig(hubConfig);
 
         createModel();
         updateModelInfo();

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/ds-utils.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/ds-utils.sjs
@@ -1,0 +1,30 @@
+/**
+ Copyright (c) 2020 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+/**
+ * Because DH app servers are still using the REST API error handler, errors should be communicated using the
+ * "RESTAPI-SRVEXERR" status code. This ensures that the provided error message can be easily communicated to a client.
+ *
+ * @param message
+ */
+function throwBadRequest(message) {
+  fn.error(null, 'RESTAPI-SRVEXERR', Sequence.from([400, message]));
+}
+
+module.exports = {
+  throwBadRequest
+};

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/entitySearch/getMatchingPropertyValues.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/entitySearch/getMatchingPropertyValues.sjs
@@ -1,21 +1,39 @@
+/*
+  Copyright 2012-2019 MarkLogic Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+'use strict';
+
+const ds = require("/data-hub/5/data-services/ds-utils.sjs");
 const lib = require('/data-hub/5/impl/hub-es.sjs');
 
 var facetValuesSearchQuery;
 if(facetValuesSearchQuery == null) {
-  throw Error("Request cannot be empty");
+  ds.throwBadRequest("Request cannot be empty");
 }
 let queryObj = JSON.parse(facetValuesSearchQuery);
 
 if(queryObj.entityTypeId == null) {
-  throw Error("Could not get matching values, search query is missing entityTypeId property");
+  ds.throwBadRequest("Could not get matching values, search query is missing entityTypeId property");
 }
 
 if(queryObj.propertyPath == null) {
-  throw Error("Could not get matching values, search query is missing propertyPath property");
+  ds.throwBadRequest("Could not get matching values, search query is missing propertyPath property");
 }
 
 if(queryObj.referenceType == null) {
-  throw Error("Could not get matching values, search query is missing referenceType property");
+  ds.throwBadRequest("Could not get matching values, search query is missing referenceType property");
 }
 
 if(queryObj.limit == null) {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/entitySearch/getMinAndMaxPropertyValues.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/entitySearch/getMinAndMaxPropertyValues.sjs
@@ -1,21 +1,39 @@
+/*
+  Copyright 2012-2019 MarkLogic Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+'use strict';
+
+const ds = require("/data-hub/5/data-services/ds-utils.sjs");
 const lib = require('/data-hub/5/impl/hub-es.sjs');
 
 var facetRangeSearchQuery;
 if(facetRangeSearchQuery == null) {
-  throw Error("Request cannot be empty");
+  ds.throwBadRequest("Request cannot be empty");
 }
 let queryObj = JSON.parse(facetRangeSearchQuery);
 
 if(queryObj.entityTypeId == null) {
-  throw Error("Could not get min and max values, search query is missing entityTypeId property");
+  ds.throwBadRequest("Could not get min and max values, search query is missing entityTypeId property");
 }
 
 if(queryObj.propertyPath == null) {
-  throw Error("Could not get min and max values, search query is missing propertyPath property");
+  ds.throwBadRequest("Could not get min and max values, search query is missing propertyPath property");
 }
 
 if(queryObj.referenceType == null) {
-  throw Error("Could not get min and max values, search query is missing referenceType property");
+  ds.throwBadRequest("Could not get min and max values, search query is missing referenceType property");
 }
 
 let entityTypeId = queryObj.entityTypeId;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/entitySearch/saveSavedQuery.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/entitySearch/saveSavedQuery.sjs
@@ -1,24 +1,42 @@
+/*
+  Copyright 2012-2019 MarkLogic Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 'use strict';
+
 declareUpdate();
+
+const ds = require("/data-hub/5/data-services/ds-utils.sjs");
 
 var saveQuery;
 var userCollections = ["http://marklogic.com/data-hub/saved-query"];
 var queryDocument = JSON.parse(saveQuery);
 
 if (queryDocument == null || queryDocument.savedQuery == null) {
-    throw Error("The request is empty or malformed");
+    ds.throwBadRequest("The request is empty or malformed");
 }
 
 if (queryDocument.savedQuery.name == null || !queryDocument.savedQuery.name) {
-    throw Error("Query name is missing");
+    ds.throwBadRequest("Query name is missing");
 }
 
 if (queryDocument.savedQuery.query == null || Object.keys(queryDocument.savedQuery.query) == 0) {
-    throw Error("Query to be saved cannot be empty");
+    ds.throwBadRequest("Query to be saved cannot be empty");
 }
 
 if (queryDocument.savedQuery.propertiesToDisplay == null || queryDocument.savedQuery.propertiesToDisplay.length == 0) {
-    throw Error("Entity type properties to be displayed cannot be empty");
+    ds.throwBadRequest("Entity type properties to be displayed cannot be empty");
 }
 
 let id = queryDocument.savedQuery.id;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/createModel.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/createModel.sjs
@@ -15,6 +15,7 @@
 */
 'use strict';
 
+const ds = require("/data-hub/5/data-services/ds-utils.sjs");
 const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
 
 var input = fn.head(xdmp.fromJSON(input));
@@ -23,7 +24,11 @@ const name = input.name;
 const description = input.description;
 
 if (name == null) {
-  new Error("The model must have an info object with a title property");
+  ds.throwBadRequest("The model must have an info object with a title property");
+}
+
+if (fn.docAvailable(entityLib.getModelUri(name))) {
+  ds.throwBadRequest(`An entity type already exists with a name of ${name}`);
 }
 
 const model = {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/saveModel.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/saveModel.sjs
@@ -15,13 +15,14 @@
 */
 'use strict';
 
+const ds = require("/data-hub/5/data-services/ds-utils.sjs");
 const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
 
 var model = fn.head(xdmp.fromJSON(model));
 
 const name = model.info.title;
 if (name == null) {
-  new Error("The model must have an info object with a title property");
+  ds.throwBadRequest("The model must have an info object with a title property");
 }
 
 entityLib.writeModel(name, model);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelEntityTypes.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelEntityTypes.sjs
@@ -15,6 +15,7 @@
 */
 'use strict';
 
+const ds = require("/data-hub/5/data-services/ds-utils.sjs");
 const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
 
 var name;
@@ -22,7 +23,7 @@ var input = fn.head(xdmp.fromJSON(input));
 
 const uri = entityLib.getModelUri(name);
 if (!fn.docAvailable(uri)) {
-  new Error("Could not find model with name: " + name);
+  ds.throwBadRequest("Could not find model with name: " + name);
 }
 
 const model = cts.doc(uri).toObject();

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelInfo.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelInfo.sjs
@@ -15,6 +15,7 @@
 */
 'use strict';
 
+const ds = require("/data-hub/5/data-services/ds-utils.sjs");
 const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
 
 var name;
@@ -22,13 +23,13 @@ var description;
 
 const uri = entityLib.getModelUri(name);
 if (!fn.docAvailable(uri)) {
-  new Error("Could not find model with name: " + name);
+  ds.throwBadRequest("Could not find model with name: " + name);
 }
 
 const model = cts.doc(uri).toObject();
 
 if (!model.definitions[name]) {
-  new Error("Could not find model with an entity type with name: " + name);
+  ds.throwBadRequest("Could not find model with an entity type with name: " + name);
 }
 
 model.definitions[name].description = description;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepDefinition/getStepDefinition.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepDefinition/getStepDefinition.sjs
@@ -15,6 +15,8 @@
 */
 'use strict';
 
+const ds = require("/data-hub/5/data-services/ds-utils.sjs");
+
 var name;
 var type;
 
@@ -29,5 +31,5 @@ let result = fn.head(fn.subsequence(cts.search(query), 1, 1));
 if (result != undefined) {
   result
 } else {
-  throw Error(`Unable to find a step definition with name ${name} and type ${type}`)
+  ds.throwBadRequest(`Unable to find a step definition with name ${name} and type ${type}`);
 }


### PR DESCRIPTION
Also added new "throwBadRequest" convenience function and updated existing DS endpoints to use this instead of "throw Error" or "new Error". This function returns an error that can then be sent to the UI, as verified by CreateModelMvcTest.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

