### PR TITLE
DHFPROD-4743:Entity table is skewed when the error from XPATH expression is longer

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.module.scss
@@ -52,25 +52,25 @@
 .filterContainer {
     padding: 8px
 }
-.searchInput { 
+.searchInput {
     min-width: 8vw;
     margin-bottom: 8px;
     display: block
 }
-.resetButton { 
+.resetButton {
     width: 90px;
-    margin-right: 8px  
+    margin-right: 8px
 }
 
 .searchSubmitButton {
     width: 90px
 }
 
-.highlightStyle { 
+.highlightStyle {
     background-color: #ffc069;
     padding: 0px
 }
-   
+
 
 .entityContainer{
     width: auto;
@@ -167,7 +167,7 @@ hr {
     margin-bottom: -12px;
 
     >.validationErrors {
-        width: 90%;
+        width: 22vw;
         line-height: normal;
         padding-top: 6px;
         padding-left: 2px;


### PR DESCRIPTION

### Description
Entity table is skewed when the error from XPATH expression is longer. This PR also fixes the issue of 'Type' not displaying fully in entity table. I am not sure if this requires test and if so please provide suggestions as to what kind of tests to add
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

