### PR TITLE
DHFPROD-4235: unit test for fixed header

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
@@ -1,89 +1,43 @@
 import React from 'react';
-import { render, cleanup, fireEvent, getByTestId } from '@testing-library/react';
+import { render, cleanup, fireEvent } from '@testing-library/react';
 import SourceToEntityMap from './source-to-entity-map';
 import data from '../../../../config/data.config';
 import { shallow } from 'enzyme';
 import SplitPane from 'react-split-pane';
 
 describe('RTL Source-to-entity map tests', () => {
-    afterEach(cleanup);
-    test('RTL tests with no source data', () => {
-        const { getByTestId,  getByText, getByRole } = render(<SourceToEntityMap {... {mapData: data.mapProps.mapData, entityTypeTitle : data.mapProps.entityTypeTitle, sourceData: [], extractCollectionFromSrcQuery: jest.fn()}} mappingVisible={true}/>);
-        expect(getByText('Source Data')).toBeInTheDocument();
-        expect(getByText('Test')).toBeDisabled;
-        expect(getByText('Clear')).toBeDisabled;
-        expect(getByTestId("entityContainer")).toBeInTheDocument();
-        expect(getByTestId("srcContainer")).toBeInTheDocument();
-        expect(getByText("Unable to find source documents using the specified collection or query.")).toBeInTheDocument;
-        expect(getByTestId("srcContainer")).toHaveClass("sourceContainer");
-        expect(getByText('Entity: Person')).toBeInTheDocument();
-        expect(getByRole('presentation').className).toEqual("Resizer vertical ");
-    });
+  afterEach(cleanup);
+  test('Verify source data table with no source data', () => {
+      const { getByTestId,  getByText, getByRole } = render(<SourceToEntityMap {...data.mapProps} sourceData={[]} mappingVisible={true}/>);
+      expect(getByText('Source Data')).toBeInTheDocument();
+      expect(getByText('Test')).toBeDisabled;
+      expect(getByText('Clear')).toBeDisabled;
+      expect(getByTestId("entityContainer")).toBeInTheDocument();
+      expect(getByTestId("srcContainer")).toBeInTheDocument();
+      expect(getByText("Unable to find source documents using the specified collection or query.")).toBeInTheDocument;
+      expect(getByTestId("srcContainer")).toHaveClass("sourceContainer");
+      expect(getByText('Entity: Person')).toBeInTheDocument();
+      expect(getByRole('presentation').className).toEqual("Resizer vertical ");
+  });
 
-    test('RTL tests with source data',  () => {
-        const { getByTestId,  getByText,container, queryByText } = render(<SourceToEntityMap {...data.mapProps}  mappingVisible={true}/>);
-        expect(getByText('Source Data')).toBeInTheDocument();
-        expect(getByText('proteinId')).toBeInTheDocument();
-        expect(getByTestId("entityContainer")).toBeInTheDocument();
-        expect(getByTestId("srcContainer")).toBeInTheDocument();
-        expect(getByTestId("srcContainer")).toHaveClass("sourceContainer");
-        expect(getByText('Entity: Person')).toBeInTheDocument();
-        expect(getByText('Test')).toBeEnabled();
-        expect(queryByText("Unable to find source documents using the specified collection or query.")).not.toBeInTheDocument();
-        let exp = getByText('mappedName');
-        expect(exp).toBeInTheDocument();
-        fireEvent.change(exp, { target: {value: "concat(name,'-NEW')" }});
-        fireEvent.blur(exp);
-        fireEvent.click(getByText('Clear'));
-        expect(getByText('Clear')).toBeEnabled();
-        expect(getByText("concat(name,'-NEW')")).toBeInTheDocument();
-        console.log(container);
-    });
-});
-
-describe('Enzyme Source-to-entity map tests', () => {
-    let wrapper: any;
-    beforeEach(() => {
-        wrapper = shallow(<SourceToEntityMap {...data.mapProps} />);
-    });
-
-    test('Enzyme tests with source data', () => {
-        //Use console.log(wrapper.debug()) for debugging the html returned by the wrapper;
-        expect(wrapper.find('#srcContainer').length).toEqual(1);
-        expect(wrapper.find('#srcDetails').length).toEqual(1);
-        expect(wrapper.find('#entityContainer').length).toEqual(1);
-        expect(wrapper.find('#noData').length).toEqual(0);
-        expect(wrapper.find('#dataPresent').length).toEqual(1);
-        //Success and Error message are shown only when a mapping expression is being saved
-        expect(wrapper.find('#successMessage').length).toEqual(0);
-        expect(wrapper.find('#errorMessage').length).toEqual(0);
-        //List and Function icon are displayed only when the entity table loads with entity properties
-        expect(wrapper.find('#listIcon').length).toEqual(0);
-        expect(wrapper.find('#functionIcon').length).toEqual(0);
-        expect(wrapper.find('#Clear-btn').length).toEqual(1);
-        expect(wrapper.find('#Test-btn').length).toEqual(1);
-        expect(wrapper.find('#errorInExp').length).toEqual(0);
-        expect(wrapper.find('#valuesAfterTest').length).toEqual(0);
-        const splitPane = wrapper.find(SplitPane);
-        expect(splitPane).toHaveLength(1);
-        expect(splitPane.prop('split')).toEqual('vertical');
-        expect(splitPane.prop('primary')).toEqual('second');
-        expect(splitPane.prop('allowResize')).toEqual(true);
-        expect(wrapper.find(SplitPane).at(0).find('#srcContainer').length).toEqual(1);
-        expect(wrapper.find(SplitPane).at(0).find('#entityContainer').length).toEqual(1)
-    });
-
-    test('Enzyme tests with no source data', () => {
-        let noDataMessage = "Unable to find source documents using the specified collection or query." +
-            "Load some data that mapping can use as reference and/or edit the step settings to use a " +
-            "source collection or query that will return some results.";
-        wrapper.setProps({sourceData: []} );
-        expect(wrapper.find('#noData').length).toEqual(1);
-        expect(wrapper.find('.emptyText').text().includes(noDataMessage)).toBeTruthy();
-        expect(wrapper.find('#dataPresent').length).toEqual(0);
-        const splitPane = wrapper.find(SplitPane);
-        expect(splitPane).toHaveLength(1);
-    });
+  test('Verify source data table with source data',  () => {
+      const { getByTestId, getByText, queryByText } = render(<SourceToEntityMap {...data.mapProps} mappingVisible={true}/>);
+      expect(getByText('Source Data')).toBeInTheDocument();
+      expect(getByText('proteinId')).toBeInTheDocument();
+      expect(getByTestId("entityContainer")).toBeInTheDocument();
+      expect(getByTestId("srcContainer")).toBeInTheDocument();
+      expect(getByTestId("srcContainer")).toHaveClass("sourceContainer");
+      expect(getByText('Entity: Person')).toBeInTheDocument();
+      expect(getByText('Test')).toBeEnabled();
+      expect(queryByText("Unable to find source documents using the specified collection or query.")).not.toBeInTheDocument();
+      let exp = getByText('mappedName');
+      expect(exp).toBeInTheDocument();
+      fireEvent.change(exp, { target: {value: "concat(name,'-NEW')" }});
+      fireEvent.blur(exp);
+      fireEvent.click(getByText('Clear'));
+      expect(getByText('Clear')).toBeEnabled();
+      expect(getByText("concat(name,'-NEW')")).toBeInTheDocument();
+  });
 
   test('XML source data renders properly',() => {
     const { getByText } = render(<SourceToEntityMap {...data.mapProps} mappingVisible={true}/>);
@@ -97,17 +51,7 @@ describe('Enzyme Source-to-entity map tests', () => {
   });
 
   test('Nested entity data renders properly',() => {
-    let entityTypePropertiesUpdated = [
-        { name: 'propId', type: 'int' },
-        { name: 'propName', type: 'string' },
-        { name: 'items', type: 'parent-ItemType [ ]'},
-        { name: 'items/type', type: 'string'},
-        { name: 'items/category', type: 'parent-catItem'},
-        { name: 'items/category/itemProdCat1', type: 'string'},
-        { name: 'items/category/itemProdCat2', type: 'string'}
-        
-      ]
-    const { getByText,getByTestId,queryByText,getByLabelText,getAllByText } = render(<SourceToEntityMap {...data.mapProps} mappingVisible={true} entityTypeProperties={entityTypePropertiesUpdated}/>);
+    const { getByText, getAllByText } = render(<SourceToEntityMap {...data.mapProps} mappingVisible={true} />);
     expect(getByText('propId')).toBeInTheDocument();
     expect(getByText('propName')).toBeInTheDocument();
     expect(getByText('items')).toBeInTheDocument();
@@ -121,4 +65,58 @@ describe('Enzyme Source-to-entity map tests', () => {
     //fireEvent.click(getByLabelText('icon: down'));
     //expect(queryByText('category')).not.toBeInTheDocument();
   })
+
+  test('Verify source and entity table have fixed header', () => {
+    const { getByText } = render(<SourceToEntityMap {...data.mapProps} mappingVisible={true} />);
+    const dataTable = getByText('proteinId').closest('div');
+    const entityTable = getByText('propId').closest('div');
+
+    expect(dataTable).toHaveAttribute('style', 'overflow-x: scroll; max-height: 60vh; overflow-y: scroll;')
+    expect(entityTable).toHaveAttribute('style', 'overflow-x: scroll; max-height: 60vh; overflow-y: scroll;')
+  })
+});
+
+describe('Enzyme Source-to-entity map tests', () => {
+  let wrapper: any;
+  beforeEach(() => {
+    wrapper = shallow(<SourceToEntityMap {...data.mapProps} />);
+  });
+
+  test('Enzyme tests with source data', () => {
+    //Use console.log(wrapper.debug()) for debugging the html returned by the wrapper;
+    expect(wrapper.find('#srcContainer').length).toEqual(1);
+    expect(wrapper.find('#srcDetails').length).toEqual(1);
+    expect(wrapper.find('#entityContainer').length).toEqual(1);
+    expect(wrapper.find('#noData').length).toEqual(0);
+    expect(wrapper.find('#dataPresent').length).toEqual(1);
+    //Success and Error message are shown only when a mapping expression is being saved
+    expect(wrapper.find('#successMessage').length).toEqual(0);
+    expect(wrapper.find('#errorMessage').length).toEqual(0);
+    //List and Function icon are displayed only when the entity table loads with entity properties
+    expect(wrapper.find('#listIcon').length).toEqual(0);
+    expect(wrapper.find('#functionIcon').length).toEqual(0);
+    expect(wrapper.find('#Clear-btn').length).toEqual(1);
+    expect(wrapper.find('#Test-btn').length).toEqual(1);
+    expect(wrapper.find('#errorInExp').length).toEqual(0);
+    expect(wrapper.find('#valuesAfterTest').length).toEqual(0);
+    const splitPane = wrapper.find(SplitPane);
+    expect(splitPane).toHaveLength(1);
+    expect(splitPane.prop('split')).toEqual('vertical');
+    expect(splitPane.prop('primary')).toEqual('second');
+    expect(splitPane.prop('allowResize')).toEqual(true);
+    expect(wrapper.find(SplitPane).at(0).find('#srcContainer').length).toEqual(1);
+    expect(wrapper.find(SplitPane).at(0).find('#entityContainer').length).toEqual(1)
+  });
+
+  test('Enzyme tests with no source data', () => {
+    let noDataMessage = "Unable to find source documents using the specified collection or query." +
+        "Load some data that mapping can use as reference and/or edit the step settings to use a " +
+        "source collection or query that will return some results.";
+    wrapper.setProps({sourceData: []} );
+    expect(wrapper.find('#noData').length).toEqual(1);
+    expect(wrapper.find('.emptyText').text().includes(noDataMessage)).toBeTruthy();
+    expect(wrapper.find('#dataPresent').length).toEqual(0);
+    const splitPane = wrapper.find(SplitPane);
+    expect(splitPane).toHaveLength(1);
+  });
 });

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
@@ -216,12 +216,10 @@ const SourceToEntityMap = (props) => {
 
     const onOk = () => {
         props.setMappingVisible(false)
-        console.log('Map Saved!')
     }
 
     const onCancel = () => {
         props.setMappingVisible(false)
-        console.log('Map cancelled!')
     }
 
     const convertMapExpToMapArt = (obj, path, val) => { 
@@ -642,7 +640,7 @@ const SourceToEntityMap = (props) => {
                         <Table
                             pagination={false}
                             className={styles.entityTable}
-                            scroll={{  x: 'max-content', y: '60vh' }}
+                            scroll={{ x: 'max-content', y: '60vh' }}
                             expandIcon={(props) => customExpandIcon(props)}
                             indentSize={14}
                             defaultExpandAllRows={true}        

--- a/marklogic-data-hub-central/ui/src/config/data.config.js
+++ b/marklogic-data-hub-central/ui/src/config/data.config.js
@@ -61,17 +61,56 @@ const loadData = {
    
 };
 
+const entityTypeProperties = [
+  { name: 'propId', type: 'int' },
+  { name: 'propName', type: 'string' },
+  { name: 'items', type: 'parent-ItemType [ ]'},
+  { name: 'items/type', type: 'string'},
+  { name: 'items/category', type: 'parent-catItem'},
+  { name: 'items/category/itemProdCat1', type: 'string'},
+  { name: 'items/category/itemProdCat2', type: 'string'},
+  { name: 'entityProp1', type: 'string' },
+  { name: 'entityProp2', type: 'string' },
+  { name: 'entityProp3', type: 'string' },
+  { name: 'entityProp4', type: 'string' },
+  { name: 'entityProp5', type: 'string' },
+  { name: 'entityProp6', type: 'string' },
+  { name: 'entityProp7', type: 'string' },
+  { name: 'entityProp8', type: 'string' },
+  { name: 'entityProp9', type: 'string' },
+  { name: 'entityProp10', type: 'string' },
+  { name: 'entityProp11', type: 'string' },
+  { name: 'entityProp12', type: 'string' },
+  { name: 'entityProp13', type: 'string' },
+  { name: 'entityProp14', type: 'string' },
+  { name: 'entityProp15', type: 'string' },
+  { name: 'entityProp16', type: 'string' } 
+];
+
+const sourceData = [
+  { key: 'proteinId', val: '123EAC' },
+  { key: '@proteinType', val: 'home' },
+  { key: 'nutFree:name', val: 'testName1' },
+  { key: 'sourceProp1', val: '124EAC' },
+  { key: 'sourceProp2', val: '125EAC' },
+  { key: 'sourceProp3', val: '126EAC' },
+  { key: 'sourceProp4', val: '127EAC' },
+  { key: 'sourceProp5', val: '128EAC' },
+  { key: 'sourceProp6', val: '129EAC' },
+  { key: 'sourceProp7', val: '130EAC' },
+  { key: 'sourceProp8', val: '131EAC' },
+  { key: 'sourceProp9', val: '132EAC' },
+  { key: 'sourceProp10', val: '133EAC' },
+  { key: 'sourceProp11', val: '134EAC' },
+  { key: 'sourceProp12', val: '135EAC' },
+  { key: 'sourceProp13', val: '136EAC' },
+  { key: 'sourceProp14', val: '137EAC' },
+  { key: 'sourceProp15', val: '138EAC' },
+  { key: 'sourceProp16', val: '139EAC' },
+];
+
 const mapProps = {
-  sourceData: [
-    { key: 'proteinId', val: '123EAC' },
-    { key: '@proteinType', val: 'home' },
-    { key: 'nutFree:name', val: 'testName1' }
-  ],
-  srcData: [
-    { key: 'proteinId', val: '123EAC' },
-    { key: '@proteinType', val: 'home' },
-    { key: 'nutFree:name', val: 'testName1' }
-  ],
+  sourceData: sourceData,
   sourceURI: '/dummy/mapping/source/uri1.json',
   mapData: {
     name: 'testMap',
@@ -80,8 +119,8 @@ const mapProps = {
     selectedSource: 'collection',
     sourceQuery: "cts.collectionQuery([''])",
     properties: {
-      id: {  sourcedFrom: 'id' },
-      name: { sourcedFrom: 'mappedName' }
+      propId: {  sourcedFrom: 'id' },
+      propName: { sourcedFrom: 'mappedName' }
     }
   },
   namespaces: {
@@ -105,10 +144,7 @@ const mapProps = {
   docNotFound: false,
   entityTypeTitle: 'Person',
   extractCollectionFromSrcQuery: jest.fn(),
-  entityTypeProperties: [
-    { name: 'id', type: 'int' },
-    { name: 'name', type: 'string' }
-  ]
+  entityTypeProperties: entityTypeProperties
 };
 
 const newMap = {


### PR DESCRIPTION
### Description
Includes a test for fixed header verification of entity and source data table. Spent some time to figure out how to better test the scrolling in RTL and ended up writing a simple test which verifies the table style for overflow. This style is enabled only when the tables are scrollable.

Test for individual scroll will be covered in e2e.

Also includes refactoring to existing tests.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

