### PR TITLE
DHFPROD-4818: Fixing cypress e2e to use developer user

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/fixtures/users/developer.json
+++ b/marklogic-data-hub-central/ui/e2e/cypress/fixtures/users/developer.json
@@ -1,0 +1,6 @@
+{
+    "user-name": "dh-dev",
+    "description": "A data hub dev user",
+    "password": "dh-dev",
+    "role": ["data-hub-developer"]
+}

--- a/marklogic-data-hub-central/ui/e2e/cypress/fixtures/users/operator.json
+++ b/marklogic-data-hub-central/ui/e2e/cypress/fixtures/users/operator.json
@@ -1,0 +1,6 @@
+{
+    "user-name": "dh-op",
+    "description": "A data hub operator user",
+    "password": "dh-op",
+    "role": ["data-hub-operator"]
+}

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/authorization.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/authorization.spec.tsx
@@ -39,12 +39,10 @@ describe('login', () => {
   });
 
   it('navigates to /home on seccessful login', () => {
-    cy.fixture('users').then(user => {
-      cy.login(user.username, user.password)
-      .wait(500)
-      .url()
-      .should('include', '/home');
-    })
+    cy.loginAsDeveloper()
+    .wait(500)
+    .url()
+    .should('include', '/home');
   });
 
 });

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/scenarios.json.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/scenarios.json.tsx
@@ -17,9 +17,7 @@ describe('json scenario on view entities page', () => {
   beforeEach(() => {
     cy.visit('/');
     cy.contains('MarkLogic Data Hub');
-    cy.fixture('users').then(user => {
-      cy.login(user.username, user.password);
-    })
+    cy.loginAsDeveloper();
     cy.wait(500);
     homePage.getViewEntities().click();
     //cy.visit('/view');
@@ -55,9 +53,7 @@ describe('json scenario on browse documents page', () => {
   beforeEach(() => {
     cy.visit('/');
     cy.contains('MarkLogic Data Hub');
-    cy.fixture('users').then(user => {
-      cy.login(user.username, user.password);
-    })
+    cy.loginAsDeveloper();
     cy.wait(500);
     homePage.getBrowseEntities().click();
     //cy.visit('/browse');
@@ -116,6 +112,7 @@ describe('json scenario on browse documents page', () => {
     browsePage.getExpandableSnippetView();
     cy.wait(500);
     browsePage.getTotalDocuments().should('be.greaterThan', 1008);
+    browsePage.getShowMoreLink().click();
     browsePage.getFacetItemCheckbox('collection', 'Person').click();
     browsePage.getSelectedFacets().should('exist');
     browsePage.getGreySelectedFacets('Person').should('exist');
@@ -135,6 +132,7 @@ describe('json scenario on browse documents page', () => {
      cy.wait(500);
      browsePage.getHubPropertiesExpanded();
      browsePage.getTotalDocuments().should('be.greaterThan', 1008);
+     browsePage.getShowMoreLink().click();
      browsePage.getFacetItemCheckbox('collection', 'Person').click();
      browsePage.getGreySelectedFacets('Person').click();
      cy.wait(500);
@@ -147,6 +145,7 @@ describe('json scenario on browse documents page', () => {
      cy.wait(500);
      browsePage.getHubPropertiesExpanded();
      browsePage.getTotalDocuments().should('be.greaterThan', 1008);
+     browsePage.getShowMoreLink().click();
      browsePage.getFacetItemCheckbox('collection', 'Person').click();
      browsePage.getFacetItemCheckbox('collection', 'Customer').click();
      browsePage.getGreySelectedFacets('Person').should('exist');
@@ -204,9 +203,7 @@ describe('json scenario for table on browse documents page', () => {
   beforeEach(() => {
     cy.visit('/');
     cy.contains('MarkLogic Data Hub');
-    cy.fixture('users').then(user => {
-      cy.login(user.username, user.password);
-    })
+    cy.loginAsDeveloper();
     cy.wait(500);
     homePage.getBrowseEntities().click();
     //cy.visit('/browse');

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/scenarios.table.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/scenarios.table.tsx
@@ -11,9 +11,7 @@ describe('table test scenarios', () => {
   beforeEach(() => {
     cy.visit('/');
     cy.contains('MarkLogic Data Hub');
-    cy.fixture('users').then(user => {
-      cy.login(user.username, user.password);
-    })
+    cy.loginAsDeveloper();
     cy.wait(500);
     homePage.getBrowseEntities().click();
     //cy.visit('/browse');
@@ -41,9 +39,7 @@ describe('column selector test scenarios', () => {
   beforeEach(() => {
     cy.visit('/');
     cy.contains('MarkLogic Data Hub');
-    cy.fixture('users').then(user => {
-      cy.login(user.username, user.password);
-    })
+    cy.loginAsDeveloper();
     cy.wait(500);
     homePage.getBrowseEntities().click();
     //cy.visit('/browse');

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/scenarios.xml.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/scenarios.xml.tsx
@@ -17,9 +17,7 @@ describe('xml scenario on view entities page', () => {
   beforeEach(() => {
     cy.visit('/');
     cy.contains('MarkLogic Data Hub');
-    cy.fixture('users').then(user => {
-      cy.login(user.username, user.password);
-    })
+    cy.loginAsDeveloper();
     cy.wait(500);
     homePage.getViewEntities().click();
     //cy.visit('/view');
@@ -55,9 +53,7 @@ describe('xml scenario on browse documents page', () => {
   beforeEach(() => {
     cy.visit('/');
     cy.contains('MarkLogic Data Hub');
-    cy.fixture('users').then(user => {
-      cy.login(user.username, user.password);
-    })
+    cy.loginAsDeveloper();
     cy.wait(500);
     homePage.getBrowseEntities().click();
     //cy.visit('/browse');
@@ -202,9 +198,7 @@ describe('xml scenario for table on browse documents page', () => {
   beforeEach(() => {
     cy.visit('/');
     cy.contains('MarkLogic Data Hub');
-    cy.fixture('users').then(user => {
-      cy.login(user.username, user.password);
-    })
+    cy.loginAsDeveloper();
     cy.wait(500);
     //cy.contains('Browse Entities');
     homePage.getBrowseEntities().click();

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/view-entities.validation.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/view-entities.validation.tsx
@@ -12,9 +12,7 @@ describe('view page validation', () => {
   beforeEach(() => {
     cy.visit('/');
     cy.contains('MarkLogic Data Hub');
-    cy.fixture('users').then(user => {
-      cy.login(user.username, user.password);
-    })
+    cy.loginAsDeveloper();
     cy.wait(500);
     homePage.getViewEntities().click();
     //cy.visit('/view');

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/commands.js
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/commands.js
@@ -28,10 +28,22 @@ import LoginPage from '../support/pages/login';
 
 const loginPage = new LoginPage();
 
-Cypress.Commands.add("login", (email, password) => {
-    loginPage.getUsername().type(email)
+Cypress.Commands.add("login", (username, password) => {
+    loginPage.getUsername().type(username)
     loginPage.getPassword().type(password)
-    loginPage.getSubmitButton().click();
+    loginPage.getLoginButton().click();
+})
+
+Cypress.Commands.add('loginAsDeveloper', () => {
+  cy.fixture('users/developer').then(developer => {
+    cy.login(developer['user-name'], developer.password)
+  })
+})
+
+Cypress.Commands.add("loginAsOperator", () => {
+  cy.fixture('users/operator').then(operator => {
+    cy.login(operator['user-name'], operator.password)
+  })
 })
 
 Cypress.on('uncaught:exception', (err, runnable) => {

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/index.js
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/index.js
@@ -1,20 +1,2 @@
-// ***********************************************************
-// This example support/index.js is processed and
-// loaded automatically before your test files.
-//
-// This is a great place to put global configuration and
-// behavior that modifies Cypress.
-//
-// You can change the location of this file or turn off
-// automatically serving support files with the
-// 'supportFile' configuration option.
-//
-// You can read more here:
-// https://on.cypress.io/configuration
-// ***********************************************************
-
-// Import commands.js using ES2015 syntax:
+//import '@testing-library/cypress/add-commands'
 import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/login.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/login.tsx
@@ -20,7 +20,7 @@ class LoginPage {
         return cy.get('#password');  
     }
 
-    getSubmitButton() {
+    getLoginButton() {
         return cy.get('#submit'); 
     }
 }

--- a/marklogic-data-hub-central/ui/e2e/setup.sh
+++ b/marklogic-data-hub-central/ui/e2e/setup.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 set e+x
 
+credentials='-PmlUsername=dh-dev -PmlPassword=dh-dev'
 cd qa-project
 
 ./gradlew hubInit
+cp ../cypress/fixtures/users/* src/main/ml-config/security/users/
 ./gradlew mlDeploy --info
 ./gradlew hubSaveIndexes --info
-./gradlew hubDeployAsDeveloper --info
+./gradlew hubDeployAsDeveloper $credentials --info
 
-./gradlew hubRunFlow -PflowName=AdvantageFlow -PentityName=Customer -PbatchSize=100 -PthreadCount=4 -Psteps="1,2"
-./gradlew hubRunFlow -PflowName=PersonFlow -PentityName=Person -PbatchSize=100 -PthreadCount=4 -Psteps="1,2"
-./gradlew hubRunFlow -PflowName=PersonXMLFlow -PentityName=PersonXML -PbatchSize=100 -PthreadCount=4 -Psteps="1,2"
+
+./gradlew hubRunFlow $credentials -PflowName=AdvantageFlow -PentityName=Customer -PbatchSize=100 -PthreadCount=4 -Psteps="1,2"
+./gradlew hubRunFlow $credentials -PflowName=PersonFlow -PentityName=Person -PbatchSize=100 -PthreadCount=4 -Psteps="1,2"
+./gradlew hubRunFlow $credentials -PflowName=PersonXMLFlow -PentityName=PersonXML -PbatchSize=100 -PthreadCount=4 -Psteps="1,2"


### PR DESCRIPTION
### Description
Updated e2e test fixtures to include developer and operator user. Added custom commands to cypress.

e2e qa-project will now create these test users while mlDeploy and run the flows as data-hub-developer

FYI @SameeraPriyathamTadikonda, just in case there are any changes required to the pipeline.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

