### PR TITLE
DHFPROD-3992: Fixing nightly tests, using JS syntax that works on 9.0-12

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadHubModulesCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadHubModulesCommand.java
@@ -108,7 +108,7 @@ public class LoadHubModulesCommand extends AbstractCommand {
             // When running tests, the config.sjs/config.xqy modules are somehow being loaded twice - they're logged at
             // the beginning and at the end of the modules being loaded. Without a batch size set, they're loaded in one
             // transaction, causing a conflicting updates error.
-            loader.setBatchSize(10);
+            loader.setBatchSize(1);
         }
 
         JarDocumentFileReader jarDocumentFileReader = new JarDocumentFileReader();

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/core.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/core.sjs
@@ -356,7 +356,9 @@ function getFullFlow(flowName, artifactVersion = 'latest') {
 }
 
 function createFullFlow(flowName, flowNode){
-  for (let [key, stepValue] of Object.entries(flowNode["steps"])) {
+  const steps = flowNode["steps"];
+  Object.keys(steps).forEach(key => {
+    let stepValue = steps[key];
     let artifactInStepType = stepValue['stepDefinitionType'].toLowerCase() === "ingestion" ? "loadData" : stepValue['stepDefinitionType'].toLowerCase();
     if(stepValue.options[artifactInStepType]){
       let artifactInStep =  stepValue.options[artifactInStepType].name;
@@ -377,9 +379,10 @@ function createFullFlow(flowName, flowNode){
         }
       }
     }
-  }
+  });
   return flowNode;
 }
+
 //TODO: Add 'processors' to step once it is known where they will go into (artifact or settings)
 function addToStep(artifactInStepType, stepValue, artifactNode,  settingsNode){
   if(artifactInStepType === 'loadData') {

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/fullcycle/SslTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/fullcycle/SslTest.groovy
@@ -64,13 +64,13 @@ class SslTest extends BaseTest {
                     gtcc.setTemplateIdOrName("admin-cert");
                     gtcc.setCommonName("localhost");
                     gtcc.execute(new com.marklogic.appdeployer.command.CommandContext(getAppConfig(), manageClient, adminManager));
-                    
+
                     def command = new com.marklogic.appdeployer.command.security.GenerateTemporaryCertificateCommand()
                     command.setTemplateIdOrName("dhf-cert")
                     command.setCommonName("localhost")
                     command.setValidFor(365)
                     command.execute(new com.marklogic.appdeployer.command.CommandContext(getAppConfig(), manageClient, adminManager));
-                    
+
                     adminConfig = getProject().property("mlAdminConfig")
                     adminConfig.setScheme("https")
                     adminConfig.setConfigureSimpleSsl(true)
@@ -216,7 +216,7 @@ class SslTest extends BaseTest {
     def "runHarmonizeFlow with default src and dest"() {
         given:
         println(runTask('hubCreateHarmonizeFlow', '-PentityName=my-new-entity', '-PflowName=my-new-harmonize-flow', '-PdataFormat=xml', '-PpluginFormat=xqy', '-PuseES=false').getOutput())
-        println(runTask('mlReLoadModules'))
+        println(runTask('hubDeployUserModules'))
 
         def newSslContext = SSLContext.getInstance("TLSv1.2")
         newSslContext.init(null, [new SimpleX509TrustManager()] as TrustManager[], null)
@@ -252,7 +252,7 @@ class SslTest extends BaseTest {
     def "runHarmonizeFlow with swapped src and dest"() {
         given:
         println(runTask('hubCreateHarmonizeFlow', '-PentityName=my-new-entity', '-PflowName=my-new-harmonize-flow', '-PdataFormat=xml', '-PpluginFormat=xqy', '-PuseES=false').getOutput())
-        println(runTask('mlReLoadModules'))
+        println(runTask('hubDeployUserModules'))
 
         def newSslContext = SSLContext.getInstance("TLSv1.2")
         newSslContext.init(null, [new SimpleX509TrustManager()] as TrustManager[], null)

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/fullcycle/TlsTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/fullcycle/TlsTest.groovy
@@ -33,7 +33,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 
 class TlsTest extends BaseTest {
-    
+
     def setupSpec() {
         createFullPropertiesFile()
         BaseTest.buildFile = BaseTest.testProjectDir.newFile('build.gradle')
@@ -69,7 +69,7 @@ class TlsTest extends BaseTest {
                     command.setCommonName("localhost")
                     command.setValidFor(365)
                     command.execute(new com.marklogic.appdeployer.command.CommandContext(getAppConfig(), manageClient, adminManager));
-                    
+
                     adminConfig = getProject().property("mlAdminConfig")
                     adminConfig.setScheme("https")
                     adminConfig.setConfigureSimpleSsl(true)
@@ -195,7 +195,7 @@ class TlsTest extends BaseTest {
                     stagingSslContext = newSslContext
                     stagingSslHostnameVerifier = DatabaseClientFactory.SSLHostnameVerifier.ANY
                     stagingTrustManager = new SimpleX509TrustManager()
-                     
+
                     finalSslContext = newSslContext
                     finalSslHostnameVerifier = DatabaseClientFactory.SSLHostnameVerifier.ANY
                     finalTrustManager = new SimpleX509TrustManager()
@@ -220,14 +220,14 @@ class TlsTest extends BaseTest {
             new File("src/test/resources/tls-test/ssl-server.json"))
         writeSSLFiles(new File(BaseTest.testProjectDir.root, "src/main/hub-internal-config/servers/staging-server.json"),
             new File("src/test/resources/tls-test/ssl-server.json"))
-       
+
         createProperties()
         result = runTask("enableSSL")
         print(result.output)
         hubConfig().refreshProject()
     }
 
-    
+
     def cleanupSpec() {
         runTask("mlUndeploy", "-Pconfirm=true")
         runTask("hubDeploySecurity")
@@ -251,7 +251,7 @@ class TlsTest extends BaseTest {
         """
     }
 
-    
+
     def "bootstrap a project with ssl out the wazoo"() {
         when:
         def result = runTask('mlDeploy', '-i')
@@ -260,7 +260,7 @@ class TlsTest extends BaseTest {
         hubConfig().stagingSslContext = newSslContext
         hubConfig().stagingSslHostnameVerifier = DatabaseClientFactory.SSLHostnameVerifier.ANY
         hubConfig().stagingTrustManager = new SimpleX509TrustManager()
-        
+
         hubConfig().finalSslContext = newSslContext
         hubConfig().finalSslHostnameVerifier = DatabaseClientFactory.SSLHostnameVerifier.ANY
         hubConfig().finalTrustManager = new SimpleX509TrustManager()
@@ -274,16 +274,16 @@ class TlsTest extends BaseTest {
         result.task(":mlDeploy").outcome == SUCCESS
     }
 
-    
+
     def "runHarmonizeFlow with default src and dest"() {
         given:
         println(runTask('hubCreateHarmonizeFlow', '-PentityName=my-new-entity', '-PflowName=my-new-harmonize-flow', '-PdataFormat=xml', '-PpluginFormat=xqy', '-PuseES=false').getOutput())
-        println(runTask('mlReLoadModules'))
+        println(runTask('hubDeployUserModules'))
         def newSslContext = SSLContext.getInstance("TLSv1.2")
         newSslContext.init(null, [new SimpleX509TrustManager()] as TrustManager[], null)
         hubConfig().stagingSslContext = newSslContext
         hubConfig().stagingSslHostnameVerifier = DatabaseClientFactory.SSLHostnameVerifier.ANY
-        
+
         hubConfig().finalSslContext = newSslContext
         hubConfig().finalSslHostnameVerifier = DatabaseClientFactory.SSLHostnameVerifier.ANY
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME)
@@ -311,11 +311,11 @@ class TlsTest extends BaseTest {
         assertXMLEqual(getXmlFromResource("run-flow-test/harmonized2.xml"), hubConfig().newFinalClient().newDocumentManager().read("/employee2.xml").next().getContent(new DOMHandle()).get())
     }
 
-    
+
     def "runHarmonizeFlow with swapped src and dest"() {
         given:
         println(runTask('hubCreateHarmonizeFlow', '-PentityName=my-new-entity', '-PflowName=my-new-harmonize-flow', '-PdataFormat=xml', '-PpluginFormat=xqy', '-PuseES=false').getOutput())
-        println(runTask('mlReLoadModules'))
+        println(runTask('hubDeployUserModules'))
         def newSslContext = SSLContext.getInstance("TLSv1.2")
         newSslContext.init(null, [new SimpleX509TrustManager()] as TrustManager[], null)
         hubConfig().stagingSslContext = newSslContext

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/BaseTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/BaseTest.groovy
@@ -138,7 +138,7 @@ class BaseTest extends Specification {
             for $database in fn:tokenize($databases, ",")
              return
                xdmp:eval(
-                 'cts:uris((),(),cts:not-query(cts:collection-query(\"http://marklogic.com/provenance-services/record\"))) ! xdmp:document-delete(.)',
+                 'cts:uris((),(),cts:not-query(cts:collection-query((\"http://marklogic.com/provenance-services/record\", "hub-core-artifact")))) ! xdmp:document-delete(.)',
                  (),
                  map:entry("database", xdmp:database($database))
                )

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/ExportLegacyJobsTaskTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/ExportLegacyJobsTaskTest.groovy
@@ -32,19 +32,15 @@ class ExportLegacyJobsTaskTest extends BaseTest {
     def setupSpec() {
         createGradleFiles()
         runTask('hubInit')
-        // this will be relatively fast (idempotent) for already-installed hubs
-        println(runTask('hubInstallModules', '-i').getOutput())
-        println(runTask('mlLoadModules', '-i').getOutput())
 
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME)
         DocumentMetadataHandle meta = new DocumentMetadataHandle();
         meta.getCollections().add("test-entity");
         installStagingDoc("/employee1.xml", meta, new File("src/test/resources/run-flow-test/employee1.xml").text)
         installStagingDoc("/employee2.xml", meta, new File("src/test/resources/run-flow-test/employee2.xml").text)
-        println(runTask('mlReLoadModules'))
 
         println(runTask('hubCreateHarmonizeFlow', '-PentityName=test-entity', '-PflowName=test-harmonize-flow', '-PdataFormat=xml', '-PpluginFormat=xqy', '-PuseES=false').getOutput())
-        println(runTask('mlReLoadModules'))
+        println(runTask('hubDeployUserModules'))
 
         installModule("/entities/my-new-entity/harmonize/my-new-harmonize-flow/content/content.xqy", "run-flow-test/content.xqy")
 

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/HubUpdateTaskTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/HubUpdateTaskTest.groovy
@@ -27,9 +27,6 @@ class HubUpdateTaskTest extends BaseTest {
     def setupSpec() {
         createGradleFiles()
         runTask('hubInit')
-        // this will be relatively fast (idempotent) for already-installed hubs
-        println(runTask('hubInstallModules', '-i').getOutput())
-        println(runTask('mlLoadModules', '-i').getOutput())
     }
 
     //if 4.0 project is upgraded, remove the backed up directories

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/JobDeleteTaskTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/JobDeleteTaskTest.groovy
@@ -39,7 +39,7 @@ class JobDeleteTaskTest extends BaseTest {
         new DatabaseManager(hubConfig().getManageClient()).clearDatabase(HubConfig.DEFAULT_JOB_NAME)
 
         println(runTask('hubCreateHarmonizeFlow', '-PentityName=test-entity', '-PflowName=test-harmonize-flow', '-PdataFormat=xml', '-PpluginFormat=xqy', '-PuseES=false').getOutput())
-        println(runTask('mlReLoadModules'))
+        println(runTask('hubDeployUserModules'))
 
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME, HubConfig.DEFAULT_JOB_NAME)
         DocumentMetadataHandle meta = new DocumentMetadataHandle();

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/ManualMergeUnmergeTaskTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/ManualMergeUnmergeTaskTest.groovy
@@ -22,7 +22,8 @@ class ManualMergeUnmergeTaskTest extends BaseTest{
         copyResourceToFile("master-test/person-1-2.json", Paths.get(testProjectDir.root.toString(),"input","person-1-2.json").toFile())
         copyResourceToFile("master-test/person-1.mapping.json", Paths.get(testProjectDir.root.toString(),"mappings","person","person-1.mapping.json").toFile())
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME, HubConfig.DEFAULT_JOB_NAME);
-        runTask('mlLoadModules')
+        runTask('hubDeployUserArtifacts')
+        runTask('hubDeployUserModules')
     }
 
     def setup() {

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/UpdateIndexesTaskTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/UpdateIndexesTaskTest.groovy
@@ -49,9 +49,10 @@ class UpdateIndexesTaskTest extends BaseTest {
 		String entityStream = new File("src/test/resources/update-indexes/my-unique-order-entity.entity.json").getAbsolutePath()
 		Files.copy(new File(entityStream).toPath(), entityDir.toPath().resolve("my-unique-order-entity.entity.json"), StandardCopyOption.REPLACE_EXISTING)
 
-		// Loading modules to databases
-		runTask('mlLoadModules')
+		runTask('hubDeployUserArtifacts')
+        Thread.sleep(1000)
         runTask('hubSaveIndexes')
+        Thread.sleep(1000)
 
 		// Copying Job database Index info files to src/main/entity-config dir
 		Path dir = hubConfig().getEntityDatabaseDir()
@@ -81,8 +82,6 @@ class UpdateIndexesTaskTest extends BaseTest {
     @IgnoreIf({ System.getProperty('mlIsProvisionedEnvironment') })
 	def "test to deploy indexes to STAGING/FINAL/JOBS Database"() {
 		given:
-        //existing staging and final indexes are from core tests and they get replaced when mlUpdateIndexes is run, so we dont need their count
-		int jobIndexCount = getJobsIndexValuesSize('//m:range-path-index')
 
 		when:
 		def result = runTask('mlUpdateIndexes')
@@ -94,11 +93,9 @@ class UpdateIndexesTaskTest extends BaseTest {
         //Test to verify range-path-index for mlUpdateIndex
 		assert (getStagingIndexValuesSize('//m:range-path-index') == 3)
 		assert (getFinalIndexValuesSize('//m:range-path-index') == 3)
-		assert (getJobsIndexValuesSize('//m:range-path-index') == jobIndexCount+1)
 
         //Test to verify xml DB index configs get updated per DHFPROD-3674
         assert (getStagingIndexValuesSize('//m:field') == 6)
         assert (getFinalIndexValuesSize('//m:field') == 6)
-        assert (getJobsIndexValuesSize('//m:field') == 3)
 	}
 }


### PR DESCRIPTION
Undoing the change to defaulting the LHMC batchSize to 10. For some reason, this fails once or twice for tests that do load modules. It seems that a "gradle clean" that's run before "gradle bootstrap" avoids the issue of config.sjs/config.xqy being found twice on the classpath.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

