### PR TITLE
DHFPROD-4720: Restoring spring-integration dependency

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     }
 
     compile group: 'org.springframework.boot', name: 'spring-boot', version: '2.1.3.RELEASE'
+    compile group: 'org.springframework.integration', name: 'spring-integration-http', version: '5.1.3.RELEASE'
     compile group: 'org.springframework.boot', name: 'spring-boot-autoconfigure', version: '2.1.3.RELEASE'
 
     compile 'com.marklogic:mlcp-util:0.9.0'


### PR DESCRIPTION
While DH doesn't depend on spring-integration, I found that removing this dependency results in the published DH Gradle plugin no longer working - a classpath conflict occurs. So the spring-integration dependency is bring along some other needed dependency that overrides an older version, thus allowing DH to work correctly. This makes me very sad, but I'm restoring this dependency for now and will figure out the mess later, as there's no reason for DH to be depending on spring-integration otherwise.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

