### PR TITLE
DHFPROD-4841: Add hubProjectPath info to README

### DIFF
--- a/marklogic-data-hub-central/README.md
+++ b/marklogic-data-hub-central/README.md
@@ -78,6 +78,10 @@ If you are connecting to a remote Data Hub instance, you can override mlHost to 
 
     ./gradlew bootRun -PmlHost=somehost
 
+To associate the middle tier with a specific Data Hub project in your local environment, use the following:
+
+    ./gradlew bootRun -PhubProjectPath=pathToLocalProject
+
 Once you have Hub Central running, you'll see the logging indicating that it is listening on port 8080. This is 
 configured via the server.port property in src/main/resources/application.properties . 
 


### PR DESCRIPTION
### Description

This bootRun option was necessary for me to get my local environment running. This information can be removed when it is no longer relevant, as @rjrudin explained will eventually be the case.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [ ] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [ ] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests

