### PR TITLE
DHFPROD-4709: Show correct source format for Load steps in flow

### DIFF
--- a/marklogic-data-hub-central/ui/src/config/bench.config.ts
+++ b/marklogic-data-hub-central/ui/src/config/bench.config.ts
@@ -216,41 +216,6 @@ const jobRespSuccess = {
   "status": 200
 };
 
-const flowsJSON = {
-  "data": [{
-    "name": "testFlow",
-    "description": "",
-    "batchSize": 100,
-    "threadCount": 4,
-    "stopOnError": false,
-    "options": {},
-    "version": 0,
-    "steps": {
-      "1": {
-        "name": "loadJSON",
-        "description": "",
-        "options": {
-          "sourceQuery": null,
-          "collections": ["loadJSON"],
-          "loadData": {
-            "name": "loadJSON"
-          },
-          "outputFormat": "json",
-          "targetDatabase": "data-hub-STAGING"
-        },
-        "customHook": {},
-        "retryLimit": 0,
-        "batchSize": 0,
-        "threadCount": 0,
-        "stepDefinitionName": "default-ingestion",
-        "stepDefinitionType": "INGESTION"
-      }
-    }
-  }]
-  ,
-  "status" :200
-}
-
 const flowsXML = {
   "data": [{
     "name": "testFlow",
@@ -270,7 +235,6 @@ const flowsXML = {
           "loadData": {
             "name": "loadXML"
           },
-          "outputFormat": "json",
           "targetDatabase": "data-hub-STAGING"
         },
         "customHook": {},
@@ -285,21 +249,6 @@ const flowsXML = {
   ,
   "status" :200
 }
-
-const loadsJSON = {"data" :
-    [{
-      "name": "loadJSON",
-      "description": "",
-      "sourceFormat": "json",
-      "targetFormat": "json",
-      "outputURIReplacement": "",
-      "inputFilePath": "/xml-test/data-sets/failedIngest",
-      "lastUpdated": "2020-04-02T23:08:28.287065-07:00",
-      "fileCount": 1,
-      "filesNeedReuploaded": false
-    }],
-  "status" :200
-};
 
 const loadsXML = {"data" :
     [{
@@ -326,9 +275,7 @@ const data = {
     jobRespFailedWithError: jobRespFailedWithError,
     jobRespFailed: jobRespFailed,
     jobRespSuccess: jobRespSuccess,
-    flowsJSON: flowsJSON,
     flowsXML: flowsXML,
-    loadsJSON: loadsJSON,
     loadsXML: loadsXML
 };
 

--- a/marklogic-data-hub-central/ui/src/config/bench.config.ts
+++ b/marklogic-data-hub-central/ui/src/config/bench.config.ts
@@ -216,6 +216,106 @@ const jobRespSuccess = {
   "status": 200
 };
 
+const flowsJSON = {
+  "data": [{
+    "name": "testFlow",
+    "description": "",
+    "batchSize": 100,
+    "threadCount": 4,
+    "stopOnError": false,
+    "options": {},
+    "version": 0,
+    "steps": {
+      "1": {
+        "name": "loadJSON",
+        "description": "",
+        "options": {
+          "sourceQuery": null,
+          "collections": ["loadJSON"],
+          "loadData": {
+            "name": "loadJSON"
+          },
+          "outputFormat": "json",
+          "targetDatabase": "data-hub-STAGING"
+        },
+        "customHook": {},
+        "retryLimit": 0,
+        "batchSize": 0,
+        "threadCount": 0,
+        "stepDefinitionName": "default-ingestion",
+        "stepDefinitionType": "INGESTION"
+      }
+    }
+  }]
+  ,
+  "status" :200
+}
+
+const flowsXML = {
+  "data": [{
+    "name": "testFlow",
+    "description": "",
+    "batchSize": 100,
+    "threadCount": 4,
+    "stopOnError": false,
+    "options": {},
+    "version": 0,
+    "steps": {
+      "1": {
+        "name": "loadXML",
+        "description": "",
+        "options": {
+          "sourceQuery": null,
+          "collections": ["loadXML"],
+          "loadData": {
+            "name": "loadXML"
+          },
+          "outputFormat": "json",
+          "targetDatabase": "data-hub-STAGING"
+        },
+        "customHook": {},
+        "retryLimit": 0,
+        "batchSize": 0,
+        "threadCount": 0,
+        "stepDefinitionName": "default-ingestion",
+        "stepDefinitionType": "INGESTION"
+      }
+    }
+  }]
+  ,
+  "status" :200
+}
+
+const loadsJSON = {"data" :
+    [{
+      "name": "loadJSON",
+      "description": "",
+      "sourceFormat": "json",
+      "targetFormat": "json",
+      "outputURIReplacement": "",
+      "inputFilePath": "/xml-test/data-sets/failedIngest",
+      "lastUpdated": "2020-04-02T23:08:28.287065-07:00",
+      "fileCount": 1,
+      "filesNeedReuploaded": false
+    }],
+  "status" :200
+};
+
+const loadsXML = {"data" :
+    [{
+      "name": "loadXML",
+      "description": "",
+      "sourceFormat": "xml",
+      "targetFormat": "xml",
+      "outputURIReplacement": "",
+      "inputFilePath": "/xml-test/data-sets/failedIngest",
+      "lastUpdated": "2020-04-02T23:08:28.287065-07:00",
+      "fileCount": 1,
+      "filesNeedReuploaded": false
+    }],
+  "status" :200
+};
+
 const data = {
     flows: flows,
     flowsWithMapping: flowsWithMapping,
@@ -225,7 +325,11 @@ const data = {
     mappings: mappings,
     jobRespFailedWithError: jobRespFailedWithError,
     jobRespFailed: jobRespFailed,
-    jobRespSuccess: jobRespSuccess
+    jobRespSuccess: jobRespSuccess,
+    flowsJSON: flowsJSON,
+    flowsXML: flowsXML,
+    loadsJSON: loadsJSON,
+    loadsXML: loadsXML
 };
 
 export default data;

--- a/marklogic-data-hub-central/ui/src/pages/Bench.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Bench.test.tsx
@@ -169,28 +169,6 @@ describe('Verify step display', () => {
         cleanup();
     });
 
-    test('Verify a load step with JSON source is displayed correctly', async () => {
-        axiosMock.get['mockImplementation']((url) => {
-            switch (url) {
-                case '/api/flows':
-                    return Promise.resolve(data.flowsJSON)
-                case '/api/artifacts/loadData':
-                    return Promise.resolve(data.loadsJSON)
-                case '/api/artifacts/mapping':
-                    return Promise.resolve(data.mappings)
-                default:
-                    return Promise.reject(new Error('not found'))
-            }
-        })
-        const { getByText, getByLabelText } = await render(<RolesContext.Provider value={ mockDevRolesService }><Bench/></RolesContext.Provider>);
-        
-        // Click disclosure icon
-        fireEvent.click(getByLabelText("icon: right"));
-        expect(await(waitForElement(() => getByText("JSON")))).toBeInTheDocument();
-        expect(await(waitForElement(() => getByText("loadJSON")))).toBeInTheDocument();
-
-    })
-
     test('Verify a load step with XML source is displayed correctly', async () => {
         axiosMock.get['mockImplementation']((url) => {
             switch (url) {

--- a/marklogic-data-hub-central/ui/src/pages/Bench.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Bench.test.tsx
@@ -161,3 +161,56 @@ describe('Verify step running', () => {
     })
 
 });
+
+describe('Verify step display', () => {
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        cleanup();
+    });
+
+    test('Verify a load step with JSON source is displayed correctly', async () => {
+        axiosMock.get['mockImplementation']((url) => {
+            switch (url) {
+                case '/api/flows':
+                    return Promise.resolve(data.flowsJSON)
+                case '/api/artifacts/loadData':
+                    return Promise.resolve(data.loadsJSON)
+                case '/api/artifacts/mapping':
+                    return Promise.resolve(data.mappings)
+                default:
+                    return Promise.reject(new Error('not found'))
+            }
+        })
+        const { getByText, getByLabelText } = await render(<RolesContext.Provider value={ mockDevRolesService }><Bench/></RolesContext.Provider>);
+        
+        // Click disclosure icon
+        fireEvent.click(getByLabelText("icon: right"));
+        expect(await(waitForElement(() => getByText("JSON")))).toBeInTheDocument();
+        expect(await(waitForElement(() => getByText("loadJSON")))).toBeInTheDocument();
+
+    })
+
+    test('Verify a load step with XML source is displayed correctly', async () => {
+        axiosMock.get['mockImplementation']((url) => {
+            switch (url) {
+                case '/api/flows':
+                    return Promise.resolve(data.flowsXML)
+                case '/api/artifacts/loadData':
+                    return Promise.resolve(data.loadsXML)
+                case '/api/artifacts/mapping':
+                    return Promise.resolve(data.mappings)
+                default:
+                    return Promise.reject(new Error('not found'))
+            }
+        })
+        const { getByText, getByLabelText } = await render(<RolesContext.Provider value={ mockDevRolesService }><Bench/></RolesContext.Provider>);
+        
+        // Click disclosure icon
+        fireEvent.click(getByLabelText("icon: right"));
+        expect(await(waitForElement(() => getByText("XML")))).toBeInTheDocument();
+        expect(await(waitForElement(() => getByText("loadXML")))).toBeInTheDocument();
+
+    })
+
+});


### PR DESCRIPTION
### Description

Source format now correctly displayed in flow steps:

<img width="1292" alt="Screen Shot 2020-04-27 at 11 58 28 AM" src="https://user-images.githubusercontent.com/477757/80409922-8a8d6300-887e-11ea-86bf-8444df0c070d.png">

The fix was actually added with this:

https://github.com/marklogic/marklogic-data-hub/pull/3876

This commit adds tests for default (JSON) and non-default (XML) steps.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

