### PR TITLE
DHFPROD-4189:Use 'lastIndexOf' to get xpath key

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
@@ -710,7 +710,7 @@ const SourceToEntityMap = (props) => {
             }
             if(element.children) {
                 flattenSourceDoc(element.children, flatArray, flatArrayKey);
-                flatArrayKey = (flatArrayKey.indexOf("/")==-1)?'':flatArrayKey.substring(0,flatArrayKey.indexOf("/"))
+                flatArrayKey = (flatArrayKey.indexOf("/")==-1)?'':flatArrayKey.substring(0,flatArrayKey.lastIndexOf("/"))
             }
         })
         return flatArray;


### PR DESCRIPTION
### Description
In my last PR for DHFPROD-4189, I changed 'lastIndexOf' to 'indexOf'. Fixing it.
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

