### PR TITLE
DHFPROD-4880: Using the Java Client for collecting URIs

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/HubClient.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/HubClient.java
@@ -17,7 +17,6 @@ package com.marklogic.hub;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.mgmt.ManageClient;
-import org.springframework.web.client.RestTemplate;
 
 public interface HubClient {
 
@@ -33,13 +32,6 @@ public interface HubClient {
     DatabaseClient getJobsClient();
 
     String getDbName(DatabaseKind kind);
-
-    /**
-     * This is needed by the CollectorImpl class, which is not yet able to use a DatabaseClient.
-     *
-     * @return
-     */
-    RestTemplate getStagingRestTemplate();
 
     /**
      * Needed for operations that happen outside of a deployment, such as clearing user data or updating indexes.

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/collector/impl/CollectorImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/collector/impl/CollectorImpl.java
@@ -17,42 +17,16 @@ package com.marklogic.hub.collector.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.DatabaseClientFactory;
-import com.marklogic.client.DatabaseClientFactory.SSLHostnameVerifier;
-import com.marklogic.client.MarkLogicIOException;
 import com.marklogic.hub.HubClient;
 import com.marklogic.hub.collector.Collector;
 import com.marklogic.hub.collector.DiskQueue;
-import com.marklogic.rest.util.MgmtResponseErrorHandler;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.HttpClient;
-import org.apache.http.conn.ssl.X509HostnameVerifier;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.web.client.RequestCallback;
-import org.springframework.web.client.ResponseExtractor;
-import org.springframework.web.client.RestTemplate;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
-import javax.naming.ldap.Rdn;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.SSLSocket;
 import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.URI;
 import java.net.URLEncoder;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateParsingException;
-import java.security.cert.X509Certificate;
-import java.util.*;
+import java.util.Map;
 
 public class CollectorImpl implements Collector {
 
@@ -75,18 +49,11 @@ public class CollectorImpl implements Collector {
         try {
             DiskQueue<String> results = new DiskQueue<>(5000);
 
-            // Important design info:
-            // The collector is invoked with a regular http client due to streaming limitations in OkHttp.
-            // https://github.com/marklogic/marklogic-data-hub/issues/632
-            // https://github.com/marklogic/marklogic-data-hub/issues/633
-            //
             String uriString = String.format(
-                "%s://%s:%d%s?flow-name=%s&database=%s&step=%s",
+                "%s://%s:%d/v1/internal/hubcollector5?flow-name=%s&database=%s&step=%s",
                 stagingClient.getSecurityContext().getSSLContext() != null ? "https" : "http",
                 stagingClient.getHost(),
                 stagingClient.getPort(),
-                "/v1/internal/hubcollector5",
-
                 URLEncoder.encode(flow, "UTF-8"),
                 URLEncoder.encode(this.sourceDatabase, "UTF-8"),
                 URLEncoder.encode(step, "UTF-8")
@@ -96,147 +63,23 @@ public class CollectorImpl implements Collector {
                 uriString += "&options=" + URLEncoder.encode(objectMapper.writeValueAsString(options), "UTF-8");
             }
 
-            URI uri = new URI(uriString);
+            /**
+             * The underlying OkHttpClient is used for performance reasons, as trying to invoke a REST extension or
+             * invoking /v1/eval results in far worse performance. See the comments in DHFPROD-4533 for more information.
+             */
+            OkHttpClient ok = (OkHttpClient) stagingClient.getClientImplementation();
+            Request request = new Request.Builder().url(uriString).get().build();
+            Response response = ok.newCall(request).execute();
 
-            RequestCallback requestCallback = request -> request.getHeaders()
-                .setAccept(Arrays.asList(MediaType.APPLICATION_OCTET_STREAM, MediaType.ALL));
-
-            // Streams the response instead of loading it all in memory
-            ResponseExtractor<Void> responseExtractor = response -> {
-                BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response.getBody(), "UTF-8"));
+            try (BufferedReader reader = new BufferedReader(response.body().charStream())) {
                 String line;
-                while ((line = bufferedReader.readLine()) != null) {
+                while ((line = reader.readLine()) != null) {
                     results.add(line);
                 }
-                bufferedReader.close();
-                return null;
-            };
-
-            hubClient.getStagingRestTemplate().execute(uri, HttpMethod.GET, requestCallback, responseExtractor);
-
+            }
             return results;
         } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
-    }
-
-    public static RestTemplate newRestTemplate(DatabaseClient collectorClient, String username, String password) {
-        DatabaseClientFactory.SecurityContext securityContext = collectorClient.getSecurityContext();
-
-        BasicCredentialsProvider prov = new BasicCredentialsProvider();
-        prov.setCredentials(
-            new AuthScope(collectorClient.getHost(), collectorClient.getPort(), AuthScope.ANY_REALM),
-            new UsernamePasswordCredentials(username, password));
-
-        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create().setDefaultCredentialsProvider(prov);
-
-        if (securityContext != null) {
-            SSLContext sslContext = securityContext.getSSLContext();
-            if (sslContext != null) {
-                httpClientBuilder.setSslcontext(sslContext);
-            }
-
-            SSLHostnameVerifier verifier = securityContext.getSSLHostnameVerifier();
-            X509HostnameVerifier hostnameVerifier = null;
-            if (verifier == SSLHostnameVerifier.ANY) {
-                hostnameVerifier = new X509HostnameVerifier() {
-                    @Override
-                    public boolean verify(String paramString, SSLSession paramSSLSession) {
-                        return true;
-                    }
-
-                    @Override
-                    public void verify(String host, SSLSocket ssl) throws IOException {
-                    }
-
-                    @Override
-                    public void verify(String host, X509Certificate cert) throws SSLException {
-                    }
-
-                    @Override
-                    public void verify(String host, String[] cns, String[] subjectAlts) throws SSLException {
-                    }
-                };
-
-            } else if (verifier == SSLHostnameVerifier.COMMON) {
-                hostnameVerifier = null;
-            } else if (verifier == SSLHostnameVerifier.STRICT) {
-                hostnameVerifier = null;
-            } else if (verifier != null) {
-                hostnameVerifier = new HostnameVerifierAdapter(verifier);
-            }
-            httpClientBuilder.setHostnameVerifier(hostnameVerifier);
-        }
-
-        HttpClient client = httpClientBuilder.build();
-
-        RestTemplate rt = new RestTemplate(new HttpComponentsClientHttpRequestFactory(client));
-        rt.setErrorHandler(new MgmtResponseErrorHandler());
-        return rt;
-    }
-
-    static private class HostnameVerifierAdapter implements X509HostnameVerifier {
-        private SSLHostnameVerifier verifier;
-
-        protected HostnameVerifierAdapter(SSLHostnameVerifier verifier) {
-            this.verifier = verifier;
-        }
-
-        public void verify(String hostname, X509Certificate cert) throws SSLException {
-            ArrayList<String> cnArray = new ArrayList<>();
-            try {
-                LdapName ldapDN = new LdapName(cert.getSubjectX500Principal().getName());
-                for (Rdn rdn : ldapDN.getRdns()) {
-                    Object value = rdn.getValue();
-                    if ("CN".equalsIgnoreCase(rdn.getType()) && value instanceof String) {
-                        cnArray.add((String) value);
-                    }
-                }
-                int type_dnsName = 2;
-                int type_ipAddress = 7;
-                ArrayList<String> subjectAltArray = new ArrayList<>();
-                Collection<List<?>> alts = cert.getSubjectAlternativeNames();
-                if (alts != null) {
-                    for (List<?> alt : alts) {
-                        if (alt != null && alt.size() == 2 && alt.get(1) instanceof String) {
-                            Integer type = (Integer) alt.get(0);
-                            if (type == type_dnsName || type == type_ipAddress) {
-                                subjectAltArray.add((String) alt.get(1));
-                            }
-                        }
-                    }
-                }
-                String[] cns = cnArray.toArray(new String[cnArray.size()]);
-                String[] subjectAlts = subjectAltArray.toArray(new String[subjectAltArray.size()]);
-                verifier.verify(hostname, cns, subjectAlts);
-            } catch (CertificateParsingException e) {
-                throw new MarkLogicIOException(e);
-            } catch (InvalidNameException e) {
-                throw new MarkLogicIOException(e);
-            }
-        }
-
-        @Override
-        public void verify(String hostname, SSLSocket ssl) throws IOException {
-            Certificate[] certificates = ssl.getSession().getPeerCertificates();
-            verify(hostname, (X509Certificate) certificates[0]);
-        }
-
-        @Override
-        public void verify(String hostname, String[] cns, String[] subjectAlts) throws SSLException {
-            verifier.verify(hostname, cns, subjectAlts);
-        }
-
-        @Override
-        public boolean verify(String hostname, SSLSession session) {
-            try {
-                Certificate[] certificates = session.getPeerCertificates();
-                verify(hostname, (X509Certificate) certificates[0]);
-                return true;
-            } catch (SSLException e) {
-                return false;
-            }
+            throw new RuntimeException(String.format("Unable to collect items to process for flow %s and step %s; cause: %s", flow, step, e));
         }
     }
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubClientImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubClientImpl.java
@@ -18,9 +18,7 @@ package com.marklogic.hub.impl;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.HubClient;
-import com.marklogic.hub.collector.impl.CollectorImpl;
 import com.marklogic.mgmt.ManageClient;
-import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;
 
@@ -31,7 +29,6 @@ public class HubClientImpl implements HubClient {
     private DatabaseClient finalClient;
     private DatabaseClient jobsClient;
     private Map<DatabaseKind, String> databaseNames;
-    private RestTemplate stagingRestTemplate;
     private ManageClient manageClient;
 
     public HubClientImpl(HubConfigImpl hubConfig, Map<DatabaseKind, String> databaseNames) {
@@ -40,10 +37,6 @@ public class HubClientImpl implements HubClient {
         finalClient = hubConfig.newFinalClient(null);
         jobsClient = hubConfig.newJobDbClient();
         this.databaseNames = databaseNames;
-
-        // TODO Move the newRestTemplate method into a more logical place to reuse this
-        this.stagingRestTemplate = CollectorImpl.newRestTemplate(stagingClient, hubConfig.getMlUsername(), hubConfig.getMlPassword());
-
         this.manageClient = hubConfig.getManageClient();
     }
 
@@ -70,11 +63,6 @@ public class HubClientImpl implements HubClient {
     @Override
     public DatabaseClient getJobsClient() {
         return jobsClient;
-    }
-
-    @Override
-    public RestTemplate getStagingRestTemplate() {
-        return stagingRestTemplate;
     }
 
     @Override


### PR DESCRIPTION
This ticket will likely go into Sprint 30. It was a simple change to make (as someone else did the real work), so I want to see how the tests run with this. 

This is the result of DHFPROD-4533, where performance testing confirmed that this approach of accessing the underlying OkHttpClient results in good performance and the same functional behavior. I ran all the tests locally, and all of them passed.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

