### PR TITLE
DHFPROD-4894: Stop printing requests/responses on MockMvc test failure

### DIFF
--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/AbstractMvcTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/AbstractMvcTest.java
@@ -5,6 +5,7 @@ import com.marklogic.hub.central.auth.LoginInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.MockMvcPrint;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
@@ -25,7 +26,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * Similar to AbstractOneUiTest, please be judicious about adding helper methods to this class. Any methods added
  * should be applicable to a wide swath of tests, not just a handful.
  */
-@AutoConfigureMockMvc
+/*
+* There is a bug in MockMvc that causes ConcurrentModificationException in the testRowExport() test.
+* This happens when it tries to read the response headers for async requests in
+* order to print the response.
+* Thus, we are switching off the printing of requests/responses on MockMvc test failure.
+* */
+@AutoConfigureMockMvc(print = MockMvcPrint.NONE)
 public abstract class AbstractMvcTest extends AbstractHubCentralTest {
 
     @Autowired


### PR DESCRIPTION
### Description
There is a bug in MockMvc that causes ConcurrentModificationException
when it tries to read the response headers for async requests in
order to print the response.
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

