### PR TITLE
DHFPROD-4775: Fixing ClearUserDataTest on ML 9.0-10-12

### DIFF
--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/HubCentral.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/HubCentral.java
@@ -74,6 +74,7 @@ public class HubCentral extends LoggingObject implements InitializingBean {
 
         if (useLocalDefaults) {
             primaryProperties.setProperty("mlIsHostLoadBalancer", "false");
+            primaryProperties.setProperty("mlIsProvisionedEnvironment", "false");
             primaryProperties.setProperty("mlAppServicesPort", "8000");
             primaryProperties.setProperty("mlAppServicesAuthentication", "digest");
             primaryProperties.setProperty("mlFinalAuth", "digest");
@@ -83,6 +84,8 @@ public class HubCentral extends LoggingObject implements InitializingBean {
             primaryProperties.setProperty("mlFinalSimpleSsl", "false");
             primaryProperties.setProperty("mlJobSimpleSsl", "false");
             primaryProperties.setProperty("mlStagingSimpleSsl", "false");
+            primaryProperties.setProperty("mlManageScheme", "http");
+            primaryProperties.setProperty("mlManageSimpleSsl", "false");
         }
 
         return propertyName -> {

--- a/marklogic-data-hub-central/src/main/resources/application.properties
+++ b/marklogic-data-hub-central/src/main/resources/application.properties
@@ -4,6 +4,9 @@ spring.thymeleaf.prefix=classpath:/static/
 # Data Hub connection properties. These default to the expected values for DHS.
 mlHost=localhost
 mlIsHostLoadBalancer=true
+mlIsProvisionedEnvironment=true
+mlManageScheme=https
+mlManageSimpleSsl=true
 mlAppServicesAuthentication=basic
 mlFinalAuth=basic
 mlJobAuth=basic

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/HubCentralTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/HubCentralTest.java
@@ -42,6 +42,9 @@ public class HubCentralTest {
         assertEquals("anyone", props.getProperty("mlAppServicesUsername"));
         assertEquals("anyword", props.getProperty("mlAppServicesPassword"));
         assertEquals("true", props.getProperty("mlIsHostLoadBalancer"));
+        assertEquals("true", props.getProperty("mlIsProvisionedEnvironment"));
+        assertEquals("https", props.getProperty("mlManageScheme"));
+        assertEquals("true", props.getProperty("mlManageSimpleSsl"));
         assertEquals("8010", props.getProperty("mlAppServicesPort"));
 
         Stream.of("mlAppServicesAuthentication", "mlFinalAuth", "mlStagingAuth", "mlJobAuth").forEach(name -> {
@@ -65,6 +68,9 @@ public class HubCentralTest {
         assertEquals("anyone", props.getProperty("mlAppServicesUsername"));
         assertEquals("anyword", props.getProperty("mlAppServicesPassword"));
         assertEquals("false", props.getProperty("mlIsHostLoadBalancer"));
+        assertEquals("false", props.getProperty("mlIsProvisionedEnvironment"));
+        assertEquals("http", props.getProperty("mlManageScheme"));
+        assertEquals("false", props.getProperty("mlManageSimpleSsl"));
         assertEquals("8000", props.getProperty("mlAppServicesPort"));
 
         Stream.of("mlAppServicesAuthentication", "mlFinalAuth", "mlStagingAuth", "mlJobAuth").forEach(name -> {
@@ -105,6 +111,7 @@ public class HubCentralTest {
         assertNotNull(hubConfig.getSslContext(DatabaseKind.JOB));
 
         assertTrue(hubConfig.getIsHostLoadBalancer());
+        assertTrue(hubConfig.getIsProvisionedEnvironment());
 
         ManageConfig manageConfig = hubConfig.getManageConfig();
         assertEquals("anyone", manageConfig.getUsername());
@@ -112,5 +119,7 @@ public class HubCentralTest {
         assertEquals("somehost", manageConfig.getHost());
         assertEquals("anyword", manageConfig.getPassword());
         assertEquals("anyword", manageConfig.getSecurityPassword());
+        assertTrue(manageConfig.isConfigureSimpleSsl());
+        assertEquals("https", manageConfig.getScheme());
     }
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/ClearUserDataTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/ClearUserDataTest.java
@@ -39,6 +39,10 @@ public class ClearUserDataTest extends AbstractHubCoreTest {
      */
     @Test
     void test() {
+        if (!isVersionCompatibleWith520Roles()) {
+            return;
+        }
+
         runAsDataHubOperator();
         addTestData();
 
@@ -75,6 +79,10 @@ public class ClearUserDataTest extends AbstractHubCoreTest {
 
     @Test
     void asUserWhoCantClearDatabases() {
+        if (!isVersionCompatibleWith520Roles()) {
+            return;
+        }
+
         runAsDataHubDeveloper();
         applyCurrentUserToManageClient();
         try {


### PR DESCRIPTION
Also added mlManageSimpleSsl/mlManageScheme to the list of properties to set default values for in DHS and for local dev. These are now needed because clearUserData talks to the Manage API.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

