### PR TITLE
DHFPROD-4216: Collapse All/Expand All buttons for Source and Entity tables in Mapping UI.

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.module.scss
@@ -60,7 +60,7 @@
 .addNewContent {
     font-size: 20px;
     color: #67749c;
-    margin-bottom: 0.3vh;
+    margin-bottom: 1.7vh;
     margin-top: 0px;
 }
 

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
@@ -55,6 +55,7 @@ const MappingCard: React.FC<Props> = (props) => {
     const [entityTypeProperties, setEntityTypeProperties] = useState<any[]>([]);
     const [tgtEntityReferences,setTgtEntityReferences] = useState({});
     let EntitYTableKeyIndex = 0;
+    let sourceTableKeyIndex = 0;
     let tgtRefs:any = {};
 
     //For storing docURIs
@@ -336,19 +337,25 @@ const MappingCard: React.FC<Props> = (props) => {
         let propty: any;
         if (obj.hasOwnProperty('#text')) {
             if (Object.keys(obj).filter((el) => /^@xmlns/.test(el) || el === '#text').length === Object.keys(obj).length) {
+                sourceTableKeyIndex = sourceTableKeyIndex + 1;
                 propty = {
+                    rowKey: sourceTableKeyIndex,
                     key: key,
                     val: obj['#text']
                 }
             } else {
+                sourceTableKeyIndex = sourceTableKeyIndex + 1;
                 propty = {
+                    rowKey: sourceTableKeyIndex,
                     key: key,
                     val: obj['#text'],
                     'children': []
                 }
             }
         } else {
+            sourceTableKeyIndex = sourceTableKeyIndex + 1;
             propty = {
+                rowKey: sourceTableKeyIndex,
                 key: key,
                 'children': []
             }
@@ -409,7 +416,9 @@ const MappingCard: React.FC<Props> = (props) => {
                     if (key !== '#text' && !/^@xmlns/.test(key)) {
                         let finalKey = !/^@/.test(key) ? getNamespace(key, val, parentNamespace) : key;
                         let propty: any;
+                        sourceTableKeyIndex = sourceTableKeyIndex + 1;
                         propty = {
+                            rowKey: sourceTableKeyIndex,
                             key: finalKey,
                             val: String(val)
                         };
@@ -420,7 +429,9 @@ const MappingCard: React.FC<Props> = (props) => {
 
             } else {
                 let finalKey = getNamespace(key, val, parentNamespace);
+                sourceTableKeyIndex = sourceTableKeyIndex + 1;
                 let propty = {
+                    rowKey: sourceTableKeyIndex,
                     key: finalKey,
                     val: ""
                 };

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.module.scss
@@ -85,7 +85,7 @@
         display: inline-block;
         vertical-align: middle;
         //height: 5vh;
-        margin-bottom: 13px;
+        margin-bottom: 3px;
         > .entityTypeTitle{
             float: left;
             padding-top: 6px;
@@ -98,8 +98,13 @@
     > .columnOptionsSelectorContainer {
         display: inline-block;
         margin-bottom: 10px;
+        > .expandCollapseBtn {
+            width: 102px;
+            height: 32px;
+        }
         > .columnOptionsSelector{
             float: right;
+            margin-top: 10px;
         }
     }
 }
@@ -371,12 +376,13 @@ hr {
 
 .navigationCollapseButtons{
     width: 100%;
+    display: inline-block;
     justify-content: space-between;
     vertical-align: middle;
-    text-align: center;
-    padding-bottom: 4px;
+    //text-align: center;
+    //padding-bottom: 2px;
     margin-top: 2px;
-    height: 5vh;
+    height: 4.5vh;
 }
 
 .navigate_source_uris{
@@ -386,7 +392,8 @@ hr {
     vertical-align: bottom;
     justify-content: space-between;
     text-align: center;
-    margin: 0px auto;
+    margin-top: -32px;
+    margin-left: 10vw;
     white-space: nowrap;
   }
  .navigate_uris_left {

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
@@ -50,6 +50,10 @@ describe('RTL Source-to-entity map tests', () => {
         mappingVisible={true}
         />);
 
+      //Expanding all the nested levels first to apply filter later
+      fireEvent.click(getByTestId('expandCollapseBtn-source'));
+      fireEvent.click(getByTestId('expandCollapseBtn-entity'));
+
       /* Test filter on Source table  */
       let filterIcon = getByTestId('filterIcon-key');
       expect(filterIcon).toBeInTheDocument();
@@ -181,6 +185,10 @@ describe('RTL Source-to-entity map tests', () => {
         mappingVisible={true}
         />);
 
+      //Expanding all the nested levels first
+      fireEvent.click(getByTestId('expandCollapseBtn-source'));
+      fireEvent.click(getByTestId('expandCollapseBtn-entity'));
+
       const sourceTableNameSort = getByTestId('sourceTableKey'); // For name column sorting
       const sourceTableValueSort = getByTestId('sourceTableValue'); // For value column sorting
 
@@ -188,43 +196,43 @@ describe('RTL Source-to-entity map tests', () => {
 
       //Check the sort order of Name column rows before enforcing sort order
       let srcTable = document.querySelectorAll('#srcContainer .ant-table-row-level-0');
-      validateMappingTableRow(srcTable, ['proteinId', 'proteinType', 'nutFreeName', 'proteinCat'], 'key');
+      validateMappingTableRow(srcTable, ['proteinId', 'proteinType', 'nutFreeName', 'proteinCat'], 'key', data.mapProps.sourceData);
 
       //Click on the Name column to sort the rows by Ascending order
       fireEvent.click(sourceTableNameSort);
       srcTable = document.querySelectorAll('#srcContainer .ant-table-row-level-0');
-      validateMappingTableRow(srcTable, ['nutFreeName', 'proteinCat', 'proteinId', 'proteinType'],  'key')
+      validateMappingTableRow(srcTable, ['nutFreeName', 'proteinCat', 'proteinId', 'proteinType'],  'key', data.mapProps.sourceData);
 
       //Click on the Name column to sort the rows by Descending order
       fireEvent.click(sourceTableNameSort);
       srcTable = document.querySelectorAll('#srcContainer .ant-table-row-level-0');
-      validateMappingTableRow(srcTable, ['proteinType','proteinId', 'proteinCat', 'nutFreeName'],  'key')
+      validateMappingTableRow(srcTable, ['proteinType','proteinId', 'proteinCat', 'nutFreeName'],  'key', data.mapProps.sourceData);
 
       //Click on the Name column again to remove the applied sort order and check if its removed
       fireEvent.click(sourceTableNameSort);
       srcTable = document.querySelectorAll('#srcContainer .ant-table-row-level-0');
-      validateMappingTableRow(srcTable, ['proteinId', 'proteinType', 'nutFreeName', 'proteinCat'], 'key')
+      validateMappingTableRow(srcTable, ['proteinId', 'proteinType', 'nutFreeName', 'proteinCat'], 'key', data.mapProps.sourceData);
 
       /* Validate sorting on Values column in source table */
 
       //Check the sort order of Values column rows before enforcing sort order
       srcTable = document.querySelectorAll('#srcContainer .ant-table-row-level-0');
-      validateMappingTableRow(srcTable, ['123EAC', 'home', undefined, 'commercial'], 'val');
+      validateMappingTableRow(srcTable, ['123EAC', 'home', undefined, 'commercial'], 'val', data.mapProps.sourceData);
 
       //Click on the Values column to sort the rows by Ascending order
       fireEvent.click(sourceTableValueSort);
       srcTable = document.querySelectorAll('#srcContainer .ant-table-row-level-0');
-      validateMappingTableRow(srcTable, ['123EAC', 'commercial', 'home', undefined], 'val')
+      validateMappingTableRow(srcTable, ['123EAC', 'commercial', 'home', undefined], 'val', data.mapProps.sourceData);
 
       //Click on the Values column to sort the rows by Descending order
       fireEvent.click(sourceTableValueSort);
       srcTable = document.querySelectorAll('#srcContainer .ant-table-row-level-0');
-      validateMappingTableRow(srcTable, ['home', 'commercial', '123EAC', undefined], 'val')
+      validateMappingTableRow(srcTable, ['home', 'commercial', '123EAC', undefined], 'val', data.mapProps.sourceData);
 
       //Click on the Value column again to remove the applied sort order and check if its removed
       fireEvent.click(sourceTableValueSort);
       srcTable = document.querySelectorAll('#srcContainer .ant-table-row-level-0');
-      validateMappingTableRow(srcTable, ['123EAC', 'home', undefined, 'commercial'], 'val');
+      validateMappingTableRow(srcTable, ['123EAC', 'home', undefined, 'commercial'], 'val', data.mapProps.sourceData);
 
       /* Validate sorting in Entity table columns */
       const entityTableNameSort = getByTestId('entityTableName'); // For value column sorting
@@ -232,34 +240,34 @@ describe('RTL Source-to-entity map tests', () => {
 
       //Check sort order of Name Column before clicking on sort button
       let entTable = document.querySelectorAll('#entityContainer .ant-table-row-level-0');
-      validateMappingTableRow(entTable, ['propId', 'propName', 'propAttribute', 'items', 'gender'], 'name');
+      validateMappingTableRow(entTable, ['propId', 'propName', 'propAttribute', 'items', 'gender'], 'name', data.mapProps.entityTypeProperties);
 
       //Click on the Name column to sort the rows by Ascending order
       fireEvent.click(entityTableNameSort);
       entTable = document.querySelectorAll('#entityContainer .ant-table-row-level-0');
-      validateMappingTableRow(entTable, ['gender', 'items', 'propAttribute', 'propId', 'propName'], 'name')
+      validateMappingTableRow(entTable, ['gender', 'items', 'propAttribute', 'propId', 'propName'], 'name', data.mapProps.entityTypeProperties);
 
       //Click on the Name column again to sort the rows by Descending order
       fireEvent.click(entityTableNameSort);
       entTable = document.querySelectorAll('#entityContainer .ant-table-row-level-0');
-      validateMappingTableRow(entTable, ['propName', 'propId', 'propAttribute', 'items', 'gender'], 'name')
+      validateMappingTableRow(entTable, ['propName', 'propId', 'propAttribute', 'items', 'gender'], 'name', data.mapProps.entityTypeProperties);
 
       fireEvent.click(entityTableNameSort); //Reset the sort order to go back to default order
 
       //Click on the Type column to sort the rows by Ascending order
       fireEvent.click(entityTableTypeSort);
       entTable = document.querySelectorAll('#entityContainer .ant-table-row-level-0');
-      validateMappingTableRow(entTable, ['int', 'ItemType [ ]', 'string', 'string', 'string'], 'type');
+      validateMappingTableRow(entTable, ['int', 'ItemType [ ]', 'string', 'string', 'string'], 'type', data.mapProps.entityTypeProperties);
 
       //Click on the Type column again to sort the rows by Descending order
       fireEvent.click(entityTableTypeSort);
       entTable = document.querySelectorAll('#entityContainer .ant-table-row-level-0');
-      validateMappingTableRow(entTable, ['string', 'string', 'string', 'ItemType [ ]', 'int'], 'type');
+      validateMappingTableRow(entTable, ['string', 'string', 'string', 'ItemType [ ]', 'int'], 'type', data.mapProps.entityTypeProperties);
 
       //Resetting the sort order to go back to default order
       fireEvent.click(entityTableTypeSort);
       entTable = document.querySelectorAll('#entityContainer .ant-table-row-level-0');
-      validateMappingTableRow(entTable, ['int', 'string', 'string', 'ItemType [ ]', 'string'], 'type');
+      validateMappingTableRow(entTable, ['int', 'string', 'string', 'ItemType [ ]', 'string'], 'type', data.mapProps.entityTypeProperties);
     });
 
     test('Verify evaluation of valid expression for mapping writer user', async () => {
@@ -390,6 +398,90 @@ describe('RTL Source-to-entity map tests', () => {
          */
     })
 
+    test('CollapseAll/Expand All feature in JSON Source data table and Entity table', () => {
+
+        const { getByTestId, getByText, debug, queryByText } = render(<SourceToEntityMap {...data.mapProps}
+            mappingVisible={true}
+        />);
+
+        /* Validate collapse-expand in source table */
+        //Check if the expected source table elements are present in the DOM before hittting the Expan/Collapse button
+        expect(queryByText('suffix')).not.toBeInTheDocument();
+        expect(getByText('nutFreeName')).toBeInTheDocument();
+        expect(getByText('FirstNamePreferred')).toBeInTheDocument();
+        expect(getByText('LastName')).toBeInTheDocument();
+
+        let expandCollapseBtn = getByTestId('expandCollapseBtn-source');
+
+        expect(expandCollapseBtn.textContent).toBe('Expand All'); // Validating the button label 
+
+        fireEvent.click(expandCollapseBtn); //Expanding all nested levels
+        expect(expandCollapseBtn.textContent).toBe('Collapse All'); // Validating the button label 
+        expect(getByText('suffix')).toBeInTheDocument();
+
+        //Check if indentation is right
+        expect(getByText('suffix').closest('td')?.firstElementChild).toHaveStyle("padding-left: 28px;");
+
+        fireEvent.click(expandCollapseBtn); //Collapsing back to the default view (root and 1st level)
+        expect(expandCollapseBtn.textContent).toBe('Expand All'); // Validating the button label 
+        expect(onClosestTableRow(getByText('suffix'))?.style.display).toBe('none'); // Checking if the row is marked hidden in DOM. All collapsed rows are marked hidden(display: none) once you click on Collapse All button.
+
+        /* Validate collapse-expand in Entity table */
+        //Check if the expected Entity table elements are present in the DOM before hittting the Expan/Collapse button
+        expect(queryByText('artCraft')).not.toBeInTheDocument();
+        expect(getByText('items')).toBeInTheDocument();
+        expect(getByText('itemTypes')).toBeInTheDocument();
+        expect(getByText('itemCategory')).toBeInTheDocument();
+
+        expandCollapseBtn = getByTestId('expandCollapseBtn-entity');
+
+        expect(expandCollapseBtn.textContent).toBe('Expand All');
+
+        fireEvent.click(expandCollapseBtn); //Expanding all nested levels
+        expect(expandCollapseBtn.textContent).toBe('Collapse All');
+        expect(getByText('artCraft')).toBeInTheDocument();
+
+        //Check if indentation is right
+        expect(getByText('artCraft').closest('td')?.firstElementChild).toHaveStyle("padding-left: 28px;");
+
+        fireEvent.click(expandCollapseBtn); //Collapsing back to the default view (root and 1st level)
+        expect(expandCollapseBtn.textContent).toBe('Expand All');
+        expect(onClosestTableRow(getByText('artCraft'))?.style.display).toBe('none'); // Checking if the row is marked hidden(collapsed) in DOM. All collapsed rows are marked hidden(display: none) once you click on Collapse All button.
+    });
+
+    test('CollapseAll/Expand All feature in XML Source data table', () => {
+
+        const { getByTestId, getByText, queryByText } = render(<SourceToEntityMap {...data.mapProps}
+            mappingVisible={true}
+            sourceData={data.xmlSourceData}
+        />);
+
+        //Check if the expected elements are present in the DOM before hittting the Expan/Collapse button
+        expect(queryByText('FirstNamePreferred')).not.toBeInTheDocument();
+        expect(queryByText('LastName')).not.toBeInTheDocument();
+        expect(getByText(/nutFree/)).toBeInTheDocument();
+        expect(getByText('@proteinType')).toBeInTheDocument();
+        expect(getByText('proteinId')).toBeInTheDocument();
+
+        let expandCollapseBtn = getByTestId('expandCollapseBtn-source');
+
+        expect(expandCollapseBtn.textContent).toBe('Expand All');
+
+        fireEvent.click(expandCollapseBtn); //Expanding all nested levels
+        expect(expandCollapseBtn.textContent).toBe('Collapse All');
+        let firstName = getByText('FirstNamePreferred');
+        let lastName = getByText('LastName');
+        expect(firstName).toBeInTheDocument();
+        expect(firstName.closest('td')?.firstElementChild).toHaveStyle("padding-left: 28px;"); // Check if the indentation is right
+        
+        expect(lastName).toBeInTheDocument();
+        expect(lastName.closest('td')?.firstElementChild).toHaveStyle("padding-left: 28px;"); // Check if the indentation is right
+
+        fireEvent.click(expandCollapseBtn); //Collapsing back to the default view (root and 1st level)
+        expect(expandCollapseBtn.textContent).toBe('Expand All');
+        expect(onClosestTableRow(firstName)?.style.display).toBe('none');
+        expect(onClosestTableRow(lastName)?.style.display).toBe('none');
+    });
 });
 
 describe('Enzyme Source-to-entity map tests', () => {
@@ -438,7 +530,11 @@ describe('Enzyme Source-to-entity map tests', () => {
     });
 
     test('XML source data renders properly',() => {
-        const { getByText } = render(<SourceToEntityMap {...data.mapProps} mappingVisible={true} sourceData={data.xmlSourceData}/>);
+        const { getByText,getByTestId } = render(<SourceToEntityMap {...data.mapProps} mappingVisible={true} sourceData={data.xmlSourceData}/>);
+        //Expanding all the nested levels first
+        fireEvent.click(getByTestId('expandCollapseBtn-source'));
+        fireEvent.click(getByTestId('expandCollapseBtn-entity'));
+
         expect(getByText('Source Data')).toBeInTheDocument();
         expect(getByText('proteinId')).toBeInTheDocument();
         expect(getByText('123EAC')).toBeInTheDocument();
@@ -450,7 +546,12 @@ describe('Enzyme Source-to-entity map tests', () => {
 
     test('Nested entity data renders properly',() => {
 
-        const { getByText,getAllByText } = render(<SourceToEntityMap {...data.mapProps} mappingVisible={true}/>);
+        const { getByText,getAllByText,getByTestId } = render(<SourceToEntityMap {...data.mapProps} mappingVisible={true}/>);
+
+        //Expanding all the nested levels first
+        fireEvent.click(getByTestId('expandCollapseBtn-source'));
+        fireEvent.click(getByTestId('expandCollapseBtn-entity'));
+
         expect(getByText('propId')).toBeInTheDocument();
         expect(getByText('propName')).toBeInTheDocument();
         expect(getByText('items')).toBeInTheDocument();
@@ -552,6 +653,9 @@ describe('RTL Source Selector/Source Search tests', () => {
         axiosMock.post.mockImplementation(data.mapProps.updateMappingArtifact);
         const {getAllByText,getByTestId, getAllByRole} = render(<SourceToEntityMap {...data.mapProps}  sourceData={data.xmlSourceData} mappingVisible={true}/>);
 
+        //Expanding all the nested levels first
+        fireEvent.click(getByTestId('expandCollapseBtn-source'));
+        fireEvent.click(getByTestId('expandCollapseBtn-entity'));
         let sourceSelector = getByTestId("itemTypes-listIcon");
 
         //corresponds to 'itemTypes' source selector

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect, CSSProperties, useRef } from "react";
+import React, { useState, useEffect, CSSProperties, useRef, useLayoutEffect } from "react";
 import { Card, Modal, Table, Icon, Popover, Input, Button, Alert, Tooltip, Dropdown, Menu, Checkbox, Row, AutoComplete} from "antd";
 import styles from './source-to-entity-map.module.scss';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -55,6 +55,16 @@ const SourceToEntityMap = (props) => {
 
     //Navigate URI buttons
     const [uriIndex, setUriIndex] = useState(0);
+
+    //For Collapse all-Expand All buttons
+    const [entityExpandedKeys, setEntityExpandedKeys] = useState<any[]>([]);
+    const [sourceExpandedKeys, setSourceExpandedKeys] = useState<any[]>([]);
+    const [expandedEntityFlag, setExpandedEntityFlag] = useState(false);
+    const [expandedSourceFlag, setExpandedSourceFlag] = useState(false);
+    const [initialSourceKeys, setInitialSourceKeys] = useState<any []>([]);
+    const [initialEntityKeys, setInitialEntityKeys] = useState<any []>([]);
+    const [allSourceKeys, setAllSourceKeys] = useState<any []>([]);
+    const [allEntityKeys, setAllEntityKeys] = useState<any []>([]);
 
     //Documentation links for using Xpath expressions
     const xPathDocLinks = <div className={styles.xpathDoc}><span id="doc">Documentation:</span>
@@ -128,6 +138,8 @@ const SourceToEntityMap = (props) => {
         initializeMapExpressions();
         onClear();
         setSavedMappingArt(props.mapData);
+        initializeEntityExpandKeys();
+        initializeSourceExpandKeys();
         return (() => {
             setMapExp({});
         })
@@ -146,6 +158,36 @@ const SourceToEntityMap = (props) => {
         setFlatArray(flattenSourceDoc([...props.sourceData], [], ''))
 
     }, [props.sourceData]);
+
+    useEffect(()=> {
+        initializeSourceExpandKeys();
+    }, [srcData])
+
+    //Set the collapse/Expand options for Source table, when mapping opens up.
+    const initializeSourceExpandKeys = () => {
+        let initialKeysToExpand:any = []; 
+        props.sourceData.map(obj => {
+            if (obj.hasOwnProperty('children')) {
+                initialKeysToExpand.push(obj.rowKey);
+            };
+        });
+        setSourceExpandedKeys([...initialKeysToExpand]);
+        setInitialSourceKeys([...initialKeysToExpand]);
+        setAllSourceKeys([...getKeysToExpandFromTable(srcData,'rowKey')]);
+    }
+
+    //Set the collapse/Expand options for Entity table, when mapping opens up.
+    const initializeEntityExpandKeys = () => {
+        let initialKeysToExpand:any = [];
+        props.entityTypeProperties.map(obj => {
+            if (obj.hasOwnProperty('children')) {
+                initialKeysToExpand.push(obj.key);
+            };
+        });
+        setEntityExpandedKeys([...initialKeysToExpand]);
+        setInitialEntityKeys([...initialKeysToExpand]);
+        setAllEntityKeys([...getKeysToExpandFromTable(props.entityTypeProperties,'key')])
+    }
 
     //To handle navigation buttons
     const onNavigateURIList = (index) => {
@@ -447,7 +489,7 @@ const SourceToEntityMap = (props) => {
         {
             title: <span data-testid="sourceTableKey">Name</span>,
             dataIndex: 'key',
-            key: 'key',
+            key: 'rowKey',
             ...getColumnFilterProps('key'),
             sorter: (a: any, b: any) => a.key?.localeCompare(b.key),
             width: '60%',
@@ -874,7 +916,7 @@ const SourceToEntityMap = (props) => {
         </div>
     );
 
-    const columnOptionsSelector = <div className={styles.columnOptionsSelector}>
+    const columnOptionsSelector =
         <Dropdown overlay={columnOptionsDropdown}
         trigger={['click']}
         onVisibleChange={handleColOptMenuVisibleChange}
@@ -883,10 +925,86 @@ const SourceToEntityMap = (props) => {
         overlayClassName={styles.columnSelectorOverlay}><a onClick={e => e.preventDefault()}>
         Column Options <Icon type="down" theme="outlined"/>
       </a></Dropdown>
-    </div>
 
     const getColumnsForEntityTable:any = () => {
         return entityColumns.map(el => checkedEntityColumns[el.key] ? el : '').filter(item => item);
+    }
+
+    //Collapse all-Expand All button
+
+    const getKeysToExpandFromTable = (dataArr,rowKey,allKeysToExpand:any = []) => {
+    
+        dataArr.map(obj => {
+            if (obj.hasOwnProperty('children')) {
+                allKeysToExpand.push(obj[rowKey]);
+                if((rowKey === 'key' && !expandedEntityFlag) || (rowKey === 'rowKey' && !expandedSourceFlag)){
+                    getKeysToExpandFromTable(obj['children'],rowKey,allKeysToExpand);
+                }
+            };
+        });
+        return allKeysToExpand;
+    }
+
+    const handleExpandCollapse = (rowKey) => {
+        if(rowKey === 'rowKey'){
+        let keys = getKeysToExpandFromTable(srcData,rowKey);
+            setSourceExpandedKeys([...keys]);
+            if(expandedSourceFlag) {
+                setExpandedSourceFlag(false);
+            } else {
+                setExpandedSourceFlag(true);
+            }
+        } else {
+        let keys = getKeysToExpandFromTable(props.entityTypeProperties,rowKey);
+            setEntityExpandedKeys([...keys]);
+            if(expandedEntityFlag) {
+                setExpandedEntityFlag(false);
+            } else {
+                setExpandedEntityFlag(true);
+            }
+        }
+    }
+
+    const toggleRowExpanded = (expanded, record, rowKey) => {
+ 
+        if (rowKey === 'key') {
+            if (!entityExpandedKeys.includes(record.key)) {
+                setEntityExpandedKeys(prevState => {
+                    let finalKeys = prevState.concat([record['key']]);
+                    if(allEntityKeys.every(item => finalKeys.includes(item))){
+                        setExpandedEntityFlag(true);
+                    }
+                    return finalKeys;
+            });
+            } else {
+                setEntityExpandedKeys(prevState => {
+                    let finalKeys = prevState.filter(item => item !== record['key']);
+                    if(!initialEntityKeys.some(item => finalKeys.includes(item))){
+                        setExpandedEntityFlag(false);
+                    }
+                    return finalKeys});
+            }
+        } else {
+            if (!sourceExpandedKeys.includes(record.rowKey)) {
+                setSourceExpandedKeys(prevState => {
+                    let finalKeys = prevState.concat([record['rowKey']])
+ 
+                    if(allSourceKeys.every(item => finalKeys.includes(item))){
+                        setExpandedSourceFlag(true);
+                    }
+                    return finalKeys;
+                });
+                
+            } else {
+                setSourceExpandedKeys(prevState => {
+                    let finalKeys = prevState.filter(item => item !== record['rowKey']);
+                    if(!initialSourceKeys.some(item => finalKeys.includes(item))){
+                        setExpandedSourceFlag(false);
+                    }
+                    return finalKeys;
+                });
+            }
+        }
     }
 
     return (<Modal
@@ -954,20 +1072,23 @@ const SourceToEntityMap = (props) => {
                             </div>
                             :
                             <div id="dataPresent">
-                                <div className={styles.navigationCollapseButtons}>{navigationButtons}</div>
+                                
+                                <div className={styles.navigationCollapseButtons}><span><Button data-testid="expandCollapseBtn-source" onClick={() => handleExpandCollapse('rowKey')} className={styles.expandCollapseBtn}>{expandedSourceFlag ? 'Collapse All' : 'Expand All'}</Button></span><span>{navigationButtons}</span></div>
                                     <Table
                                         pagination={false}
-                                        defaultExpandAllRows={true}
                                         expandIcon={(props) => customExpandIcon(props)}
+                                        onExpand={(expanded,record) => toggleRowExpanded(expanded,record,'rowKey')}
+                                        expandedRowKeys={sourceExpandedKeys}
                                         className={styles.sourceTable}
                                         rowClassName={() => styles.sourceTableRows}
                                         scroll={{y: '60vh', x: 'max-content' }}
                                         indentSize={14}
+                                        //defaultExpandAllRows={true}
                                         //size="small"
                                         columns={columns}
                                         dataSource={srcData}
                                         tableLayout="unset"
-                                        rowKey={record => JSON.stringify(record)}
+                                        rowKey={(record) => record.rowKey}
                                     />
                             </div> }
                     </div>
@@ -978,17 +1099,20 @@ const SourceToEntityMap = (props) => {
                         <div className={styles.entityDetails}>
                             <span className={styles.entityTypeTitle}><p ><i><FontAwesomeIcon icon={faObjectUngroup} size="sm" className={styles.entityIcon} /></i> Entity: {props.entityTypeTitle}</p></span>
                         </div>
-                        <div className={styles.columnOptionsSelectorContainer}>{columnOptionsSelector}</div>
+                        <div className={styles.columnOptionsSelectorContainer}>
+                            <span><Button data-testid="expandCollapseBtn-entity" onClick={() => handleExpandCollapse('key')} className={styles.expandCollapseBtn}>{expandedEntityFlag ? 'Collapse All' : 'Expand All'}</Button></span><span className={styles.columnOptionsSelector}>{columnOptionsSelector}</span></div>
                         <Table
                             pagination={false}
                             className={styles.entityTable}
                             expandIcon={(props) => customExpandIcon(props)}
+                            onExpand={(expanded,record) => toggleRowExpanded(expanded,record,'key')}
+                            expandedRowKeys={entityExpandedKeys}
                             indentSize={14}
-                            defaultExpandAllRows={true}
+                            //defaultExpandAllRows={true}
                             columns={getColumnsForEntityTable()}
                             dataSource={props.entityTypeProperties}
                             tableLayout="unset"
-                            rowKey={record => JSON.stringify(record)}
+                            rowKey={(record: any) => record.key}
                         />
                     </div>
                 </SplitPane>

--- a/marklogic-data-hub-central/ui/src/config/data.config.js
+++ b/marklogic-data-hub-central/ui/src/config/data.config.js
@@ -63,47 +63,49 @@ const loadData = {
 
 const xmlSourceData = [
   {
-    key: 'sampleProtein', children: [
-      { key: 'proteinId', val: '123EAC' },
-      { key: '@proteinType', val: 'home' },
+    rowKey: 1, key: 'sampleProtein', children: [
+      { rowKey: 2, key: 'proteinId', val: '123EAC' },
+      { rowKey: 3, key: '@proteinType', val: 'home' },
       {
-      key: 'nutFree:name', children: [
-        { key: 'FirstNamePreferred', val: 'John' },
-        { key: 'LastName', val: 'Smith' }
+        rowKey: 4, key: 'nutFree:name', children: [
+        { rowKey: 5, key: 'FirstNamePreferred', val: 'John' },
+        { rowKey: 6, key: 'LastName', val: 'Smith' }
       ]
       },
-      { key: 'proteinCat', val: 'commercial' }
+      { rowKey: 7, key: 'proteinCat', val: 'commercial' }
     ]
   }
 ];
 
 const jsonSourceData = [
-  { key: 'proteinId', val: '123EAC' },
-  { key: 'proteinType', val: 'home' },
+  { rowKey: 1, key: 'proteinId', val: '123EAC' },
+  { rowKey: 2, key: 'proteinType', val: 'home' },
   {
-    key: 'nutFreeName', children: [
-      { key: 'FirstNamePreferred', val: 'John' },
-      { key: 'LastName', val: 'Smith' }
+    rowKey: 3, key: 'nutFreeName', children: [
+      { rowKey: 4, key: 'FirstNamePreferred', val: 'John' },
+      { rowKey: 5, key: 'LastName', val: 'Smith' , children: [
+        { rowKey: 6, key: 'suffix', val: 'Sr.' }
+      ]}
     ]
   },
-  { key: 'proteinCat', val: 'commercial' }
+  { rowKey: 7, key: 'proteinCat', val: 'commercial' }
 ];
 
 const entityTypeProperties = [
-  { name: 'propId', type: 'int' },
-  { name: 'propName', type: 'string' },
-  { name: 'propAttribute', type: 'string' },
+  { key: 1, name: 'propId', type: 'int' },
+  { key: 2, name: 'propName', type: 'string' },
+  { key: 3, name: 'propAttribute', type: 'string' },
   {
-    name: 'items', type: 'parent-ItemType [ ]', children: [
-      { name: 'items/itemTypes', type: 'string' },
+    key: 4, name: 'items', type: 'parent-ItemType [ ]', children: [
+      { key: 5, name: 'items/itemTypes', type: 'string' },
       {
-        name: 'items/itemCategory', type: 'parent-catItem', children: [
-          { name: 'items/itemCategory/artCraft', type: 'string' },
-          { name: 'items/itemCategory/automobile', type: 'string' }
+        key: 6, name: 'items/itemCategory', type: 'parent-catItem', children: [
+          { key: 7, name: 'items/itemCategory/artCraft', type: 'string' },
+          { key: 8, name: 'items/itemCategory/automobile', type: 'string' }
         ]
       }]
   },
-  { name: 'gender', type: 'string' }
+  { key: 9, name: 'gender', type: 'string' }
 ];
 
 const testJSONResponse = { 

--- a/marklogic-data-hub-central/ui/src/util/test-utils.tsx
+++ b/marklogic-data-hub-central/ui/src/util/test-utils.tsx
@@ -1,8 +1,14 @@
-const validateMappingTableRow = (dataTable, {...rowValue}, colName) => {
+const validateMappingTableRow = (dataTable, {...rowValue}, colName, srcData) => {
     let rowKey = 0;
     dataTable.forEach(item => {
         let att: any = item.getAttribute('data-row-key') ? item.getAttribute('data-row-key') : '{}';
-        let row = JSON.parse(att);
+        let row: any = {};
+        if (srcData[0].hasOwnProperty('name') && srcData[0].hasOwnProperty('type')) {
+            row = srcData.find(obj => obj.key.toString() === att);
+        } else {
+            row = srcData.find(obj => obj.rowKey.toString() === att);
+        }
+
         let keyCol = '';
         if (['key', 'name'].includes(colName)) {
             if (row.hasOwnProperty('name') && row.hasOwnProperty('type')) {


### PR DESCRIPTION
### Description
This PR enables the Collapse All and Expand All buttons in Source and Entity tables in mapping UI.
Also, it fixes the bug where the nested levels used to collapse when navigating between source documents, using the navigation buttons.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

