### PR TITLE
DHFPROD-4804: Added hubVersion Gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ task updateVersion {
                      "marklogic-data-hub-central/gradle.properties",
                      "marklogic-data-hub-central/src/main/resources/application.properties",
                      "marklogic-data-hub/src/main/resources/scaffolding/build_gradle",
-                     "marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java",
+                     "marklogic-data-hub/src/main/java/com/marklogic/hub/impl/VersionInfo.java",
                      "examples/dh-5-example/build.gradle",
                      "examples/dhf5-custom-hook/build.gradle",
                      "examples/insurance/build.gradle",

--- a/marklogic-data-hub/README.md
+++ b/marklogic-data-hub/README.md
@@ -1,0 +1,21 @@
+This guide provides help with various development tasks associated with this subproject. It is intended as a companion
+to the CONTRIBUTING guide for this project, which covers some of the main tasks associated with developing this project.
+
+## Adding new Data Services interfaces
+
+DS interfaces are defined in src/main/ml-modules/root/data-hub/5/data-services. You can define a new DS interface - or 
+add endpoints to an existing interface - by adding files to this directory. The common approach is to just copy files
+from an existing directory, copy those into a new directory, and then modify the files.
+
+The build.gradle file in this project will then dynamically define a new Gradle task to generate the Java interface 
+for your service. For example, if your new service directory is named "myService", you can run the following task, which 
+must be run from the same directory that this README is in: (note that Gradle doesn't care about capitalization, so you
+don't need to get that part exactly right):
+
+    ../gradlew generatemyServiceInterface
+ 
+If you ever want to generate the Java interfaces for all data services, you can run this task:
+
+    ../gradlew generateDataServiceInterfaces
+    
+

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/SystemService.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/SystemService.java
@@ -1,0 +1,84 @@
+package com.marklogic.hub.dataservices;
+
+// IMPORTANT: Do not edit. This file is generated.
+
+import com.marklogic.client.io.Format;
+
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.io.marker.JSONWriteHandle;
+
+import com.marklogic.client.impl.BaseProxy;
+
+/**
+ * Provides a set of operations on the database server
+ */
+public interface SystemService {
+    /**
+     * Creates a SystemService object for executing operations on the database server.
+     *
+     * The DatabaseClientFactory class can create the DatabaseClient parameter. A single
+     * client object can be used for any number of requests and in multiple threads.
+     *
+     * @param db	provides a client for communicating with the database server
+     * @return	an object for executing database operations
+     */
+    static SystemService on(DatabaseClient db) {
+      return on(db, null);
+    }
+    /**
+     * Creates a SystemService object for executing operations on the database server.
+     *
+     * The DatabaseClientFactory class can create the DatabaseClient parameter. A single
+     * client object can be used for any number of requests and in multiple threads.
+     *
+     * The service declaration uses a custom implementation of the same service instead
+     * of the default implementation of the service by specifying an endpoint directory
+     * in the modules database with the implementation. A service.json file with the
+     * declaration can be read with FileHandle or a string serialization of the JSON
+     * declaration with StringHandle.
+     *
+     * @param db	provides a client for communicating with the database server
+     * @param serviceDeclaration	substitutes a custom implementation of the service
+     * @return	an object for executing database operations
+     */
+    static SystemService on(DatabaseClient db, JSONWriteHandle serviceDeclaration) {
+        final class SystemServiceImpl implements SystemService {
+            private DatabaseClient dbClient;
+            private BaseProxy baseProxy;
+
+            private BaseProxy.DBFunctionRequest req_getVersions;
+
+            private SystemServiceImpl(DatabaseClient dbClient, JSONWriteHandle servDecl) {
+                this.dbClient  = dbClient;
+                this.baseProxy = new BaseProxy("/data-hub/5/data-services/system/", servDecl);
+
+                this.req_getVersions = this.baseProxy.request(
+                    "getVersions.sjs", BaseProxy.ParameterValuesKind.NONE);
+            }
+
+            @Override
+            public com.fasterxml.jackson.databind.JsonNode getVersions() {
+                return getVersions(
+                    this.req_getVersions.on(this.dbClient)
+                    );
+            }
+            private com.fasterxml.jackson.databind.JsonNode getVersions(BaseProxy.DBFunctionRequest request) {
+              return BaseProxy.JsonDocumentType.toJsonNode(
+                request.responseSingle(false, Format.JSON)
+                );
+            }
+        }
+
+        return new SystemServiceImpl(db, serviceDeclaration);
+    }
+
+  /**
+   * Invokes the getVersions operation on the database server
+   *
+   * 
+   * @return	as output
+   */
+    com.fasterxml.jackson.databind.JsonNode getVersions();
+
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -1804,20 +1804,7 @@ public class HubConfigImpl implements HubConfig
     }
 
     @Override public String getJarVersion() {
-        Properties properties = new Properties();
-        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream("version.properties")) {
-            properties.load(inputStream);
-        } catch (IOException e)
-        {
-            throw new RuntimeException(e);
-        }
-        String version = (String)properties.get("version");
-
-        // this lets debug builds work from an IDE
-        if (version.equals("${project.version}")) {
-            version = "5.3-SNAPSHOT";
-        }
-        return version;
+        return VersionInfo.getBuildVersion();
     }
 
     @Override public String getDHFVersion() {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/VersionInfo.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/VersionInfo.java
@@ -1,0 +1,55 @@
+package com.marklogic.hub.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.hub.HubClient;
+import com.marklogic.hub.dataservices.SystemService;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * This is intended to replace some of the Versions class with a HubClient-friendly and non-Spring-dependent way of
+ * accessing version data.
+ */
+public class VersionInfo {
+
+    private String hubVersion;
+    private String markLogicVersion;
+
+    public static VersionInfo newVersionInfo(HubClient hubClient) {
+        JsonNode json = SystemService.on(hubClient.getStagingClient()).getVersions();
+        return new VersionInfo(
+            json.get("hubVersion").asText(),
+            json.get("markLogicVersion").asText()
+        );
+    }
+
+    private VersionInfo(String hubVersion, String markLogicVersion) {
+        this.hubVersion = hubVersion;
+        this.markLogicVersion = markLogicVersion;
+    }
+
+    public String getHubVersion() {
+        return hubVersion;
+    }
+
+    public String getMarkLogicVersion() {
+        return markLogicVersion;
+    }
+
+    /**
+     * @return the version of the build containing this class
+     */
+    public static String getBuildVersion() {
+        Properties properties = new Properties();
+        try (InputStream inputStream = VersionInfo.class.getClassLoader().getResourceAsStream("version.properties")) {
+            properties.load(inputStream);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to get library version from version.properties, cause: " + e.getMessage(), e);
+        }
+
+        String version = properties.getProperty("version");
+        return "${project.version}".equals(version) ? "5.3-SNAPSHOT" : version;
+    }
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/system/getVersions.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/system/getVersions.api
@@ -1,0 +1,7 @@
+{
+    "functionName": "getVersions",
+    "return": {
+        "datatype": "jsonDocument",
+        "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+    }
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/system/getVersions.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/system/getVersions.sjs
@@ -1,0 +1,25 @@
+/**
+ Copyright 2012-2020 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+const config = require("/com.marklogic.hub/config.sjs");
+
+const versions = {
+  hubVersion: config.HUBVERSION,
+  markLogicVersion: xdmp.version()
+};
+
+versions

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/system/service.json
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/system/service.json
@@ -1,0 +1,4 @@
+{
+  "endpointDirectory": "/data-hub/5/data-services/system/",
+  "$javaClass": "com.marklogic.hub.dataservices.SystemService"
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/system/GetVersionsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/system/GetVersionsTest.java
@@ -1,0 +1,24 @@
+package com.marklogic.hub.dataservices.system;
+
+import com.marklogic.hub.AbstractHubCoreTest;
+import com.marklogic.hub.impl.VersionInfo;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GetVersionsTest extends AbstractHubCoreTest {
+
+    @Test
+    void test() {
+        runAsDataHubOperator();
+
+        final String expectedMarkLogicVersion = getHubClient().getStagingClient().newServerEval().javascript("xdmp.version()").evalAs(String.class);
+        final String expectedHubClientVersion = adminHubConfig.getJarVersion();
+
+        VersionInfo versionInfo = VersionInfo.newVersionInfo(getHubClient());
+        assertEquals(expectedHubClientVersion, versionInfo.getHubVersion(),
+            "The version from HubClient, which is obtained from version.properties in the DH jar, " +
+                "should match the DH version reported by the endpoint");
+        assertEquals(expectedMarkLogicVersion, versionInfo.getMarkLogicVersion());
+    }
+}

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -93,6 +93,9 @@ class DataHubPlugin implements Plugin<Project> {
             description: "Ascertains whether a MarkLogic server can accept installation of the DHF.  Requires administrative privileges to the server.")
         project.task("hubInfo", group: deployGroup, type: HubInfoTask)
         project.task("hubUpdate", group: deployGroup, type: UpdateHubTask)
+        project.task("hubVersion", group: deployGroup, type: HubVersionTask,
+            description: "Prints the versions of Data Hub and MarkLogic associated with the value of mlHost, and also prints the version of " +
+                "Data Hub associated with this Gradle task")
 
         String scaffoldGroup = "MarkLogic Data Hub Scaffolding"
         project.task("hubInit", group: scaffoldGroup, type: InitProjectTask)

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/HubVersionTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/HubVersionTask.groovy
@@ -1,0 +1,22 @@
+package com.marklogic.gradle.task
+
+
+import com.marklogic.hub.impl.VersionInfo
+import org.gradle.api.tasks.TaskAction
+
+class HubVersionTask extends HubTask {
+
+    @TaskAction
+    void getHubVersion() {
+        VersionInfo versionInfo = VersionInfo.newVersionInfo(getHubConfig().newHubClient())
+        println "Version information is displayed below. The 'Data Hub version' refers to the version of Data Hub that "
+        println "is installed in the given host, while 'Data Hub client version' refers to the version of the Data Hub "
+        println "client library used by this Gradle task. These two version should match in order to ensure proper behavior "
+        println "of the Gradle tasks that you run. "
+        println ""
+        println "           Data Hub host: " + getHubConfig().getHost()
+        println "       MarkLogic version: " + versionInfo.getMarkLogicVersion()
+        println "        Data Hub version: " + versionInfo.getHubVersion()
+        println " Data Hub client version: " + VersionInfo.getBuildVersion()
+    }
+}

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/HubVersionTaskTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/HubVersionTaskTest.groovy
@@ -1,0 +1,24 @@
+package com.marklogic.gradle.task
+
+import org.gradle.testkit.runner.UnexpectedBuildFailure
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class HubVersionTaskTest extends BaseTest {
+
+    def setupSpec() {
+        createGradleFiles()
+        runTask('hubInit')
+    }
+
+    def "run hubVersion"() {
+        when:
+        def result
+        result = runTask("hubVersion")
+
+        then:
+        notThrown(UnexpectedBuildFailure)
+        result.task(":hubVersion").outcome == SUCCESS
+        // This is a smoke test to verify an error is not thrown; printing the output for manual inspection
+        println "Output of hubVersion task: " + result.output
+    }
+}


### PR DESCRIPTION
### Description

One note - there's some cleanup I'm aiming to do when we do the story for getting rid of mlDHFVersion - the existing Versions class can be simplified a bit at that point. But I didn't want to touch it now because it has to account for DH not being installed, which of course is not a use case for HC. VersionInfo is intended to be a clean, simple way to get version data when you know you can connect to DH. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

