### PR TITLE
DHFPROD-4933:Add 'operator' authority if user has the 'data-hub-operator' role

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/security.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/security.sjs
@@ -64,6 +64,10 @@ class Security {
         response.authorities.push(readAuthority);
       }
     }
+    const currentRoleNames = xdmp.getCurrentRoles().toArray().map(roleId => xdmp.roleName(roleId));
+    if(currentRoleNames.includes("data-hub-operator")){
+      response.authorities.push('operator');
+    }
 
     return response;
   }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/security/getAuthoritiesTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/security/getAuthoritiesTest.sjs
@@ -8,11 +8,11 @@ function invokeService() {
 }
 
 const response = invokeService();
-const minExpectedAuthorities = ["readLoadData", "readFlow", "readStepDefinition", "readMapping", "readMatching"];
+const minExpectedAuthorities = ["readLoadData", "readFlow", "readStepDefinition", "readMapping", "readMatching", "operator"];
 
 const result = [
     // The inequality references are assuming that the least privileged role used to run the tests is data-hub-operator
-    test.assertTrue(response.authorities.length >= 5, "The minimum number of authorities any user has"),
+    test.assertTrue(response.authorities.length >= 6, "The minimum number of authorities any user has"),
     test.assertTrue(minExpectedAuthorities.every(authority => response.authorities.includes(authority)))
 ];
 


### PR DESCRIPTION


### Description
Add 'operator' authority if user has the 'data-hub-operator' role. I believe this will be a temporary fix that will go away once @ryanjdew 's  security stories get merged 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

