### PR TITLE
DHFPROD-4985: getPrimaryEntityTypes now uses the final DB client

### DIFF
--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/ModelController.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/ModelController.java
@@ -55,7 +55,8 @@ public class ModelController extends BaseController {
     @ResponseBody
     @ApiOperation(value = "Get primary entity types; does not include entity definitions that are considered 'structured' types", response = PrimaryEntityTypeList.class)
     public ResponseEntity<JsonNode> getPrimaryEntityTypes() {
-        return ResponseEntity.ok(newService().getPrimaryEntityTypes());
+        // This must use the final client instead of staging so that the entityInstanceCount is derived from final
+        return ResponseEntity.ok(ModelsService.on(getHubClient().getFinalClient()).getPrimaryEntityTypes());
     }
 
     @RequestMapping(method = RequestMethod.POST)

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/ModelControllerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/ModelControllerTest.java
@@ -8,15 +8,16 @@ import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.hub.central.AbstractHubCentralTest;
 import com.marklogic.hub.central.controllers.ModelController;
+import com.marklogic.hub.test.Customer;
+import com.marklogic.hub.test.ReferenceModelProject;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ModelControllerTest extends AbstractHubCentralTest {
 
-    private final static String MODEL_NAME = "UiTestEntity";
+    private final static String MODEL_NAME = "Customer";
 
     @Autowired
     ModelController controller;
@@ -37,9 +38,17 @@ public class ModelControllerTest extends AbstractHubCentralTest {
         JsonNode model = controller.createModel(input).getBody();
         assertEquals(MODEL_NAME, model.get("info").get("title").asText());
 
+        // Create a customer in final so we have a way to verify the entity instance count
+        new ReferenceModelProject(getHubClient()).createCustomerInstance(new Customer(1, "Jane"));
         ArrayNode entityTypes = (ArrayNode) controller.getPrimaryEntityTypes().getBody();
         assertEquals(1, entityTypes.size(), "A new model should have been created " +
             "and thus there should be one primary entity type");
+
+        JsonNode customerType = entityTypes.get(0);
+        assertEquals("Customer", customerType.get("entityName").asText());
+        assertEquals(1, customerType.get("entityInstanceCount").asInt(),
+            "Should have a count of one because there's one document in the 'Customer' collection");
+
     }
 
     private void updateModelInfo() {

--- a/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/Customer.java
+++ b/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/Customer.java
@@ -6,6 +6,14 @@ public class Customer {
     int customerNumber;
     String customerSince;
 
+    public Customer(int customerId, String name) {
+        this.customerId = customerId;
+        this.name = name;
+    }
+
+    public Customer() {
+    }
+
     public int getCustomerId() {
         return customerId;
     }


### PR DESCRIPTION
Was mistakenly using staging before

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

