### PR TITLE
DHFPROD-4944: Fixing the issue where source data table overlaps Expand/Collapse button on screen resize

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.module.scss
@@ -98,15 +98,17 @@
     > .columnOptionsSelectorContainer {
         display: inline-block;
         margin-bottom: 10px;
-        > .expandCollapseBtn {
-            width: 102px;
-            height: 32px;
-        }
+
         > .columnOptionsSelector{
             float: right;
             margin-top: 10px;
         }
     }
+}
+
+> .expandCollapseBtn {
+    width: 102px;
+    height: 32px;
 }
 
 .DropdownMenuItem {
@@ -378,11 +380,8 @@ hr {
     width: 100%;
     display: inline-block;
     justify-content: space-between;
-    vertical-align: middle;
-    //text-align: center;
-    //padding-bottom: 2px;
-    margin-top: 2px;
-    height: 4.5vh;
+    margin-bottom: -4px;
+    margin-top: 4px;
 }
 
 .navigate_source_uris{
@@ -393,7 +392,7 @@ hr {
     justify-content: space-between;
     text-align: center;
     margin-top: -32px;
-    margin-left: 10vw;
+    margin-left: 45%;
     white-space: nowrap;
   }
  .navigate_uris_left {


### PR DESCRIPTION
### Description
This PR fixes the bug DHFPROD-4944 where source data table used to overlaps Expand/Collapse button on screen resize. 

Simple and small bug fix so no test is required.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

