### PR TITLE
DHFPROD-4056: Tile UI fixes

### DIFF
--- a/marklogic-data-hub-central/ui/src/App.tsx
+++ b/marklogic-data-hub-central/ui/src/App.tsx
@@ -62,7 +62,7 @@ const App: React.FC<Props> = ({history, location}) => {
         if (location.state && location.state.hasOwnProperty('from')) {
             history.push(location.state['from'].pathname);
         } else {
-            history.push('/home');
+            history.push('/tiles');
         }
       }
     }

--- a/marklogic-data-hub-central/ui/src/config/tiles.config.ts
+++ b/marklogic-data-hub-central/ui/src/config/tiles.config.ts
@@ -33,7 +33,7 @@ const tiles: Record<TileId, TileItem>  = {
         title: 'Curate',
         iconType: 'fa', 
         icon: faObjectUngroup, 
-        color: '#FFC53D',
+        color: '#BC811D',
         bgColor: '#F8F2E8',
         border: '#dcbd8a',
     },

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.test.tsx
@@ -24,7 +24,7 @@ describe('TilesView component', () => {
         expect(getByLabelText("tool-model")).toBeInTheDocument();
         expect(getByLabelText('tool-model')).toHaveStyle('color: rgb(34, 7, 94);')
         expect(getByLabelText("tool-curate")).toBeInTheDocument();
-        expect(getByLabelText('tool-curate')).toHaveStyle('color: rgb(255, 197, 61);')
+        expect(getByLabelText('tool-curate')).toHaveStyle('color: rgb(188, 129, 29);')
         expect(getByLabelText("tool-run")).toBeInTheDocument();
         expect(getByLabelText('tool-run')).toHaveStyle('color: rgb(6, 17, 120);')
         expect(getByLabelText("tool-explore")).toBeInTheDocument();     


### PR DESCRIPTION
Minor updates:
- Update Curate icon color per @jbelonoj request (#FFC53D -> #BC811D)
- Update login landing page per @sbayatpur request (/home -> /tiles)
(Users can still get to temporary landing page via app title link.)

No tests necessary.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

