### PR TITLE
DHFPROD-4456: Ensure all tools handle middle tier failure

### DIFF
--- a/marklogic-data-hub-central/ui/src/pages/Curate.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Curate.tsx
@@ -39,8 +39,8 @@ const Curate: React.FC = () => {
               setEntityModels({...models});
           }
         } catch (error) {
-            let message = error;
-            console.error('Error while fetching entities Info', message);
+            console.error('Error fetching entities', error);
+            handleError(error);
         } finally {
           resetSessionTime();
         }

--- a/marklogic-data-hub-central/ui/src/pages/Run.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Run.tsx
@@ -82,7 +82,8 @@ const Run = (props) => {
                 setFlows(response.data);
             }
         } catch (error) {
-            console.error('********* ERROR', error);
+            console.error('Error getting flows', error);
+            handleError(error)
         } finally {
           resetSessionTime();
         }

--- a/marklogic-data-hub-central/ui/src/util/environment.tsx
+++ b/marklogic-data-hub-central/ui/src/util/environment.tsx
@@ -20,7 +20,7 @@ export function setEnvironment()  {
 export function getEnvironment():any {
     let env: any;
     env = localStorage.getItem('environment');
-    if (env) {
+    if(env) {
         return JSON.parse(env);
     }
     else{


### PR DESCRIPTION
### Description

Update HC tool views such that all views handle cases when middle tier has gone down (a 504 error results and an error dialog appears in the UI). This includes when clicking the Download button under Manage Project. Here is a screencast:

https://drive.google.com/file/d/1LB2WTXT75m4O1Z-E0KBkUIrXIxcJRPMt/view

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

