### PR TITLE
DHFPROD-4819: And DHFPROD-4820 - New roles for entity models

### DIFF
--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/ModelController.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/ModelController.java
@@ -26,6 +26,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -40,6 +41,7 @@ public class ModelController extends BaseController {
     @RequestMapping(method = RequestMethod.GET)
     @ResponseBody
     @ApiOperation("This should no longer be used, use /primaryEntityTypes instead")
+    @Secured("ROLE_readEntityModel")
     public ResponseEntity<?> getModels() {
         return ResponseEntity.ok(newModelManager().getModels());
     }
@@ -47,6 +49,7 @@ public class ModelController extends BaseController {
     @RequestMapping(value = "/job-info", method = RequestMethod.GET)
     @ResponseBody
     @ApiOperation(value = "Get info about the latest job info for each model", response = LatestJobInfoList.class)
+    @Secured("ROLE_readEntityModel")
     public ResponseEntity<List<JsonNode>> getLatestJobInfoForAllModels() {
         return ResponseEntity.ok(newModelManager().getLatestJobInfoForAllModels());
     }
@@ -54,6 +57,7 @@ public class ModelController extends BaseController {
     @RequestMapping(value = "/primaryEntityTypes", method = RequestMethod.GET)
     @ResponseBody
     @ApiOperation(value = "Get primary entity types; does not include entity definitions that are considered 'structured' types", response = PrimaryEntityTypeList.class)
+    @Secured("ROLE_readEntityModel")
     public ResponseEntity<JsonNode> getPrimaryEntityTypes() {
         // This must use the final client instead of staging so that the entityInstanceCount is derived from final
         return ResponseEntity.ok(ModelsService.on(getHubClient().getFinalClient()).getPrimaryEntityTypes());
@@ -63,11 +67,13 @@ public class ModelController extends BaseController {
     @ResponseBody
     @ApiOperation(value = "Create a new model and return the persisted model descriptor", response = ModelDescriptor.class)
     @ApiImplicitParam(required = true, paramType = "body", dataType = "CreateModelInput")
+    @Secured("ROLE_writeEntityModel")
     public ResponseEntity<JsonNode> createModel(@RequestBody @ApiParam(hidden = true) JsonNode input) {
         return new ResponseEntity<>(newService().createModel(input), HttpStatus.CREATED);
     }
 
     @RequestMapping(value = "/{modelName}/info", method = RequestMethod.PUT)
+    @Secured("ROLE_writeEntityModel")
     public ResponseEntity<Void> updateModelInfo(@PathVariable String modelName, @RequestBody UpdateModelInfoInput input) {
         newService().updateModelInfo(modelName, input.description);
         return new ResponseEntity<>(HttpStatus.OK);
@@ -75,11 +81,11 @@ public class ModelController extends BaseController {
 
     @RequestMapping(value = "/{modelName}/entityTypes", method = RequestMethod.PUT)
     @ApiImplicitParam(required = true, paramType = "body", dataType = "ModelDefinitions")
+    @Secured("ROLE_writeEntityModel")
     public ResponseEntity<Void> updateModelEntityTypes(@ApiParam(hidden = true) @RequestBody JsonNode entityTypes, @PathVariable String modelName) {
         newService().updateModelEntityTypes(modelName, entityTypes);
         return new ResponseEntity<>(HttpStatus.OK);
     }
-
 
     private ModelManager newModelManager() {
         return new ModelManager(getHubClient());

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/environment/ClearUserDataTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/environment/ClearUserDataTest.java
@@ -4,10 +4,8 @@ import com.marklogic.hub.central.AbstractMvcTest;
 import com.marklogic.hub.deploy.commands.LoadHubArtifactsCommand;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.security.access.AccessDeniedException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 public class ClearUserDataTest extends AbstractMvcTest {
@@ -41,11 +39,7 @@ public class ClearUserDataTest extends AbstractMvcTest {
             return;
         }
         loginAsTestUserWithRoles("hub-central-user","data-hub-developer");
-
-        mockMvc.perform(post(PATH).session(mockHttpSession))
-            .andDo(result -> {
-                assertTrue(result.getResolvedException() instanceof AccessDeniedException);
-            });
+        verifyRequestIsForbidden(post(PATH));
     }
 }
 

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/environment/DownloadConfigurationFilesTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/environment/DownloadConfigurationFilesTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
@@ -15,6 +16,7 @@ import java.util.zip.ZipInputStream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class DownloadConfigurationFilesTest extends AbstractMvcTest {
 
@@ -24,9 +26,7 @@ public class DownloadConfigurationFilesTest extends AbstractMvcTest {
     void permittedUser() throws Exception {
         installReferenceModelProject();
 
-        setTestUserRoles("hub-central-downloader");
-
-        loginAsTestUser();
+        loginAsTestUserWithRoles("hub-central-downloader");
 
         mockMvc.perform(get(PATH).session(mockHttpSession))
             .andDo(result -> {
@@ -51,11 +51,7 @@ public class DownloadConfigurationFilesTest extends AbstractMvcTest {
 
     @Test
     void forbiddenUser() throws Exception {
-        setTestUserRoles("hub-central-user");
-        loginAsTestUser();
-        mockMvc.perform(get(PATH).session(mockHttpSession))
-            .andDo(result -> {
-                assertTrue(result.getResolvedException() instanceof AccessDeniedException);
-            });
+        loginAsTestUserWithRoles("hub-central-user");
+        verifyRequestIsForbidden(get(PATH));
     }
 }

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/ModelControllerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/ModelControllerTest.java
@@ -12,6 +12,7 @@ import com.marklogic.hub.test.Customer;
 import com.marklogic.hub.test.ReferenceModelProject;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -23,6 +24,7 @@ public class ModelControllerTest extends AbstractHubCentralTest {
     ModelController controller;
 
     @Test
+    @WithMockUser(roles = {"readEntityModel", "writeEntityModel"})
     void testModelsServicesEndpoints() {
         createModel();
         updateModelInfo();

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/ModelMvcTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/ModelMvcTest.java
@@ -1,0 +1,37 @@
+package com.marklogic.hub.central.controllers.model;
+
+import com.marklogic.hub.central.AbstractMvcTest;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class ModelMvcTest extends AbstractMvcTest {
+
+    /**
+     * ModelControllerTest verifies that a user can write entity models, just need to verify the inverse here.
+     *
+     * @throws Exception
+     */
+    @Test
+    void canReadButNotWriteModels() throws Exception {
+        loginAsTestUserWithRoles("hub-central-entity-model-reader");
+
+        getJson("/api/models/primaryEntityTypes").andExpect(status().isOk());
+        getJson("/api/models").andExpect(status().isOk());
+        getJson("/api/models/job-info").andExpect(status().isOk());
+
+        verifyRequestIsForbidden(buildJsonPost("/api/models", "{}"));
+        verifyRequestIsForbidden(buildJsonPut("/api/models/doesntMatter/info", "{}"));
+        verifyRequestIsForbidden(buildJsonPut("/api/models/doesntMatter/entityTypes", "{}"));
+    }
+
+    @Test
+    void cannotReadModels() throws Exception {
+        loginAsTestUserWithRoles("hub-central-user");
+
+        verifyRequestIsForbidden(get("/api/models/primaryEntityTypes"));
+        verifyRequestIsForbidden(get("/api/models"));
+        verifyRequestIsForbidden(get("/api/models/job-info"));
+    }
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/privileges/data-hub-read-entity-model.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/privileges/data-hub-read-entity-model.json
@@ -1,0 +1,5 @@
+{
+  "privilege-name": "data-hub:readEntityModel",
+  "action": "http://marklogic.com/data-hub/privileges/read-entity-model",
+  "kind": "execute"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/privileges/data-hub-write-entity-model.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/privileges/data-hub-write-entity-model.json
@@ -1,0 +1,5 @@
+{
+  "privilege-name": "data-hub:writeEntityModel",
+  "action": "http://marklogic.com/data-hub/privileges/write-entity-model",
+  "kind": "execute"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-entity-model-reader.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-entity-model-reader.json
@@ -1,4 +1,11 @@
 {
   "role-name": "data-hub-entity-model-reader",
-  "description": "Permits reading entity model documents"
+  "description": "Permits reading entity model documents",
+  "privilege": [
+    {
+      "privilege-name": "data-hub:readEntityModel",
+      "action": "http://marklogic.com/data-hub/privileges/read-entity-model",
+      "kind": "execute"
+    }
+  ]
 }

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-entity-model-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-entity-model-writer.json
@@ -1,4 +1,11 @@
 {
   "role-name": "data-hub-entity-model-writer",
-  "description": "Permits updating entity model documents"
+  "description": "Permits updating entity model documents",
+  "privilege": [
+    {
+      "privilege-name": "data-hub:writeEntityModel",
+      "action": "http://marklogic.com/data-hub/privileges/write-entity-model",
+      "kind": "execute"
+    }
+  ]
 }

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-entity-model-reader.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-entity-model-reader.json
@@ -1,0 +1,8 @@
+{
+  "role-name": "hub-central-entity-model-reader",
+  "description": "Permits reading entity models in Hub Central",
+  "role": [
+    "hub-central-user",
+    "data-hub-entity-model-reader"
+  ]
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-entity-model-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-entity-model-writer.json
@@ -1,0 +1,8 @@
+{
+  "role-name": "hub-central-entity-model-writer",
+  "description": "Permits writing entity models in Hub Central",
+  "role": [
+    "hub-central-entity-model-reader",
+    "data-hub-entity-model-writer"
+  ]
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/createModel.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/createModel.sjs
@@ -15,6 +15,8 @@
 */
 'use strict';
 
+xdmp.securityAssert("http://marklogic.com/data-hub/privileges/write-entity-model", "execute");
+
 const ds = require("/data-hub/5/data-services/ds-utils.sjs");
 const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
 

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/getPrimaryEntityTypes.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/getPrimaryEntityTypes.sjs
@@ -15,6 +15,8 @@
 */
 'use strict';
 
+xdmp.securityAssert("http://marklogic.com/data-hub/privileges/read-entity-model", "execute");
+
 const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
 
 fn.collection(entityLib.getModelCollection()).toArray().map(model => {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/saveModel.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/saveModel.sjs
@@ -15,6 +15,8 @@
 */
 'use strict';
 
+xdmp.securityAssert("http://marklogic.com/data-hub/privileges/write-entity-model", "execute");
+
 const ds = require("/data-hub/5/data-services/ds-utils.sjs");
 const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
 

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelEntityTypes.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelEntityTypes.sjs
@@ -15,6 +15,8 @@
 */
 'use strict';
 
+xdmp.securityAssert("http://marklogic.com/data-hub/privileges/write-entity-model", "execute");
+
 const ds = require("/data-hub/5/data-services/ds-utils.sjs");
 const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
 

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelInfo.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelInfo.sjs
@@ -15,6 +15,8 @@
 */
 'use strict';
 
+xdmp.securityAssert("http://marklogic.com/data-hub/privileges/write-entity-model", "execute");
+
 const ds = require("/data-hub/5/data-services/ds-utils.sjs");
 const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
 


### PR DESCRIPTION
Created read/write-entity-model privileges, and adding them to the similarly-named existing DH roles. That avoids having to modify any of the other DH roles, like data-hub-developer/operator. 

Also improved HubProjectImpl so that we no longer need to record every role/privilege that we create.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [ ] JIRA_ID included in all the commit messages
- [ ] PR title is in the format JIRA_ID:Title
- [ ] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [ ] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests

