### PR TITLE
DHFPROD-5037: DH fields/indexes are now retained during hubDeploy

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/RemoveDatabaseNameFromDatabaseFieldsPayloadTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/RemoveDatabaseNameFromDatabaseFieldsPayloadTest.java
@@ -1,0 +1,26 @@
+package com.marklogic.hub.deploy.commands;
+
+import com.marklogic.rest.util.Fragment;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RemoveDatabaseNameFromDatabaseFieldsPayloadTest {
+
+    @Test
+    void test() {
+        String xml = "<database-properties xmlns=\"http://marklogic.com/manage\">\n" +
+            "  <database-name>data-hub-JOBS</database-name>\n" +
+            "  <triple-index>true</triple-index>\n" +
+            "</database-properties>";
+
+        Fragment frag = new Fragment(xml);
+        assertTrue(frag.elementExists("/node()/m:database-name"));
+        assertEquals("true", frag.getElementValue("/node()/m:triple-index"));
+
+        xml = new DeployDatabaseFieldCommand.HubDatabaseManager(null).removeDatabaseNameFromXmlPayload(xml);
+        frag = new Fragment(xml);
+        assertFalse(frag.elementExists("/node()/m:database-name"));
+        assertEquals("true", frag.getElementValue("/node()/m:triple-index"));
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/DeployCustomUserFieldsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/DeployCustomUserFieldsTest.java
@@ -1,0 +1,76 @@
+package com.marklogic.hub.dhs;
+
+import com.marklogic.appdeployer.command.CommandContext;
+import com.marklogic.hub.AbstractHubCoreTest;
+import com.marklogic.hub.DatabaseKind;
+import com.marklogic.hub.deploy.commands.DeployDatabaseFieldCommand;
+import com.marklogic.mgmt.api.API;
+import com.marklogic.mgmt.api.database.Database;
+import com.marklogic.mgmt.mapper.DefaultResourceMapper;
+import com.marklogic.mgmt.resource.databases.DatabaseManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DeployCustomUserFieldsTest extends AbstractHubCoreTest {
+
+    @BeforeEach
+    void beforeEach() {
+        resetFieldsAndIndexes();
+    }
+
+    @AfterEach
+    void afterEach() {
+        // dhsDeployer mucks around with appConfig, so gotta reset everything
+        adminHubConfig.resetAppConfigs();
+        adminHubConfig.resetHubConfigs();
+        adminHubConfig.refreshProject();
+
+        resetFieldsAndIndexes();
+    }
+
+    @Test
+    void test() {
+        // Project is expected to only have a final-database file so that we don't end up deploying anything beyond that
+        installProjectInFolder("test-projects/user-fields", false);
+
+        // Get the initial counts of fields/indexes for later comparisons
+        runAsDataHubDeveloper();
+        Database db = readFinalDatabase();
+        final int initialFieldCount = db.getField().size();
+        final int initialFieldIndexCount = db.getRangeFieldIndex().size();
+        final int initialPathIndexCount = db.getRangePathIndex().size();
+
+        // Deploy as a data-hub-developer
+        new DhsDeployer().deployAsDeveloper(getHubConfig());
+
+        // Verify that the existing DH fields/indexes still exist, and we have the user fields/indexes too (1 of each)
+        db = readFinalDatabase();
+        assertEquals(initialFieldCount + 1, db.getField().size());
+        assertEquals(initialFieldIndexCount + 1, db.getRangeFieldIndex().size());
+        assertEquals(initialPathIndexCount + 1, db.getRangePathIndex().size());
+    }
+
+    private Database readFinalDatabase() {
+        String json = new DatabaseManager(adminHubConfig.getManageClient()).getPropertiesAsJson(adminHubConfig.getDbName(DatabaseKind.FINAL));
+        return new DefaultResourceMapper(new API(adminHubConfig.getManageClient())).readResource(json, Database.class);
+    }
+
+    private void resetFieldsAndIndexes() {
+        runAsFlowDeveloper();
+
+        // Wipe out all fields/indexes
+        Database db = new Database(new API(adminHubConfig.getManageClient()), adminHubConfig.getDbName(DatabaseKind.FINAL));
+        db.setField(new ArrayList<>());
+        db.setRangeFieldIndex(new ArrayList<>());
+        db.setRangePathIndex(new ArrayList<>());
+        db.save();
+
+        // Then run the command to deploy the OOTB fields/indexes
+        new DeployDatabaseFieldCommand().execute(new CommandContext(adminHubConfig.getAppConfig(), adminHubConfig.getManageClient(), null));
+    }
+}

--- a/marklogic-data-hub/src/test/resources/test-projects/user-fields/ml-config/databases/final-database.json
+++ b/marklogic-data-hub/src/test/resources/test-projects/user-fields/ml-config/databases/final-database.json
@@ -1,0 +1,32 @@
+{
+  "database-name": "%%mlFinalDbName%%",
+  "schema-database": "%%mlFinalSchemasDbName%%",
+  "triggers-database": "%%mlFinalTriggersDbName%%",
+  "triple-index": true,
+  "collection-lexicon": true,
+  "uri-lexicon": true,
+  "field": [
+    {
+      "field-name": "exampleField",
+      "include-root": false
+    }
+  ],
+  "range-field-index": [
+    {
+      "scalar-type": "string",
+      "field-name": "exampleField",
+      "invalid-values": "reject",
+      "range-value-positions": false,
+      "collation": "http://marklogic.com/collation/"
+    }
+  ],
+  "range-path-index": [
+    {
+      "scalar-type": "int",
+      "path-expression": "/examplePathIndex",
+      "collation": "",
+      "range-value-positions": false,
+      "invalid-values": "reject"
+    }
+  ]
+}

--- a/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
+++ b/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
@@ -222,6 +222,10 @@ public abstract class AbstractHubTest extends TestObject {
                 loadModules = true;
             }
 
+            File configDir = new File(testProjectDir, "ml-config");
+            if (configDir.exists()) {
+                FileUtils.copyDirectory(configDir, hubProject.getUserConfigDir().toFile());
+            }
         } catch (IOException e) {
             throw new RuntimeException("Unable to load project files: " + e.getMessage(), e);
         }


### PR DESCRIPTION
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

