### PR TITLE
DHFPROD-4935: Fixing bad paths in 9-rewriter.xml

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/rest-api/rewriter/9-rewriter.xml
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/rest-api/rewriter/9-rewriter.xml
@@ -374,7 +374,7 @@
                 <match-query-param name="transform">
                     <dispatch>/data-hub/5/rest-api/endpoints/document-item-update.xqy</dispatch>
                 </match-query-param>
-                <dispatch>/data-hub/5/rest-api/endpoints/document-item-update-put.xqy</dispatch>
+                <dispatch>/MarkLogic/rest-api/endpoints/document-item-update-put.xqy</dispatch>
             </match-method>
             <match-method any-of="DELETE">
                 <match-query-param name="txid">
@@ -390,7 +390,7 @@
                 <match-query-param name="category" repeated="true">
                   <dispatch>/data-hub/5/rest-api/endpoints/document-item-update.xqy</dispatch>
                 </match-query-param>
-                <dispatch>/data-hub/5/rest-api/endpoints/document-item-update-delete.xqy</dispatch>
+                <dispatch>/MarkLogic/rest-api/endpoints/document-item-update-delete.xqy</dispatch>
              </match-method>
             <match-method any-of="POST">
                 <match-query-param name="txid">


### PR DESCRIPTION
For testing, I used a script that's attached to 4935

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

