### PR TITLE
DHFPROD-4671: Fixing LoadHubModulesCommandTest

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadHubModulesCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadHubModulesCommandTest.java
@@ -15,62 +15,25 @@
  */
 package com.marklogic.hub.deploy.commands;
 
-import com.marklogic.appdeployer.command.CommandContext;
 import com.marklogic.appdeployer.command.modules.LoadModulesCommand;
-import com.marklogic.hub.HubTestBase;
-import com.marklogic.hub.ApplicationConfig;
-import com.marklogic.mgmt.ManageClient;
-import org.junit.jupiter.api.BeforeEach;
+import com.marklogic.hub.AbstractHubCoreTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = ApplicationConfig.class)
-public class LoadHubModulesCommandTest extends HubTestBase {
-
-    private static Logger logger = LoggerFactory.getLogger(LoadHubModulesCommandTest.class);
-
-    LoadHubModulesCommand loadHubModulesCommand;
-    CommandContext commandContext;
-
-    @BeforeEach
-    public void setup() {
-        createProjectDir();
-        loadHubModulesCommand = new LoadHubModulesCommand();
-        loadHubModulesCommand.setHubConfig(adminHubConfig);
-        //ManageClient manageClient = new ManageClient(new com.marklogic.mgmt.ManageConfig(host, 8002, secUser, secPassword));
-        commandContext = new CommandContext(adminHubConfig.getAppConfig(), adminHubConfig.getManageClient(), null);
-    }
+public class LoadHubModulesCommandTest extends AbstractHubCoreTest {
 
     @Test
-    public void ensureHubFourLoaded() {
-        loadHubModulesCommand.execute(commandContext);
-
-        String jarVersion = adminHubConfig.getJarVersion();
-
-
-        //logger.info(jarVersion);
-
-        // this test will work until major version 10
-        assertTrue(jarVersion.charAt(0) >= '4');
-        assertEquals(jarVersion, versions.getHubVersion(),
+    public void verifyHubVersion() {
+        assertEquals(adminHubConfig.getJarVersion(), versions.getHubVersion(),
             "Jar version must match version in config.xqy/config.sjs after installation");
-
     }
 
     @Test
     public void hubModulesShouldBeLoadedBeforeAllOtherModules() {
-        LoadModulesCommand loadModulesCommand = new LoadModulesCommand();
         assertTrue(
-            loadHubModulesCommand.getExecuteSortOrder() < loadModulesCommand.getExecuteSortOrder(),
+            new LoadHubModulesCommand().getExecuteSortOrder() < new LoadModulesCommand().getExecuteSortOrder(),
             "Hub modules need to be loaded before all other modules so that the DHF-specific REST " +
                 "rewriter is guaranteed to be loaded before any calls are made to /v1/config/* for " +
                 "loading REST extensions");


### PR DESCRIPTION
I removed the call to load hub modules, which fails intermittently in the Jenkins environment. And it was unnecessary - we know the hub modules have been loaded already, the point of the test was to verify that the versions match. 

This likely isn't related to 4671, just borrowing that JIRA ID because it's the latest commit on develop right now.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

