### PR TITLE
DHFPROD-5079: Removing mlLoadBalancerHosts

### DIFF
--- a/azure/flow-runner-function/src/main/java/com/marklogic/dhf/azure/FunctionDataHubFlow.java
+++ b/azure/flow-runner-function/src/main/java/com/marklogic/dhf/azure/FunctionDataHubFlow.java
@@ -149,7 +149,6 @@ public class FunctionDataHubFlow {
             hubConfig.applyProperties(new SimplePropertySource(props));
 
             hubConfig.setHost(host);
-            hubConfig.setLoadBalancerHost(host);
             hubConfig.setMlUsername(username);
             hubConfig.setMlPassword(password);
             hubConfig.setAuthMethod(DatabaseKind.STAGING, "basic");

--- a/examples/dhf4/disconnected-project/gradle.properties
+++ b/examples/dhf4/disconnected-project/gradle.properties
@@ -37,7 +37,7 @@ mlPassword=
 # mlManageScheme=https
 # mlManageSimpleSsl=true
 #
-# If specified, mlSecurityUsername/mlSecurityPassword is used for talking to Security end points on port 8002; this 
+# If specified, mlSecurityUsername/mlSecurityPassword is used for talking to Security end points on port 8002; this
 # user must have the "manage-admin" and "security" roles.
 #
 # mlSecurityUsername=
@@ -126,13 +126,6 @@ mlFlowOperatorUserPassword=_RK6_vC*eR9J&6<PEE6V
 mlFlowDeveloperRole=flow-developer-role
 mlFlowDeveloperUserName=flow-developer
 mlFlowDeveloperUserPassword=o@r*'.2HAt(3iAoXR/*v
-
-# Deprecated property
-# If you are working with a load balancer please indicate so using
-# property "mlIsHostLoadBalancer"
-# When "mlIsHostLoadBalancer" is set to "true", the value specified for "mlHost" will be used as the load balancer.
-# You do not need to explicitly set the value of "mlLoadBalancerHosts" but if you do it must match the value of the property "mlHost"
-# mlLoadBalancerHosts=your-load-balancer-hostname
 
 # If DHF is running in a provisioned environment please specify it here
 # mlIsProvisionedEnvironment=false

--- a/examples/dhf4/external-security/gradle-example.properties
+++ b/examples/dhf4/external-security/gradle-example.properties
@@ -31,7 +31,7 @@ mlPassword=
 # mlManageScheme=https
 # mlManageSimpleSsl=true
 #
-# If specified, mlSecurityUsername/mlSecurityPassword is used for talking to Security end points on port 8002; this 
+# If specified, mlSecurityUsername/mlSecurityPassword is used for talking to Security end points on port 8002; this
 # user must have the "manage-admin" and "security" roles.
 #
 # mlSecurityUsername=
@@ -120,13 +120,6 @@ mlFlowOperatorUserPassword=_RK6_vC*eR9J&6<PEE6V
 mlFlowDeveloperRole=flow-developer-role
 mlFlowDeveloperUserName=flow-developer
 mlFlowDeveloperUserPassword=o@r*'.2HAt(3iAoXR/*v
-
-# Deprecated property
-# If you are working with a load balancer please indicate so using
-# property "mlIsHostLoadBalancer"
-# When "mlIsHostLoadBalancer" is set to "true", the value specified for "mlHost" will be used as the load balancer.
-# You do not need to explicitly set the value of "mlLoadBalancerHosts" but if you do it must match the value of the property "mlHost"
-# mlLoadBalancerHosts=your-load-balancer-hostname
 
 # If DHF is running in a provisioned environment please specify it here
 # mlIsProvisionedEnvironment=false

--- a/marklogic-data-hub-central/ui/e2e/qa-project/gradle.properties
+++ b/marklogic-data-hub-central/ui/e2e/qa-project/gradle.properties
@@ -110,12 +110,5 @@ mlFlowDeveloperRole=flow-developer-role
 mlFlowDeveloperUserName=flow-developer
 mlFlowDeveloperPassword=e8b~m#Evpd3{DDlCf<K'
 
-# Deprecated property
-# If you are working with a load balancer please indicate so using
-# property "mlIsHostLoadBalancer"
-# When "mlIsHostLoadBalancer" is set to "true", the value specified for "mlHost" will be used as the load balancer.
-# You do not need to explicitly set the value of "mlLoadBalancerHosts" but if you do it must match the value of the property "mlHost"
-# mlLoadBalancerHosts=your-load-balancer-hostname
-
 # If DHF is running in a provisioned environment please specify it here
 # mlIsProvisionedEnvironment=false

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/HubConfig.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/HubConfig.java
@@ -331,12 +331,6 @@ public interface HubConfig {
     void setFlowDeveloperUserName(String flowDeveloperUserName);
 
     /**
-     * Gets a string of load balancer host
-     * @return String of load balancer host
-     */
-    String getLoadBalancerHost();
-
-    /**
      * Signifies if the host is a load balancer host.
      * @return a Boolean.
      */

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -143,8 +143,6 @@ public class HubConfigImpl implements HubConfig
     private String mlUsername = null;
     private String mlPassword = null;
 
-    private String loadBalancerHost;
-
     // This name makes it sound like it's more important than it is; as of 5.3.0, it only impacts the legacy MlcpRunner
     // and thus only impacts running DHF 4 input flows. Otherwise, it is ignored.
     private Boolean isHostLoadBalancer;
@@ -933,12 +931,6 @@ public class HubConfigImpl implements HubConfig
     }
 
 
-
-    @JsonIgnore
-    @Override  public String getLoadBalancerHost() {
-        return loadBalancerHost;
-    }
-
     @Override
     public Boolean getIsHostLoadBalancer(){
         return isHostLoadBalancer;
@@ -952,10 +944,6 @@ public class HubConfigImpl implements HubConfig
     @Override
     public void setIsProvisionedEnvironment(boolean isProvisionedEnvironment) {
         this.isProvisionedEnvironment = isProvisionedEnvironment;
-    }
-
-    public void setLoadBalancerHost(String loadBalancerHost) {
-        this.loadBalancerHost = loadBalancerHost;
     }
 
     @Override public String getCustomForestPath() {
@@ -1078,39 +1066,6 @@ public class HubConfigImpl implements HubConfig
             jobSslContext = SimpleX509TrustManager.newSSLContext();
             jobSslHostnameVerifier = DatabaseClientFactory.SSLHostnameVerifier.ANY;
             jobTrustManager = new SimpleX509TrustManager();
-        }
-
-        if (isHostLoadBalancer != null){
-            if (isHostLoadBalancer) {
-                if (host != null && loadBalancerHost != null){
-                    logger.warn("\"mlLoadBalancerHosts\" is a deprecated property. When \"mlIsHostLoadBalancer\" is set to \"true\"properties, the value specified for \"mlHost\" will be used as the load balancer.");
-                    if (!host.equals(loadBalancerHost)) {
-                        throw new DataHubConfigurationException("\"mlLoadBalancerHosts\" must be the same as \"mlHost\"");
-                    }
-                    else {
-                        loadBalancerHost = host;
-                    }
-                }
-            }
-            else {
-                if (loadBalancerHost != null){
-                    throw new DataHubConfigurationException("\"mlIsHostLoadBalancer\" must not be false if you are using \"mlLoadBalancerHosts\"");
-                }
-            }
-        }
-        else{
-            if (host != null && loadBalancerHost != null){
-                if (!host.equals(loadBalancerHost)) {
-                    throw new DataHubConfigurationException("\"mlLoadBalancerHosts\" must be the same as \"mlHost\"");
-                }
-                else {
-                    isHostLoadBalancer = true;
-                    loadBalancerHost = host;
-                }
-            }
-            else {
-                isHostLoadBalancer = false;
-            }
         }
     }
 
@@ -1680,7 +1635,6 @@ public class HubConfigImpl implements HubConfig
         DHFVersion = "2.0.0";
         host = "localhost";
         hubLogLevel = "default";
-        loadBalancerHost = null;
         isHostLoadBalancer = false;
         isProvisionedEnvironment = false;
 
@@ -1793,7 +1747,9 @@ public class HubConfigImpl implements HubConfig
         propertyConsumerMap.put("mlDHFVersion", prop -> DHFVersion = prop);
         propertyConsumerMap.put("mlHost", prop -> setHost(prop));
         propertyConsumerMap.put("mlIsHostLoadBalancer", prop -> isHostLoadBalancer = Boolean.parseBoolean(prop));
-        propertyConsumerMap.put("mlLoadBalancerHosts", prop -> loadBalancerHost = prop);
+        propertyConsumerMap.put("mlLoadBalancerHosts", prop ->
+            logger.warn("mlLoadBalancerHosts was deprecated in version 4.0.1 and does not have any impact on Data Hub functionality. " +
+                "It can be safely removed from your set of properties."));
         propertyConsumerMap.put("mlIsProvisionedEnvironment", prop -> isProvisionedEnvironment = Boolean.parseBoolean(prop));
 
         propertyConsumerMap.put("mlStagingAppserverName", prop -> stagingHttpName = prop);

--- a/marklogic-data-hub/src/main/resources/scaffolding/gradle_properties
+++ b/marklogic-data-hub/src/main/resources/scaffolding/gradle_properties
@@ -31,7 +31,7 @@ mlPassword=
 # mlManageScheme=https
 # mlManageSimpleSsl=true
 #
-# If specified, mlSecurityUsername/mlSecurityPassword is used for talking to Security end points on port 8002; this 
+# If specified, mlSecurityUsername/mlSecurityPassword is used for talking to Security end points on port 8002; this
 # user must have the "manage-admin" and "security" roles.
 #
 # mlSecurityUsername=
@@ -109,13 +109,6 @@ mlFlowOperatorPassword=%%mlFlowOperatorPassword%%
 mlFlowDeveloperRole=%%mlFlowDeveloperRole%%
 mlFlowDeveloperUserName=%%mlFlowDeveloperUserName%%
 mlFlowDeveloperPassword=%%mlFlowDeveloperPassword%%
-
-# Deprecated property
-# If you are working with a load balancer please indicate so using
-# property "mlIsHostLoadBalancer"
-# When "mlIsHostLoadBalancer" is set to "true", the value specified for "mlHost" will be used as the load balancer.
-# You do not need to explicitly set the value of "mlLoadBalancerHosts" but if you do it must match the value of the property "mlHost"
-# mlLoadBalancerHosts=your-load-balancer-hostname
 
 # If DHF is running in a provisioned environment please specify it here
 # mlIsProvisionedEnvironment=false

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/core/HubConfigTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/core/HubConfigTest.java
@@ -9,9 +9,8 @@ import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.HubTestBase;
 import com.marklogic.hub.error.DataHubConfigurationException;
-
-import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -99,54 +98,21 @@ public class HubConfigTest extends HubTestBase {
         props.put("mlFinalPort", port);
 
         //these values not set by dhf-default, so checking for null
-        if(certFile != null)
+        if (certFile != null)
             props.put("mlFinalCertFile", certFile);
-        if(certPassword !=null)
+        if (certPassword != null)
             props.put("mlFinalCertPassword", certPassword);
-        if(extName != null)
+        if (extName != null)
             props.put("mlFinalExternalName", extName);
         props.put("mlFinalSimpleSsl", sslMethod);
         //if sslContext is set , it is assumed that it is a secure connection, hence unsetting them
-        if(! sslMethod) {
+        if (!sslMethod) {
             adminHubConfig.setSslContext(DatabaseKind.FINAL, null);
             adminHubConfig.setSslHostnameVerifier(DatabaseKind.FINAL, null);
             adminHubConfig.setTrustManager(DatabaseKind.FINAL, null);
         }
 
 
-    }
-
-    @Test
-    public void testLoadBalancerProps() {
-        deleteProp("mlLoadBalancerHosts");
-        resetProperties();
-        adminHubConfig.refreshProject();
-        assertNull(adminHubConfig.getLoadBalancerHost());
-
-        writeProp("mlIsHostLoadBalancer", "true");
-        resetProperties();
-        adminHubConfig.refreshProject();
-        assertTrue(adminHubConfig.getIsHostLoadBalancer());
-
-        writeProp("mlLoadBalancerHosts", adminHubConfig.getHost());
-        resetProperties();
-        adminHubConfig.refreshProject();
-        assertEquals(adminHubConfig.getHost(), adminHubConfig.getLoadBalancerHost());
-
-        try {
-            writeProp("mlLoadBalancerHosts", "host1");
-            resetProperties();
-            adminHubConfig.refreshProject();
-        }
-        catch (DataHubConfigurationException e){
-            assertEquals( "\"mlLoadBalancerHosts\" must be the same as \"mlHost\"", e.getMessage());
-        }
-
-        deleteProp("mlLoadBalancerHosts");
-        deleteProp("mlIsHostLoadBalancer");
-        resetProperties();
-        adminHubConfig.refreshProject();
-        assertFalse(adminHubConfig.getIsHostLoadBalancer());
     }
 
     @Test
@@ -183,9 +149,7 @@ public class HubConfigTest extends HubTestBase {
 
             assertEquals(jsonNode.get("finalPort").asInt(), (int) config.getPort(DatabaseKind.FINAL));
 
-        }
-        catch (Exception e)
-        {
+        } catch (Exception e) {
             throw new DataHubConfigurationException("Your datahub configuration could not serialize");
         }
     }

--- a/web/src/test/java/com/marklogic/hub/web/web/HubConfigJsonTest.java
+++ b/web/src/test/java/com/marklogic/hub/web/web/HubConfigJsonTest.java
@@ -59,7 +59,6 @@ public class HubConfigJsonTest {
 
         hubConfig.setMlUsername("mluser");
         hubConfig.setMlPassword("mlpassword");
-        hubConfig.setLoadBalancerHost("somehost");
 
         String expected = "{\n" +
             "  \"stagingDbName\": \"data-hub-STAGING\",\n" +
@@ -101,7 +100,5 @@ public class HubConfigJsonTest {
             "had public getters in HubConfigImpl, but this seems like an unintended error, as we wouldn't want to " +
             "serialize passwords out into a JSON string");
         assertFalse(actualJson.has("mlPassword"));
-        assertFalse(actualJson.has("loadBalancerHost"), "It is not known why this is JsonIgnore'd, but that was the " +
-            "case with HubConfigImpl, so it's expected to be enforced by AbstractHubConfig as well");
     }
 }


### PR DESCRIPTION
Was deprecated back in 4.0.1; this is killing it almost completely.  If a user does try to set it (which doesn't impact anything), a warning message will be logged informing the user that they can safely remove the property from their configuration.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

