### PR TITLE
DHFPROD-5060: Spec for returning entity properties in search

### DIFF
--- a/examples/reference-entity-model/entities/Customer.entity.json
+++ b/examples/reference-entity-model/entities/Customer.entity.json
@@ -18,17 +18,36 @@
           "datatype": "string",
           "collation": "http://marklogic.com/collation/codepoint"
         },
+        "nicknames": {
+          "datatype": "array",
+          "description": "Example of a multi-value property of simple values",
+          "items": {
+            "datatype": "string"
+          }
+        },
         "shipping": {
-          "$ref": "#/definitions/Address"
+          "datatype": "array",
+          "description": "Example of a multi-value property of structured values",
+          "items": {
+            "$ref": "#/definitions/Address"
+          }
         },
         "billing": {
+          "description": "Example of a single-value structured property",
           "$ref": "#/definitions/Address"
+        },
+        "birthDate": {
+          "datatype": "date"
+        },
+        "status": {
+          "datatype": "string"
         },
         "customerSince": {
           "datatype": "date"
         },
         "orders": {
           "datatype": "array",
+          "description": "Example of a relationship to another entity type",
           "items": {
             "$ref": "http://example.org/Order-0.0.1/Order"
           }

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/EntitySearchController.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/EntitySearchController.java
@@ -23,6 +23,7 @@ import com.marklogic.hub.central.managers.EntitySearchManager;
 import com.marklogic.hub.central.models.DocSearchQueryInfo;
 import com.marklogic.hub.central.models.Document;
 import com.marklogic.hub.central.models.SearchQuery;
+import com.marklogic.hub.central.schemas.EntitySearchResponseSchema;
 import com.marklogic.hub.dataservices.EntitySearchService;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiOperation;
@@ -49,7 +50,8 @@ public class EntitySearchController extends BaseController {
 
     @RequestMapping(method = RequestMethod.POST)
     @ResponseBody
-    @ApiOperation("Response is a MarkLogic JSON search response")
+    @ApiOperation(value = "Response is a MarkLogic JSON search response. Please see ./specs/EntitySearchResponse.schema.json for complete information, as swagger-ui does not capture all the details",
+        response = EntitySearchResponseSchema.class)
     public String search(@RequestBody SearchQuery searchQuery) {
         return newEntitySearchManager().search(searchQuery).get();
     }

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/EntitySearchPropertyDefinitionSchema.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/EntitySearchPropertyDefinitionSchema.java
@@ -1,0 +1,218 @@
+
+package com.marklogic.hub.central.schemas;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * EntitySearchPropertyDefinition
+ * <p>
+ * Defines a property definition of an entity instance; may refer to a structured property too
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "propertyPath",
+    "propertyLabel",
+    "datatype",
+    "multiple",
+    "properties"
+})
+public class EntitySearchPropertyDefinitionSchema {
+
+    /**
+     * The unique path to this property. For a structured property, uses dot notation - e.g. billing.street.fiveDigit
+     * 
+     */
+    @JsonProperty("propertyPath")
+    @JsonPropertyDescription("The unique path to this property. For a structured property, uses dot notation - e.g. billing.street.fiveDigit")
+    private String propertyPath;
+    /**
+     * This is equivalent to the property path, with dots being converted into spaces for structured properties
+     * 
+     */
+    @JsonProperty("propertyLabel")
+    @JsonPropertyDescription("This is equivalent to the property path, with dots being converted into spaces for structured properties")
+    private String propertyLabel;
+    @JsonProperty("datatype")
+    private String datatype;
+    /**
+     * true if the property allows for an array of values
+     * 
+     */
+    @JsonProperty("multiple")
+    @JsonPropertyDescription("true if the property allows for an array of values")
+    private Boolean multiple;
+    /**
+     * For a structured property, this will be an array of EntitySearchPropertyDefinition objects
+     * 
+     */
+    @JsonProperty("properties")
+    @JsonPropertyDescription("For a structured property, this will be an array of EntitySearchPropertyDefinition objects")
+    private List<EntitySearchPropertyDefinitionSchema> properties = new ArrayList<EntitySearchPropertyDefinitionSchema>();
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * The unique path to this property. For a structured property, uses dot notation - e.g. billing.street.fiveDigit
+     * 
+     */
+    @JsonProperty("propertyPath")
+    public String getPropertyPath() {
+        return propertyPath;
+    }
+
+    /**
+     * The unique path to this property. For a structured property, uses dot notation - e.g. billing.street.fiveDigit
+     * 
+     */
+    @JsonProperty("propertyPath")
+    public void setPropertyPath(String propertyPath) {
+        this.propertyPath = propertyPath;
+    }
+
+    /**
+     * This is equivalent to the property path, with dots being converted into spaces for structured properties
+     * 
+     */
+    @JsonProperty("propertyLabel")
+    public String getPropertyLabel() {
+        return propertyLabel;
+    }
+
+    /**
+     * This is equivalent to the property path, with dots being converted into spaces for structured properties
+     * 
+     */
+    @JsonProperty("propertyLabel")
+    public void setPropertyLabel(String propertyLabel) {
+        this.propertyLabel = propertyLabel;
+    }
+
+    @JsonProperty("datatype")
+    public String getDatatype() {
+        return datatype;
+    }
+
+    @JsonProperty("datatype")
+    public void setDatatype(String datatype) {
+        this.datatype = datatype;
+    }
+
+    /**
+     * true if the property allows for an array of values
+     * 
+     */
+    @JsonProperty("multiple")
+    public Boolean getMultiple() {
+        return multiple;
+    }
+
+    /**
+     * true if the property allows for an array of values
+     * 
+     */
+    @JsonProperty("multiple")
+    public void setMultiple(Boolean multiple) {
+        this.multiple = multiple;
+    }
+
+    /**
+     * For a structured property, this will be an array of EntitySearchPropertyDefinition objects
+     * 
+     */
+    @JsonProperty("properties")
+    public List<EntitySearchPropertyDefinitionSchema> getProperties() {
+        return properties;
+    }
+
+    /**
+     * For a structured property, this will be an array of EntitySearchPropertyDefinition objects
+     * 
+     */
+    @JsonProperty("properties")
+    public void setProperties(List<EntitySearchPropertyDefinitionSchema> properties) {
+        this.properties = properties;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(EntitySearchPropertyDefinitionSchema.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append("propertyPath");
+        sb.append('=');
+        sb.append(((this.propertyPath == null)?"<null>":this.propertyPath));
+        sb.append(',');
+        sb.append("propertyLabel");
+        sb.append('=');
+        sb.append(((this.propertyLabel == null)?"<null>":this.propertyLabel));
+        sb.append(',');
+        sb.append("datatype");
+        sb.append('=');
+        sb.append(((this.datatype == null)?"<null>":this.datatype));
+        sb.append(',');
+        sb.append("multiple");
+        sb.append('=');
+        sb.append(((this.multiple == null)?"<null>":this.multiple));
+        sb.append(',');
+        sb.append("properties");
+        sb.append('=');
+        sb.append(((this.properties == null)?"<null>":this.properties));
+        sb.append(',');
+        sb.append("additionalProperties");
+        sb.append('=');
+        sb.append(((this.additionalProperties == null)?"<null>":this.additionalProperties));
+        sb.append(',');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.datatype == null)? 0 :this.datatype.hashCode()));
+        result = ((result* 31)+((this.propertyLabel == null)? 0 :this.propertyLabel.hashCode()));
+        result = ((result* 31)+((this.multiple == null)? 0 :this.multiple.hashCode()));
+        result = ((result* 31)+((this.additionalProperties == null)? 0 :this.additionalProperties.hashCode()));
+        result = ((result* 31)+((this.propertyPath == null)? 0 :this.propertyPath.hashCode()));
+        result = ((result* 31)+((this.properties == null)? 0 :this.properties.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof EntitySearchPropertyDefinitionSchema) == false) {
+            return false;
+        }
+        EntitySearchPropertyDefinitionSchema rhs = ((EntitySearchPropertyDefinitionSchema) other);
+        return (((((((this.datatype == rhs.datatype)||((this.datatype!= null)&&this.datatype.equals(rhs.datatype)))&&((this.propertyLabel == rhs.propertyLabel)||((this.propertyLabel!= null)&&this.propertyLabel.equals(rhs.propertyLabel))))&&((this.multiple == rhs.multiple)||((this.multiple!= null)&&this.multiple.equals(rhs.multiple))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.propertyPath == rhs.propertyPath)||((this.propertyPath!= null)&&this.propertyPath.equals(rhs.propertyPath))))&&((this.properties == rhs.properties)||((this.properties!= null)&&this.properties.equals(rhs.properties))));
+    }
+
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/EntitySearchResponseSchema.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/EntitySearchResponseSchema.java
@@ -1,0 +1,228 @@
+
+package com.marklogic.hub.central.schemas;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * EntitySearchResponse
+ * <p>
+ * Defines a MarkLogic JSON search response that includes entity-specific data needed by the UI. Note that some things - like facets and matches - are explicitly omitted because they're already defined by the ML docs.
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "snippet-format",
+    "total",
+    "start",
+    "page-length",
+    "results",
+    "selectedPropertyDefinitions",
+    "entityPropertyDefinitions"
+})
+public class EntitySearchResponseSchema {
+
+    @JsonProperty("snippet-format")
+    private String snippetFormat;
+    @JsonProperty("total")
+    private Double total;
+    @JsonProperty("start")
+    private Double start;
+    @JsonProperty("page-length")
+    private Double pageLength;
+    @JsonProperty("results")
+    private List<EntitySearchResultSchema> results = new ArrayList<EntitySearchResultSchema>();
+    /**
+     * Defines the array of selected properties, which will either be a default set based on the entity type, or chosen by a client
+     * 
+     */
+    @JsonProperty("selectedPropertyDefinitions")
+    @JsonPropertyDescription("Defines the array of selected properties, which will either be a default set based on the entity type, or chosen by a client")
+    private List<EntitySearchPropertyDefinitionSchema> selectedPropertyDefinitions = new ArrayList<EntitySearchPropertyDefinitionSchema>();
+    /**
+     * Defines the entire set of properties for an entity type, including structured properties
+     * 
+     */
+    @JsonProperty("entityPropertyDefinitions")
+    @JsonPropertyDescription("Defines the entire set of properties for an entity type, including structured properties")
+    private List<EntitySearchPropertyDefinitionSchema> entityPropertyDefinitions = new ArrayList<EntitySearchPropertyDefinitionSchema>();
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("snippet-format")
+    public String getSnippetFormat() {
+        return snippetFormat;
+    }
+
+    @JsonProperty("snippet-format")
+    public void setSnippetFormat(String snippetFormat) {
+        this.snippetFormat = snippetFormat;
+    }
+
+    @JsonProperty("total")
+    public Double getTotal() {
+        return total;
+    }
+
+    @JsonProperty("total")
+    public void setTotal(Double total) {
+        this.total = total;
+    }
+
+    @JsonProperty("start")
+    public Double getStart() {
+        return start;
+    }
+
+    @JsonProperty("start")
+    public void setStart(Double start) {
+        this.start = start;
+    }
+
+    @JsonProperty("page-length")
+    public Double getPageLength() {
+        return pageLength;
+    }
+
+    @JsonProperty("page-length")
+    public void setPageLength(Double pageLength) {
+        this.pageLength = pageLength;
+    }
+
+    @JsonProperty("results")
+    public List<EntitySearchResultSchema> getResults() {
+        return results;
+    }
+
+    @JsonProperty("results")
+    public void setResults(List<EntitySearchResultSchema> results) {
+        this.results = results;
+    }
+
+    /**
+     * Defines the array of selected properties, which will either be a default set based on the entity type, or chosen by a client
+     * 
+     */
+    @JsonProperty("selectedPropertyDefinitions")
+    public List<EntitySearchPropertyDefinitionSchema> getSelectedPropertyDefinitions() {
+        return selectedPropertyDefinitions;
+    }
+
+    /**
+     * Defines the array of selected properties, which will either be a default set based on the entity type, or chosen by a client
+     * 
+     */
+    @JsonProperty("selectedPropertyDefinitions")
+    public void setSelectedPropertyDefinitions(List<EntitySearchPropertyDefinitionSchema> selectedPropertyDefinitions) {
+        this.selectedPropertyDefinitions = selectedPropertyDefinitions;
+    }
+
+    /**
+     * Defines the entire set of properties for an entity type, including structured properties
+     * 
+     */
+    @JsonProperty("entityPropertyDefinitions")
+    public List<EntitySearchPropertyDefinitionSchema> getEntityPropertyDefinitions() {
+        return entityPropertyDefinitions;
+    }
+
+    /**
+     * Defines the entire set of properties for an entity type, including structured properties
+     * 
+     */
+    @JsonProperty("entityPropertyDefinitions")
+    public void setEntityPropertyDefinitions(List<EntitySearchPropertyDefinitionSchema> entityPropertyDefinitions) {
+        this.entityPropertyDefinitions = entityPropertyDefinitions;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(EntitySearchResponseSchema.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append("snippetFormat");
+        sb.append('=');
+        sb.append(((this.snippetFormat == null)?"<null>":this.snippetFormat));
+        sb.append(',');
+        sb.append("total");
+        sb.append('=');
+        sb.append(((this.total == null)?"<null>":this.total));
+        sb.append(',');
+        sb.append("start");
+        sb.append('=');
+        sb.append(((this.start == null)?"<null>":this.start));
+        sb.append(',');
+        sb.append("pageLength");
+        sb.append('=');
+        sb.append(((this.pageLength == null)?"<null>":this.pageLength));
+        sb.append(',');
+        sb.append("results");
+        sb.append('=');
+        sb.append(((this.results == null)?"<null>":this.results));
+        sb.append(',');
+        sb.append("selectedPropertyDefinitions");
+        sb.append('=');
+        sb.append(((this.selectedPropertyDefinitions == null)?"<null>":this.selectedPropertyDefinitions));
+        sb.append(',');
+        sb.append("entityPropertyDefinitions");
+        sb.append('=');
+        sb.append(((this.entityPropertyDefinitions == null)?"<null>":this.entityPropertyDefinitions));
+        sb.append(',');
+        sb.append("additionalProperties");
+        sb.append('=');
+        sb.append(((this.additionalProperties == null)?"<null>":this.additionalProperties));
+        sb.append(',');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.entityPropertyDefinitions == null)? 0 :this.entityPropertyDefinitions.hashCode()));
+        result = ((result* 31)+((this.total == null)? 0 :this.total.hashCode()));
+        result = ((result* 31)+((this.pageLength == null)? 0 :this.pageLength.hashCode()));
+        result = ((result* 31)+((this.start == null)? 0 :this.start.hashCode()));
+        result = ((result* 31)+((this.snippetFormat == null)? 0 :this.snippetFormat.hashCode()));
+        result = ((result* 31)+((this.additionalProperties == null)? 0 :this.additionalProperties.hashCode()));
+        result = ((result* 31)+((this.results == null)? 0 :this.results.hashCode()));
+        result = ((result* 31)+((this.selectedPropertyDefinitions == null)? 0 :this.selectedPropertyDefinitions.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof EntitySearchResponseSchema) == false) {
+            return false;
+        }
+        EntitySearchResponseSchema rhs = ((EntitySearchResponseSchema) other);
+        return (((((((((this.entityPropertyDefinitions == rhs.entityPropertyDefinitions)||((this.entityPropertyDefinitions!= null)&&this.entityPropertyDefinitions.equals(rhs.entityPropertyDefinitions)))&&((this.total == rhs.total)||((this.total!= null)&&this.total.equals(rhs.total))))&&((this.pageLength == rhs.pageLength)||((this.pageLength!= null)&&this.pageLength.equals(rhs.pageLength))))&&((this.start == rhs.start)||((this.start!= null)&&this.start.equals(rhs.start))))&&((this.snippetFormat == rhs.snippetFormat)||((this.snippetFormat!= null)&&this.snippetFormat.equals(rhs.snippetFormat))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.results == rhs.results)||((this.results!= null)&&this.results.equals(rhs.results))))&&((this.selectedPropertyDefinitions == rhs.selectedPropertyDefinitions)||((this.selectedPropertyDefinitions!= null)&&this.selectedPropertyDefinitions.equals(rhs.selectedPropertyDefinitions))));
+    }
+
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/EntitySearchResultPropertySchema.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/EntitySearchResultPropertySchema.java
@@ -1,0 +1,109 @@
+
+package com.marklogic.hub.central.schemas;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * EntitySearchResultProperty
+ * <p>
+ * Defines a property of an entity instance within a search result
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "propertyPath",
+    "propertyValue"
+})
+public class EntitySearchResultPropertySchema {
+
+    @JsonProperty("propertyPath")
+    private Double propertyPath;
+    @JsonProperty("propertyValue")
+    private Object propertyValue;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("propertyPath")
+    public Double getPropertyPath() {
+        return propertyPath;
+    }
+
+    @JsonProperty("propertyPath")
+    public void setPropertyPath(Double propertyPath) {
+        this.propertyPath = propertyPath;
+    }
+
+    @JsonProperty("propertyValue")
+    public Object getPropertyValue() {
+        return propertyValue;
+    }
+
+    @JsonProperty("propertyValue")
+    public void setPropertyValue(Object propertyValue) {
+        this.propertyValue = propertyValue;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(EntitySearchResultPropertySchema.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append("propertyPath");
+        sb.append('=');
+        sb.append(((this.propertyPath == null)?"<null>":this.propertyPath));
+        sb.append(',');
+        sb.append("propertyValue");
+        sb.append('=');
+        sb.append(((this.propertyValue == null)?"<null>":this.propertyValue));
+        sb.append(',');
+        sb.append("additionalProperties");
+        sb.append('=');
+        sb.append(((this.additionalProperties == null)?"<null>":this.additionalProperties));
+        sb.append(',');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.propertyValue == null)? 0 :this.propertyValue.hashCode()));
+        result = ((result* 31)+((this.additionalProperties == null)? 0 :this.additionalProperties.hashCode()));
+        result = ((result* 31)+((this.propertyPath == null)? 0 :this.propertyPath.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof EntitySearchResultPropertySchema) == false) {
+            return false;
+        }
+        EntitySearchResultPropertySchema rhs = ((EntitySearchResultPropertySchema) other);
+        return ((((this.propertyValue == rhs.propertyValue)||((this.propertyValue!= null)&&this.propertyValue.equals(rhs.propertyValue)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.propertyPath == rhs.propertyPath)||((this.propertyPath!= null)&&this.propertyPath.equals(rhs.propertyPath))));
+    }
+
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/EntitySearchResultSchema.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/EntitySearchResultSchema.java
@@ -1,0 +1,129 @@
+
+package com.marklogic.hub.central.schemas;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * EntitySearchResult
+ * <p>
+ * Defines a search result for an entity instance
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "index",
+    "uri",
+    "entityProperties"
+})
+public class EntitySearchResultSchema {
+
+    @JsonProperty("index")
+    private Double index;
+    @JsonProperty("uri")
+    private String uri;
+    @JsonProperty("entityProperties")
+    private List<EntitySearchResultPropertySchema> entityProperties = new ArrayList<EntitySearchResultPropertySchema>();
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("index")
+    public Double getIndex() {
+        return index;
+    }
+
+    @JsonProperty("index")
+    public void setIndex(Double index) {
+        this.index = index;
+    }
+
+    @JsonProperty("uri")
+    public String getUri() {
+        return uri;
+    }
+
+    @JsonProperty("uri")
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    @JsonProperty("entityProperties")
+    public List<EntitySearchResultPropertySchema> getEntityProperties() {
+        return entityProperties;
+    }
+
+    @JsonProperty("entityProperties")
+    public void setEntityProperties(List<EntitySearchResultPropertySchema> entityProperties) {
+        this.entityProperties = entityProperties;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(EntitySearchResultSchema.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append("index");
+        sb.append('=');
+        sb.append(((this.index == null)?"<null>":this.index));
+        sb.append(',');
+        sb.append("uri");
+        sb.append('=');
+        sb.append(((this.uri == null)?"<null>":this.uri));
+        sb.append(',');
+        sb.append("entityProperties");
+        sb.append('=');
+        sb.append(((this.entityProperties == null)?"<null>":this.entityProperties));
+        sb.append(',');
+        sb.append("additionalProperties");
+        sb.append('=');
+        sb.append(((this.additionalProperties == null)?"<null>":this.additionalProperties));
+        sb.append(',');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.index == null)? 0 :this.index.hashCode()));
+        result = ((result* 31)+((this.additionalProperties == null)? 0 :this.additionalProperties.hashCode()));
+        result = ((result* 31)+((this.uri == null)? 0 :this.uri.hashCode()));
+        result = ((result* 31)+((this.entityProperties == null)? 0 :this.entityProperties.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof EntitySearchResultSchema) == false) {
+            return false;
+        }
+        EntitySearchResultSchema rhs = ((EntitySearchResultSchema) other);
+        return (((((this.index == rhs.index)||((this.index!= null)&&this.index.equals(rhs.index)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.uri == rhs.uri)||((this.uri!= null)&&this.uri.equals(rhs.uri))))&&((this.entityProperties == rhs.entityProperties)||((this.entityProperties!= null)&&this.entityProperties.equals(rhs.entityProperties))));
+    }
+
+}

--- a/specs/models/EntitySearchPropertyDefinition.schema.json
+++ b/specs/models/EntitySearchPropertyDefinition.schema.json
@@ -1,0 +1,29 @@
+{
+  "title": "EntitySearchPropertyDefinition",
+  "description": "Defines a property definition of an entity instance; may refer to a structured property too",
+  "type": "object",
+  "properties": {
+    "propertyPath": {
+      "description": "The unique path to this property. For a structured property, uses dot notation - e.g. billing.street.fiveDigit",
+      "type": "string"
+    },
+    "propertyLabel": {
+      "description": "This is equivalent to the property path, with dots being converted into spaces for structured properties",
+      "type": "string"
+    },
+    "datatype": {
+      "type": "string"
+    },
+    "multiple": {
+      "description": "true if the property allows for an array of values",
+      "type": "boolean"
+    },
+    "properties": {
+      "type": "array",
+      "description": "For a structured property, this will be an array of EntitySearchPropertyDefinition objects",
+      "items": {
+        "$ref": "./EntitySearchPropertyDefinition.schema.json"
+      }
+    }
+  }
+}

--- a/specs/models/EntitySearchResponse.schema.json
+++ b/specs/models/EntitySearchResponse.schema.json
@@ -1,0 +1,39 @@
+{
+  "title": "EntitySearchResponse",
+  "description": "Defines a MarkLogic JSON search response that includes entity-specific data needed by the UI. Note that some things - like facets and matches - are explicitly omitted because they're already defined by the ML docs.",
+  "type": "object",
+  "properties": {
+    "snippet-format": {
+      "type": "string"
+    },
+    "total": {
+      "type": "number"
+    },
+    "start": {
+      "type": "number"
+    },
+    "page-length": {
+      "type": "number"
+    },
+    "results": {
+      "type": "array",
+      "items": {
+        "$ref": "./EntitySearchResult.schema.json"
+      }
+    },
+    "selectedPropertyDefinitions": {
+      "description": "Defines the array of selected properties, which will either be a default set based on the entity type, or chosen by a client",
+      "type" : "array",
+      "items": {
+        "$ref": "./EntitySearchPropertyDefinition.schema.json"
+      }
+    },
+    "entityPropertyDefinitions": {
+      "description": "Defines the entire set of properties for an entity type, including structured properties",
+      "type" : "array",
+      "items": {
+        "$ref": "./EntitySearchPropertyDefinition.schema.json"
+      }
+    }
+  }
+}

--- a/specs/models/EntitySearchResult.schema.json
+++ b/specs/models/EntitySearchResult.schema.json
@@ -1,0 +1,19 @@
+{
+  "title": "EntitySearchResult",
+  "description": "Defines a search result for an entity instance",
+  "type": "object",
+  "properties": {
+    "index": {
+      "type": "number"
+    },
+    "uri": {
+      "type": "string"
+    },
+    "entityProperties": {
+      "type": "array",
+      "items": {
+        "$ref": "./EntitySearchResultProperty.schema.json"
+      }
+    }
+  }
+}

--- a/specs/models/EntitySearchResultProperty.schema.json
+++ b/specs/models/EntitySearchResultProperty.schema.json
@@ -1,0 +1,48 @@
+{
+  "title": "EntitySearchResultProperty",
+  "description": "Defines a property of an entity instance within a search result",
+  "type": "object",
+  "properties": {
+    "propertyPath": {
+      "type": "number"
+    },
+    "propertyValue": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "This will be present for a single-value property"
+        },
+        {
+          "type": "array",
+          "description": "This will be present for a multi-value property that is an array of simple types",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "array",
+          "description": "This will be present for a single-value structured property, where each item in the array is an EntitySearchResultProperty for the structured property",
+          "items": {
+            "type": "./EntitySearchResultProperty.schema.json"
+          }
+        },
+        {
+          "type": "array",
+          "description": "This will be present for a multi-value structured property, where each item corresponds to a structured type instance",
+          "items": {
+            "type": "object",
+            "properties": {
+              "properties": {
+                "type": "array",
+                "description": "An array of property values for the structured type instance",
+                "items": {
+                  "type": "./EntitySearchResultProperty.schema.json"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This defines additions to an ML JSON search response. 

It also adds to the Customer reference entity to address some missing scenarios. 

The Swagger can be viewed at localhost:8080/swagger-ui.html, but our JSON Schema -> Swagger generator doesn't like certain things in the spec, such as "oneOf". So it's best to look at these specs directly to understand them.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

