### PR TITLE
DHFPROD-4388: Removing the default collections from Target Collections field in Advanced Settings dialog

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings-dialog.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings-dialog.test.tsx
@@ -26,7 +26,7 @@ describe('Update data load settings component', () => {
     //Add a check for target format once implemented
     //Should show default collections applied???
     expect(getByText('Target Collections:')).toBeInTheDocument();
-    expect(getByText('Please select target collections')).toBeInTheDocument();
+    expect(getByText('Please add target collections')).toBeInTheDocument();
     expect(getByText('Default Collections:')).toBeInTheDocument();
     expect(getByText('Target Permissions:')).toBeInTheDocument();
     expect(getByText('Provenance Granularity:')).toBeInTheDocument();
@@ -49,7 +49,7 @@ describe('Update data load settings component', () => {
     expect(getByText('Target Database:')).toBeInTheDocument();
     expect(getByText('data-hub-STAGING')).toBeInTheDocument();
     expect(getByText('Target Collections:')).toBeInTheDocument();
-    expect(getByText('Please select target collections')).toBeInTheDocument();
+    expect(getByText('Please add target collections')).toBeInTheDocument();
     expect(getByText('Default Collections:')).toBeInTheDocument();
     expect(getByText('Target Permissions:')).toBeInTheDocument();
     expect(getByText('Provenance Granularity:')).toBeInTheDocument();
@@ -186,7 +186,7 @@ describe('Update data load settings component', () => {
 
   test('Verify discard dialog modal when Cancel is clicked', () => {
     const { rerender, queryByText, getByPlaceholderText, getByText } = render(<AdvancedSettingsDialog {...data.advancedSettings} />);
-    //fireEvent.change(getByText('Please select target collections'), { target: { value: 'test-collection' }});
+    //fireEvent.change(getByText('Please add target collections'), { target: { value: 'test-collection' }});
     fireEvent.click(getByText('Custom Hook'));
     fireEvent.change(getByPlaceholderText('Please enter module'), { target: { value: 'test-module' }});
     expect(getByPlaceholderText('Please enter module')).toHaveValue('test-module');

--- a/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings-dialog.tsx
+++ b/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings-dialog.tsx
@@ -466,8 +466,8 @@ const getSettingsArtifact = async () => {
             id="additionalColl"
             mode="tags"
             style={{width: '100%'}}
-            placeholder="Please select target collections"
-            value={defaultCollections.concat(additionalCollections)}
+            placeholder="Please add target collections"
+            value={additionalCollections}
             disabled={!canReadWrite}
             onChange={handleAddColl}
             className={styles.inputWithTooltip}

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.test.tsx
@@ -48,17 +48,22 @@ describe('Load data component', () => {
   })
 
   test('Verify Load settings from list view renders correctly', async () => {
-    const { getByText, getByTestId, getByTitle } = render(<LoadList {...data.loadData} />)
+    const { getByText, getByTestId, getByTitle,queryByTitle } = render(<LoadList {...data.loadData} />)
 
     await wait(() => {
       fireEvent.click(getByTestId(data.loadData.data[0].name+'-settings'));
     })
+
+    let targetCollection = getByTitle('customerCollection'); // Additional target collection (Added by user)
+
     expect(getByText('Advanced Settings')).toBeInTheDocument();
     // Check if the settings API is being called.
     expect(axiosMock.get).toBeCalledWith('/api/steps/ingestion/' + data.loadData.data[0].name + '/settings');
     expect(getByText('Target Collections:')).toBeInTheDocument();
-    expect(getByTitle(data.loadData.data[0].name)).toBeInTheDocument();
+    expect(targetCollection).toBeInTheDocument(); //Should be available in the document
+    expect(targetCollection).not.toBe(data.loadData.data[0].name); //Should not be same as the default collection
     expect(getByText('Default Collections:')).toBeInTheDocument();
     expect(getByTestId(`defaultCollections-${data.loadData.data[0].name}`)).toBeInTheDocument();
+    expect(queryByTitle(data.loadData.data[0].name)).not.toBeInTheDocument();  // The default collection should not be a part of the Target Collection list
   })
 });

--- a/marklogic-data-hub-central/ui/src/config/load.config.ts
+++ b/marklogic-data-hub-central/ui/src/config/load.config.ts
@@ -50,7 +50,7 @@ const loadSettings = {"data" :
         "collections": [
           "testLoad"
         ],
-        "additionalCollections": [],
+        "additionalCollections": ['customerCollection'],
         "lastUpdated": "2020-05-27T12:19:02.446622-07:00"
     },
     "status" :200


### PR DESCRIPTION
### Description
This PR involves removal of the default collections from Target Collections field in Advanced Settings dialog.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

