### PR TITLE
DHFPROD-5110: Entity types that are empty strings no longer cause error

### DIFF
--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/managers/EntitySearchManager.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/managers/EntitySearchManager.java
@@ -166,17 +166,17 @@ public class EntitySearchManager {
         // Creating queries object
         List<StructuredQueryDefinition> queries = new ArrayList<>();
 
+        final String[] entityTypeCollections = searchQuery.getQuery().getEntityTypeCollections();
+
         // Filtering search results for docs related to an entity
-        if (!CollectionUtils.isEmpty(searchQuery.getQuery().getEntityTypeIds())) {
-            // Collections to search
-            String[] collections = searchQuery.getQuery().getEntityTypeIds().toArray(new String[0]);
+        if (entityTypeCollections != null && entityTypeCollections.length > 0) {
             // Collections that have the mastering audit and notification docs. Excluding docs from
             // these collection in search results
             String[] excludedCollections = getExcludedCollections(
                 searchQuery.getQuery().getEntityTypeIds());
 
             StructuredQueryDefinition finalCollQuery = queryBuilder
-                .andNot(queryBuilder.collection(collections),
+                .andNot(queryBuilder.collection(entityTypeCollections),
                     queryBuilder.collection(excludedCollections));
 
             queries.add(finalCollQuery);

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/models/DocSearchQueryInfo.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/models/DocSearchQueryInfo.java
@@ -33,6 +33,23 @@ public class DocSearchQueryInfo {
     this.selectedFacets = new HashMap<>();
   }
 
+    /**
+     * @return an array of non-empty entityTypeIds; this is used to handle empty strings being passed in by the UI,
+     * which seems like a bug, but we don't want it to cause a problem
+     */
+  public String[] getEntityTypeCollections() {
+      if (entityTypeIds != null && !entityTypeIds.isEmpty()) {
+          List<String> filteredTypes = new ArrayList<>();
+          entityTypeIds.forEach(type -> {
+              if (type != null && type.trim().length() > 0) {
+                  filteredTypes.add(type);
+              }
+          });
+          return filteredTypes.toArray(new String[]{});
+      }
+      return null;
+  }
+
   public String getSearchText() {
     return searchText;
   }

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/managers/EntitySearchManagerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/managers/EntitySearchManagerTest.java
@@ -19,9 +19,12 @@ package com.marklogic.hub.central.managers;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.hub.central.AbstractHubCentralTest;
 import com.marklogic.hub.central.exceptions.DataHubException;
+import com.marklogic.hub.central.models.DocSearchQueryInfo;
 import com.marklogic.hub.central.models.SearchQuery;
+import com.marklogic.hub.test.ReferenceModelProject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,6 +48,22 @@ public class EntitySearchManagerTest extends AbstractHubCentralTest {
     @AfterEach
     public void resetData() {
         EntitySearchManager.QUERY_OPTIONS = ACTUAL_QUERY_OPTIONS;
+    }
+
+    @Test
+    void noEntityTypesSelected() {
+        // Need at least one entity model to exist for this scenario
+        installReferenceModelProject(true);
+
+        SearchQuery query = new SearchQuery();
+        DocSearchQueryInfo info = new DocSearchQueryInfo();
+        info.setEntityTypeIds(Arrays.asList(" "));
+        query.setQuery(info);
+
+        String results = entitySearchManager.search(query).get();
+        ObjectNode node = readJsonObject(results);
+        assertEquals(0, node.get("total").asInt(), "When entityTypeIds has values, but they're all empty strings, the " +
+            "backend should return no results, and not throw an error");
     }
 
     @Test


### PR DESCRIPTION
I think the root cause is that the UI is passing empty strings, but this at least prevents an error from occurring.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

