### PR TITLE
DHFPROD-4984: Filter object/array type properties using entity model

### DIFF
--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/EntitySearchController.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/EntitySearchController.java
@@ -19,10 +19,10 @@ package com.marklogic.hub.central.controllers;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marklogic.hub.central.managers.EntitySearchManager;
-import com.marklogic.hub.central.models.DocSearchQueryInfo;
-import com.marklogic.hub.central.models.Document;
-import com.marklogic.hub.central.models.SearchQuery;
+import com.marklogic.hub.central.entities.search.EntitySearchManager;
+import com.marklogic.hub.central.entities.search.models.DocSearchQueryInfo;
+import com.marklogic.hub.central.entities.search.models.Document;
+import com.marklogic.hub.central.entities.search.models.SearchQuery;
 import com.marklogic.hub.central.schemas.EntitySearchResponseSchema;
 import com.marklogic.hub.dataservices.EntitySearchService;
 import io.swagger.annotations.ApiImplicitParam;
@@ -51,7 +51,7 @@ public class EntitySearchController extends BaseController {
     @RequestMapping(method = RequestMethod.POST)
     @ResponseBody
     @ApiOperation(value = "Response is a MarkLogic JSON search response. Please see ./specs/EntitySearchResponse.schema.json for complete information, as swagger-ui does not capture all the details",
-        response = EntitySearchResponseSchema.class)
+            response = EntitySearchResponseSchema.class)
     public String search(@RequestBody SearchQuery searchQuery) {
         return newEntitySearchManager().search(searchQuery).get();
     }

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/Constants.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/Constants.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2012-2020 MarkLogic Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.marklogic.hub.central.entities.search;
+
+public class Constants {
+
+    public static final String COLLECTION_CONSTRAINT_NAME = "Collection";
+    public static final String CREATED_ON_CONSTRAINT_NAME = "createdOnRange";
+    public static final String JOB_WORD_CONSTRAINT_NAME = "createdByJobWord";
+    public static final String JOB_RANGE_CONSTRAINT_NAME = "createdByJob";
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/EntitySearchManager.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/EntitySearchManager.java
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  */
-package com.marklogic.hub.central.managers;
+package com.marklogic.hub.central.entities.search;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -32,45 +32,36 @@ import com.marklogic.client.io.marker.StructureWriteHandle;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.RawCombinedQueryDefinition;
 import com.marklogic.client.query.StructuredQueryBuilder;
-import com.marklogic.client.query.StructuredQueryBuilder.Operator;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.hub.HubClient;
+import com.marklogic.hub.central.entities.search.impl.CollectionFacetHandler;
+import com.marklogic.hub.central.entities.search.impl.CreatedOnFacetHandler;
+import com.marklogic.hub.central.entities.search.impl.EntityPropertyFacetHandler;
+import com.marklogic.hub.central.entities.search.impl.JobRangeFacetHandler;
+import com.marklogic.hub.central.entities.search.models.DocSearchQueryInfo;
+import com.marklogic.hub.central.entities.search.models.Document;
+import com.marklogic.hub.central.entities.search.models.SearchQuery;
 import com.marklogic.hub.central.exceptions.DataHubException;
-import com.marklogic.hub.central.models.DocSearchQueryInfo;
-import com.marklogic.hub.central.models.Document;
-import com.marklogic.hub.central.models.SearchQuery;
+import com.marklogic.hub.central.managers.ModelManager;
 import com.marklogic.hub.dataservices.EntitySearchService;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.util.CollectionUtils;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import java.util.function.Function;
 
 public class EntitySearchManager {
 
-    private static final String COLLECTION_CONSTRAINT_NAME = "Collection";
-    private static final String CREATED_ON_CONSTRAINT_NAME = "createdOnRange";
-    private static final String JOB_WORD_CONSTRAINT_NAME = "createdByJobWord";
-    private static final String JOB_RANGE_CONSTRAINT_NAME = "createdByJob";
-
     private static final String MASTERING_AUDIT_COLLECTION_NAME = "mdm-auditing";
     private static final String[] IGNORED_SM_COLLECTION_SUFFIX = {"auditing", "notification"};
-
-    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-    private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter
-        .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
     private static final String SEARCH_HEAD = "<search xmlns=\"http://marklogic.com/appservices/search\">\n";
     private static final String SEARCH_TAIL = "</search>";
@@ -82,14 +73,15 @@ public class EntitySearchManager {
 
     private static final Logger logger = LoggerFactory.getLogger(EntitySearchManager.class);
 
-
     public static String QUERY_OPTIONS = "exp-final-entity-options";
+    private static Map<String, FacetHandler> facetHandlerMap;
     private DatabaseClient finalDatabaseClient;
     private ModelManager modelManager;
 
     public EntitySearchManager(HubClient hubClient) {
         this.finalDatabaseClient = hubClient.getFinalClient();
         this.modelManager = new ModelManager(hubClient);
+        initializeFacetHandlerMap();
     }
 
     public StringHandle search(SearchQuery searchQuery) {
@@ -118,13 +110,13 @@ public class EntitySearchManager {
             // Resorting to string contains check as there isn't any other discernible difference
             if (e.getLocalizedMessage().contains(QUERY_OPTIONS)) {
                 logger.error("If this is a configuration issue, fix the configuration issues as shown in"
-                    + " the logs for enabling faceted search on the entity properties."
-                    + "\n"
-                    + "If the " + QUERY_OPTIONS
-                    + " search options file is missing, please look into documentation "
-                    + "for creating the options file. If the database is indexing then it might take some "
-                    + "time for the file to get generated. This file is required to enable "
-                    + "various search features.");
+                        + " the logs for enabling faceted search on the entity properties."
+                        + "\n"
+                        + "If the " + QUERY_OPTIONS
+                        + " search options file is missing, please look into documentation "
+                        + "for creating the options file. If the database is indexing then it might take some "
+                        + "time for the file to get generated. This file is required to enable "
+                        + "various search features.");
             }
 
             throw new DataHubException(e.getServerMessage(), e);
@@ -172,11 +164,11 @@ public class EntitySearchManager {
             // Collections that have the mastering audit and notification docs. Excluding docs from
             // these collection in search results
             String[] excludedCollections = getExcludedCollections(
-                searchQuery.getQuery().getEntityTypeIds());
+                    searchQuery.getQuery().getEntityTypeIds());
 
             StructuredQueryDefinition finalCollQuery = queryBuilder
-                .andNot(queryBuilder.collection(entityTypeCollections),
-                    queryBuilder.collection(excludedCollections));
+                    .andNot(queryBuilder.collection(entityTypeCollections),
+                            queryBuilder.collection(excludedCollections));
 
             queries.add(finalCollQuery);
         }
@@ -187,38 +179,9 @@ public class EntitySearchManager {
 
         // Filtering by facets
         searchQuery.getQuery().getSelectedFacets().forEach((facetType, data) -> {
-            StructuredQueryDefinition facetDef = null;
-
-            switch (facetType) {
-                case COLLECTION_CONSTRAINT_NAME:
-                    facetDef = queryBuilder
-                            .collectionConstraint(facetType, data.getStringValues().toArray(new String[0]));
-                    break;
-                case JOB_RANGE_CONSTRAINT_NAME:
-                    facetDef = queryBuilder
-                            .wordConstraint(JOB_WORD_CONSTRAINT_NAME,
-                                    data.getStringValues().toArray(new String[0]));
-                    break;
-                case CREATED_ON_CONSTRAINT_NAME:
-                    // Converting the date in string format from yyyy-MM-dd format to yyyy-MM-dd HH:mm:ss format
-                    LocalDate startDate = LocalDate.parse(data.getRangeValues().getLowerBound(), DATE_FORMAT);
-                    String startDateTime = startDate.atStartOfDay(ZoneId.systemDefault())
-                            .format(DATE_TIME_FORMAT);
-
-                    // Converting the date in string format from yyyy-MM-dd format to yyyy-MM-dd HH:mm:ss format
-                    // Adding 1 day to end date to get docs harmonized on the end date as well.
-                    LocalDate endDate = LocalDate.parse(data.getRangeValues().getUpperBound(), DATE_FORMAT)
-                            .plusDays(1);
-                    String endDateTime = endDate.atStartOfDay(ZoneId.systemDefault()).format(DATE_TIME_FORMAT);
-
-                    facetDef = queryBuilder
-                            .and(queryBuilder.rangeConstraint(facetType, Operator.GE, startDateTime),
-                                    queryBuilder.rangeConstraint(facetType, Operator.LT, endDateTime));
-                    break;
-                default:  // If a property is not a Hub property, then it is an Entity Property
-                    facetDef = getEntityPropertyConstraints(facetType, data, queryBuilder);
-                    break;
-            }
+            // If a property is not a Hub property, then it is an Entity Property
+            StructuredQueryDefinition facetDef = facetHandlerMap.getOrDefault(facetType, new EntityPropertyFacetHandler(facetType))
+                    .buildQuery(data, queryBuilder);
 
             if (facetDef != null) {
                 queries.add(facetDef);
@@ -226,10 +189,15 @@ public class EntitySearchManager {
         });
 
         // And between all the queries
-        StructuredQueryDefinition finalQueryDef = queryBuilder
-            .and(queries.toArray(new StructuredQueryDefinition[0]));
+        return queryBuilder
+                .and(queries.toArray(new StructuredQueryDefinition[0]));
+    }
 
-        return finalQueryDef;
+    private void initializeFacetHandlerMap() {
+        facetHandlerMap = new HashMap<>();
+        facetHandlerMap.put(Constants.COLLECTION_CONSTRAINT_NAME, new CollectionFacetHandler());
+        facetHandlerMap.put(Constants.JOB_RANGE_CONSTRAINT_NAME, new JobRangeFacetHandler());
+        facetHandlerMap.put(Constants.CREATED_ON_CONSTRAINT_NAME, new CreatedOnFacetHandler());
     }
 
     private String[] getExcludedCollections(List<String> entityNames) {
@@ -241,34 +209,6 @@ public class EntitySearchManager {
         });
         excludedCol.add(MASTERING_AUDIT_COLLECTION_NAME);
         return excludedCol.toArray(new String[0]);
-    }
-
-    private StructuredQueryDefinition getEntityPropertyConstraints(String facetType, DocSearchQueryInfo.FacetData data,
-                                                                   StructuredQueryBuilder queryBuilder) {
-        StructuredQueryDefinition facetDef = null;
-        switch (data.getDataType()) {
-            case "int":
-            case "integer":
-            case "decimal":
-            case "long":
-            case "float":
-            case "double":
-            case "date":
-            case "dateTime":
-                String lowerBound = data.getRangeValues().getLowerBound();
-                String upperBound = data.getRangeValues().getUpperBound();
-                if (StringUtils.isNotEmpty(lowerBound) || StringUtils.isNotEmpty(upperBound)) {
-                    facetDef = queryBuilder
-                        .and(queryBuilder.rangeConstraint(facetType, Operator.GE, lowerBound),
-                            queryBuilder.rangeConstraint(facetType, Operator.LE, upperBound));
-                }
-                break;
-
-            default:
-                facetDef = queryBuilder.rangeConstraint(facetType, StructuredQueryBuilder.Operator.EQ,
-                    data.getStringValues().toArray(new String[0]));
-        }
-        return facetDef;
     }
 
     protected String buildSearchOptions(String query, SearchQuery searchQuery) {
@@ -331,40 +271,40 @@ public class EntitySearchManager {
 
     protected SearchQuery transformToSearchQuery(JsonNode queryDocument) {
         return Optional.of(queryDocument)
-            .map(node -> node.get("savedQuery"))
-            .map(node -> node.get("query"))
-            .map(node -> {
-                try {
-                    return new ObjectMapper().treeToValue(node, DocSearchQueryInfo.class);
-                }
-                catch (JsonProcessingException e) {
-                    throw new DataHubException("Invalid query");
-                }
-            })
-            .map(docSearchQueryInfo -> {
-                final SearchQuery query = new SearchQuery();
-                query.setQuery(docSearchQueryInfo);
-                return query;
-            })
-            .orElseThrow(() -> new DataHubException("Valid query required"));
+                .map(node -> node.get("savedQuery"))
+                .map(node -> node.get("query"))
+                .map(node -> {
+                    try {
+                        return new ObjectMapper().treeToValue(node, DocSearchQueryInfo.class);
+                    }
+                    catch (JsonProcessingException e) {
+                        throw new DataHubException("Invalid query");
+                    }
+                })
+                .map(docSearchQueryInfo -> {
+                    final SearchQuery query = new SearchQuery();
+                    query.setQuery(docSearchQueryInfo);
+                    return query;
+                })
+                .orElseThrow(() -> new DataHubException("Valid query required"));
     }
 
     protected String getEntityTypeIdForRowExport(JsonNode queryDocument) {
         return Optional.of(queryDocument)
-            .map(node -> node.get("savedQuery"))
-            .map(node -> node.get("query"))
-            .map(node -> node.get("entityTypeIds"))
-            .map(node -> node.get(0))
-            .map(JsonNode::textValue)
-            .orElse(null);
+                .map(node -> node.get("savedQuery"))
+                .map(node -> node.get("query"))
+                .map(node -> node.get("entityTypeIds"))
+                .map(node -> node.get(0))
+                .map(JsonNode::textValue)
+                .orElse(null);
     }
 
     protected List<String> getColumnNamesForRowExport(JsonNode queryDocument) {
         List<String> columns = new ArrayList<>();
         Optional.of(queryDocument)
-            .map(node -> node.get("savedQuery"))
-            .map(node -> node.get("propertiesToDisplay"))
-            .ifPresent(node -> node.forEach(colNode -> columns.add(colNode.textValue())));
+                .map(node -> node.get("savedQuery"))
+                .map(node -> node.get("propertiesToDisplay"))
+                .ifPresent(node -> node.forEach(colNode -> columns.add(colNode.textValue())));
         return columns;
     }
 
@@ -373,11 +313,11 @@ public class EntitySearchManager {
      */
     protected String getQueryName(JsonNode queryDocument) {
         return Optional.of(queryDocument)
-            .map(node -> node.get("savedQuery"))
-            .map(node -> node.get("name"))
-            .map(JsonNode::textValue)
-            .filter(StringUtils::isNotBlank)
-            .orElse(null);
+                .map(node -> node.get("savedQuery"))
+                .map(node -> node.get("name"))
+                .map(JsonNode::textValue)
+                .filter(StringUtils::isNotBlank)
+                .orElse(null);
     }
 
     /**
@@ -390,8 +330,8 @@ public class EntitySearchManager {
         String queryOptions;
         try {
             queryOptions = finalDatabaseClient.newServerConfigManager()
-                .newQueryOptionsManager()
-                .readOptionsAs(queryOptionsName, Format.XML, String.class);
+                    .newQueryOptionsManager()
+                    .readOptionsAs(queryOptionsName, Format.XML, String.class);
         }
         catch (ResourceNotFoundException e) {
             throw new DataHubException(String.format("Could not find search options: %s", queryOptionsName), e);
@@ -402,8 +342,8 @@ public class EntitySearchManager {
     private void prepareResponseHeader(HttpServletResponse response, String contentType, String fileName) {
         response.setContentType(contentType);
         response.setHeader(
-            "Content-Disposition",
-            "attachment;filename=" + fileName);
+                "Content-Disposition",
+                "attachment;filename=" + fileName);
     }
 
     private String getFileNameForDownload(JsonNode queryDocument, String fileExtension) {

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/FacetHandler.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/FacetHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2012-2020 MarkLogic Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.marklogic.hub.central.entities.search;
+
+import com.marklogic.client.query.StructuredQueryBuilder;
+import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.hub.central.entities.search.models.DocSearchQueryInfo;
+
+public interface FacetHandler {
+
+    StructuredQueryDefinition buildQuery(DocSearchQueryInfo.FacetData data, StructuredQueryBuilder queryBuilder);
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/impl/CollectionFacetHandler.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/impl/CollectionFacetHandler.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012-2020 MarkLogic Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.marklogic.hub.central.entities.search.impl;
+
+import com.marklogic.client.query.StructuredQueryBuilder;
+import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.hub.central.entities.search.Constants;
+import com.marklogic.hub.central.entities.search.FacetHandler;
+import com.marklogic.hub.central.entities.search.models.DocSearchQueryInfo;
+
+public class CollectionFacetHandler implements FacetHandler {
+
+    @Override
+    public StructuredQueryDefinition buildQuery(DocSearchQueryInfo.FacetData data, StructuredQueryBuilder queryBuilder) {
+        return queryBuilder
+                .collectionConstraint(Constants.COLLECTION_CONSTRAINT_NAME, data.getStringValues().toArray(new String[0]));
+    }
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/impl/CreatedOnFacetHandler.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/impl/CreatedOnFacetHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012-2020 MarkLogic Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.marklogic.hub.central.entities.search.impl;
+
+import com.marklogic.client.query.StructuredQueryBuilder;
+import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.hub.central.entities.search.Constants;
+import com.marklogic.hub.central.entities.search.FacetHandler;
+import com.marklogic.hub.central.entities.search.models.DocSearchQueryInfo;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+public class CreatedOnFacetHandler implements FacetHandler {
+
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+
+    @Override
+    public StructuredQueryDefinition buildQuery(DocSearchQueryInfo.FacetData data, StructuredQueryBuilder queryBuilder) {
+        // Converting the date in string format from yyyy-MM-dd format to yyyy-MM-dd HH:mm:ss format
+        LocalDate startDate = LocalDate.parse(data.getRangeValues().getLowerBound(), DATE_FORMAT);
+        String startDateTime = startDate.atStartOfDay(ZoneId.systemDefault())
+                .format(DATE_TIME_FORMAT);
+
+        // Converting the date in string format from yyyy-MM-dd format to yyyy-MM-dd HH:mm:ss format
+        // Adding 1 day to end date to get docs harmonized on the end date as well.
+        LocalDate endDate = LocalDate.parse(data.getRangeValues().getUpperBound(), DATE_FORMAT)
+                .plusDays(1);
+        String endDateTime = endDate.atStartOfDay(ZoneId.systemDefault()).format(DATE_TIME_FORMAT);
+
+        return queryBuilder
+                .and(queryBuilder.rangeConstraint(Constants.CREATED_ON_CONSTRAINT_NAME, StructuredQueryBuilder.Operator.GE, startDateTime),
+                        queryBuilder.rangeConstraint(Constants.CREATED_ON_CONSTRAINT_NAME, StructuredQueryBuilder.Operator.LT, endDateTime));
+
+    }
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/impl/EntityPropertyFacetHandler.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/impl/EntityPropertyFacetHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012-2020 MarkLogic Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.marklogic.hub.central.entities.search.impl;
+
+import com.marklogic.client.query.StructuredQueryBuilder;
+import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.hub.central.entities.search.FacetHandler;
+import com.marklogic.hub.central.entities.search.models.DocSearchQueryInfo;
+import org.apache.commons.lang3.StringUtils;
+
+public class EntityPropertyFacetHandler implements FacetHandler {
+
+    private final String constraintName;
+
+    public EntityPropertyFacetHandler(String constraintName) {
+        this.constraintName = constraintName;
+    }
+
+    @Override
+    public StructuredQueryDefinition buildQuery(DocSearchQueryInfo.FacetData data, StructuredQueryBuilder queryBuilder) {
+        StructuredQueryDefinition facetDef = null;
+        switch (data.getDataType()) {
+            case "int":
+            case "integer":
+            case "decimal":
+            case "long":
+            case "float":
+            case "double":
+            case "date":
+            case "dateTime":
+                String lowerBound = data.getRangeValues().getLowerBound();
+                String upperBound = data.getRangeValues().getUpperBound();
+                if (StringUtils.isNotEmpty(lowerBound) || StringUtils.isNotEmpty(upperBound)) {
+                    facetDef = queryBuilder
+                            .and(queryBuilder.rangeConstraint(constraintName, StructuredQueryBuilder.Operator.GE, lowerBound),
+                                    queryBuilder.rangeConstraint(constraintName, StructuredQueryBuilder.Operator.LE, upperBound));
+                }
+                break;
+
+            default:
+                facetDef = queryBuilder.rangeConstraint(constraintName, StructuredQueryBuilder.Operator.EQ,
+                        data.getStringValues().toArray(new String[0]));
+        }
+        return facetDef;
+    }
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/impl/JobRangeFacetHandler.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/impl/JobRangeFacetHandler.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012-2020 MarkLogic Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.marklogic.hub.central.entities.search.impl;
+
+import com.marklogic.client.query.StructuredQueryBuilder;
+import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.hub.central.entities.search.Constants;
+import com.marklogic.hub.central.entities.search.FacetHandler;
+import com.marklogic.hub.central.entities.search.models.DocSearchQueryInfo;
+
+public class JobRangeFacetHandler implements FacetHandler {
+
+    @Override
+    public StructuredQueryDefinition buildQuery(DocSearchQueryInfo.FacetData data, StructuredQueryBuilder queryBuilder) {
+        return queryBuilder
+                .wordConstraint(Constants.JOB_WORD_CONSTRAINT_NAME, data.getStringValues().toArray(new String[0]));
+    }
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/models/DocSearchQueryInfo.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/models/DocSearchQueryInfo.java
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  */
-package com.marklogic.hub.central.models;
+package com.marklogic.hub.central.entities.search.models;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/models/Document.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/models/Document.java
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  */
-package com.marklogic.hub.central.models;
+package com.marklogic.hub.central.entities.search.models;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/models/SearchQuery.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/models/SearchQuery.java
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  */
-package com.marklogic.hub.central.models;
+package com.marklogic.hub.central.entities.search.models;
 
 import java.util.List;
 import java.util.Optional;

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/EntitySearchControllerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/EntitySearchControllerTest.java
@@ -145,20 +145,22 @@ public class EntitySearchControllerTest extends AbstractMvcTest {
             "        \"propertiesToDisplay\": [\n" +
             "            \"customerId\",\n" +
             "            \"name\",\n" +
-            "            \"customerNumber\"\n" +
+            "            \"customerNumber\",\n" +
+            "            \"shipping\",\n" +
+            "            \"orders\"\n" +
             "        ]\n" +
             "    }\n" +
             "}";
 
-        int limit = 2;
+        // Even though "propertiesToDisplay" has 5 columns we only export 3 since we dont export object and array type properties for now.
         int totalColumns = 3;
+        int limit = 2;
         Object[] customer1Info = {customer1.getCustomerId(), customer1.getName(), customer1.getCustomerNumber()};
         Object[] customer2Info = {customer2.getCustomerId(), customer2.getName(), customer2.getCustomerNumber()};
 
 
         // Try exporting without the required role "hub-central-entity-exporter"
-        setTestUserRoles("hub-central-user","data-hub-operator");
-        loginAsTestUser();
+        loginAsTestUserWithRoles("hub-central-user","data-hub-operator");
         postWithParams(EXPORT_PATH, getRequestParams(limit, json))
             .andExpect(status().isForbidden());
         getJson(EXPORT_PATH + "/query/non-existent-query-id", getRequestParams(limit, null))
@@ -166,8 +168,7 @@ public class EntitySearchControllerTest extends AbstractMvcTest {
 
 
         // Set the required role and re-login
-        setTestUserRoles("data-hub-operator", "hub-central-entity-exporter", "hub-central-saved-query-user");
-        loginAsTestUser();
+        loginAsTestUserWithRoles("data-hub-operator", "hub-central-entity-exporter", "hub-central-saved-query-user");
 
         // Export using query document
         postWithParams(EXPORT_PATH, getRequestParams(limit, json))

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/EntitySearchManagerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/EntitySearchManagerTest.java
@@ -14,17 +14,16 @@
  *  limitations under the License.
  *
  */
-package com.marklogic.hub.central.managers;
+package com.marklogic.hub.central.entities.search;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.hub.central.AbstractHubCentralTest;
+import com.marklogic.hub.central.entities.search.models.DocSearchQueryInfo;
+import com.marklogic.hub.central.entities.search.models.SearchQuery;
 import com.marklogic.hub.central.exceptions.DataHubException;
-import com.marklogic.hub.central.models.DocSearchQueryInfo;
-import com.marklogic.hub.central.models.SearchQuery;
-import com.marklogic.hub.test.ReferenceModelProject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,7 +62,7 @@ public class EntitySearchManagerTest extends AbstractHubCentralTest {
         String results = entitySearchManager.search(query).get();
         ObjectNode node = readJsonObject(results);
         assertEquals(0, node.get("total").asInt(), "When entityTypeIds has values, but they're all empty strings, the " +
-            "backend should return no results, and not throw an error");
+                "backend should return no results, and not throw an error");
     }
 
     @Test
@@ -99,7 +98,7 @@ public class EntitySearchManagerTest extends AbstractHubCentralTest {
         sortOrderList.add(sortOrder);
         searchQuery.setSortOrder(sortOrderList);
         String expectedResult = "<search xmlns=\"http://marklogic.com/appservices/search\">\n<options><sort-order type=\"xs:string\" direction=\"ascending\"><element ns=\"\" name=\"entityTypeProperty1\"/>\n" +
-            "</sort-order><sort-order direction=\"descending\"><field name=\"datahubCreatedOn\"/>\n</sort-order></options><query><collection-query><uri>collection1</uri></collection-query></query></search>";
+                "</sort-order><sort-order direction=\"descending\"><field name=\"datahubCreatedOn\"/>\n</sort-order></options><query><collection-query><uri>collection1</uri></collection-query></query></search>";
         assertTrue(entitySearchManager.buildSearchOptions(query, searchQuery).equals(expectedResult));
     }
 
@@ -116,18 +115,18 @@ public class EntitySearchManagerTest extends AbstractHubCentralTest {
     @Test
     void testGetColumnNamesForRowExport() throws JsonProcessingException {
         String json = "{\n" +
-            "  \"savedQuery\": {\n" +
-            "    \"name\": \"some-query\",\n" +
-            "    \"description\": \"some-query-description\",\n" +
-            "    \"query\": {\n" +
-            "      \"searchText\": \"some-string\",\n" +
-            "      \"entityTypeIds\": [\n" +
-            "        \"Entity1\"\n" +
-            "      ]\n" +
-            "    },\n" +
-            "    \"propertiesToDisplay\": [\"facet1\", \"EntityTypeProperty1\"]\n" +
-            "  }\n" +
-            "}";
+                "  \"savedQuery\": {\n" +
+                "    \"name\": \"some-query\",\n" +
+                "    \"description\": \"some-query-description\",\n" +
+                "    \"query\": {\n" +
+                "      \"searchText\": \"some-string\",\n" +
+                "      \"entityTypeIds\": [\n" +
+                "        \"Entity1\"\n" +
+                "      ]\n" +
+                "    },\n" +
+                "    \"propertiesToDisplay\": [\"facet1\", \"EntityTypeProperty1\"]\n" +
+                "  }\n" +
+                "}";
         JsonNode queryDocument = new ObjectMapper().readTree(json);
         List<String> expectedCols = Arrays.asList("facet1", "EntityTypeProperty1");
 
@@ -140,18 +139,18 @@ public class EntitySearchManagerTest extends AbstractHubCentralTest {
     void testGetQueryName() throws JsonProcessingException {
         String expectedQueryName = "query123";
         String json = "{\n" +
-            "  \"savedQuery\": {\n" +
-            "    \"name\": \"" + expectedQueryName + "\",\n" +
-            "    \"description\": \"some-query-description\",\n" +
-            "    \"query\": {\n" +
-            "      \"searchText\": \"some-string\",\n" +
-            "      \"entityTypeIds\": [\n" +
-            "        \"Entity1\"\n" +
-            "      ]\n" +
-            "    },\n" +
-            "    \"propertiesToDisplay\": [\"facet1\", \"EntityTypeProperty1\", \"facet1.facet\", \"EntityTypeProperty1.property\", \"EntityType-Property\"]\n" +
-            "  }\n" +
-            "}";
+                "  \"savedQuery\": {\n" +
+                "    \"name\": \"" + expectedQueryName + "\",\n" +
+                "    \"description\": \"some-query-description\",\n" +
+                "    \"query\": {\n" +
+                "      \"searchText\": \"some-string\",\n" +
+                "      \"entityTypeIds\": [\n" +
+                "        \"Entity1\"\n" +
+                "      ]\n" +
+                "    },\n" +
+                "    \"propertiesToDisplay\": [\"facet1\", \"EntityTypeProperty1\", \"facet1.facet\", \"EntityTypeProperty1.property\", \"EntityType-Property\"]\n" +
+                "  }\n" +
+                "}";
         JsonNode queryDocument = new ObjectMapper().readTree(json);
 
         String actualQueryName = entitySearchManager.getQueryName(queryDocument);
@@ -162,18 +161,18 @@ public class EntitySearchManagerTest extends AbstractHubCentralTest {
     @Test
     void testGetEntityTypeForRowExport() throws JsonProcessingException {
         String json = "{\n" +
-            "  \"savedQuery\": {\n" +
-            "    \"name\": \"some-query\",\n" +
-            "    \"description\": \"some-query-description\",\n" +
-            "    \"query\": {\n" +
-            "      \"searchText\": \"some-string\",\n" +
-            "      \"entityTypeIds\": [\n" +
-            "        \"Entity-1\"\n" +
-            "      ]\n" +
-            "    },\n" +
-            "    \"propertiesToDisplay\": [\"facet1\", \"EntityTypeProperty1\", \"facet1.facet\", \"EntityTypeProperty1.property\", \"EntityType-Property\"]\n" +
-            "  }\n" +
-            "}";
+                "  \"savedQuery\": {\n" +
+                "    \"name\": \"some-query\",\n" +
+                "    \"description\": \"some-query-description\",\n" +
+                "    \"query\": {\n" +
+                "      \"searchText\": \"some-string\",\n" +
+                "      \"entityTypeIds\": [\n" +
+                "        \"Entity-1\"\n" +
+                "      ]\n" +
+                "    },\n" +
+                "    \"propertiesToDisplay\": [\"facet1\", \"EntityTypeProperty1\", \"facet1.facet\", \"EntityTypeProperty1.property\", \"EntityType-Property\"]\n" +
+                "  }\n" +
+                "}";
         String expectedEntityTypeId = "Entity-1";
         JsonNode queryDocument = new ObjectMapper().readTree(json);
 

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/impl/AbstractFacetHandlerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/impl/AbstractFacetHandlerTest.java
@@ -1,0 +1,13 @@
+package com.marklogic.hub.central.entities.search.impl;
+
+import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.rest.util.Fragment;
+import org.jdom2.Namespace;
+
+public class AbstractFacetHandlerTest {
+
+    protected Fragment toFragment(StructuredQueryDefinition structuredQueryDefinition) {
+        return new Fragment(structuredQueryDefinition.serialize(),
+                Namespace.getNamespace("search", "http://marklogic.com/appservices/search"));
+    }
+}

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/impl/CollectionFacetHandlerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/impl/CollectionFacetHandlerTest.java
@@ -1,0 +1,31 @@
+package com.marklogic.hub.central.entities.search.impl;
+
+import com.marklogic.client.query.StructuredQueryBuilder;
+import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.hub.central.entities.search.Constants;
+import com.marklogic.hub.central.entities.search.models.DocSearchQueryInfo;
+import com.marklogic.rest.util.Fragment;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CollectionFacetHandlerTest extends AbstractFacetHandlerTest {
+
+    @Test
+    public void testCollectionFacet() {
+        String uri = "myCollection";
+        String constraintName = Constants.COLLECTION_CONSTRAINT_NAME;
+        DocSearchQueryInfo.FacetData facetData = new DocSearchQueryInfo.FacetData();
+        facetData.setStringValues(Collections.singletonList(uri));
+        CollectionFacetHandler collectionFacetHandler = new CollectionFacetHandler();
+        StructuredQueryBuilder queryBuilder = new StructuredQueryBuilder();
+
+        StructuredQueryDefinition queryDefinition = collectionFacetHandler.buildQuery(facetData, queryBuilder);
+        Fragment fragment = toFragment(queryDefinition);
+
+        assertEquals(uri, fragment.getElementValue("//search:uri"));
+        assertEquals(constraintName, fragment.getElementValue("//search:constraint-name"));
+    }
+}

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/impl/CreatedOnFacetHandlerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/impl/CreatedOnFacetHandlerTest.java
@@ -1,0 +1,41 @@
+package com.marklogic.hub.central.entities.search.impl;
+
+import com.marklogic.client.query.StructuredQueryBuilder;
+import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.hub.central.entities.search.Constants;
+import com.marklogic.hub.central.entities.search.models.DocSearchQueryInfo;
+import com.marklogic.rest.util.Fragment;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CreatedOnFacetHandlerTest extends AbstractFacetHandlerTest {
+
+    @Test
+    public void testCreatedOnDateRangeFacet() {
+        String constraintName = Constants.CREATED_ON_CONSTRAINT_NAME;
+        String lowerBound = "2020-06-14";
+        String upperBound = "2020-06-17";
+        String expectedUpperBound = "2020-06-18";
+        DocSearchQueryInfo.FacetData facetData = new DocSearchQueryInfo.FacetData();
+        DocSearchQueryInfo.RangeValues rangeValues = new DocSearchQueryInfo.RangeValues();
+        rangeValues.setLowerBound(lowerBound);
+        rangeValues.setUpperBound(upperBound);
+        facetData.setRangeValues(rangeValues);
+        CreatedOnFacetHandler createdOnFacetHandler = new CreatedOnFacetHandler();
+        StructuredQueryBuilder queryBuilder = new StructuredQueryBuilder();
+
+        StructuredQueryDefinition queryDefinition = createdOnFacetHandler.buildQuery(facetData, queryBuilder);
+        Fragment fragment = toFragment(queryDefinition);
+
+        assertEquals(Arrays.asList(constraintName, constraintName), fragment.getElementValues("//search:constraint-name"));
+        assertTrue(fragment.getElementValue("//search:value[../search:range-operator='GE']").contains(lowerBound),
+                "Expected lower bound to include: " + lowerBound);
+        assertTrue(fragment.getElementValue("//search:value[../search:range-operator='LT']").contains(expectedUpperBound),
+                "Upper bound is one day more than what was passed in order to include the passed in date as well" +
+                        " for comparison. Expected upper bound to include: " + expectedUpperBound);
+    }
+}

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/impl/EntityPropertyFacetHandlerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/impl/EntityPropertyFacetHandlerTest.java
@@ -1,0 +1,54 @@
+package com.marklogic.hub.central.entities.search.impl;
+
+import com.marklogic.client.query.StructuredQueryBuilder;
+import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.hub.central.entities.search.models.DocSearchQueryInfo;
+import com.marklogic.rest.util.Fragment;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EntityPropertyFacetHandlerTest extends AbstractFacetHandlerTest {
+
+    @Test
+    public void testStringRangeFacet() {
+        String value = "FlowName";
+        String constraintName = "createdInFlowRange";
+        DocSearchQueryInfo.FacetData facetData = new DocSearchQueryInfo.FacetData();
+        facetData.setStringValues(Collections.singletonList(value));
+        EntityPropertyFacetHandler entityPropertyFacetHandler = new EntityPropertyFacetHandler(constraintName);
+        StructuredQueryBuilder queryBuilder = new StructuredQueryBuilder();
+
+        StructuredQueryDefinition queryDefinition = entityPropertyFacetHandler.buildQuery(facetData, queryBuilder);
+        Fragment fragment = toFragment(queryDefinition);
+
+        assertEquals(value, fragment.getElementValue("//search:value"));
+        assertEquals(constraintName, fragment.getElementValue("//search:constraint-name"));
+        assertEquals(StructuredQueryBuilder.Operator.EQ.toString(), fragment.getElementValue("//search:range-operator"));
+    }
+
+    @Test
+    public void testNumericRangeFacet() {
+        String constraintName = "rangeFacet";
+        String lowerBound = "-1";
+        String upperBound = "1";
+        DocSearchQueryInfo.FacetData facetData = new DocSearchQueryInfo.FacetData();
+        facetData.setDataType("int");
+        DocSearchQueryInfo.RangeValues rangeValues = new DocSearchQueryInfo.RangeValues();
+        rangeValues.setLowerBound(lowerBound);
+        rangeValues.setUpperBound(upperBound);
+        facetData.setRangeValues(rangeValues);
+        EntityPropertyFacetHandler entityPropertyFacetHandler = new EntityPropertyFacetHandler(constraintName);
+        StructuredQueryBuilder queryBuilder = new StructuredQueryBuilder();
+
+        StructuredQueryDefinition queryDefinition = entityPropertyFacetHandler.buildQuery(facetData, queryBuilder);
+        Fragment fragment = toFragment(queryDefinition);
+
+        assertEquals(Arrays.asList(constraintName, constraintName), fragment.getElementValues("//search:constraint-name"));
+        assertEquals(lowerBound, fragment.getElementValue("//search:value[../search:range-operator='GE']"));
+        assertEquals(upperBound, fragment.getElementValue("//search:value[../search:range-operator='LE']"));
+    }
+}

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/impl/JobRangeFacetHandlerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/impl/JobRangeFacetHandlerTest.java
@@ -1,0 +1,32 @@
+package com.marklogic.hub.central.entities.search.impl;
+
+import com.marklogic.client.query.StructuredQueryBuilder;
+import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.hub.central.entities.search.Constants;
+import com.marklogic.hub.central.entities.search.models.DocSearchQueryInfo;
+import com.marklogic.rest.util.Fragment;
+import org.jdom2.Namespace;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JobRangeFacetHandlerTest {
+
+    @Test
+    public void testJobRangeFacet() {
+        String text = "xyz-abc";
+        String constraintName = Constants.JOB_WORD_CONSTRAINT_NAME;
+        DocSearchQueryInfo.FacetData facetData = new DocSearchQueryInfo.FacetData();
+        facetData.setStringValues(Collections.singletonList(text));
+        JobRangeFacetHandler jobRangeFacetHandler = new JobRangeFacetHandler();
+        StructuredQueryBuilder queryBuilder = new StructuredQueryBuilder();
+
+        StructuredQueryDefinition queryDefinition = jobRangeFacetHandler.buildQuery(facetData, queryBuilder);
+        Fragment fragment = new Fragment(queryDefinition.serialize(), Namespace.getNamespace("sch", "http://marklogic.com/appservices/search"));
+
+        assertEquals(text, fragment.getElementValue("//sch:text"));
+        assertEquals(constraintName, fragment.getElementValue("//sch:constraint-name"));
+    }
+}

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/managers/EntitySearchManagerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/managers/EntitySearchManagerTest.java
@@ -125,11 +125,11 @@ public class EntitySearchManagerTest extends AbstractHubCentralTest {
             "        \"Entity1\"\n" +
             "      ]\n" +
             "    },\n" +
-            "    \"propertiesToDisplay\": [\"facet1\", \"EntityTypeProperty1\", \"facet1.facet\", \"EntityTypeProperty1.property\", \"EntityType-Property\"]\n" +
+            "    \"propertiesToDisplay\": [\"facet1\", \"EntityTypeProperty1\"]\n" +
             "  }\n" +
             "}";
         JsonNode queryDocument = new ObjectMapper().readTree(json);
-        List<String> expectedCols = Arrays.asList("facet1", "EntityTypeProperty1", "EntityType_Property");
+        List<String> expectedCols = Arrays.asList("facet1", "EntityTypeProperty1");
 
         List<String> actualCols = entitySearchManager.getColumnNamesForRowExport(queryDocument);
 
@@ -174,7 +174,7 @@ public class EntitySearchManagerTest extends AbstractHubCentralTest {
             "    \"propertiesToDisplay\": [\"facet1\", \"EntityTypeProperty1\", \"facet1.facet\", \"EntityTypeProperty1.property\", \"EntityType-Property\"]\n" +
             "  }\n" +
             "}";
-        String expectedEntityTypeId = "Entity_1";
+        String expectedEntityTypeId = "Entity-1";
         JsonNode queryDocument = new ObjectMapper().readTree(json);
 
         String actualEntityTypeId = entitySearchManager.getEntityTypeIdForRowExport(queryDocument);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/entity-lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/entity-lib.sjs
@@ -161,6 +161,20 @@ function getLatestJobData(entityName) {
   return null;
 }
 
+/**
+ * Use this to get the EntityType from a definitions object when all you have is an entity name - e.g. Customer.
+ *
+ * @param entityName
+ * @returns {null|*}
+ */
+function findEntityTypeByEntityName(entityName) {
+  const uri = entityLib.getModelUri(entityName);
+  if (!fn.docAvailable(uri)) {
+    return null;
+  }
+  return cts.doc(uri).toObject().definitions[entityName];
+}
+
 function getModelUri(entityName) {
   return "/entities/" + xdmp.urlEncode(entityName) + ".entity.json";
 }
@@ -232,6 +246,7 @@ module.exports = {
   getEntityTypeIdParts,
   getLatestJobData,
   getModelCollection,
+  findEntityTypeByEntityName,
   getModelUri,
   validateModelDefinitions,
   writeModel


### PR DESCRIPTION
### Description
Moved the logic for filtering out array/object type properties to the data service.
Also, we now use the entity model to filter out array/object type properties instead of relying on the column names sent by the FE.
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

