### PR TITLE
DHFPROD-4670: Add hub-central-flow-writer role

### DIFF
--- a/examples/reference-entity-model/src/main/ml-config/security/users/hub-developer.json
+++ b/examples/reference-entity-model/src/main/ml-config/security/users/hub-developer.json
@@ -8,6 +8,6 @@
     "hub-central-entity-model-writer",
     "hub-central-load-writer",
     "hub-central-mapping-writer",
-    "hub-central-step-runner"
+    "hub-central-flow-writer"
   ]
 }

--- a/examples/reference-entity-model/src/main/ml-config/security/users/pari.json
+++ b/examples/reference-entity-model/src/main/ml-config/security/users/pari.json
@@ -7,6 +7,6 @@
     "hub-central-downloader",
     "hub-central-load-writer",
     "hub-central-mapping-writer",
-    "hub-central-step-runner"
+    "hub-central-flow-writer"
   ]
 }

--- a/examples/reference-entity-model/src/main/ml-config/security/users/wailin.json
+++ b/examples/reference-entity-model/src/main/ml-config/security/users/wailin.json
@@ -5,6 +5,7 @@
   "role": [
     "hub-central-load-writer",
     "hub-central-mapping-writer",
+    "hub-central-step-runner",
     "hub-central-downloader"
   ]
 }

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/FlowController.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/FlowController.java
@@ -46,7 +46,7 @@ public class FlowController extends BaseController {
     @ResponseBody
     @ApiOperation(value = "Get all user flows with a few key data points for each step, " +
         "regardless of whether it's referenced or inline", response = FlowsWithStepDetails.class)
-    @Secured("ROLE_readStep")
+    @Secured("ROLE_readFlow")
     public ResponseEntity<JsonNode> getFlowsWithStepDetails() {
         return ResponseEntity.ok(newFlowService().getFlowsWithStepDetails());
     }
@@ -54,6 +54,7 @@ public class FlowController extends BaseController {
     @RequestMapping(method = RequestMethod.POST)
     @ResponseBody
     @ApiOperation(value = "Create a flow", response = FlowInfo.class)
+    @Secured("ROLE_writeFlow")
     public ResponseEntity<JsonNode> createFlow(@RequestBody FlowInfo info) {
         return jsonCreated(newFlowService().createFlow(info.name, info.description));
     }
@@ -61,12 +62,14 @@ public class FlowController extends BaseController {
     @RequestMapping(value = "/{flowName}", method = RequestMethod.PUT)
     @ResponseBody
     @ApiOperation(value = "Update a flow", response = FlowInfo.class)
+    @Secured("ROLE_writeFlow")
     public ResponseEntity<JsonNode> updateFlowInfo(@PathVariable String flowName, @RequestBody UpdateFlowInfo info) {
         return ResponseEntity.ok(newFlowService().updateFlowInfo(flowName, info.description));
     }
 
     @RequestMapping(value = "/{flowName}", method = RequestMethod.DELETE)
     @ResponseBody
+    @Secured("ROLE_writeFlow")
     public ResponseEntity<Void> deleteFlow(@PathVariable String flowName) {
         newFlowService().deleteFlow(flowName);
         return new ResponseEntity<>(HttpStatus.OK);
@@ -74,12 +77,14 @@ public class FlowController extends BaseController {
 
     @RequestMapping(value = "/{flowName}/steps", method = RequestMethod.POST)
     @ApiOperation(value = "Add a step to a flow", response = FlowWithStepDetails.class)
+    @Secured("ROLE_writeFlow")
     public ResponseEntity<JsonNode> addStepToFlow(@PathVariable String flowName, @RequestBody AddStepInfo info) {
         return ResponseEntity.ok(newFlowService().addStepToFlow(flowName, info.stepName, info.stepDefinitionType));
     }
 
     @RequestMapping(value = "/{flowName}/steps/{stepNumber}", method = RequestMethod.DELETE)
     @ApiOperation(value = "Remove a step from a flow", response = FlowWithStepDetails.class)
+    @Secured("ROLE_writeFlow")
     public ResponseEntity<JsonNode> removeStepFromFlow(@PathVariable String flowName, @PathVariable String stepNumber) {
         return ResponseEntity.ok(newFlowService().removeStepFromFlow(flowName, stepNumber));
     }

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/FlowMvcTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/FlowMvcTest.java
@@ -25,12 +25,7 @@ public class FlowMvcTest extends AbstractMvcTest {
     @Test
     void runIngestionStep() throws Exception {
         installReferenceModelProject();
-        if(isVersionCompatibleWith520Roles()) {
-            loginAsTestUserWithRoles("hub-central-step-runner");
-        }
-        else {
-            loginAsTestUserWithRoles("hub-central-step-runner", "flow-operator-role");
-        }
+        loginAsTestUserWithRoles("hub-central-step-runner");
 
         MockMultipartFile file1 = new MockMultipartFile("files","file1.json", MediaType.APPLICATION_JSON, "{\"name\": \"Joe\"}".getBytes(StandardCharsets.UTF_8));
         MockMultipartFile file2 = new MockMultipartFile("files","file2.json", MediaType.APPLICATION_JSON, "{\"name\": \"John\"}".getBytes(StandardCharsets.UTF_8));

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/steps/FlowControllerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/steps/FlowControllerTest.java
@@ -20,6 +20,8 @@ public class FlowControllerTest extends AbstractMvcTest {
     void test() throws Exception {
         installReferenceModelProject();
 
+        loginAsTestUserWithRoles("hub-central-flow-writer");
+
         // Get the initial count of flows
         getJson(PATH).andExpect(status().isOk())
             .andDo(result -> {

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
@@ -278,4 +278,74 @@ describe("Entity Tiles component", () => {
     })
 
   });
+
+  test('Verify Mapping card allows step to be added to flow with writeFlow authority', async () => {
+    const authorityService = new AuthoritiesService();
+    authorityService.setAuthorities(['readMapping','writeFlow']);
+    let entityModel = data.primaryEntityTypes.data[0];
+    let mapping = data.mappings.data[0].artifacts;
+    const mockAddStepToFlow = jest.fn();
+    const noopFun = jest.fn();
+    const {getByText} = render(<MemoryRouter><AuthoritiesContext.Provider value={authorityService}><MappingCard
+      data={mapping}
+      flows={data.flows.data}
+      entityTypeTitle={entityModel.entityName}
+      getMappingArtifactByMapName={noopFun}
+      deleteMappingArtifact={noopFun}
+      createMappingArtifact={noopFun}
+      updateMappingArtifact={noopFun}
+      canReadOnly={authorityService.canReadMapping()}
+      canReadWrite={authorityService.canWriteMapping()}
+      canWriteFlow={authorityService.canWriteFlow()}
+      entityModel={entityModel}
+      addStepToFlow={mockAddStepToFlow}
+      addStepToNew={noopFun}/>
+    </AuthoritiesContext.Provider></MemoryRouter>);
+
+    fireEvent.mouseOver(getByText(mapping[0].name));
+
+    // test adding to existing flow
+    expect(getByText('Add step to an existing flow')).toBeInTheDocument();
+    fireEvent.click(getByText('Select Flow'));
+    fireEvent.click(getByText(data.flows.data[0].name));
+    fireEvent.click(getByText('Yes'));
+    expect(mockAddStepToFlow).toBeCalledTimes(1);
+
+    // adding to new flow
+    fireEvent.mouseOver(getByText(mapping[0].name));
+    expect(getByText('Add step to a new flow')).toBeInTheDocument();
+    // TODO calling addStepToNew not implemented yet
+  });
+
+  test('Verify Mapping card does not allow a step to be added to flow with readFlow authority only', async () => {
+    const authorityService = new AuthoritiesService();
+    authorityService.setAuthorities(['readMapping','readFlow']);
+    let entityModel = data.primaryEntityTypes.data[0];
+    let mapping = data.mappings.data[0].artifacts;
+    const mockAddStepToFlow = jest.fn();
+    const noopFun = jest.fn();
+    const {getByText, queryByText} = render(<MemoryRouter><AuthoritiesContext.Provider value={authorityService}><MappingCard
+      data={mapping}
+      flows={data.flows}
+      entityTypeTitle={entityModel.entityName}
+      getMappingArtifactByMapName={noopFun}
+      deleteMappingArtifact={noopFun}
+      createMappingArtifact={noopFun}
+      updateMappingArtifact={noopFun}
+      canReadOnly={authorityService.canReadMapping()}
+      canReadWrite={authorityService.canWriteMapping()}
+      canWriteFlow={authorityService.canWriteFlow()}
+      entityModel={entityModel}
+      addStepToFlow={mockAddStepToFlow}
+      addStepToNew={noopFun}/>
+    </AuthoritiesContext.Provider></MemoryRouter>);
+
+    fireEvent.mouseOver(getByText(mapping[0].name));
+
+    // test adding to existing flow
+    expect(queryByText('Add step to an existing flow')).not.toBeInTheDocument();
+
+    // test adding to new flow
+    expect(queryByText('Add step to a new flow')).not.toBeInTheDocument();
+  });
 });

--- a/marklogic-data-hub-central/ui/src/components/load/load-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-card.test.tsx
@@ -113,4 +113,68 @@ describe('Load Card component', () => {
 
   });
 
+  test('Verify Load card allows step to be added to flow with writeFlow authority', async () => {
+    const authorityService = new AuthoritiesService();
+    authorityService.setAuthorities(['readIngestion','writeFlow']);
+    const mockAddStepToFlow = jest.fn();
+    const mockAddStepToNew = jest.fn();
+    const mockCreateLoadArtifact = jest.fn();
+    const mockDeleteLoadArtifact = jest.fn();
+    const {getByText, getByTestId} = render(<MemoryRouter><AuthoritiesContext.Provider value={authorityService}><LoadCard
+      addStepToFlow={mockAddStepToFlow}
+      addStepToNew={mockAddStepToNew}
+      canReadOnly={authorityService.canReadLoad()}
+      canReadWrite={authorityService.canWriteLoad()}
+      canWriteFlow={authorityService.canWriteFlow()}
+      createLoadArtifact={mockCreateLoadArtifact}
+      data={data.loadData.data}
+      deleteLoadArtifact={mockDeleteLoadArtifact}
+      flows={data.flows}/>
+    </AuthoritiesContext.Provider></MemoryRouter>);
+
+    const loadStepName = data.loadData.data[0].name;
+    fireEvent.mouseOver(getByText(loadStepName));
+
+    // test adding to existing flow
+    expect(getByTestId(`${loadStepName}-toExistingFlow`)).toBeInTheDocument();
+    fireEvent.click(getByTestId(`${loadStepName}-flowsList`));
+    fireEvent.click(getByText(data.flows[0].name));
+    fireEvent.click(getByText('Yes'));
+    expect(mockAddStepToFlow).toBeCalledTimes(1);
+    // adding to new flow
+    fireEvent.mouseOver(getByText(loadStepName));
+    expect(getByTestId(`${loadStepName}-toNewFlow`)).toBeInTheDocument();
+    // TODO calling addStepToNew not implemented yet
+  });
+
+  test('Verify Load card does not allow a step to be added to flow with readFlow authority only', async () => {
+    const authorityService = new AuthoritiesService();
+    authorityService.setAuthorities(['readIngestion','readFlow']);
+    const mockAddStepToFlow = jest.fn();
+    const mockAddStepToNew = jest.fn();
+    const mockCreateLoadArtifact = jest.fn();
+    const mockDeleteLoadArtifact = jest.fn();
+    const {getByText, queryByTestId, queryByText} = render(<MemoryRouter><AuthoritiesContext.Provider value={authorityService}><LoadCard
+      addStepToFlow={mockAddStepToFlow}
+      addStepToNew={mockAddStepToNew}
+      canReadOnly={authorityService.canReadLoad()}
+      canReadWrite={authorityService.canWriteLoad()}
+      canWriteFlow={authorityService.canWriteFlow()}
+      createLoadArtifact={mockCreateLoadArtifact}
+      data={data.loadData.data}
+      deleteLoadArtifact={mockDeleteLoadArtifact}
+      flows={data.flows}/>
+    </AuthoritiesContext.Provider></MemoryRouter>);
+
+    fireEvent.mouseOver(getByText(data.loadData.data[0].name));
+
+    const loadStepName = data.loadData.data[0].name;
+    // adding to new flow
+    fireEvent.mouseOver(getByText(loadStepName));
+    // test adding to existing flow
+    expect(queryByTestId(`${loadStepName}-toExistingFlow`)).not.toBeInTheDocument();
+
+    // test adding to new flow
+    expect(queryByTestId(`${loadStepName}-toNewFlow`)).not.toBeInTheDocument();
+  });
 });

--- a/marklogic-data-hub-central/ui/src/config/authorities.config.ts
+++ b/marklogic-data-hub-central/ui/src/config/authorities.config.ts
@@ -31,10 +31,10 @@ class DeveloperRolesService implements IAuthoritiesContextInterface{
     public canWriteEntityModel:() => boolean = () => {
         return true;
     };
-    public canReadStep:() => boolean = () => {
+    public canReadFlow:() => boolean = () => {
         return true;
     };
-    public canWriteStep:() => boolean = () => {
+    public canWriteFlow:() => boolean = () => {
         return true;
     };
     public canReadStepDefinition:() => boolean = () => {
@@ -49,7 +49,7 @@ class DeveloperRolesService implements IAuthoritiesContextInterface{
     public isSavedQueryUser:() => boolean = () => {
         return true;
     };
-    public hasOperatorRole:() => boolean = () => {
+    public canRunStep:() => boolean = () => {
         return true;
     };
 }
@@ -85,10 +85,10 @@ class OperatorRolesService implements IAuthoritiesContextInterface{
     public canWriteEntityModel:() => boolean = () => {
         return false;
     };
-    public canReadStep:() => boolean = () => {
+    public canReadFlow:() => boolean = () => {
         return true;
     };
-    public canWriteStep:() => boolean = () => {
+    public canWriteFlow:() => boolean = () => {
         return false;
     };
     public canReadStepDefinition:() => boolean = () => {
@@ -103,7 +103,7 @@ class OperatorRolesService implements IAuthoritiesContextInterface{
     public isSavedQueryUser:() => boolean = () => {
         return false;
     };
-    public hasOperatorRole:() => boolean = () => {
+    public canRunStep:() => boolean = () => {
         return true;
     };
   }

--- a/marklogic-data-hub-central/ui/src/config/mocks.config.ts
+++ b/marklogic-data-hub-central/ui/src/config/mocks.config.ts
@@ -95,6 +95,36 @@ const loadAPI = (axiosMock) => {
     })
   };
 
+  const runCrudAPI = (axiosMock) => {
+    // call Run API for the GET operations
+    runAPI(axiosMock);
+    axiosMock.post['mockImplementation']((url) => {
+      switch (url) {
+        case '/api/flows':
+          return Promise.resolve({status: 201, data: {}});
+        default:
+          return Promise.reject(new Error('not found'));
+      }
+    })
+    const updateURL = `/api/flows/${curateData.flowsWithMapping.data[0].name}`;
+    axiosMock.put['mockImplementation']((url) => {
+      switch (url) {
+        case updateURL:
+          return Promise.resolve({status: 200, data: {}});
+        default:
+          return Promise.reject(new Error('not found'));
+      }
+    })
+    return axiosMock.delete['mockImplementation']((url) => {
+      switch (url) {
+        case updateURL:
+          return Promise.resolve({status: 200, data: {}});
+        default:
+          return Promise.reject(new Error('not found'));
+      }
+    })
+  };
+
   const runErrorsAPI = (axiosMock) => {
     return axiosMock.get['mockImplementation']((url) => {
       switch (url) {
@@ -148,6 +178,7 @@ const loadAPI = (axiosMock) => {
     loadAPI: loadAPI,
     curateAPI: curateAPI,
     runAPI: runAPI,
+    runCrudAPI: runCrudAPI,
     runErrorsAPI: runErrorsAPI,
     runFailedAPI: runFailedAPI,
     runXMLAPI: runXMLAPI,

--- a/marklogic-data-hub-central/ui/src/config/run.config.ts
+++ b/marklogic-data-hub-central/ui/src/config/run.config.ts
@@ -264,6 +264,18 @@ const flows = {
               "stepDefinitionType": "INGESTION",
               "stepNumber": "1",
               "sourceFormat": "json"
+          },
+          {
+            "stepName": "mapping1",
+            "stepDefinitionType": "MAPPING",
+            "stepNumber": "2",
+            "sourceFormat": "json"
+          },
+          {
+            "stepName": "custom1",
+            "stepDefinitionType": "CUSTOM",
+            "stepNumber": "3",
+            "sourceFormat": "json"
           }
       ]
   }]
@@ -280,6 +292,11 @@ const flowsWithMapping = {
               "stepName": "Mapping1",
               "stepDefinitionType": "MAPPING",
               "stepNumber": "1"
+          },
+          {
+            "stepName": "Custom1",
+            "stepDefinitionType": "CUSTOM",
+            "stepNumber": "2"
           }
       ]
   }]

--- a/marklogic-data-hub-central/ui/src/pages/Curate.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Curate.tsx
@@ -24,7 +24,7 @@ const Curate: React.FC = () => {
     const canWriteMapping = authorityService.canWriteMapping();
     const canReadMatchMerge = authorityService.canReadMatchMerge();
     const canWriteMatchMerge = authorityService.canWriteMatchMerge();
-    const canWriteFlow = authorityService.canWriteStep();
+    const canWriteFlow = authorityService.canWriteFlow();
 
     const getEntityModels = async () => {
         try {

--- a/marklogic-data-hub-central/ui/src/pages/Load.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Load.tsx
@@ -23,7 +23,7 @@ const Load: React.FC = () => {
   const authorityService = useContext(AuthoritiesContext);
   const canReadOnly = authorityService.canReadLoad();
   const canReadWrite = authorityService.canWriteLoad();
-  const canWriteFlow = authorityService.canWriteStep();
+  const canWriteFlow = authorityService.canWriteFlow();
 
   //Set context for switching views
   const handleViewSelection = (view) => {

--- a/marklogic-data-hub-central/ui/src/pages/Run.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Run.tsx
@@ -32,9 +32,9 @@ const Run = (props) => {
 
     // For role-based privileges
     const authorityService = useContext(AuthoritiesContext);
-    const canReadFlow = authorityService.canReadStep();
-    const canWriteFlow = authorityService.canWriteStep();
-    const hasOperatorRole = authorityService.hasOperatorRole();
+    const canReadFlow = authorityService.canReadFlow();
+    const canWriteFlow = authorityService.canWriteFlow();
+    const hasOperatorRole = authorityService.canRunStep();
 
     //For handling flows expand and collapse within Run tile
     const [newFlowName, setNewFlowName] = useState('');

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.test.tsx
@@ -127,8 +127,10 @@ describe('Tiles View component tests for Developer user', () => {
     });
 
     test('Verify Run tile displays from toolbar', async () => {
+        const authorityService = new AuthoritiesService();
+        authorityService.setAuthorities(['readFlow','writeFlow','runStep']);
         const {getByLabelText, getByText, queryByText, getByTestId} = await render(<Router history={history}>
-            <AuthoritiesContext.Provider value={ mockDevRolesService}><TilesView/></AuthoritiesContext.Provider>
+            <AuthoritiesContext.Provider value={ authorityService}><TilesView/></AuthoritiesContext.Provider>
             </Router>);
 
         // Run tile not shown initially
@@ -158,11 +160,10 @@ describe('Tiles View component tests for Developer user', () => {
         expect(getByTestId('runStep-1')).toBeInTheDocument();
     });
 
-    test('Verify run tile cannot edit with only readStep authority', async () => {
+    test('Verify run tile cannot edit or run with only readFlow authority', async () => {
         const authorityService = new AuthoritiesService();
-        authorityService.setAuthorities(['readStep']);
+        authorityService.setAuthorities(['readFlow']);
         const {getByLabelText, getByText, queryByText, getByTestId} = render(<Router history={history}><AuthoritiesContext.Provider value={authorityService}><TilesView/></AuthoritiesContext.Provider></Router>);
-
 
         // Run tile not shown initially
         expect(queryByText("icon-run")).not.toBeInTheDocument();
@@ -189,10 +190,31 @@ describe('Tiles View component tests for Developer user', () => {
         // test run
         fireEvent.click(getByLabelText('icon: right'));
         expect(getByTestId('runStepDisabled-1')).toBeInTheDocument();
-
+        expect(getByTestId('runStepDisabled-2')).toBeInTheDocument();
+        expect(getByTestId('runStepDisabled-3')).toBeInTheDocument();
     });
 
-    test('Verify run tile does not load from toolbar without readStep authority', async () => {
+    test('Verify run tile can read/run with readFlow and runStep authority', async () => {
+        const authorityService = new AuthoritiesService();
+        authorityService.setAuthorities(['readFlow','runStep']);
+        const {getByLabelText, getByText, queryByText, getByTestId} = render(<Router history={history}><AuthoritiesContext.Provider value={authorityService}><TilesView/></AuthoritiesContext.Provider></Router>);
+
+
+        // Run tile not shown initially
+        expect(queryByText("icon-run")).not.toBeInTheDocument();
+        expect(queryByText("title-run")).not.toBeInTheDocument();
+
+        fireEvent.click(getByLabelText("tool-run"));
+
+        expect(await(waitForElement(() => getByLabelText("icon-run")))).toBeInTheDocument();
+        // test run
+        fireEvent.click(getByLabelText('icon: right'));
+        expect(getByTestId('runStep-1')).toBeInTheDocument();
+        expect(getByTestId('runStep-2')).toBeInTheDocument();
+        expect(getByTestId('runStep-3')).toBeInTheDocument();
+    });
+
+    test('Verify run tile does not load from toolbar without readFlow authority', async () => {
         const authorityService = new AuthoritiesService();
         authorityService.setAuthorities([]);
         const {getByLabelText, queryByLabelText, queryByText} = render(<Router history={history}><AuthoritiesContext.Provider value={authorityService}><TilesView/></AuthoritiesContext.Provider></Router>);

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.tsx
@@ -57,7 +57,7 @@ const TilesView = (props) => {
         load: auth.canReadLoad() || auth.canWriteLoad(),
         model: auth.canReadEntityModel() || auth.canWriteEntityModel(),
         curate: auth.canReadMapping() || auth.canWriteMapping() || auth.canReadMatchMerge() || auth.canWriteMatchMerge(),
-        run: auth.canReadStep() || auth.canWriteStep(),
+        run: auth.canReadFlow() || auth.canWriteFlow(),
         explore: true, 
         // TODO - Needs to be updated if there are any changes in authorities for Explorer
         // explore: auth.canReadFlow() || auth.canWriteFlow(),

--- a/marklogic-data-hub-central/ui/src/util/authorities.tsx
+++ b/marklogic-data-hub-central/ui/src/util/authorities.tsx
@@ -11,13 +11,13 @@ export interface IAuthoritiesContextInterface {
     canWriteLoad: () => boolean;
     canReadEntityModel: () => boolean;
     canWriteEntityModel: () => boolean;
-    canReadStep: () => boolean;
-    canWriteStep: () => boolean;
+    canReadFlow: () => boolean;
+    canWriteFlow: () => boolean;
     canReadStepDefinition: () => boolean;
     canWriteStepDefinition: () => boolean;
     canExportEntityInstances: () => boolean;
     isSavedQueryUser: () => boolean;
-    hasOperatorRole: () => boolean;
+    canRunStep: () => boolean;
 }
 
 /**
@@ -58,11 +58,11 @@ export class AuthoritiesService implements IAuthoritiesContextInterface {
     public canWriteEntityModel:() => boolean = () => {
         return this.authorities.includes('writeEntityModel');
     };
-    public canReadStep:() => boolean = () => {
-        return this.authorities.includes('readStep');
+    public canReadFlow:() => boolean = () => {
+        return this.authorities.includes('readFlow');
     };
-    public canWriteStep:() => boolean = () => {
-        return this.authorities.includes('writeStep');
+    public canWriteFlow:() => boolean = () => {
+        return this.authorities.includes('writeFlow');
     };
     public canReadStepDefinition:() => boolean = () => {
         return this.authorities.includes('readStepDefinition');
@@ -73,8 +73,8 @@ export class AuthoritiesService implements IAuthoritiesContextInterface {
     public canExportEntityInstances:() => boolean = () => {
         return this.authorities.includes('exportEntityInstances');
     };
-    public hasOperatorRole:() => boolean = () => {
-        return this.authorities.includes('operator') || this.authorities.includes('runStep');
+    public canRunStep:() => boolean = () => {
+        return this.authorities.includes('runStep');
     };
     public isSavedQueryUser:() => boolean = () => {
         return this.authorities.includes('savedQueryUser');

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/privileges/data-hub-read-flow.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/privileges/data-hub-read-flow.json
@@ -1,0 +1,5 @@
+{
+  "privilege-name": "data-hub:readFlow",
+  "action": "http://marklogic.com/data-hub/privileges/read-flow",
+  "kind": "execute"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/privileges/data-hub-read-step.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/privileges/data-hub-read-step.json
@@ -1,5 +1,0 @@
-{
-  "privilege-name": "data-hub:readStep",
-  "action": "http://marklogic.com/data-hub/privileges/read-step",
-  "kind": "execute"
-}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/privileges/data-hub-write-flow.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/privileges/data-hub-write-flow.json
@@ -1,0 +1,5 @@
+{
+  "privilege-name": "data-hub:writeFlow",
+  "action": "http://marklogic.com/data-hub/privileges/write-flow",
+  "kind": "execute"
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-common-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-common-writer.json
@@ -31,11 +31,6 @@
       "kind": "execute"
     },
     {
-      "privilege-name": "xdmp:invoke",
-      "action": "http://marklogic.com/xdmp/privileges/xdmp-invoke",
-      "kind": "execute"
-    },
-    {
       "privilege-name": "xdmp:xslt-invoke",
       "action": "http://marklogic.com/xdmp/privileges/xslt-invoke",
       "kind": "execute"

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-common.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-common.json
@@ -13,6 +13,11 @@
       "kind": "execute"
     },
     {
+      "privilege-name": "xdmp:invoke",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-invoke",
+      "kind": "execute"
+    },
+    {
       "privilege-name": "xdmp:invoke-in",
       "action": "http://marklogic.com/xdmp/privileges/xdmp-invoke-in",
       "kind": "execute"

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-flow-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-flow-writer.json
@@ -1,0 +1,15 @@
+{
+  "role-name": "hub-central-flow-writer",
+  "description": "Permits reading and writing to flows in Hub Central",
+  "role": [
+    "hub-central-step-runner",
+    "data-hub-flow-writer"
+  ],
+  "privilege": [
+    {
+      "privilege-name": "data-hub:writeFlow",
+      "action": "http://marklogic.com/data-hub/privileges/write-flow",
+      "kind": "execute"
+    }
+  ]
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-step-runner.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-step-runner.json
@@ -6,6 +6,7 @@
     "data-hub-common-writer",
     "data-hub-flow-reader",
     "data-hub-ingestion-reader",
+    "data-hub-job-internal",
     "data-hub-job-reader",
     "data-hub-mapping-reader",
     "data-hub-match-merge-reader",
@@ -19,8 +20,8 @@
       "kind": "execute"
     },
     {
-      "privilege-name": "data-hub:readStep",
-      "action": "http://marklogic.com/data-hub/privileges/read-step",
+      "privilege-name": "data-hub:readFlow",
+      "action": "http://marklogic.com/data-hub/privileges/read-flow",
       "kind": "execute"
     },
     {

--- a/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/Installer.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/Installer.java
@@ -54,6 +54,7 @@ public class Installer extends HubTestBase implements InitializingBean {
         dataHubDeveloper.addRole("hub-central-mapping-reader");
         dataHubDeveloper.addRole("hub-central-mapping-writer");
         dataHubDeveloper.addRole("hub-central-step-runner");
+        dataHubDeveloper.addRole("hub-central-flow-writer");
         dataHubDeveloper.save();
 
         User dataHubOperator = new User(api, "test-data-hub-operator");

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/security/getAuthoritiesTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/security/getAuthoritiesTest.sjs
@@ -65,8 +65,8 @@ hubTest.runWithRolesAndPrivileges(['hub-central-step-runner'], [], function() {
     const Security = require('/data-hub/5/impl/security.sjs');
     const authorities = new Security().getDataHubAuthorities();
     assertions.push(test.assertTrue(authorities.includes('loginToHubCentral'), 'hub-central-step-runner should have "loginToHubCentral"'));
-    assertions.push(test.assertTrue(authorities.includes('readStep'), 'hub-central-step-runner should have "readStep"'));
+    assertions.push(test.assertTrue(authorities.includes('readFlow'), 'hub-central-step-runner should have "readFlow"'));
     assertions.push(test.assertTrue(authorities.includes('runStep'), 'hub-central-step-runner should have "runStep"'));
-    assertions.push(test.assertFalse(authorities.includes('writeStep'), 'hub-central-step-runner should not have "writeStep"'));
+    assertions.push(test.assertFalse(authorities.includes('writeFlow'), 'hub-central-step-runner should not have "writeFlow"'));
 });
 assertions;

--- a/specs/docs/security/DataHubSecurity.md
+++ b/specs/docs/security/DataHubSecurity.md
@@ -119,7 +119,7 @@ Role to determine if a user can clear their data through Hub Central.
 Can run steps through Hub Central
 
 #### Associate Authorities
- - readStep
+ - readFlow
  - runStep
 
 #### Inherited Roles
@@ -136,7 +136,7 @@ Can run steps through Hub Central
 Can create and run steps though Hub Central
 
 #### Associate Authorities
- - writeStep
+ - writeFlow
 
 #### Inherited Roles
  - hub-central-step-runner


### PR DESCRIPTION
### Description
Also:
-  adjusted the privileges to data-hub-common to be able to call mlHubversion extension
- fixed an issue where flow-operator was needed in addition to hub-central-step-runner on ML 9.0-12

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

