### PR TITLE
DHFPROD-4912: Fixing QS's dependency on dhfversion

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/Versions.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/Versions.java
@@ -121,18 +121,22 @@ public class Versions extends LoggingObject {
             if (fallbackToLocalProject) {
                 logger.info("Unable to determine installed version, likely because DH is not yet installed: " + ex.getMessage());
                 logger.info("Will try to determine version from local project");
-                String version = hubConfig != null ? determineVersionFromLocalProject(hubConfig.getHubProject()) : null;
-                if (version == null) {
-                    version = "2.0.0";
-                    logger.warn("Unable to determine version from local project, will fallback to earliest known version: " + version);
-                } else {
-                    logger.info("Local project version: " + version);
-                }
-                return version;
+                return getLocalProjectVersion();
             } else {
                 throw ex;
             }
         }
+    }
+
+    public String getLocalProjectVersion() {
+        String version = hubConfig != null ? determineVersionFromLocalProject(hubConfig.getHubProject()) : null;
+        if (version == null) {
+            version = "2.0.0";
+            logger.warn("Unable to determine version from local project, will fallback to earliest known version: " + version);
+        } else {
+            logger.info("Local project version: " + version);
+        }
+        return version;
     }
 
     /**

--- a/web/src/main/java/com/marklogic/hub/web/service/EnvironmentConfig.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/EnvironmentConfig.java
@@ -52,6 +52,8 @@ public class EnvironmentConfig {
 
     private String marklogicVersion;
 
+    private String DHFVersion;
+
     private boolean isVersionCompatibleWithES;
 
     public InstallInfo getInstallInfo() {
@@ -86,6 +88,10 @@ public class EnvironmentConfig {
         return marklogicVersion;
     }
 
+    public String getDHFVersion() {
+        return DHFVersion;
+    }
+
     public boolean isVersionCompatibleWithES() {
         return isVersionCompatibleWithES;
     }
@@ -99,11 +105,17 @@ public class EnvironmentConfig {
         this.installedVersion = versions.getInstalledVersion(true);
         this.marklogicVersion = versions.getMarkLogicVersion();
         this.runningVersion = this.mlSettings.getJarVersion();
+        // The references in QS to "dhfversion" cannot be removed via DHFPROD-4912, as QS is unfortunately tightly
+        // bound to this value. So we need something here. The new getLocalProjectVersion concept in 5.3 will work,
+        // with the one caveat being that if it cannot be identified, then 2.0.0 is used as a fallback, and QS likely
+        // does not want to display that to the user.
+        this.DHFVersion = versions.getLocalProjectVersion();
         this.isVersionCompatibleWithES = versions.isVersionCompatibleWithES();
 
         // Replace "-SNAPSHOT" in version with ".0" as QS compares versions and fails if version number contains text
         installedVersion = installedVersion.replace("-SNAPSHOT", ".0");
         runningVersion = runningVersion.replace("-SNAPSHOT", ".0");
+        DHFVersion = DHFVersion.replace("-SNAPSHOT", ".0");
     }
 
     private DatabaseClient _stagingClient = null;

--- a/web/src/main/ui/app/components/header/ui/header-ui.component.html
+++ b/web/src/main/ui/app/components/header/ui/header-ui.component.html
@@ -1,7 +1,7 @@
 <header class="mdl-layout__header">
   <div class="mdl-layout__header-row">
     <a class="isActive('/')" [routerLink]="['']"><img src="/img/odh.svg"></a>
-    <span class="mdl-layout-title">Data Hub QuickStart    <span class="version-link">v{{settings.dhfversion}}</span></span>
+    <span class="mdl-layout-title">Data Hub QuickStart    <span class="version-link">v{{settings.runningVersion}}</span></span>
     <!-- Add spacer, to align navigation to the right -->
     <div class="mdl-layout-spacer"></div>
     <div *ngIf="runningJobs !== 0" layout="row" layout-align="center center" class="job-progress" [routerLink]="['jobs']">

--- a/web/src/main/ui/app/components/login/ui/login-ui.component.html
+++ b/web/src/main/ui/app/components/login/ui/login-ui.component.html
@@ -332,7 +332,7 @@
           </div>
           <div *ngIf="currentEnvironment.runningVersion !== currentEnvironment.dhfversion">
             <h3>DHF Project Version Mismatch!</h3>
-            <p>Your project ({{currentEnvironment.dhfversion}}) does not match the DHF version running ({{currentEnvironment.runningVersion}}). Please upgrade your project first before
+            <p>Your project version does not match the QuickStart version ({{currentEnvironment.runningVersion}}). Please upgrade your project first before
               attempting to install DHF.
             </p>
           </div>

--- a/web/src/main/ui/app/models/hub-settings.model.ts
+++ b/web/src/main/ui/app/models/hub-settings.model.ts
@@ -6,6 +6,7 @@ export class HubSettings {
   dhfversion: string = null;
   marklogicVersion: string = null;
   installedVersion: string = null;
+  runningVersion: string = null;
   isVersionCompatibleWithES: boolean = null;
 
   stagingDbName: string = null;

--- a/web/src/main/ui/app/services/environment/environment.service.ts
+++ b/web/src/main/ui/app/services/environment/environment.service.ts
@@ -26,6 +26,7 @@ export class EnvironmentService {
       this.settings.dhfversion = json.dhfversion;
       this.settings.installedVersion = json.installedVersion;
       this.settings.marklogicVersion = json.marklogicVersion;
+      this.settings.runningVersion = json.runningVersion;
       this.settings.isVersionCompatibleWithES = json.versionCompatibleWithES;
       this.marklogicVersion = json.marklogicVersion;
       if (json.runningVersion === '0.1.2' || json.runningVersion === '%%mlHubVersion%%' || json.installedVersion === '%%mlHubVersion%%') {


### PR DESCRIPTION
Instead of reverting (https://github.com/marklogic/marklogic-data-hub/pull/4061), I think this may address QS's dependency on mlDHFVersion. 

This is now populated via versions.getLocalProjectVersion. And the header of QS has been 
changed to reference runningVersion instead of local project version.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

