### PR TITLE
DHFPROD-4971:Validate 'Target Permissions'  in HC

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings-dialog.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings-dialog.module.scss
@@ -79,11 +79,11 @@ span.readOnlyLabel {
     vertical-align: bottom;
 }
 
-.formItem { 
+.formItem {
     margin-bottom: 8px !important;
 }
 
-.formItemTargetCollections { 
+.formItemTargetCollections {
     margin-bottom: 5px !important;
 }
 
@@ -109,4 +109,11 @@ span.readOnlyLabel {
 }
 .inputWithTooltip{
     width: 95% !important;
+}
+.validationError {
+    line-height: normal;
+    padding-top: 5px;
+    padding-left: 1px;
+    padding-bottom: 1px;
+    color: #DB4f59;
 }

--- a/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings-dialog.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings-dialog.test.tsx
@@ -36,6 +36,8 @@ describe('Update data load settings component', () => {
     //should be the last field in the form
     fireEvent.mouseOver(tooltip[tooltip.length-1]);
     await waitForElement(() => getByText(AdvancedSettings.batchSize))
+    fireEvent.mouseOver(tooltip[tooltip.length-4]);
+    await waitForElement(() => getByText(AdvancedSettings.targetPermissions))
     expect(getByText('Custom Hook')).toBeInTheDocument();
     fireEvent.click(getByText('Custom Hook'));
     expect(getByPlaceholderText('Please enter module')).toBeInTheDocument();
@@ -162,7 +164,7 @@ describe('Update data load settings component', () => {
     expect(getByRole('switch')).toBeDisabled();
   });
 
-  test('Verify post is called when Mapping configuration is saved', async () => {
+  test('Verify put is called when Mapping configuration is saved', async () => {
     //Enhance this test once DHFPROD-4712 is fixed
     axiosMock.put.mockImplementationOnce(jest.fn(() => Promise.resolve({ status: 200, data: {} })));
     const { getByText } = render(<AdvancedSettingsDialog {...data.advancedSettings} />);
@@ -173,7 +175,7 @@ describe('Update data load settings component', () => {
     expect(axiosMock.put).toHaveBeenCalledTimes(1);
   });
 
-  test('Verify post is called when Load Data configuration is saved', async () => {
+  test('Verify put is called when Load Data configuration is saved', async () => {
     axiosMock.put.mockImplementationOnce(jest.fn(() => Promise.resolve({ status: 200, data: {} })));
     const { getByText } = render(<AdvancedSettingsDialog {...data.advancedSettings} activityType={'ingestion'} />);
     expect(getByText('Save')).toBeInTheDocument();

--- a/marklogic-data-hub-central/ui/src/config/messages.config.ts
+++ b/marklogic-data-hub-central/ui/src/config/messages.config.ts
@@ -1,0 +1,9 @@
+const AdvancedSettingsMessages = {
+    'targetPermissions': {
+        'incorrectFormat' : 'The format of the string is incorrect. The required format is role,capability,role,capability,....',
+        'invalidCapabilities' : 'The string contains invalid capabilities. Capabilities must be read, insert, update or execute.'
+    }
+}
+export {
+    AdvancedSettingsMessages
+}

--- a/marklogic-data-hub-central/ui/src/config/mocks.config.ts
+++ b/marklogic-data-hub-central/ui/src/config/mocks.config.ts
@@ -11,6 +11,17 @@ const loadAPI = (axiosMock) => {
           return Promise.reject(new Error('not found'))
       }
     });
+    axiosMock.put['mockImplementation']((url) => {
+        switch (url) {
+            case '/api/steps/ingestion/' + loadData.loads.data[0].name + '/settings':
+                return Promise.resolve({
+                    "data": {},
+                    "status": 200
+                });
+            default:
+                return Promise.reject(new Error('not found'));
+        }
+    })
     return axiosMock.get['mockImplementation']((url) => {
       switch (url) {
         case '/api/flows':
@@ -32,6 +43,17 @@ const loadAPI = (axiosMock) => {
                 return Promise.resolve(loadData.genericSuccess);
             default:
                 return Promise.reject(new Error('not found'))
+        }
+    });
+    axiosMock.put['mockImplementation']((url) => {
+        switch (url) {
+            case '/api/steps/mapping/' + curateData.mappings.data[0].artifacts[0].name + '/settings':
+                return Promise.resolve({
+                    "data": {},
+                    "status": 200
+                });
+            default:
+                return Promise.reject(new Error('not found'));
         }
     });
     return axiosMock.get['mockImplementation']((url) => {
@@ -121,7 +143,7 @@ const loadAPI = (axiosMock) => {
       }
     })
   };
-  
+
   const mocks = {
     loadAPI: loadAPI,
     curateAPI: curateAPI,
@@ -130,5 +152,5 @@ const loadAPI = (axiosMock) => {
     runFailedAPI: runFailedAPI,
     runXMLAPI: runXMLAPI,
   };
-  
+
   export default mocks;

--- a/marklogic-data-hub-central/ui/src/config/tooltips.config.js
+++ b/marklogic-data-hub-central/ui/src/config/tooltips.config.js
@@ -4,7 +4,8 @@ const AdvancedSettings = {
     'sourceQuery' : 'The collection tag or CTS query that selects the source data to process in this step.',
     'targetFormat': 'The format of the documents in the target database.',
     'additionalCollections': 'The collection tags to add to the default tags assigned to the processed document.',
-    'targetPermissions': 'The comma-separated permissions required to access the processed document.',
+    'targetPermissions': 'A comma-delimited string that defines permissions required to access the processed document. ' +
+      'The string must be in the format role,capability,role,capability,..., where capability can be read, insert, update, or execute.',
     'module': 'The path to your custom hook module.',
     'cHParameters': 'Parameters, as key-value pairs, to pass to your custom hook module.',
     'user': 'The user account to use to run the module. The default is the user running the flow; e.g., data-hub-operator.',

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/impl/FlowRunnerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/impl/FlowRunnerTest.java
@@ -82,8 +82,10 @@ public class FlowRunnerTest extends HubTestBase {
         XMLDocumentManager docMgr = stagingClient.newXMLDocumentManager();
         DocumentMetadataHandle metadataHandle = new DocumentMetadataHandle();
         docMgr.readMetadata("/ingest-xml.xml", metadataHandle);
-        DocumentMetadataHandle.DocumentPermissions perms = metadataHandle.getPermissions();
-        Assertions.assertEquals(2, perms.get("data-hub-operator").size());
+        DocumentMetadataHandle.DocumentPermissions permissions = metadataHandle.getPermissions();
+        Assertions.assertEquals(2, permissions.get("data-hub-operator").size());
+        Assertions.assertTrue(permissions.get("data-hub-operator").contains(DocumentMetadataHandle.Capability.READ));
+        Assertions.assertTrue(permissions.get("data-hub-operator").contains(DocumentMetadataHandle.Capability.UPDATE));
         RunStepResponse stepResp = resp.getStepResponses().get("1");
         Assertions.assertNotNull(stepResp.getStepStartTime());
         Assertions.assertNotNull(stepResp.getStepEndTime());


### PR DESCRIPTION
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:
Validate 'Target Permissions' in HC (It was already added as part of DHFPROD-4388, modified the tooltip here)
- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

