### PR TITLE
DHFPROD-4670: Display disabled links for adding to flow for non-flow writer

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.module.scss
@@ -94,6 +94,15 @@
     cursor: pointer;
 }
 
+.cardDisabledLink {
+    color: #3f4692;
+    background-color: #ecf6fe;
+    margin-bottom: 13px;
+    padding: 8px;
+    font-size: 14px;
+    cursor: not-allowed;
+}
+
 .cardNonLink {
     color: rgba(0, 0, 0, 0.65);
     background-color: #ecf6fe;

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
@@ -20,7 +20,7 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
-describe("Entity Tiles component", () => {
+describe("Mapping Card component", () => {
   beforeEach(() => {
     mocks.curateAPI(axiosMock);
   });
@@ -286,7 +286,7 @@ describe("Entity Tiles component", () => {
     let mapping = data.mappings.data[0].artifacts;
     const mockAddStepToFlow = jest.fn();
     const noopFun = jest.fn();
-    const {getByText} = render(<MemoryRouter><AuthoritiesContext.Provider value={authorityService}><MappingCard
+    const {getByText, getByTestId} = render(<MemoryRouter><AuthoritiesContext.Provider value={authorityService}><MappingCard
       data={mapping}
       flows={data.flows.data}
       entityTypeTitle={entityModel.entityName}
@@ -302,18 +302,19 @@ describe("Entity Tiles component", () => {
       addStepToNew={noopFun}/>
     </AuthoritiesContext.Provider></MemoryRouter>);
 
-    fireEvent.mouseOver(getByText(mapping[0].name));
+    const mappingStepName = mapping[0].name;
+    fireEvent.mouseOver(getByText(mappingStepName));
 
     // test adding to existing flow
-    expect(getByText('Add step to an existing flow')).toBeInTheDocument();
-    fireEvent.click(getByText('Select Flow'));
+    expect(getByTestId(`${mappingStepName}-toExistingFlow`)).toBeInTheDocument();
+    fireEvent.click(getByTestId(`${mappingStepName}-flowsList`));
     fireEvent.click(getByText(data.flows.data[0].name));
     fireEvent.click(getByText('Yes'));
     expect(mockAddStepToFlow).toBeCalledTimes(1);
 
     // adding to new flow
-    fireEvent.mouseOver(getByText(mapping[0].name));
-    expect(getByText('Add step to a new flow')).toBeInTheDocument();
+    fireEvent.mouseOver(getByText(mappingStepName));
+    expect(getByTestId(`${mappingStepName}-toNewFlow`)).toBeInTheDocument();
     // TODO calling addStepToNew not implemented yet
   });
 
@@ -324,7 +325,7 @@ describe("Entity Tiles component", () => {
     let mapping = data.mappings.data[0].artifacts;
     const mockAddStepToFlow = jest.fn();
     const noopFun = jest.fn();
-    const {getByText, queryByText} = render(<MemoryRouter><AuthoritiesContext.Provider value={authorityService}><MappingCard
+    const {getByText, queryByText, queryByTestId} = render(<MemoryRouter><AuthoritiesContext.Provider value={authorityService}><MappingCard
       data={mapping}
       flows={data.flows}
       entityTypeTitle={entityModel.entityName}
@@ -339,13 +340,18 @@ describe("Entity Tiles component", () => {
       addStepToFlow={mockAddStepToFlow}
       addStepToNew={noopFun}/>
     </AuthoritiesContext.Provider></MemoryRouter>);
+    const mappingStepName = mapping[0].name;
 
-    fireEvent.mouseOver(getByText(mapping[0].name));
+    fireEvent.mouseOver(getByText(mappingStepName));
 
     // test adding to existing flow
-    expect(queryByText('Add step to an existing flow')).not.toBeInTheDocument();
+    expect(queryByTestId(`${mappingStepName}-toExistingFlow`)).toBeInTheDocument();
+    fireEvent.click(queryByTestId(`${mappingStepName}-flowsList`));
+    expect(queryByText(data.flows.data[0].name)).not.toBeInTheDocument();
+
 
     // test adding to new flow
-    expect(queryByText('Add step to a new flow')).not.toBeInTheDocument();
+    expect(queryByTestId(`${mappingStepName}-toNewFlow`)).not.toBeInTheDocument();
+    expect(queryByTestId(`${mappingStepName}-disabledToNewFlow`)).toBeInTheDocument();
   });
 });

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
@@ -645,8 +645,8 @@ const MappingCard: React.FC<Props> = (props) => {
                                     state: {
                                         stepToAdd : elem.name,
                                         stepDefinitionType : 'mapping'
-                                    }}}><div className={styles.cardLink} data-testid={`${elem.name}-toNewFlow`}> Add step to a new flow</div></Link> : null }
-                                    { props.canWriteFlow ? <div className={styles.cardNonLink} data-testid={`${elem.name}-toExistingFlow`}>
+                                    }}}><div className={styles.cardLink} data-testid={`${elem.name}-toNewFlow`}> Add step to a new flow</div></Link> : <div className={styles.cardDisabledLink} data-testid={`${elem.name}-disabledToNewFlow`}> Add step to a new flow</div> }
+                                    <div className={styles.cardNonLink} data-testid={`${elem.name}-toExistingFlow`}>
                                         Add step to an existing flow
                                         <div className={styles.cardLinkSelect}>
                                             <Select
@@ -654,6 +654,7 @@ const MappingCard: React.FC<Props> = (props) => {
                                                 onChange={(flowName) => handleSelect({flowName: flowName, mappingName: elem.name})}
                                                 placeholder="Select Flow"
                                                 defaultActiveFirstOption={false}
+                                                disabled={!props.canWriteFlow}
                                                 data-testid={`${elem.name}-flowsList`}
                                             >
                                                 { props.flows && props.flows.length > 0 ? props.flows.map((f,i) => (
@@ -661,7 +662,7 @@ const MappingCard: React.FC<Props> = (props) => {
                                                 )) : null}
                                             </Select>
                                         </div>
-                                    </div>: null}
+                                    </div>
                                 </div>
                             </Card>
                         </div>

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
@@ -12,6 +12,9 @@ jest.mock('axios');
 
 describe('RTL Source-to-entity map tests', () => {
     afterEach(cleanup);
+
+    beforeEach(() => jest.setTimeout(20000));
+
     test('RTL tests with no source data', () => {
         const { getByTestId,  getByText, getByRole } = render(<SourceToEntityMap {... {mapData: data.mapProps.mapData,entityTypeProperties:data.mapProps.entityTypeProperties, entityTypeTitle : data.mapProps.entityTypeTitle, sourceData: [], extractCollectionFromSrcQuery: jest.fn()}} mappingVisible={true}/>);
         expect(getByText('Source Data')).toBeInTheDocument();

--- a/marklogic-data-hub-central/ui/src/components/load/load-card.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/load/load-card.module.scss
@@ -86,6 +86,15 @@
     cursor: pointer;
 }
 
+.cardDisabledLink {
+    color: #3f4692;
+    background-color: #ecf6fe;
+    margin-bottom: 13px;
+    padding: 8px;
+    font-size: 14px;
+    cursor: not-allowed;
+}
+
 .cardNonLink {
     color: rgba(0, 0, 0, 0.65);
     background-color: #ecf6fe;

--- a/marklogic-data-hub-central/ui/src/components/load/load-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-card.test.tsx
@@ -172,9 +172,12 @@ describe('Load Card component', () => {
     // adding to new flow
     fireEvent.mouseOver(getByText(loadStepName));
     // test adding to existing flow
-    expect(queryByTestId(`${loadStepName}-toExistingFlow`)).not.toBeInTheDocument();
+    expect(queryByTestId(`${loadStepName}-toExistingFlow`)).toBeInTheDocument();
+    fireEvent.click(queryByTestId(`${loadStepName}-flowsList`));
+    expect(queryByText(data.flows[0].name)).not.toBeInTheDocument();
 
     // test adding to new flow
     expect(queryByTestId(`${loadStepName}-toNewFlow`)).not.toBeInTheDocument();
+    expect(queryByTestId(`${loadStepName}-disabledToNewFlow`)).toBeInTheDocument();
   });
 });

--- a/marklogic-data-hub-central/ui/src/components/load/load-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-card.tsx
@@ -198,14 +198,14 @@ const LoadCard: React.FC<Props> = (props) => {
                             </div>
                             <div className={styles.stepNameStyle}>{getInitialChars(elem.name, 25, '...')}</div>
                             <div className={styles.lastUpdatedStyle}>Last Updated: {convertDateFromISO(elem.lastUpdated)}</div>
-                            {props.canWriteFlow ? <div className={styles.cardLinks} style={{display: showLinks === elem.name ? 'block' : 'none'}}>
-                                <Link id="tiles-run" to={
+                            <div className={styles.cardLinks} style={{display: showLinks === elem.name ? 'block' : 'none'}}>
+                                {props.canWriteFlow ? <Link id="tiles-run" to={
                                     {pathname: '/tiles-run',
                                     state: {
                                         stepToAdd : elem.name,
                                         stepDefinitionType : 'ingestion',
                                         existingFlow: false
-                                    }}}><div className={styles.cardLink} data-testid={`${elem.name}-toNewFlow`}>Add step to a new flow</div></Link>
+                                    }}}><div className={styles.cardLink} data-testid={`${elem.name}-toNewFlow`}>Add step to a new flow</div></Link>: <div className={styles.cardDisabledLink} data-testid={`${elem.name}-disabledToNewFlow`}> Add step to a new flow</div>}
                                 <div className={styles.cardNonLink} data-testid={`${elem.name}-toExistingFlow`}>
                                     Add step to an existing flow
                                     <div className={styles.cardLinkSelect}>
@@ -215,6 +215,7 @@ const LoadCard: React.FC<Props> = (props) => {
                                             placeholder="Select Flow"
                                             defaultActiveFirstOption={false}
                                             data-testid={`${elem.name}-flowsList`}
+                                            disabled={!props.canWriteFlow}
                                         >
                                             { props.flows && props.flows.length > 0 ? props.flows.map((f,i) => (
                                                 <Option value={f.name} key={i}>{f.name}</Option>
@@ -222,7 +223,7 @@ const LoadCard: React.FC<Props> = (props) => {
                                         </Select>
                                     </div>
                                 </div>
-                            </div> : null}
+                            </div>
                         </Card>
                     </div>
                 </Col>)) : <span></span> }


### PR DESCRIPTION
### Description

Before it wasn't showing the links without the role. According to the JIRA ticket it should show, but be disabled.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [ ] JIRA_ID included in all the commit messages
- [ ] PR title is in the format JIRA_ID:Title
- [ ] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [ ] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests

