### PR TITLE
DHFPROD-5170: Remove the word "documents" in search results

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
@@ -22,7 +22,7 @@ describe('RTL Source-to-entity map tests', () => {
         expect(getByText('Clear')).toBeDisabled;
         expect(getByTestId("entityContainer")).toBeInTheDocument();
         expect(getByTestId("srcContainer")).toBeInTheDocument();
-        expect(getByText("Unable to find source documents using the specified collection or query.")).toBeInTheDocument;
+        expect(getByText("Unable to find source records using the specified collection or query.")).toBeInTheDocument;
         expect(getByTestId("srcContainer")).toHaveClass("sourceContainer");
         expect(getByText('Entity: Person')).toBeInTheDocument();
         expect(getByRole('presentation').className).toEqual("Resizer vertical ");
@@ -37,7 +37,7 @@ describe('RTL Source-to-entity map tests', () => {
         expect(getByTestId("srcContainer")).toHaveClass("sourceContainer");
         expect(getByText('Entity: Person')).toBeInTheDocument();
         expect(getByText('Test')).toBeEnabled();
-        expect(queryByText("Unable to find source documents using the specified collection or query.")).not.toBeInTheDocument();
+        expect(queryByText("Unable to find source records using the specified collection or query.")).not.toBeInTheDocument();
         let exp = getByText('testNameInExp');
         expect(exp).toBeInTheDocument();
         fireEvent.change(exp, { target: {value: "concat(name,'-NEW')" }});
@@ -84,7 +84,7 @@ describe('RTL Source-to-entity map tests', () => {
             mappingVisible={true}
             entityTypeProperties={nestedEntityWithSameName}
         />);
-        
+
         fireEvent.change(getAllByTestId('propName-mapexpression')[0], { target: { value: "concat(propName,'-NEW')" } });
         fireEvent.blur(getAllByTestId('propName-mapexpression')[0])
         await(waitForElement(() => (getByTestId('successMessage'))))
@@ -754,7 +754,7 @@ describe('Enzyme Source-to-entity map tests', () => {
     });
 
     test('Enzyme tests with no source data', () => {
-        let noDataMessage = "Unable to find source documents using the specified collection or query." +
+        let noDataMessage = "Unable to find source records using the specified collection or query." +
             "Load some data that mapping can use as reference and/or edit the step settings to use a " +
             "source collection or query that will return some results.";
         wrapper.setProps({sourceData: []} );

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
@@ -1159,7 +1159,7 @@ const SourceToEntityMap = (props) => {
                                 <br/><br/>
                                 <Card className={styles.emptyCard} size="small">
                                     <div className={styles.emptyText}>
-                                        <p>Unable to find source documents using the specified collection or query.</p>
+                                        <p>Unable to find source records using the specified collection or query.</p>
                                         <p>Load some data that mapping can use as reference and/or edit the step
                                             settings to use a source collection or query that will return some results.</p>
                                     </div>

--- a/marklogic-data-hub-central/ui/src/components/load/new-load-dialog/new-load-dialog.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/new-load-dialog/new-load-dialog.test.tsx
@@ -38,7 +38,7 @@ describe('New/edit load data configuration', () => {
     let tooltip  = getAllByLabelText('icon: question-circle');
     //should be the last field in the form
     fireEvent.mouseOver(tooltip[tooltip.length-1]);
-    await waitForElement(() => getByText("The prefix you want for the URIs of the loaded documents. Example: If your prefix is /rawData/ and you load a file called customer1.json, the URI of the loaded document becomes /rawData/customer1.json."))
+    await waitForElement(() => getByText("The prefix you want for the URIs of the loaded records. Example: If your prefix is /rawData/ and you load a file called customer1.json, the URI of the loaded record becomes /rawData/customer1.json."))
     expect(getByText("Target Format:")).toHaveTextContent('Target Format: *');
     expect(getByText("Target URI Prefix:")).toHaveTextContent('Target URI Prefix:');
   });

--- a/marklogic-data-hub-central/ui/src/components/search-summary/search-summary.tsx
+++ b/marklogic-data-hub-central/ui/src/components/search-summary/search-summary.tsx
@@ -33,7 +33,7 @@ const SearchSummary: React.FC<Props> = (props) => {
     <div className={styles.searchSummaryContainer}>
       <Text>Showing </Text>
       <span className={styles.summaryValue}>{isNoDocuments() ? 0 : numberConverter(props.start)}-{isEndOfPage() ? numberConverter(props.total) : numberConverter(props.start + props.pageSize -1)}</span> <Text>of</Text> <span className={styles.summaryValue} data-cy='total-documents'>{numberConverter(props.total)}</span>
-      <Text> documents</Text>
+      <Text> results</Text>
     </div>
   );
 }

--- a/marklogic-data-hub-central/ui/src/config/guided-tour-steps.js
+++ b/marklogic-data-hub-central/ui/src/config/guided-tour-steps.js
@@ -2,11 +2,11 @@
 const viewSteps = [
   {
     selector: '[class*="View_statsContainer"]',
-    content: 'Here are the number of entities and total number of documents.'
+    content: 'Here are the number of entities and total number of records.'
   },
   {
     selector: '.ant-table-body',
-    content: 'The table shows each entity, total documents per entity, and last harmonized date per entity.'
+    content: 'The table shows each entity, total records per entity, and last harmonized date per entity.'
   },
   {
     selector: '.ant-table-row-expand-icon',
@@ -21,7 +21,7 @@ const browseTableViewSteps = [
   },
   {
     selector: '[id*="sideBarContainer"]',
-    content: 'Here are the available faceted search options. Entity Properties are per selected entity. Hub Properties are per document.'
+    content: 'Here are the available faceted search options. Entity Properties are per selected entity. Hub Properties are per record.'
   },
   {
     selector: '[id*="snippetView"]',
@@ -29,19 +29,19 @@ const browseTableViewSteps = [
   },
   {
     selector: '.ant-table-row',
-    content: 'Document results include entity name, primary key (or document URI), table information, and metadata'
+    content: 'Record results include entity name, primary key (or record URI), table information, and metadata'
   },
   {
     selector: '.ant-table-row-expand-icon-cell',
-    content: 'Expansion button will show all the properties of each document'
+    content: 'Expansion button will show all the properties of each record'
   },
   {
     selector: '[id*="instance"]',
-    content: 'Click on this to see instance view of the document on a separate page'
+    content: 'Click on this to see instance view of the record on a separate page'
   },
   {
     selector: '[id*="source"]',
-    content: 'Click on this to see source view of the document on a separate page'
+    content: 'Click on this to see source view of the record on a separate page'
   }
 
 ];
@@ -53,7 +53,7 @@ const browseSnippetViewSteps = [
   },
   {
     selector: '[id*="sideBarContainer"]',
-    content: 'Here are the available faceted search options. Entity Properties are per selected entity. Hub Properties are per document.'
+    content: 'Here are the available faceted search options. Entity Properties are per selected entity. Hub Properties are per record.'
   },
   {
     selector: '[id*="tableView"]',
@@ -61,19 +61,19 @@ const browseSnippetViewSteps = [
   },
   {
     selector: '.ant-list-item',
-    content: 'Document results include entity name, primary key (or document URI), snippet information, and metadata'
+    content: 'Record results include entity name, primary key (or record URI), snippet information, and metadata'
   },
   {
     selector: '[class*="search-result_title"]',
-    content: 'Expansion button will show all the properties of each document'
+    content: 'Expansion button will show all the properties of each record'
   },
   {
     selector: '[id*="instance"]',
-    content: 'Click on this to see instance view of the document on a separate page'
+    content: 'Click on this to see instance view of the record on a separate page'
   },
   {
     selector: '[id*="source"]',
-    content: 'Click on this to see source view of the document on a separate page'
+    content: 'Click on this to see source view of the record on a separate page'
   }
 
 ];
@@ -81,7 +81,7 @@ const browseSnippetViewSteps = [
 const detailSteps = [
   {
     selector: '#header',
-    content: 'Here is the entity name, primary key (or document URI), and metadata.'
+    content: 'Here is the entity name, primary key (or record URI), and metadata.'
   },
   {
     selector: '#subMenu',

--- a/marklogic-data-hub-central/ui/src/config/tooltips.config.js
+++ b/marklogic-data-hub-central/ui/src/config/tooltips.config.js
@@ -2,11 +2,11 @@ const AdvancedSettings = {
     'name': 'The name of this step definition.',
     'description': 'The description of this step definition.',
     'sourceQuery' : 'The collection tag or CTS query that selects the source data to process in this step.',
-    'targetFormat': 'The format of the documents in the target database.',
-    'additionalCollections': 'The collection tags to add to the default tags assigned to the processed document.',
-    'targetPermissions': 'A comma-delimited string that defines permissions required to access the processed document. ' +
+    'targetFormat': 'The format of the records in the target database.',
+    'additionalCollections': 'The collection tags to add to the default tags assigned to the processed record.',
+    'targetPermissions': 'A comma-delimited string that defines permissions required to access the processed record. ' +
     'The string must be in the format role,capability,role,capability,..., where capability can be read, insert, update, or execute.',
-    'headers': 'A JSON object that represents additional metadata to add to the header section of the envelope of each document.',
+    'headers': 'A JSON object that represents additional metadata to add to the header section of the envelope of each record.',
     'provGranularity': 'The level of detail logged for provenance. Choose *coarse* for the default level or *off* for no provenance logging.',
     'processors': 'Custom modules that perform additional processes after the core step processes are completed and before the results are saved.',
     'customHook': 'A custom module that performs additional processes in its own transaction before or after the core step transaction. Results are saved within a transaction.',
@@ -29,7 +29,7 @@ const NewLoadTooltips = {
     'files' : 'Click *Upload* to select the source files. The total size of the files must be 100MB or less.',
     'sourceFormat': 'The format of the source files to load.',
     'fieldSeparator': 'The delimiter in source files. Required if *Source Format* is *Delimited Text*.',
-    'outputURIPrefix': 'The prefix you want for the URIs of the loaded documents. Example: If your prefix is /rawData/ and you load a file called customer1.json, the URI of the loaded document becomes /rawData/customer1.json.'
+    'outputURIPrefix': 'The prefix you want for the URIs of the loaded records. Example: If your prefix is /rawData/ and you load a file called customer1.json, the URI of the loaded record becomes /rawData/customer1.json.'
 }
 
 const AdvLoadTooltips = {


### PR DESCRIPTION
### Description
Changed the word "documents" to "results"/"records" in various areas in the UI visible to the user to remove MarkLogic specific language.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

