### PR TITLE
DHFPROD-5093: Terminology changes to Hub Central

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
@@ -583,21 +583,21 @@ describe('RTL Source-to-entity map tests', () => {
 
         let expandCollapseBtn = getByTestId('expandCollapseBtn-source');
 
-        expect(expandCollapseBtn.textContent).toBe('Expand All'); // Validating the button label
+        expect(expandCollapseBtn.textContent).toBe('Expand'); // Validating the button label
 
         fireEvent.click(expandCollapseBtn); //Expanding all nested levels
-        expect(expandCollapseBtn.textContent).toBe('Collapse All'); // Validating the button label
+        expect(expandCollapseBtn.textContent).toBe('Collapse'); // Validating the button label
         expect(getByText('suffix')).toBeInTheDocument();
 
         //Check if indentation is right
         expect(getByText('suffix').closest('td')?.firstElementChild).toHaveStyle("padding-left: 28px;");
 
         fireEvent.click(expandCollapseBtn); //Collapsing back to the default view (root and 1st level)
-        expect(expandCollapseBtn.textContent).toBe('Expand All'); // Validating the button label
+        expect(expandCollapseBtn.textContent).toBe('Expand'); // Validating the button label
         expect(onClosestTableRow(getByText('suffix'))?.style.display).toBe('none'); // Checking if the row is marked hidden in DOM. All collapsed rows are marked hidden(display: none) once you click on Collapse All button.
 
         /* Validate collapse-expand in Entity table */
-        //Check if the expected Entity table elements are present in the DOM before hittting the Expan/Collapse button
+        //Check if the expected Entity table elements are present in the DOM before hittting the Expand/Collapse button
         expect(queryByText('artCraft')).not.toBeInTheDocument();
         expect(getByText('items')).toBeInTheDocument();
         expect(getByText('itemTypes')).toBeInTheDocument();
@@ -605,17 +605,17 @@ describe('RTL Source-to-entity map tests', () => {
 
         expandCollapseBtn = getByTestId('expandCollapseBtn-entity');
 
-        expect(expandCollapseBtn.textContent).toBe('Expand All');
+        expect(expandCollapseBtn.textContent).toBe('Expand');
 
         fireEvent.click(expandCollapseBtn); //Expanding all nested levels
-        expect(expandCollapseBtn.textContent).toBe('Collapse All');
+        expect(expandCollapseBtn.textContent).toBe('Collapse');
         expect(getByText('artCraft')).toBeInTheDocument();
 
         //Check if indentation is right
         expect(getByText('artCraft').closest('td')?.firstElementChild).toHaveStyle("padding-left: 28px;");
 
         fireEvent.click(expandCollapseBtn); //Collapsing back to the default view (root and 1st level)
-        expect(expandCollapseBtn.textContent).toBe('Expand All');
+        expect(expandCollapseBtn.textContent).toBe('Expand');
         expect(onClosestTableRow(getByText('artCraft'))?.style.display).toBe('none'); // Checking if the row is marked hidden(collapsed) in DOM. All collapsed rows are marked hidden(display: none) once you click on Collapse All button.
     });
 
@@ -635,10 +635,10 @@ describe('RTL Source-to-entity map tests', () => {
 
         let expandCollapseBtn = getByTestId('expandCollapseBtn-source');
 
-        expect(expandCollapseBtn.textContent).toBe('Expand All');
+        expect(expandCollapseBtn.textContent).toBe('Expand');
 
         fireEvent.click(expandCollapseBtn); //Expanding all nested levels
-        expect(expandCollapseBtn.textContent).toBe('Collapse All');
+        expect(expandCollapseBtn.textContent).toBe('Collapse');
         let firstName = getByText('FirstNamePreferred');
         let lastName = getByText('LastName');
         expect(firstName).toBeInTheDocument();
@@ -648,7 +648,7 @@ describe('RTL Source-to-entity map tests', () => {
         expect(lastName.closest('td')?.firstElementChild).toHaveStyle("padding-left: 28px;"); // Check if the indentation is right
 
         fireEvent.click(expandCollapseBtn); //Collapsing back to the default view (root and 1st level)
-        expect(expandCollapseBtn.textContent).toBe('Expand All');
+        expect(expandCollapseBtn.textContent).toBe('Expand');
         expect(onClosestTableRow(firstName)?.style.display).toBe('none');
         expect(onClosestTableRow(lastName)?.style.display).toBe('none');
     });

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
@@ -1168,7 +1168,7 @@ const SourceToEntityMap = (props) => {
                             :
                             <div id="dataPresent">
 
-                                <div className={styles.navigationCollapseButtons}><span><Button data-testid="expandCollapseBtn-source" onClick={() => handleExpandCollapse('rowKey')} className={styles.expandCollapseBtn}>{expandedSourceFlag ? 'Collapse All' : 'Expand All'}</Button></span><span>{navigationButtons}</span></div>
+                                <div className={styles.navigationCollapseButtons}><span><Button data-testid="expandCollapseBtn-source" onClick={() => handleExpandCollapse('rowKey')} className={styles.expandCollapseBtn}>{expandedSourceFlag ? 'Collapse' : 'Expand'}</Button></span><span>{navigationButtons}</span></div>
                                     <Table
                                         pagination={false}
                                         expandIcon={(props) => customExpandIcon(props)}
@@ -1196,7 +1196,7 @@ const SourceToEntityMap = (props) => {
                         </div>
                         <div ref={dummyNode}></div>
                         <div className={styles.columnOptionsSelectorContainer}>
-                            <span><Button data-testid="expandCollapseBtn-entity" onClick={() => handleExpandCollapse('key')} className={styles.expandCollapseBtn}>{expandedEntityFlag ? 'Collapse All' : 'Expand All'}</Button></span><span className={styles.columnOptionsSelector}>{columnOptionsSelector}</span></div>
+                            <span><Button data-testid="expandCollapseBtn-entity" onClick={() => handleExpandCollapse('key')} className={styles.expandCollapseBtn}>{expandedEntityFlag ? 'Collapse' : 'Expand'}</Button></span><span className={styles.columnOptionsSelector}>{columnOptionsSelector}</span></div>
                         <Table
                             pagination={false}
                             className={styles.entityTable}

--- a/marklogic-data-hub-central/ui/src/components/load/new-load-dialog/new-load-dialog.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/new-load-dialog/new-load-dialog.test.tsx
@@ -40,7 +40,7 @@ describe('New/edit load data configuration', () => {
     fireEvent.mouseOver(tooltip[tooltip.length-1]);
     await waitForElement(() => getByText("The prefix you want for the URIs of the loaded documents. Example: If your prefix is /rawData/ and you load a file called customer1.json, the URI of the loaded document becomes /rawData/customer1.json."))
     expect(getByText("Target Format:")).toHaveTextContent('Target Format: *');
-    expect(getByText("Output URI Prefix:")).toHaveTextContent('Output URI Prefix:');
+    expect(getByText("Target URI Prefix:")).toHaveTextContent('Target URI Prefix:');
   });
 
   test('fields with Delimited Text render', () => {

--- a/marklogic-data-hub-central/ui/src/components/load/new-load-dialog/new-load-dialog.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/new-load-dialog/new-load-dialog.tsx
@@ -521,7 +521,7 @@ const NewLoadDialog = (props) => {
           </Tooltip>
         </Form.Item>
         <Form.Item label={<span>
-          Output URI Prefix:&nbsp;
+          Target URI Prefix:&nbsp;
             </span>} labelAlign="left">
           <Input
             id="outputUriPrefix"


### PR DESCRIPTION
### Description
Updated collapse/expand button labels in Mapping Step Details and changed 'Output URI Prefix' to 'Target URI Prefix' for consistency in Load Data form.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

