### PR TITLE
DHFPROD-5032: Can now migrate installed flows

### DIFF
--- a/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/TestObject.java
+++ b/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/TestObject.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.ext.helper.LoggingObject;
 
+import java.io.File;
+
 /**
  * Base class for any object that helps with writing tests. Should only contain the most generic helper methods.
  */
@@ -23,6 +25,14 @@ public abstract class TestObject extends LoggingObject {
     protected ObjectNode readJsonObject(String json) {
         try {
             return (ObjectNode) objectMapper.readTree(json);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected ObjectNode readJsonObject(File file) {
+        try {
+            return (ObjectNode) objectMapper.readTree(file);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/ml-data-hub-plugin/build.gradle
+++ b/ml-data-hub-plugin/build.gradle
@@ -91,6 +91,7 @@ test {
     // TODO put fullcycle tests in another project?
     //include 'com/marklogic/gradle/fullcycle/**'
     include 'com/marklogic/gradle/task/**'
+    include 'com/marklogic/hub/gradle/task/**'
     classpath = project.sourceSets.main.runtimeClasspath + project.sourceSets.test.runtimeClasspath
 }
 

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -28,6 +28,8 @@ import com.marklogic.gradle.task.databases.ClearModulesDatabaseTask
 import com.marklogic.gradle.task.databases.UpdateIndexesTask
 import com.marklogic.gradle.task.deploy.DeployAsDeveloperTask
 import com.marklogic.gradle.task.deploy.DeployAsSecurityAdminTask
+import com.marklogic.hub.gradle.task.DeleteInstalledLegacyMappingsTask
+import com.marklogic.hub.gradle.task.MigrateProjectFlowsTask
 import com.marklogic.hub.ApplicationConfig
 import com.marklogic.hub.deploy.commands.*
 import com.marklogic.hub.deploy.util.ModuleWatchingConsumer
@@ -101,8 +103,18 @@ class DataHubPlugin implements Plugin<Project> {
         project.task("hubVersion", group: deployGroup, type: HubVersionTask,
             description: "Prints the versions of Data Hub and MarkLogic associated with the value of mlHost, and also prints the version of " +
                 "Data Hub associated with this Gradle task")
-        project.task("hubMigrateFlows", group: deployGroup, type: FlowMigrationTask,
-            description: "Migrate flows and mappings created before version 5.3.0 into the new format required for usage within Hub Central")
+
+        String flowMigrationGroup = "Data Hub Flow Migration"
+        project.task("hubDeleteInstalledLegacyMappings", group: flowMigrationGroup, type: DeleteInstalledLegacyMappingsTask,
+            description: "Delete installed legacy mappings, which are mappings that have not been converted into the format required by Hub Central"
+        ).mustRunAfter("hubDeployUserArtifacts")
+        project.task("hubMigrateProjectFlows", group: flowMigrationGroup, type: MigrateProjectFlowsTask,
+            description: "Migrate flows and mappings in the local project that were created before version 5.3.0 into the new format required for usage within Hub Central"
+        )
+        project.task("hubMigrateInstalledFlows", group: flowMigrationGroup, type: DeleteInstalledLegacyMappingsTask,
+            dependsOn: ["hubDeployUserArtifacts", "hubDeleteInstalledLegacyMappings"],
+            description: "Deploys user artifacts and then deletes installed legacy mappings"
+        )
 
         String scaffoldGroup = "MarkLogic Data Hub Scaffolding"
         project.task("hubInit", group: scaffoldGroup, type: InitProjectTask)

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/hub/gradle/task/DeleteInstalledLegacyMappingsTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/hub/gradle/task/DeleteInstalledLegacyMappingsTask.groovy
@@ -1,0 +1,13 @@
+package com.marklogic.hub.gradle.task
+
+import com.marklogic.gradle.task.AbstractConfirmableTask
+import com.marklogic.hub.flow.impl.FlowMigrator
+
+class DeleteInstalledLegacyMappingsTask extends AbstractConfirmableTask {
+
+    @Override
+    void executeIfConfirmed() {
+        new FlowMigrator(getProject().property("hubConfig")).deleteInstalledLegacyMappings()
+    }
+
+}

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/hub/gradle/task/MigrateProjectFlowsTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/hub/gradle/task/MigrateProjectFlowsTask.groovy
@@ -1,8 +1,9 @@
-package com.marklogic.gradle.task
+package com.marklogic.hub.gradle.task
 
+import com.marklogic.gradle.task.AbstractConfirmableTask
 import com.marklogic.hub.flow.impl.FlowMigrator
 
-class FlowMigrationTask extends AbstractConfirmableTask {
+class MigrateProjectFlowsTask extends AbstractConfirmableTask {
 
     @Override
     void executeIfConfirmed() {

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/hub/gradle/task/DeleteInstalledLegacyMappingsTaskTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/hub/gradle/task/DeleteInstalledLegacyMappingsTaskTest.groovy
@@ -1,0 +1,24 @@
+package com.marklogic.hub.gradle.task
+
+import com.marklogic.gradle.task.BaseTest
+import org.gradle.testkit.runner.UnexpectedBuildFailure
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class DeleteInstalledLegacyMappingsTaskTest extends BaseTest {
+
+    def setupSpec() {
+        createGradleFiles()
+        runTask('hubInit')
+    }
+
+    def "simple smoke test"() {
+        when:
+        def result
+        result = runTask("hubDeleteInstalledLegacyMappings", '-Pconfirm=true')
+
+        then:
+        notThrown(UnexpectedBuildFailure)
+        result.task(":hubDeleteInstalledLegacyMappings").outcome == SUCCESS
+    }
+}

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/hub/gradle/task/MigrateProjectFlowsTaskTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/hub/gradle/task/MigrateProjectFlowsTaskTest.groovy
@@ -1,50 +1,51 @@
-package com.marklogic.gradle.task
+package com.marklogic.hub.gradle.task
 
+import com.marklogic.gradle.task.BaseTest
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.gradle.testkit.runner.UnexpectedBuildSuccess
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 //This is a smoke test to ensure the tasks run fine
 
-class FlowMigratonTaskTest extends BaseTest {
+class MigrateProjectFlowsTaskTest extends BaseTest {
 
     def setupSpec() {
         createGradleFiles()
         runTask('hubInit')
         //hubInit doesn't create mappings dir any more.
-        if(! new File(testProjectDir.getRoot(),'mappings').exists()){
-            testProjectDir.newFolder("mappings")
+        if(! new File(BaseTest.testProjectDir.getRoot(),'mappings').exists()){
+            BaseTest.testProjectDir.newFolder("mappings")
         }
     }
 
-    def "run hubMigrateFlows without confirm"() {
+    def "run without confirm"() {
         when:
         def result
-        result = runFailTask("hubMigrateFlows")
+        result = runFailTask("hubMigrateProjectFlows")
 
         then:
         notThrown(UnexpectedBuildSuccess)
         result.output.contains("To execute this task, set the 'confirm' property to 'true'; e.g. '-Pconfirm=true'")
     }
 
-    def "run hubMigrateFlows with confirm"() {
+    def "run with confirm"() {
         when:
         def result
-        result = runTask("hubMigrateFlows", '-Pconfirm=true')
+        result = runTask("hubMigrateProjectFlows", '-Pconfirm=true')
 
         then:
         notThrown(UnexpectedBuildFailure)
-        result.task(":hubMigrateFlows").outcome == SUCCESS
+        result.task(":hubMigrateProjectFlows").outcome == SUCCESS
     }
 
-    def "run hubMigrateFlows should not throw NPE"() {
+    def "run should not throw NPE"() {
         when:
         def result
-        runTask("hubMigrateFlows", '-Pconfirm=true')
-        result = runTask("hubMigrateFlows", '-Pconfirm=true')
+        runTask("hubMigrateProjectFlows", '-Pconfirm=true')
+        result = runTask("hubMigrateProjectFlows", '-Pconfirm=true')
 
         then:
         notThrown(UnexpectedBuildFailure)
-        result.task(":hubMigrateFlows").outcome == SUCCESS
+        result.task(":hubMigrateProjectFlows").outcome == SUCCESS
     }
 }


### PR DESCRIPTION
The new Gradle task is a combo of deploying user artifacts and deleting legacy mappings. 

Renamed hubMigrateFlows to hubMigrateProjectFlows to make it more clear that it only impacts the project files.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

