### PR TITLE
DHFPROD-5189: Update migrate task name for qa-project setup

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/setup.sh
+++ b/marklogic-data-hub-central/ui/e2e/setup.sh
@@ -20,7 +20,7 @@ then
 else
         cd qa-project
         ./gradlew hubInit
-        ./gradlew hubMigrateFlows -Pconfirm=true
+        ./gradlew hubMigrateProjectFlows -Pconfirm=true
         cp ../cypress/fixtures/users/* src/main/ml-config/security/users/
 
         ./gradlew mlDeploy -PmlHost=$mlHost --info --stacktrace


### PR DESCRIPTION
### Description
hubMigrateFlows task name has changed to hubMigrateProjectFlows. Updated setup script for qa-project in e2e.
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- N/A Added Tests
  

- ##### Reviewer:

- N/A Reviewed Tests

