### PR TITLE
DHFPROD-5200: Adding serviceName to systemInfo endpoint

### DIFF
--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/auth/AuthenticationFilter.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/auth/AuthenticationFilter.java
@@ -109,6 +109,6 @@ public class AuthenticationFilter extends AbstractAuthenticationProcessingFilter
         if (!hasLoginAuthority[0]) {
             throw new InsufficientAuthenticationException("User doesn't have necessary privileges to access Hub Central");
         }
-        return new AuthenticationToken(username, password, hubCentral.getProjectName(), authorities);
+        return new AuthenticationToken(username, password, authorities);
     }
 }

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/auth/AuthenticationToken.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/auth/AuthenticationToken.java
@@ -30,14 +30,12 @@ public class AuthenticationToken extends AbstractAuthenticationToken {
 
     private final String username;
     private String password;
-    private final String projectName;
 
-    public AuthenticationToken(String username, String password, String projectName, Collection<GrantedAuthority> authorities) {
+    public AuthenticationToken(String username, String password, Collection<GrantedAuthority> authorities) {
         super(authorities);
         super.setAuthenticated(true);
         this.username = username;
         this.password = password;
-        this.projectName = projectName;
     }
 
     public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
@@ -59,10 +57,6 @@ public class AuthenticationToken extends AbstractAuthenticationToken {
 
     public Object getPrincipal() {
         return this.username;
-    }
-
-    public String getProjectName() {
-        return projectName;
     }
 
 }

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/auth/LoginHandler.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/auth/LoginHandler.java
@@ -56,7 +56,6 @@ public class LoginHandler implements AuthenticationSuccessHandler {
             }
         });
         jsonResponse.putArray("authorities").addAll(authorities);
-        jsonResponse.put("projectName", token.getProjectName());
 
         clearAuthenticationAttributes(request);
 

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/EnvironmentController.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/EnvironmentController.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.hub.central.HubCentral;
 import com.marklogic.hub.impl.ArtifactManagerImpl;
 import com.marklogic.hub.impl.DataHubImpl;
-import com.marklogic.hub.impl.Versions;
+import com.marklogic.hub.impl.VersionInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
@@ -46,14 +46,6 @@ public class EnvironmentController extends BaseController {
 
     private ObjectMapper mapper = new ObjectMapper();
 
-    @RequestMapping(value = "/api/info", method = RequestMethod.GET)
-    @ResponseBody
-    public EnvironmentInfo getInfo() {
-        EnvironmentInfo info = new EnvironmentInfo();
-        info.sessionTimeout = environment.getProperty("server.servlet.session.timeout");
-        return info;
-    }
-
     @RequestMapping(value = "/api/environment/downloadProjectFiles", produces = "application/zip", method = RequestMethod.GET)
     @Secured("ROLE_downloadProjectFiles")
     public void downloadProjectFilesAsZip(HttpServletResponse response) {
@@ -74,23 +66,25 @@ public class EnvironmentController extends BaseController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @RequestMapping(value = "/api/environment/project-info", method = RequestMethod.GET)
+    @RequestMapping(value = "/api/environment/systemInfo", method = RequestMethod.GET)
     @ResponseBody
-    public ProjectInfo getProjectInfo() {
-        Versions versions = new Versions(getHubClient());
-        ProjectInfo info = new ProjectInfo();
-        info.projectName = hubCentral.getProjectName();
-        info.dataHubVersion = versions.getInstalledVersion();
-        info.marklogicVersion = versions.getMarkLogicVersion();
+    public SystemInfo getSystemInfo() {
+        VersionInfo versionInfo = VersionInfo.newVersionInfo(getHubClient());
+        SystemInfo info = new SystemInfo();
+        info.serviceName = versionInfo.getClusterName();
+        info.dataHubVersion = versionInfo.getHubVersion();
+        info.marklogicVersion = versionInfo.getMarkLogicVersion();
         info.host = hubCentral.getHost();
+        info.sessionTimeout = environment.getProperty("server.servlet.session.timeout");
         return info;
     }
 
-    public static class ProjectInfo {
-        public String projectName;
+    public static class SystemInfo {
+        public String serviceName;
         public String dataHubVersion;
         public String marklogicVersion;
         public String host;
+        public String sessionTimeout;
     }
 
     public static class EnvironmentInfo {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/VersionInfo.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/VersionInfo.java
@@ -16,18 +16,21 @@ public class VersionInfo {
 
     private String hubVersion;
     private String markLogicVersion;
+    private String clusterName;
 
     public static VersionInfo newVersionInfo(HubClient hubClient) {
         JsonNode json = SystemService.on(hubClient.getStagingClient()).getVersions();
         return new VersionInfo(
             json.get("hubVersion").asText(),
-            json.get("markLogicVersion").asText()
+            json.get("markLogicVersion").asText(),
+            json.get("clusterName").asText()
         );
     }
 
-    private VersionInfo(String hubVersion, String markLogicVersion) {
+    private VersionInfo(String hubVersion, String markLogicVersion, String clusterName) {
         this.hubVersion = hubVersion;
         this.markLogicVersion = markLogicVersion;
+        this.clusterName = clusterName;
     }
 
     public String getHubVersion() {
@@ -36,6 +39,10 @@ public class VersionInfo {
 
     public String getMarkLogicVersion() {
         return markLogicVersion;
+    }
+
+    public String getClusterName() {
+        return clusterName;
     }
 
     /**

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/system/getVersions.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/system/getVersions.sjs
@@ -19,7 +19,8 @@ const config = require("/com.marklogic.hub/config.sjs");
 
 const versions = {
   hubVersion: config.HUBVERSION,
-  markLogicVersion: xdmp.version()
+  markLogicVersion: xdmp.version(),
+  clusterName: xdmp.clusterName()
 };
 
 versions

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/system/GetVersionsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/system/GetVersionsTest.java
@@ -1,5 +1,6 @@
 package com.marklogic.hub.dataservices.system;
 
+import com.marklogic.client.DatabaseClient;
 import com.marklogic.hub.AbstractHubCoreTest;
 import com.marklogic.hub.impl.VersionInfo;
 import org.junit.jupiter.api.Test;
@@ -12,13 +13,16 @@ public class GetVersionsTest extends AbstractHubCoreTest {
     void test() {
         runAsDataHubOperator();
 
-        final String expectedMarkLogicVersion = getHubClient().getStagingClient().newServerEval().javascript("xdmp.version()").evalAs(String.class);
+        DatabaseClient stagingClient = getHubClient().getStagingClient();
+        final String expectedMarkLogicVersion = stagingClient.newServerEval().javascript("xdmp.version()").evalAs(String.class);
         final String expectedHubClientVersion = adminHubConfig.getJarVersion();
+        final String expectedClusterName = stagingClient.newServerEval().javascript("xdmp.clusterName()").evalAs(String.class);
 
         VersionInfo versionInfo = VersionInfo.newVersionInfo(getHubClient());
         assertEquals(expectedHubClientVersion, versionInfo.getHubVersion(),
             "The version from HubClient, which is obtained from version.properties in the DH jar, " +
                 "should match the DH version reported by the endpoint");
         assertEquals(expectedMarkLogicVersion, versionInfo.getMarkLogicVersion());
+        assertEquals(expectedClusterName, versionInfo.getClusterName());
     }
 }


### PR DESCRIPTION
/api/environment/project-info is now /api/environment/systemInfo as well. 

No longer including projectName in the authentication response either, to avoid redundancy. 

Thinking that SystemService.getVersions should be renamed to SystemService.getSystemInfo too, but will tackle that later in a separate PR to minimize the amount of changes here.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests

