### PR TITLE
DHFPROD-5139: User with hub-central-entity-exporter role can't export data

### DIFF
--- a/examples/reference-entity-model/src/main/ml-config/security/users/bertrand.json
+++ b/examples/reference-entity-model/src/main/ml-config/security/users/bertrand.json
@@ -5,6 +5,7 @@
   "role": [
     "data-hub-operator",
     "hub-central-mapping-reader",
-    "hub-central-entity-exporter"
+    "hub-central-entity-exporter",
+    "hub-central-saved-query-user"
   ]
 }

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/EntitySearchControllerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/EntitySearchControllerTest.java
@@ -160,15 +160,15 @@ public class EntitySearchControllerTest extends AbstractMvcTest {
 
 
         // Try exporting without the required role "hub-central-entity-exporter"
-        loginAsTestUserWithRoles("hub-central-user","data-hub-operator");
+        loginAsTestUserWithRoles("hub-central-user");
         postWithParams(EXPORT_PATH, getRequestParams(limit, json))
             .andExpect(status().isForbidden());
         getJson(EXPORT_PATH + "/query/non-existent-query-id", getRequestParams(limit, null))
             .andExpect(status().isForbidden());
 
 
-        // Set the required role and re-login
-        loginAsTestUserWithRoles("data-hub-operator", "hub-central-entity-exporter", "hub-central-saved-query-user");
+        // Log in with role "hub-central-entity-exporter"
+        loginAsTestUserWithRoles("hub-central-entity-exporter");
 
         // Export using query document
         postWithParams(EXPORT_PATH, getRequestParams(limit, json))
@@ -182,6 +182,10 @@ public class EntitySearchControllerTest extends AbstractMvcTest {
                 assertTrue(actualRowSet.contains(getHashCode(customer1Info)));
                 assertTrue(actualRowSet.contains(getHashCode(customer2Info)));
             });
+
+
+        // Log in with exporter and saved-query roles
+        loginAsTestUserWithRoles("hub-central-entity-exporter", "hub-central-saved-query-user");
 
         // Save the query document
         postJson(SAVED_QUERIES_PATH, json)

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-entity-exporter.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-entity-exporter.json
@@ -2,12 +2,24 @@
   "role-name": "hub-central-entity-exporter",
   "description": "Permits exporting entity instance documents",
   "role": [
-    "hub-central-user"
+    "hub-central-user",
+    "data-hub-entity-model-reader",
+    "tde-view"
   ],
   "privilege": [
     {
       "privilege-name": "hub-central:exportEntityInstances",
       "action": "http://marklogic.com/data-hub/hub-central/privileges/export-entity-instances",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:xslt-eval",
+      "action": "http://marklogic.com/xdmp/privileges/xslt-eval",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:value",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-value",
       "kind": "execute"
     }
   ]


### PR DESCRIPTION
### Description
Added necessary roles and privileges for user with role "hub-central-entity-exporter" to export CSV data. Also correctly renamed a file and added "hub-central-saved-query-user" role to the bertrand user in reference-entity-model.


#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

