### PR TITLE
DHFPROD-5044: Highlight filter icon when mapping source is being filtered

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.module.scss
@@ -36,21 +36,24 @@
     word-break: break-all;
 }
 
-.sourceTable {
-    & thead > tr > th {
+.sourceTable{
+      & thead > tr > th {
         background-color: #fafafa;
         line-height: 2px;
-      };
-    & tbody > tr > td {
+      };  
+      & tbody > tr > td {
         line-height: 2px;
     }
 }
+
+
+
 .sourceTableRows{
     line-height: 1px;
 }
 
 .filterContainer {
-    padding: 8px
+    padding: 8px;
 }
 .searchInput {
     min-width: 8vw;

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.scss
@@ -1,0 +1,9 @@
+
+.active{
+    color: #fafafa;
+    margin-left: -7px !important;
+}
+
+.ant-table-filter-icon.ant-dropdown-trigger.ant-table-filter-selected{
+    background: #394494; 
+}

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect, CSSProperties, useRef, useLayoutEffect } from "react";
 import { Card, Modal, Table, Icon, Popover, Input, Button, Alert, Tooltip, Dropdown, Menu, Checkbox, Row, AutoComplete} from "antd";
 import styles from './source-to-entity-map.module.scss';
+import './source-to-entity-map.scss';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faObjectUngroup, faList, faPencilAlt, faSearch } from "@fortawesome/free-solid-svg-icons";
 import { getInitialChars, convertDateFromISO, getLastChars } from "../../../../util/conversionFunctions";
@@ -9,6 +10,7 @@ import { getMappingValidationResp } from "../../../../util/manageArtifacts-servi
 import DropDownWithSearch from "../../../common/dropdown-with-search/dropdownWithSearch";
 import SplitPane from 'react-split-pane';
 import Highlighter from 'react-highlight-words';
+import ColumnGroup from "antd/lib/table/ColumnGroup";
 
 const SourceToEntityMap = (props) => {
 
@@ -476,7 +478,7 @@ const SourceToEntityMap = (props) => {
               </Button>
             </div>
         ),
-        filterIcon: filtered => <i><FontAwesomeIcon data-testid={`filterIcon-${dataIndex}`} icon={faSearch} size="lg" style={{ color: filtered ? '#5B69AF' : undefined }} /></i>,
+        filterIcon: filtered => <i><FontAwesomeIcon data-testid={`filterIcon-${dataIndex}`} icon={faSearch} size="lg" className={ filtered ? 'active' : 'inactive' }  /></i>,
         onFilter: (value, record) => {
             let recordString = getPropValueFromDataIndex(record, dataIndex);
             return recordString.toString().toLowerCase().includes(value.toLowerCase());


### PR DESCRIPTION
Added source-to-entity-map.scss for antd style override.
Modified source-to-entity-map.tsx and updated source-to-entity-map.modules.scss

### Description
When a filter is in use, the filter icon is now highlighted in a more noticeable fashion.
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

