### PR TITLE
DHFPROD-4997:View Custom ingestion step

### DIFF
--- a/marklogic-data-hub-central/ui/src/api/__mocks__/mocks.data.ts
+++ b/marklogic-data-hub-central/ui/src/api/__mocks__/mocks.data.ts
@@ -67,7 +67,7 @@ const curateAPI = (axiosMock) => {
       case '/api/steps/ingestion':
         return Promise.resolve(loadData.loads);
       case '/api/steps/ingestion/' + loadData.loads.data[0].name:
-        return Promise.resolve(loadData.loadSettings);    
+        return Promise.resolve(loadData.loadSettings);
       case '/api/steps/mapping':
         return Promise.resolve(curateData.mappings);
       case '/api/steps/mapping/' + curateData.mappings.data[0].artifacts[0].name:
@@ -183,6 +183,9 @@ const advancedAPI = (axiosMock) => {
       switch (url) {
           case '/api/steps/ingestion/AdvancedLoad':
               return Promise.resolve(advancedData.stepLoad);
+          //Settings for a custom ingestion step
+          case '/api/steps/ingestion/CustomLoad':
+              return Promise.resolve({data:{...advancedData.stepLoad.data, stepDefinitionName:'custom-ingestion', name: 'CustomLoad'},status: 200});
           case '/api/steps/mapping/AdvancedMapping':
               return Promise.resolve(advancedData.stepMapping);
           default:

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/advanced-settings.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/advanced-settings.data.ts
@@ -21,7 +21,7 @@ const advancedMapping = {
 };
 
 // Returned from endpoint: /api/steps/ingestion/AdvancedLoad
-const stepLoad = { "data" : 
+const stepLoad = { "data" :
     {
         "collections": [ "testCollection" ],
         "additionalCollections": [ "addedCollection" ],
@@ -54,7 +54,7 @@ const stepLoad = { "data" :
 };
 
 // Returned from endpoint: /api/steps/ingestion/AdvancedMapping
-const stepMapping = { "data" : 
+const stepMapping = { "data" :
     {
         "collections": [ "testCollection" ],
         "additionalCollections": [ "addedCollection" ],
@@ -88,6 +88,7 @@ const stepMapping = { "data" :
 
 const data = {
     advancedLoad: advancedLoad,
+    customLoad: {...advancedLoad, stepData: {name: 'CustomLoad'}},
     advancedMapping: advancedMapping,
     stepLoad: stepLoad,
     stepMapping: stepMapping,

--- a/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings-dialog.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings-dialog.test.tsx
@@ -25,7 +25,8 @@ describe('Advanced Step Settings dialog', () => {
     );
 
     expect(getByText('Advanced Step Settings')).toBeInTheDocument();
-
+    //'Step Definition Name' should be present only for custom ingestion steps
+    expect(queryByText('Step Definition Name')).not.toBeInTheDocument();
     //Verify if the step name is available in the settings dialog
     expect(document.querySelector('div p:nth-child(2)').textContent).toEqual(data.advancedLoad.stepData.name);
 
@@ -57,6 +58,48 @@ describe('Advanced Step Settings dialog', () => {
     fireEvent.click(getByText('Custom Hook'));
     expect(getByText('{ "hook": true }')).toBeInTheDocument();
 
+  });
+
+  /* Custom ingestion step should be same as default-ingestion except that for "step definition name"
+     field which should be present*/
+  test('Verify settings for Custom Load step', async () => {
+      const { getByText, getAllByText, queryByText } = render(
+          <AdvancedSettingsDialog {...data.customLoad} />
+      );
+
+      expect(getByText('Advanced Step Settings')).toBeInTheDocument();
+
+      //Verify if the step name is available in the settings dialog
+      expect(document.querySelector('div p:nth-child(2)').textContent).toEqual(data.customLoad.stepData.name);
+      expect(queryByText('Source Database')).not.toBeInTheDocument();
+      expect(getByText('Target Database')).toBeInTheDocument();
+      expect(getByText('data-hub-STAGING')).toBeInTheDocument();
+
+      expect(getByText('Target Collections')).toBeInTheDocument();
+      expect(getByText('Please add target collections')).toBeInTheDocument();
+      expect(getByText('Default Collections')).toBeInTheDocument();
+
+      expect((await(waitForElement(() => getAllByText('custom-ingestion')))).length > 0);
+      expect(getByText('Step Definition Name')).toBeInTheDocument();
+
+      expect(getByText('Target Permissions')).toBeInTheDocument();
+
+      expect(getByText('Provenance Granularity')).toBeInTheDocument();
+      expect(getByText('Coarse-grained')).toBeInTheDocument();
+
+      expect(getByText('Batch Size')).toBeInTheDocument();
+
+      expect(getByText('Header Content')).toBeInTheDocument();
+      expect(getByText('{ "header": true }')).toBeInTheDocument();
+
+      expect(getByText('Processors')).toBeInTheDocument();
+      expect(getByText('Custom Hook')).toBeInTheDocument();
+
+      fireEvent.click(getByText('Processors'));
+      expect(getByText('{ "processor": true }')).toBeInTheDocument();
+
+      fireEvent.click(getByText('Custom Hook'));
+      expect(getByText('{ "hook": true }')).toBeInTheDocument();
   });
 
   test('Verify settings for Mapping', async () => {
@@ -345,7 +388,7 @@ describe('Advanced Step Settings dialog', () => {
     fireEvent.click(getByText('Processors'));
     fireEvent.click(getByText('Custom Hook'));
     let tipIcons  = getAllByLabelText('icon: question-circle');
-    const tips = ['sourceDatabase', 'targetDatabase', 'additionalCollections', 'targetPermissions', 
+    const tips = ['sourceDatabase', 'targetDatabase', 'additionalCollections', 'targetPermissions',
       'targetFormat', 'provGranularity', 'batchSize', 'headers', 'processors', 'customHook'];
     tips.forEach(async (tip, i) => {
       fireEvent.mouseOver(tipIcons[i]);


### PR DESCRIPTION
### Description
View Custom ingestion step. It should show up in "Load"  tile as usual and on opening "Settings", "Step Definition Name" should be present(which is not present for ootb ingestion step).
https://wiki.marklogic.com/display/ENGINEERING/Data+Load?preview=/125169351/171055005/CustomLoadDataSettings.png

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

