### PR TITLE
DHFPROD-5083: Fixed reference to optionsFile in hubRunFlow

### DIFF
--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/RunFlowTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/RunFlowTask.groovy
@@ -134,7 +134,7 @@ class RunFlowTask extends HubTask {
         inputs.setSteps(steps)
 
         if (project.ext.properties.containsKey("optionsFile")){
-            inputs.setOptionsFile(project.ext.options)
+            inputs.setOptionsFile(project.ext.optionsFile)
         }
         else if (project.ext.properties.containsKey("options")) {
             inputs.setOptionsJSON(project.ext.options)


### PR DESCRIPTION
I could not figure out how to test just this change, i.e. without setting up a real project with a flow file and an options file (I imagine previous editors of this file ran into the same problem, as we have very little coverage of this class). The fix is obvious though. I did a manual test in the reference project where I added {"disableJobOutput":true} to an options.json file, then referenced it via -PoptionsFile and also included -PshowOptions=true, and that worked correctly - i.e. no job/batch documents were created.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
