### PR TITLE
DHFPROD-4180: Delete entity model

### DIFF
--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/SwaggerConfig.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/SwaggerConfig.java
@@ -70,24 +70,25 @@ public class SwaggerConfig {
      */
     private List<ResolvedType> getResolvedTypes(TypeResolver typeResolver) {
         return Stream.of(
-            EntitySearchController.FacetValues.class,
-            EntitySearchController.FacetValuesQuery.class,
-            EntitySearchController.IndexMinMaxQuery.class,
-            EntitySearchController.SavedQueryRequest.class,
-            EntitySearchController.SavedQueries.class,
-            FlowSchema.class,
-            IngestionStepController.IngestionSteps.class,
-            MappingController.MappingArtifact.class,
-            MappingStepController.class,
-            MatchingController.MatchingArtifact.class,
-            MatchingController.MatchingArtifacts.class,
-            MappingStepController.MappingSteps.class,
-            ModelController.CreateModelInput.class,
-            ModelController.LatestJobInfo.class,
-            ModelDefinitions.class,
-            ModelDescriptor.class,
-            PrimaryEntityType.class,
-            StepSchema.class
+                EntitySearchController.FacetValues.class,
+                EntitySearchController.FacetValuesQuery.class,
+                EntitySearchController.IndexMinMaxQuery.class,
+                EntitySearchController.SavedQueryRequest.class,
+                EntitySearchController.SavedQueries.class,
+                FlowSchema.class,
+                IngestionStepController.IngestionSteps.class,
+                MappingController.MappingArtifact.class,
+                MappingStepController.class,
+                MatchingController.MatchingArtifact.class,
+                MatchingController.MatchingArtifacts.class,
+                MappingStepController.MappingSteps.class,
+                ModelController.CreateModelInput.class,
+                ModelController.LatestJobInfo.class,
+                ModelController.ModelReferencesInfo.class,
+                ModelDefinitions.class,
+                ModelDescriptor.class,
+                PrimaryEntityType.class,
+                StepSchema.class
         ).map(type -> typeResolver.resolve(type)).collect(Collectors.toList());
     }
 }

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/ModelController.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/ModelController.java
@@ -90,6 +90,28 @@ public class ModelController extends BaseController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @RequestMapping(value = "/{modelName}", method = RequestMethod.DELETE)
+    @Secured("ROLE_writeEntityModel")
+    public ResponseEntity<Void> deleteModel(@PathVariable String modelName) {
+        newService().deleteModel(modelName);
+
+        /*
+        * We're not doing anything with indexes or protected paths here because we don't have a reliable way to
+        * identify the ones to delete and we only expect entity types to be deleted
+        * in a development environment where it's usually fine if some old indexes / protected paths hang around.
+        */
+        logger.info("Deploying search options");
+        deploySearchOptions(newService().generateModelConfig());
+
+        return emptyOk();
+    }
+
+    @RequestMapping(value = "/{modelName}/references", method = RequestMethod.GET)
+    @ApiOperation(value = "Get step and model names that refer to this model.", response = ModelReferencesInfo.class)
+    public ResponseEntity<JsonNode> getModelReferences(@PathVariable String modelName) {
+        return ResponseEntity.ok(newService().getModelReferences(modelName));
+    }
+
     @RequestMapping(value = "/{modelName}/entityTypes", method = RequestMethod.PUT)
     @ApiImplicitParam(required = true, paramType = "body", dataType = "ModelDefinitions")
     @Secured("ROLE_writeEntityModel")
@@ -252,5 +274,10 @@ public class ModelController extends BaseController {
 
     public static class UpdateModelInfoInput {
         public String description;
+    }
+
+    public static class ModelReferencesInfo {
+        public List<String> stepAndMappingNames;
+        public List<String> entityNames;
     }
 }

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/AbstractModelTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/AbstractModelTest.java
@@ -1,0 +1,27 @@
+package com.marklogic.hub.central.controllers.model;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.admin.QueryOptionsManager;
+import com.marklogic.client.io.Format;
+import com.marklogic.hub.central.AbstractHubCentralTest;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+public abstract class AbstractModelTest extends AbstractHubCentralTest {
+
+    protected void assertSearchOptions(String modelName, BiConsumer<Boolean, String> assertion, boolean expected) {
+        String startsWith = (expected) ? "Expected " : "Did not expect ";
+        DatabaseClient stagingDatabaseClient = getHubClient().getStagingClient();
+        DatabaseClient finalDatabaseClient = getHubClient().getFinalClient();
+        Map<String, DatabaseClient> clientMap = new HashMap<>();
+        clientMap.put("staging", stagingDatabaseClient);
+        clientMap.put("final", finalDatabaseClient);
+        clientMap.forEach((databaseKind, databaseClient) -> {
+            QueryOptionsManager queryOptionsManager = databaseClient.newServerConfigManager().newQueryOptionsManager();
+            assertion.accept(queryOptionsManager.readOptionsAs("exp-" + databaseKind + "-entity-options", Format.XML, String.class).contains(modelName), startsWith + modelName + " to be in options file " + "exp-" + databaseKind + "-entity-options");
+            assertion.accept(queryOptionsManager.readOptionsAs(databaseKind + "-entity-options", Format.XML, String.class).contains(modelName), startsWith + modelName + " to be in options file " + databaseKind + "-entity-options");
+        });
+    }
+}

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/CreateAndUpdateModelTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/CreateAndUpdateModelTest.java
@@ -5,11 +5,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.admin.QueryOptionsManager;
-import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.hub.DatabaseKind;
-import com.marklogic.hub.central.AbstractHubCentralTest;
 import com.marklogic.hub.central.controllers.ModelController;
 import com.marklogic.hub.test.Customer;
 import com.marklogic.hub.test.ReferenceModelProject;
@@ -22,20 +19,19 @@ import com.marklogic.mgmt.api.database.PathNamespace;
 import com.marklogic.mgmt.mapper.DefaultResourceMapper;
 import com.marklogic.mgmt.resource.databases.DatabaseManager;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ModelControllerTest extends AbstractHubCentralTest {
+public class CreateAndUpdateModelTest extends AbstractModelTest {
 
     private final static String MODEL_NAME = "Customer";
     private final static String ENTITY_PROPERTY_1 = "someProperty";
@@ -75,12 +71,12 @@ public class ModelControllerTest extends AbstractHubCentralTest {
         new ReferenceModelProject(getHubClient()).createCustomerInstance(new Customer(1, "Jane"));
         ArrayNode entityTypes = (ArrayNode) controller.getPrimaryEntityTypes().getBody();
         assertEquals(1, entityTypes.size(), "A new model should have been created " +
-            "and thus there should be one primary entity type");
+                "and thus there should be one primary entity type");
 
         JsonNode customerType = entityTypes.get(0);
         assertEquals("Customer", customerType.get("entityName").asText());
         assertEquals(1, customerType.get("entityInstanceCount").asInt(),
-            "Should have a count of one because there's one document in the 'Customer' collection");
+                "Should have a count of one because there's one document in the 'Customer' collection");
 
     }
 
@@ -99,21 +95,21 @@ public class ModelControllerTest extends AbstractHubCentralTest {
         loadUnrelatedIndexes();
 
         String entityTypes = "{\"" + MODEL_NAME + "\" : {\n" +
-            "      \"required\" : [ ],\n" +
-            "      \"pii\" : [ \"" + ENTITY_PROPERTY_1 + "\" ]," +
-            "      \"elementRangeIndex\" : [ \"" + ENTITY_PROPERTY_1 + "\" ],\n" +
-            "      \"rangeIndex\" : [ \"" + ENTITY_PROPERTY_2 + "\" ]," +
-            "      \"properties\" : {\n" +
-            "        \"" + ENTITY_PROPERTY_1 + "\" : {\n" +
-            "          \"datatype\" : \"string\",\n" +
-            "          \"collation\" : \"http://marklogic.com/collation/codepoint\"\n" +
-            "        },\n" +
-            "         \"" + ENTITY_PROPERTY_2 + "\" : {\n" +
-            "          \"datatype\" : \"string\",\n" +
-            "          \"collation\" : \"http://marklogic.com/collation/codepoint\"\n" +
-            "        }" +
-            "      }\n" +
-            "    }}";
+                "      \"required\" : [ ],\n" +
+                "      \"pii\" : [ \"" + ENTITY_PROPERTY_1 + "\" ]," +
+                "      \"elementRangeIndex\" : [ \"" + ENTITY_PROPERTY_1 + "\" ],\n" +
+                "      \"rangeIndex\" : [ \"" + ENTITY_PROPERTY_2 + "\" ]," +
+                "      \"properties\" : {\n" +
+                "        \"" + ENTITY_PROPERTY_1 + "\" : {\n" +
+                "          \"datatype\" : \"string\",\n" +
+                "          \"collation\" : \"http://marklogic.com/collation/codepoint\"\n" +
+                "        },\n" +
+                "         \"" + ENTITY_PROPERTY_2 + "\" : {\n" +
+                "          \"datatype\" : \"string\",\n" +
+                "          \"collation\" : \"http://marklogic.com/collation/codepoint\"\n" +
+                "        }" +
+                "      }\n" +
+                "    }}";
 
         try {
             controller.updateModelEntityTypes(objectMapper.readTree(entityTypes), MODEL_NAME);
@@ -122,7 +118,7 @@ public class ModelControllerTest extends AbstractHubCentralTest {
             throw new RuntimeException(e);
         }
 
-        assertSearchOptionsDeployment();
+        assertSearchOptions(MODEL_NAME, Assertions::assertTrue, true);
         assertPIIFilesDeployment();
         assertIndexDeployment();
 
@@ -131,19 +127,6 @@ public class ModelControllerTest extends AbstractHubCentralTest {
 
     private JsonNode loadModel(DatabaseClient client) {
         return client.newJSONDocumentManager().read("/entities/" + MODEL_NAME + ".entity.json", new JacksonHandle()).get();
-    }
-
-    private void assertSearchOptionsDeployment() {
-        DatabaseClient stagingDatabaseClient = getHubClient().getStagingClient();
-        DatabaseClient finalDatabaseClient = getHubClient().getFinalClient();
-        Map<String, DatabaseClient> clientMap = new HashMap<>();
-        clientMap.put("staging", stagingDatabaseClient);
-        clientMap.put("final", finalDatabaseClient);
-        clientMap.forEach((databaseKind, databaseClient) -> {
-            QueryOptionsManager queryOptionsManager = databaseClient.newServerConfigManager().newQueryOptionsManager();
-            assertTrue(queryOptionsManager.readOptionsAs("exp-" + databaseKind + "-entity-options", Format.XML, String.class).contains(MODEL_NAME), "Expected " + MODEL_NAME + " to be in options file " + "exp-" + databaseKind + "-entity-options");
-            assertTrue(queryOptionsManager.readOptionsAs(databaseKind + "-entity-options", Format.XML, String.class).contains(MODEL_NAME), "Expected " + MODEL_NAME + " to be in options file " + databaseKind + "-entity-options");
-        });
     }
 
     private void assertPIIFilesDeployment() {
@@ -175,7 +158,7 @@ public class ModelControllerTest extends AbstractHubCentralTest {
         List<PathNamespace> pathNamespaces = db.getPathNamespace();
         assertEquals(2, pathNamespaces.size());
         assertEquals("ex", pathNamespaces.get(0).getPrefix(), "The existing namespace is expected to be first, as the model-based " +
-            "properties are expected to be merged on top of the existing properties");
+                "properties are expected to be merged on top of the existing properties");
         assertEquals("http://example.org", pathNamespaces.get(0).getNamespaceUri());
         assertEquals("es", pathNamespaces.get(1).getPrefix());
         assertEquals("http://marklogic.com/entity-services", pathNamespaces.get(1).getNamespaceUri());
@@ -193,35 +176,35 @@ public class ModelControllerTest extends AbstractHubCentralTest {
 
     private void loadUnrelatedIndexes() {
         String indexConfig = "{\n" +
-            "   \"lang\":\"zxx\",\n" +
-            "   \"path-namespace\":[\n" +
-            "      {\n" +
-            "         \"prefix\":\"ex\",\n" +
-            "         \"namespace-uri\":\"http://example.org\"\n" +
-            "      }\n" +
-            "   ],\n" +
-            "   \"range-element-index\":[\n" +
-            "      {\n" +
-            "         \"invalid-values\":\"reject\",\n" +
-            "         \"localname\":\"" + DATABASE_PROPERTY_1 + "\",\n" +
-            "         \"namespace-uri\":null,\n" +
-            "         \"range-value-positions\":false,\n" +
-            "         \"scalar-type\":\"decimal\"\n" +
-            "      }\n" +
-            "   ],\n" +
-            "   \"range-path-index\":[\n" +
-            "      {\n" +
-            "         \"scalar-type\":\"string\",\n" +
-            "         \"path-expression\":\"//*:instance/" + DATABASE_PROPERTY_2 + "\",\n" +
-            "         \"collation\":\"http://marklogic.com/collation/\",\n" +
-            "         \"range-value-positions\":false,\n" +
-            "         \"invalid-values\":\"reject\"\n" +
-            "      }\n" +
-            "   ]\n" +
-            "}";
+                "   \"lang\":\"zxx\",\n" +
+                "   \"path-namespace\":[\n" +
+                "      {\n" +
+                "         \"prefix\":\"ex\",\n" +
+                "         \"namespace-uri\":\"http://example.org\"\n" +
+                "      }\n" +
+                "   ],\n" +
+                "   \"range-element-index\":[\n" +
+                "      {\n" +
+                "         \"invalid-values\":\"reject\",\n" +
+                "         \"localname\":\"" + DATABASE_PROPERTY_1 + "\",\n" +
+                "         \"namespace-uri\":null,\n" +
+                "         \"range-value-positions\":false,\n" +
+                "         \"scalar-type\":\"decimal\"\n" +
+                "      }\n" +
+                "   ],\n" +
+                "   \"range-path-index\":[\n" +
+                "      {\n" +
+                "         \"scalar-type\":\"string\",\n" +
+                "         \"path-expression\":\"//*:instance/" + DATABASE_PROPERTY_2 + "\",\n" +
+                "         \"collation\":\"http://marklogic.com/collation/\",\n" +
+                "         \"range-value-positions\":false,\n" +
+                "         \"invalid-values\":\"reject\"\n" +
+                "      }\n" +
+                "   ]\n" +
+                "}";
 
         ManageClient manageClient = getHubClient().getManageClient();
         Stream.of(getHubConfig().getDbName(DatabaseKind.STAGING), getHubConfig().getDbName(DatabaseKind.FINAL))
-            .forEach(databaseKind -> manageClient.putJson("/manage/v2/databases/" + databaseKind + "/properties", indexConfig));
+                .forEach(databaseKind -> manageClient.putJson("/manage/v2/databases/" + databaseKind + "/properties", indexConfig));
     }
 }

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/DeleteModelTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/DeleteModelTest.java
@@ -1,0 +1,99 @@
+package com.marklogic.hub.central.controllers.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.FailedRequestException;
+import com.marklogic.client.document.GenericDocumentManager;
+import com.marklogic.hub.DatabaseKind;
+import com.marklogic.hub.central.controllers.ModelController;
+import com.marklogic.hub.impl.EntityManagerImpl;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DeleteModelTest extends AbstractModelTest {
+
+    @Autowired
+    ModelController controller;
+
+    @Test
+    @WithMockUser(roles = {"writeEntityModel"})
+    void testModelDeletionEndpoints() {
+        runAsDataHubDeveloper();
+        installProjectInFolder("test-projects/delete-model-project");
+        new EntityManagerImpl(getHubConfig()).deployQueryOptions();
+
+        runAsTestUserWithRoles("hub-central-entity-model-writer");
+        verifyEntity2BasedArtifactsExist();
+        getModelReferences();
+        deleteModel();
+        verifyEntity2BasedArtifactsDontExist();
+        verifyReferencesToEntity2DontExistInEntity1();
+    }
+
+    private void getModelReferences() {
+        JsonNode jsonNode = controller.getModelReferences("Entity2").getBody();
+        assertNotNull(jsonNode);
+        assertEquals(2, jsonNode.get("stepAndMappingNames").size());
+        assertEquals(1, jsonNode.get("entityNames").size());
+        Stream.of("testMap2", "matching-step")
+                .forEach(s -> assertTrue(jsonNode.get("stepAndMappingNames").toString().contains(s)));
+        assertTrue(jsonNode.get("entityNames").toString().contains("Entity1"));
+    }
+
+    private void deleteModel() {
+        assertThrows(FailedRequestException.class, () -> controller.deleteModel("Entity2"), "Should throw an exception since the entity is referenced in steps.");
+
+        runAsDataHubDeveloper();
+        removeReferencesToEntity();
+        runAsTestUserWithRoles("hub-central-entity-model-writer");
+
+        assertTrue(controller.deleteModel("Entity2").getStatusCode().is2xxSuccessful(), "Should be ok since we deleted the steps that refer to the entity.");
+
+        // Needed because a post-commit trigger is executed after a model is deleted
+        runAsDataHubDeveloper();
+        waitForTasksToFinish();
+        runAsTestUserWithRoles("hub-central-entity-model-writer");
+    }
+
+    private void removeReferencesToEntity() {
+        DatabaseClient stagingDatabaseClient = getHubClient().getStagingClient();
+        DatabaseClient finalDatabaseClient = getHubClient().getFinalClient();
+        Stream.of(stagingDatabaseClient, finalDatabaseClient)
+                .forEach(databaseClient -> databaseClient
+                        .newDocumentManager()
+                        .delete("/flows/testFlow.flow.json", "/steps/mapping/testMap2.step.json"));
+    }
+
+    private void verifyReferencesToEntity2DontExistInEntity1() {
+        assertFalse(getFinalDoc("/entities/Entity1.entity.json").toString().contains("Entity2"), "Expected the properties that refer to Entity2 to be deleted from Entity1.");
+        assertFalse(getStagingDoc("/entities/Entity1.entity.json").toString().contains("Entity2"), "Expected the properties that refer to Entity2 to be deleted from Entity1.");
+    }
+
+    private void verifyEntity2BasedArtifactsDontExist() {
+        assertSearchOptions("Entity2", Assertions::assertFalse, false);
+        assertSchemasAndTDE(Assertions::assertNull);
+    }
+
+    private void verifyEntity2BasedArtifactsExist() {
+        assertSearchOptions("Entity2", Assertions::assertTrue, true);
+        assertSchemasAndTDE(Assertions::assertNotNull);
+    }
+
+    private void assertSchemasAndTDE(Consumer<Object> assertion) {
+        DatabaseClient stagingSchemaClient = getHubConfig().newStagingClient(getHubConfig().getDbName(DatabaseKind.STAGING_SCHEMAS));
+        DatabaseClient finalSchemaClient = getHubConfig().newFinalClient(getHubConfig().getDbName(DatabaseKind.FINAL_SCHEMAS));
+        Stream.of(stagingSchemaClient, finalSchemaClient).forEach(databaseClient -> {
+            GenericDocumentManager documentManager = databaseClient.newDocumentManager();
+            assertion.accept(documentManager.exists("/entities/Entity2.entity.schema.json"));
+            assertion.accept(documentManager.exists("/entities/Entity2.entity.xsd"));
+            assertion.accept(documentManager.exists("/tde/Entity2-1.0.0.tdex"));
+        });
+    }
+}

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/ModelMvcTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/ModelMvcTest.java
@@ -8,7 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class ModelMvcTest extends AbstractMvcTest {
 
     /**
-     * ModelControllerTest verifies that a user can write entity models, just need to verify the inverse here.
+     * DeleteModelTest and CreateAndUpdateModelTest verify that a user can write and delete entity models, just need to verify the inverse here.
      *
      * @throws Exception
      */
@@ -23,5 +23,6 @@ public class ModelMvcTest extends AbstractMvcTest {
         verifyRequestIsForbidden(buildJsonPost("/api/models", "{}"));
         verifyRequestIsForbidden(buildJsonPut("/api/models/doesntMatter/info", "{}"));
         verifyRequestIsForbidden(buildJsonPut("/api/models/doesntMatter/entityTypes", "{}"));
+        delete("/api/models/doesntMatter").andExpect(status().isForbidden());
     }
 }

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/EntitySearchManagerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/EntitySearchManagerTest.java
@@ -76,7 +76,7 @@ public class EntitySearchManagerTest extends AbstractHubCentralTest {
         // Adding propertiesToDisplay to search query which are user selected columns
         List<String> propertiesToDisplay = Arrays.asList("name", "customerId");
         query.setPropertiesToDisplay(propertiesToDisplay);
-        results = entitySearchManager.search(query);
+        results = new EntitySearchManager(getHubClient()).search(query);
         node = readJsonObject(results.get());
         assertTrue(node.has("selectedPropertyDefinitions"), "Including this makes life easy on the UI so it knows what " +
                 "columns to display");

--- a/marklogic-data-hub-central/src/test/resources/test-projects/delete-model-project/entities/Entity1.entity.json
+++ b/marklogic-data-hub-central/src/test/resources/test-projects/delete-model-project/entities/Entity1.entity.json
@@ -1,0 +1,29 @@
+{
+  "info": {
+    "title": "Entity1",
+    "version": "1.0.0",
+    "baseUri": "http://example.org/"
+  },
+  "definitions": {
+    "Entity1": {
+      "properties": {
+        "property1": {
+          "$ref": "#/definitions/Property1"
+        },
+        "entity2": {
+          "datatype": "array",
+          "items": {
+            "$ref": "http://example.org/Entity2-1.0.0/Entity2"
+          }
+        }
+      }
+    },
+    "Property1": {
+      "properties": {
+        "testProperty": {
+          "$ref": "http://example.org/Entity2-1.0.0/Entity2"
+        }
+      }
+    }
+  }
+}

--- a/marklogic-data-hub-central/src/test/resources/test-projects/delete-model-project/entities/Entity2.entity.json
+++ b/marklogic-data-hub-central/src/test/resources/test-projects/delete-model-project/entities/Entity2.entity.json
@@ -1,0 +1,20 @@
+{
+  "info": {
+    "title": "Entity2",
+    "version": "1.0.0",
+    "baseUri": "http://example.org/"
+  },
+  "definitions": {
+    "Entity2": {
+      "required": [],
+      "elementRangeIndex": [
+        "property1"
+      ],
+      "properties": {
+        "property1": {
+          "datatype": "string"
+        }
+      }
+    }
+  }
+}

--- a/marklogic-data-hub-central/src/test/resources/test-projects/delete-model-project/flows/testFlow.flow.json
+++ b/marklogic-data-hub-central/src/test/resources/test-projects/delete-model-project/flows/testFlow.flow.json
@@ -1,0 +1,27 @@
+{
+  "name": "testFlow",
+  "steps": {
+    "1": {
+      "stepId": "testMap1-mapping"
+    },
+    "2": {
+      "stepId": "testMap2-mapping"
+    },
+    "3": {
+      "name": "matching-step",
+      "stepDefinitionName": "default-matching",
+      "stepDefinitionType": "matching",
+      "options": {
+        "targetEntity": "Entity2"
+      }
+    },
+    "4": {
+      "name": "merging-step",
+      "stepDefinitionName": "default-merging",
+      "stepDefinitionType": "merging",
+      "options": {
+        "targetEntity": "Entity1"
+      }
+    }
+  }
+}

--- a/marklogic-data-hub-central/src/test/resources/test-projects/delete-model-project/steps/mapping/testMap1.step.json
+++ b/marklogic-data-hub-central/src/test/resources/test-projects/delete-model-project/steps/mapping/testMap1.step.json
@@ -1,0 +1,6 @@
+{
+  "name": "testMap1",
+  "selectedSource": "collection",
+  "targetEntityType": "http://example.org/Entity1-1.0.0/Entity1",
+  "properties": {}
+}

--- a/marklogic-data-hub-central/src/test/resources/test-projects/delete-model-project/steps/mapping/testMap2.step.json
+++ b/marklogic-data-hub-central/src/test/resources/test-projects/delete-model-project/steps/mapping/testMap2.step.json
@@ -1,0 +1,6 @@
+{
+  "name": "testMap2",
+  "selectedSource": "collection",
+  "targetEntityType": "http://example.org/Entity2-1.0.0/Entity2",
+  "properties": {}
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/ModelsService.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/ModelsService.java
@@ -53,6 +53,7 @@ public interface ModelsService {
             private BaseProxy.DBFunctionRequest req_getPrimaryEntityTypes;
             private BaseProxy.DBFunctionRequest req_deleteModel;
             private BaseProxy.DBFunctionRequest req_createModel;
+            private BaseProxy.DBFunctionRequest req_getModelReferences;
             private BaseProxy.DBFunctionRequest req_updateModelEntityTypes;
 
             private ModelsServiceImpl(DatabaseClient dbClient, JSONWriteHandle servDecl) {
@@ -71,6 +72,8 @@ public interface ModelsService {
                     "deleteModel.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC);
                 this.req_createModel = this.baseProxy.request(
                     "createModel.sjs", BaseProxy.ParameterValuesKind.SINGLE_NODE);
+                this.req_getModelReferences = this.baseProxy.request(
+                    "getModelReferences.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC);
                 this.req_updateModelEntityTypes = this.baseProxy.request(
                     "updateModelEntityTypes.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_MIXED);
             }
@@ -157,6 +160,21 @@ public interface ModelsService {
             }
 
             @Override
+            public com.fasterxml.jackson.databind.JsonNode getModelReferences(String entityName) {
+                return getModelReferences(
+                    this.req_getModelReferences.on(this.dbClient), entityName
+                    );
+            }
+            private com.fasterxml.jackson.databind.JsonNode getModelReferences(BaseProxy.DBFunctionRequest request, String entityName) {
+              return BaseProxy.JsonDocumentType.toJsonNode(
+                request
+                      .withParams(
+                          BaseProxy.atomicParam("entityName", false, BaseProxy.StringType.fromString(entityName))
+                          ).responseSingle(false, Format.JSON)
+                );
+            }
+
+            @Override
             public com.fasterxml.jackson.databind.JsonNode updateModelEntityTypes(String name, com.fasterxml.jackson.databind.JsonNode input) {
                 return updateModelEntityTypes(
                     this.req_updateModelEntityTypes.on(this.dbClient), name, input
@@ -224,6 +242,14 @@ public interface ModelsService {
    * @return	as output
    */
     com.fasterxml.jackson.databind.JsonNode createModel(com.fasterxml.jackson.databind.JsonNode input);
+
+  /**
+   * Returns a json containing the names of the models and steps that reference the given entity model.
+   *
+   * @param entityName	The name of the primary entity in the model
+   * @return	as output
+   */
+    com.fasterxml.jackson.databind.JsonNode getModelReferences(String entityName);
 
   /**
    * Invokes the updateModelEntityTypes operation on the database server

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/mapping/MappingImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/mapping/MappingImpl.java
@@ -61,7 +61,7 @@ public class MappingImpl implements Mapping {
         if (entity != null) {
             InfoType info = entity.getInfo();
             if (info != null) {
-                String prefix = info.getBaseUri() != null ? info.getBaseUri() + "/" : "";
+                String prefix = info.getBaseUri() != null ? info.getBaseUri() : "";
                 this.targetEntityType = prefix + info.getTitle() + "-" + info.getVersion() + "/" + info.getTitle();
                 DefinitionType definition = entity.getDefinitions().getDefinitions().get(info.getTitle());
                 if (definition != null) {

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-entity-model-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-entity-model-writer.json
@@ -3,12 +3,25 @@
   "description": "Permits writing entity models in Hub Central",
   "role": [
     "hub-central-entity-model-reader",
-    "data-hub-entity-model-writer"
+    "data-hub-entity-model-writer",
+    "data-hub-mapping-reader",
+    "data-hub-flow-reader",
+    "tde-admin"
   ],
   "privilege": [
     {
       "privilege-name": "hub-central:writeEntityModel",
       "action": "http://marklogic.com/data-hub/hub-central/privileges/write-entity-model",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "rest-admin",
+      "action": "http://marklogic.com/xdmp/privileges/rest-admin",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:eval",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-eval",
       "kind": "execute"
     }
   ]

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/triggers/entity-model-delete-trigger.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/triggers/entity-model-delete-trigger.xqy
@@ -1,37 +1,38 @@
 xquery version '1.0-ml';
 
-import module namespace es = "http://marklogic.com/entity-services"
-  at "/MarkLogic/entity-services/entity-services.xqy";
-import module namespace tde = "http://marklogic.com/xdmp/tde"
-        at "/MarkLogic/tde.xqy";
 import module namespace trgr = 'http://marklogic.com/xdmp/triggers' at '/MarkLogic/triggers.xqy';
 
-declare variable $ENTITY-MODEL-COLLECTION as xs:string := "http://marklogic.com/entity-services/models";
-declare variable $TDE-COLLECTION as xs:string := "http://marklogic.com/entity-services/models";
+declare namespace tde = "http://marklogic.com/xdmp/tde";
 
 declare variable $trgr:uri as xs:string external;
 
-let $entity-def := fn:doc($trgr:uri)
-let $entity-title := $entity-def/info/title
-let $entity-version := $entity-def/info/version
-let $tde-uri := "/tde/" || $entity-title || "-" || $entity-version || ".tdex"
+let $tde-uri :=
+  let $entity-name := fn:replace($trgr:uri, "/entities/", "")
+  let $entity-name := fn:replace($entity-name, ".entity.json", "")
+  where $entity-name
+  return xdmp:invoke-function(
+    function() {
+      let $query := cts:and-query((
+        cts:collection-query("ml-data-hub-tde"),
+        cts:element-value-query(xs:QName("tde:context"), ".//" || $entity-name || "[node()]")
+      ))
+      return cts:uris((), ("limit=1"), $query)
+    }, map:entry("database", xdmp:schema-database())
+  )
+
 let $schema-xml-uri := fn:replace($trgr:uri, "\.json$", ".xsd")
 let $schema-json-uri := fn:replace($trgr:uri, "\.json$", ".schema.json")
+
 return (
   xdmp:invoke-function(
     function() {
-      if (fn:doc-available($trgr:uri)) then
-        xdmp:document-delete($trgr:uri)
-      else (),
-      if (fn:doc-available($tde-uri)) then
-        xdmp:document-delete($tde-uri)
-      else (),
-      if (fn:doc-available($schema-xml-uri)) then
-        xdmp:document-delete($schema-xml-uri)
-      else (),
-      if (fn:doc-available($schema-json-uri)) then
-        xdmp:document-delete($schema-json-uri)
-      else ()
+      for $uri in ($trgr:uri, $tde-uri, $schema-xml-uri, $schema-json-uri)
+      return
+        if (fn:doc-available($uri)) then (
+          xdmp:log("entity-model-delete-trigger.xqy: Deleting: " || $uri),
+          xdmp:document-delete($uri)
+        ) else
+          xdmp:log("entity-model-delete-trigger.xqy: Document not available, so not deleting: " || $uri)
     }, map:entry("database", xdmp:schema-database())
   )
 );

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/triggers/entity-model-trigger.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/triggers/entity-model-trigger.xqy
@@ -28,8 +28,8 @@ let $entity-def-map as map:map := $entity-def
 
 let $schema-permissions := (
   xdmp:default-permissions(),
-  xdmp:permission("data-hub-developer", "update"),
-  xdmp:permission("data-hub-operator", "read")
+  xdmp:permission("data-hub-common", "read"),
+  xdmp:permission("data-hub-entity-model-writer", "update")
 )
 
 let $entity-base-uri := $entity-def/info/baseUri

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/getModelReferences.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/getModelReferences.api
@@ -1,0 +1,15 @@
+{
+  "functionName": "getModelReferences",
+  "desc": "Returns a json containing the names of the models and steps that reference the given entity model.",
+  "params": [
+    {
+      "name": "entityName",
+      "datatype": "string",
+      "desc": "The name of the primary entity in the model"
+    }
+  ],
+  "return": {
+    "datatype": "jsonDocument",
+    "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+  }
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/getModelReferences.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/getModelReferences.sjs
@@ -15,12 +15,13 @@
 */
 'use strict';
 
-const ds = require("/data-hub/5/data-services/ds-utils.sjs");
 const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
+const ds = require("/data-hub/5/data-services/ds-utils.sjs");
+
 
 var entityName;
 if (!entityName) {
-  ds.throwBadRequest("Must specify a name in order to delete an entity model");
+  ds.throwBadRequest("Must specify a name in order to get model references");
 }
 
 const entityModel = entityLib.findModelByEntityName(entityName);
@@ -32,9 +33,7 @@ const entityTypeId = entityLib.getEntityTypeId(entityModel, entityName);
 const entityModelUri = entityLib.getModelUri(entityName);
 
 const stepAndMappingNames = entityLib.findModelReferencesInSteps(entityName, entityTypeId);
-if (stepAndMappingNames.length) {
-  ds.throwServerError(`Cannot delete the entity type '${entityName}' because it is referenced by the following step and/or mapping names: ${stepAndMappingNames}`);
-}
+const entityNames = entityLib.findModelReferencesInOtherModels(entityModelUri, entityTypeId);
+const result = {stepAndMappingNames, entityNames};
 
-entityLib.deleteModel(entityName);
-entityLib.deleteModelReferencesInOtherModels(entityModelUri, entityTypeId);
+result;

--- a/marklogic-data-hub/src/main/resources/scaffolding/Entity.json
+++ b/marklogic-data-hub/src/main/resources/scaffolding/Entity.json
@@ -2,7 +2,7 @@
   "info" : {
     "title" : "placeholder",
     "version" : "1.0.0",
-    "baseUri" : "http://example.org",
+    "baseUri" : "http://example.org/",
     "description" : ""
   },
   "definitions" : {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/hubcentral/ApplyDownloadedZipToProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/hubcentral/ApplyDownloadedZipToProjectTest.java
@@ -36,7 +36,7 @@ public class ApplyDownloadedZipToProjectTest extends AbstractHubCoreTest {
      */
     @Test
     void deleteOneEntityThenDownloadAndApply() {
-        installProjectInFolder("test-projects/all-artifacts");
+        installProjectInFolder("test-projects/download-artifacts");
         generateEntityBasedArtifacts();
         verifyEntityBasedArtifactsExist();
 
@@ -61,7 +61,7 @@ public class ApplyDownloadedZipToProjectTest extends AbstractHubCoreTest {
      */
     @Test
     void deleteAllArtifactsBeforeApplyingZip() {
-        installProjectInFolder("test-projects/all-artifacts");
+        installProjectInFolder("test-projects/download-artifacts");
         generateEntityBasedArtifacts();
         verifyEntityBasedArtifactsExist();
 
@@ -70,8 +70,6 @@ public class ApplyDownloadedZipToProjectTest extends AbstractHubCoreTest {
         ModelsService.on(stagingClient).deleteModel("Person");
         FlowService.on(stagingClient).deleteFlow("testFlow");
         StepService.on(stagingClient).deleteStep("ingestion", "validArtifact");
-        StepService.on(stagingClient).deleteStep("mapping", "OrderMappingJson");
-        StepService.on(stagingClient).deleteStep("mapping", "TestOrderMapping1");
         ArtifactService.on(stagingClient).deleteArtifact("stepDefinition", "testStep");
 
         setTestUserRoles("data-hub-developer", "hub-central-downloader");
@@ -87,7 +85,7 @@ public class ApplyDownloadedZipToProjectTest extends AbstractHubCoreTest {
 
     @Test
     void fileDoesNotExist() {
-        installProjectInFolder("test-projects/all-artifacts");
+        installProjectInFolder("test-projects/download-artifacts");
         generateEntityBasedArtifacts();
         try {
             new HubCentralManager().applyHubCentralZipToProject(getHubConfig().getHubProject(), new File("doesnt-exist.zip"));
@@ -177,8 +175,6 @@ public class ApplyDownloadedZipToProjectTest extends AbstractHubCoreTest {
         assertTrue(new File(project.getFlowsDir().toFile(), "testFlow.flow.json").exists());
         assertTrue(new File(project.getHubEntitiesDir().toFile(), "Person.entity.json").exists());
         assertTrue(project.getStepFile(StepDefinition.StepDefinitionType.INGESTION, "validArtifact").exists());
-        assertTrue(project.getStepFile(StepDefinition.StepDefinitionType.MAPPING, "OrderMappingJson").exists());
-        assertTrue(project.getStepFile(StepDefinition.StepDefinitionType.MAPPING, "TestOrderMapping1").exists());
 
         verifyCustomStepDefinitionExists();
     }

--- a/marklogic-data-hub/src/test/resources/test-projects/download-artifacts/entities/Order.entity.json
+++ b/marklogic-data-hub/src/test/resources/test-projects/download-artifacts/entities/Order.entity.json
@@ -1,0 +1,22 @@
+{
+  "info": {
+    "title": "Order",
+    "version": "0.0.1",
+    "baseUri": "http://marklogic.com/example/"
+  },
+  "definitions": {
+    "Order": {
+      "required": [],
+      "pii": ["orderID", "orderName"],
+      "rangeIndex": ["orderID"],
+      "properties": {
+        "orderID": {
+          "datatype": "string"
+        },
+        "orderName": {
+          "datatype": "string"
+        }
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/resources/test-projects/download-artifacts/entities/Person.entity.json
+++ b/marklogic-data-hub/src/test/resources/test-projects/download-artifacts/entities/Person.entity.json
@@ -1,0 +1,19 @@
+{
+  "info": {
+    "title": "Person",
+    "version": "0.0.1",
+    "baseUri": "http://marklogic.com/example/"
+  },
+  "definitions": {
+    "Person": {
+      "required": [],
+      "pii": [],
+      "rangeIndex": ["personID"],
+      "properties": {
+        "personID": {
+          "datatype": "string"
+        }
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/resources/test-projects/download-artifacts/flows/testFlow.flow.json
+++ b/marklogic-data-hub/src/test/resources/test-projects/download-artifacts/flows/testFlow.flow.json
@@ -1,0 +1,15 @@
+{
+  "name": "testFlow",
+  "steps": {
+    "1": {
+      "name": "testStep",
+      "stepDefinitionName": "testStep",
+      "stepDefinitionType": "CUSTOM",
+      "options": {
+        "sourceQuery": "cts.collectionQuery('doesnt-matter')",
+        "sourceDatabase": "data-hub-FINAL",
+        "targetDatabase": "data-hub-FINAL"
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/resources/test-projects/download-artifacts/step-definitions/custom/testStep/testStep.step.json
+++ b/marklogic-data-hub/src/test/resources/test-projects/download-artifacts/step-definitions/custom/testStep/testStep.step.json
@@ -1,0 +1,9 @@
+{
+  "lang": "zxx",
+  "name": "testStep",
+  "type": "CUSTOM",
+  "options": {
+    "outputFormat": "json"
+  },
+  "modulePath": "/doesnt/matter.sjs"
+}

--- a/marklogic-data-hub/src/test/resources/test-projects/download-artifacts/steps/ingestion/validArtifact.step.json
+++ b/marklogic-data-hub/src/test/resources/test-projects/download-artifacts/steps/ingestion/validArtifact.step.json
@@ -1,0 +1,8 @@
+{
+  "name": "validArtifact",
+  "sourceFormat": "xml",
+  "targetFormat": "json",
+  "targetDatabase": "data-hub-STAGING",
+  "permissions": "data-hub-ingestion-reader,read,data-hub-ingestion-writer,update",
+  "provenanceGranularity": "coarse-grained"
+}

--- a/ml-data-hub-plugin/src/test/resources/my-new-entity.entity.json
+++ b/ml-data-hub-plugin/src/test/resources/my-new-entity.entity.json
@@ -2,7 +2,7 @@
   "info" : {
     "title" : "my-new-entity",
     "version" : "1.0.0",
-    "baseUri" : "http://example.org",
+    "baseUri" : "http://example.org/",
     "description" : ""
   },
   "definitions" : {


### PR DESCRIPTION
### Description
* Added two new endpoints
    1. GET /api/models/{modelName}/references - Returns the usage of the model in steps and other models
    2. DELETE /api/models/{modelName} - Deletes the model
* Updated `hub-central-entity-model-writer` role to make it work with deletion.
* Added update permission for `data-hub-entity-model-writer` role on schema and TDE docs.
* Fixed the baseUri to include the closing `/`

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

