### PR TITLE
DHFPROD-4976: Retaining language in database files when it's valid

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/core.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/core.sjs
@@ -193,7 +193,7 @@ function setArtifact(artifactType, artifactName, artifact) {
         artifact = Object.assign({}, artifactLibrary.defaultArtifact(artifactName, artifact.targetEntityType), artifact);
     }
     artifact.lastUpdated = fn.string(fn.currentDateTime());
-    dataHub.hubUtils.replaceLangWithLanguage(artifact);
+    dataHub.hubUtils.replaceLanguageWithLang(artifact);
     for (const db of artifactDatabases) {
         dataHub.hubUtils.writeDocument(`${artifactDirectory}${xdmp.urlEncode(artifactName)}${artifactFileExtension}`, artifact, artifactPermissions, artifactCollections, db);
     }

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/entity-lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/entity-lib.sjs
@@ -231,7 +231,7 @@ function writeModel(entityName, model) {
 
   const dataHub = DataHubSingleton.instance();
 
-  dataHub.hubUtils.replaceLangWithLanguage(model);
+  dataHub.hubUtils.replaceLanguageWithLang(model);
 
   let permsString = dataHub.config.MODELPERMISSIONS;
   if (!permsString || permsString.startsWith("%%ml")) {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils.sjs
@@ -246,7 +246,7 @@ class HubUtils {
    *
    * @param artifact
    */
-  replaceLangWithLanguage(artifact) {
+  replaceLanguageWithLang(artifact) {
     if (artifact.language) {
       artifact.lang = artifact.language;
       delete artifact.language;

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/DeployHubDatabaseCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/DeployHubDatabaseCommandTest.java
@@ -1,0 +1,60 @@
+package com.marklogic.hub.deploy.commands;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.hub.AbstractHubCoreTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DeployHubDatabaseCommandTest extends AbstractHubCoreTest {
+
+    DeployHubDatabaseCommand command;
+    ObjectNode payload;
+
+    @BeforeEach
+    void beforeEach() {
+        command = new DeployHubDatabaseCommand(getHubConfig(), null, "doesnt-matter.json");
+
+        payload = objectMapper.createObjectNode();
+        payload.put("database-name", "test");
+    }
+
+    @Test
+    void payloadHasValidLanguageProperty() {
+        payload.put("language", "en");
+
+        ObjectNode updatedPayload = readJsonObject(command.preparePayloadBeforeSubmitting(payload.toString()));
+        assertEquals("test", updatedPayload.get("database-name").asText());
+        assertTrue(updatedPayload.has("language"), "language should still be present since it's a valid database property");
+    }
+
+    @Test
+    void payloadHasLanguageOfZxx() {
+        payload.put("language", "zxx");
+
+        ObjectNode updatedPayload = readJsonObject(command.preparePayloadBeforeSubmitting(payload.toString()));
+        assertEquals("test", updatedPayload.get("database-name").asText());
+        assertFalse(updatedPayload.has("language"), "A language with a value of 'zxx' should have been removed; this " +
+            "should be very unusual, as it likely was not added by a user (who in theory would have selected a valid " +
+            "value), but we have had some tests fail where a database payload does have a language (instead of 'lang') " +
+            "value of 'zxx'. And since we know that's not a valid language value, we can safely remove it.");
+    }
+
+    @Test
+    void isProvisionedEnvironment() {
+        final boolean originalValue = getHubConfig().getIsProvisionedEnvironment();
+        try {
+            getHubConfig().setIsProvisionedEnvironment(true);
+            payload.put("schema-database", "test1");
+            payload.put("triggers-database", "test2");
+
+            ObjectNode updatedPayload = readJsonObject(command.preparePayloadBeforeSubmitting(payload.toString()));
+            assertEquals("test", updatedPayload.get("database-name").asText());
+            assertFalse(updatedPayload.has("schema-database"));
+            assertFalse(updatedPayload.has("triggers-database"));
+        } finally {
+            getHubConfig().setIsProvisionedEnvironment(originalValue);
+        }
+    }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-utils/replaceLanguageWithLang.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-utils/replaceLanguageWithLang.sjs
@@ -9,7 +9,7 @@ let artifact = {
   "definitions": {},
   "language": "zxx"
 };
-hubUtils.replaceLangWithLanguage(artifact);
+hubUtils.replaceLanguageWithLang(artifact);
 assertions.push(
   test.assertEqual("zxx", artifact.lang),
   test.assertTrue(artifact.language === undefined)
@@ -18,7 +18,7 @@ assertions.push(
 artifact = {
   "langNotHere": "hello"
 };
-hubUtils.replaceLangWithLanguage(artifact);
+hubUtils.replaceLanguageWithLang(artifact);
 assertions.push(
   test.assertEqual("hello", fn.string(artifact.langNotHere)),
   test.assertEqual(1, Object.keys(artifact).length)


### PR DESCRIPTION
Also fixed the name of what's now replaceLanguageWithLang.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

