### PR TITLE
DHFPROD-4180: HC tests now run as hub-central-user by default

### DIFF
--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/ModelControllerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/ModelControllerTest.java
@@ -56,6 +56,7 @@ public class ModelControllerTest extends AbstractHubCentralTest {
     @Test
     @WithMockUser(roles = {"writeEntityModel"})
     void testModelsServicesEndpoints() {
+        runAsDataHubDeveloper();
         createModel();
         updateModelInfo();
         updateModelEntityTypes();

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/managers/MapSearchManagerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/managers/MapSearchManagerTest.java
@@ -5,15 +5,9 @@ import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.central.AbstractHubCentralTest;
 import com.marklogic.hub.central.models.SJSSearchQuery;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class MapSearchManagerTest extends AbstractHubCentralTest {
-
-    @BeforeEach
-    void before() {
-        addStagingDoc("input/employee2.json", "/employee2.json", "UrisOnly");
-    }
 
     @Test
     void sjsSearchUrisOnly() {
@@ -26,6 +20,10 @@ class MapSearchManagerTest extends AbstractHubCentralTest {
     }
 
     private void sjsSearch(boolean urisOnly) {
+        runAsDataHubDeveloper();
+        addStagingDoc("input/employee2.json", "/employee2.json", "UrisOnly");
+
+        runAsTestUserWithRoles("hub-central-mapping-reader");
         SJSSearchQuery query = new SJSSearchQuery();
         query.database = getHubClient().getDbName(DatabaseKind.STAGING);
         query.sourceQuery = "cts.collectionQuery('UrisOnly')";

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-user.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-user.json
@@ -1,8 +1,9 @@
 {
   "role-name": "hub-central-user",
-  "description": "This role grants access to Hub Central",
+  "description": "This role grants access to Hub Central. It also grants read access to entity models due to many Hub Central features depending on reading entity models.",
   "role": [
-    "data-hub-common"
+    "data-hub-common",
+    "data-hub-entity-model-reader"
   ],
   "privilege": [
     {

--- a/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/ReferenceModelProject.java
+++ b/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/ReferenceModelProject.java
@@ -28,7 +28,7 @@ public class ReferenceModelProject extends TestObject {
         customer.put("name", name);
         DocumentMetadataHandle metadata = new DocumentMetadataHandle()
             .withCollections(INPUT_COLLECTION)
-            .withPermission("data-hub-operator", DocumentMetadataHandle.Capability.READ, DocumentMetadataHandle.Capability.UPDATE);
+            .withPermission("data-hub-common", DocumentMetadataHandle.Capability.READ, DocumentMetadataHandle.Capability.UPDATE);
         mgr.write("/customer" + customerId + ".json", metadata, new JacksonHandle(customer));
     }
 
@@ -56,7 +56,7 @@ public class ReferenceModelProject extends TestObject {
 
         DocumentMetadataHandle metadata = new DocumentMetadataHandle()
             .withCollections(customerEntityType)
-            .withPermission("data-hub-operator", DocumentMetadataHandle.Capability.READ, DocumentMetadataHandle.Capability.UPDATE);
+            .withPermission("data-hub-common", DocumentMetadataHandle.Capability.READ, DocumentMetadataHandle.Capability.UPDATE);
         mgr.write("/" + customerEntityType + customer.customerId + ".json", metadata, new JacksonHandle(envelope));
     }
 


### PR DESCRIPTION
Doing this as part of 4180 to help ensure tests for deleting an entity model are running as a minimally-privileged user.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

