### PR TITLE
Fixing Issue #4121: Create an example of a custom hook updating a URI

### DIFF
--- a/examples/dhf5-custom-hook/README.md
+++ b/examples/dhf5-custom-hook/README.md
@@ -29,9 +29,17 @@ Next, start up QuickStart and browse to this project folder and login to QuickSt
 
 ## How to test the custom hook
 
+### Orders Custom Hook
+
 Once you're logged into QuickStart, run the "LoadOrders" flow twice. When the flow is run the second time, the order documents 
 created during the first run will be archived - which in this simple example means being written to a different URI in 
 an archive collection.
 
 The custom hook is defined at src/main/ml-modules/root/custom-modules/ingestion/IngestOrders/archive-hook.sjs, and it 
 is associated with the flow via flows/LoadOrders.flow.json.
+
+### Customer Custom Hook
+
+Once you're logged into QuickStart, run the "LoadCustomers" flow. After running the flow you will see the URIs in staging contianing a random UUID that is generated when ingesting the CSV data. The URI in Final will reflect the ID of the person coming from the canonical instance. 
+
+The custom hook is defined at src/main/ml-modules/root/custom-modules/mapping/MapCustomers/custom-uri-hook.sjs, and it is associated with the flow via flows/LoadCustomers.flow.json.

--- a/examples/dhf5-custom-hook/entities/Customer.entity.json
+++ b/examples/dhf5-custom-hook/entities/Customer.entity.json
@@ -1,0 +1,34 @@
+{
+  "info": {
+    "title": "Customer",
+    "version": "0.0.1",
+    "baseUri": "http://example.org/"
+  },
+  "definitions": {
+    "Customer": {
+      "required": [],
+      "pii": [],
+      "elementRangeIndex": [],
+      "rangeIndex": [],
+      "wordLexicon": [],
+      "properties": {
+        "id": {
+          "datatype": "string",
+          "collation": "http://marklogic.com/collation/codepoint"
+        },
+        "firstName": {
+          "datatype": "string",
+          "collation": "http://marklogic.com/collation/codepoint"
+        },
+        "lastName": {
+          "datatype": "string",
+          "collation": "http://marklogic.com/collation/codepoint"
+        },
+        "email": {
+          "datatype": "string",
+          "collation": "http://marklogic.com/collation/codepoint"
+        }
+      }
+    }
+  }
+}

--- a/examples/dhf5-custom-hook/flows/LoadCustomers.flow.json
+++ b/examples/dhf5-custom-hook/flows/LoadCustomers.flow.json
@@ -1,0 +1,85 @@
+{
+  "name": "LoadCustomers",
+  "description": "",
+  "batchSize": 100,
+  "threadCount": 4,
+  "stopOnError": false,
+  "options": {},
+  "version": 0,
+  "steps": {
+    "1": {
+      "name": "IngestCustomers",
+      "description": "",
+      "options": {
+        "additionalCollections": [],
+        "headers": {
+          "sources": [
+            {
+              "name": "LoadCustomers"
+            }
+          ],
+          "createdOn": "currentDateTime",
+          "createdBy": "currentUser"
+        },
+        "sourceQuery": "cts.collectionQuery([])",
+        "collections": [
+          "IngestCustomers"
+        ],
+        "permissions": "data-hub-operator,read,data-hub-operator,update",
+        "outputFormat": "json",
+        "targetDatabase": "data-hub-STAGING"
+      },
+      "customHook": {
+        "module": "",
+        "parameters": {},
+        "user": "",
+        "runBefore": false
+      },
+      "retryLimit": null,
+      "batchSize": 100,
+      "threadCount": 4,
+      "stepDefinitionName": "default-ingestion",
+      "stepDefinitionType": "INGESTION",
+      "fileLocations": {
+        "inputFilePath": "input/customers",
+        "inputFileType": "csv",
+        "outputURIReplacement": ".*/input,''",
+        "separator": ","
+      }
+    },
+    "2": {
+      "name": "MapCustomers",
+      "description": "",
+      "options": {
+        "additionalCollections": [],
+        "sourceQuery": "cts.collectionQuery([\"IngestCustomers\"])",
+        "mapping": {
+          "name": "LoadCustomers-MapCustomers",
+          "version": 0
+        },
+        "targetEntity": "Customer",
+        "sourceDatabase": "data-hub-STAGING",
+        "collections": [
+          "MapCustomers",
+          "Customer"
+        ],
+        "permissions": "data-hub-operator,read,data-hub-operator,update",
+        "validateEntity": false,
+        "sourceCollection": "IngestCustomers",
+        "outputFormat": "json",
+        "targetDatabase": "data-hub-FINAL"
+      },
+      "customHook": {
+        "module": "/custom-modules/mapping/MapCustomers/custom-uri-hook.sjs",
+        "parameters": {},
+        "user": "flow-operator",
+        "runBefore": false
+      },
+      "retryLimit": 0,
+      "batchSize": 100,
+      "threadCount": 4,
+      "stepDefinitionName": "entity-services-mapping",
+      "stepDefinitionType": "MAPPING"
+    }
+  }
+}

--- a/examples/dhf5-custom-hook/input/customers/customers.csv
+++ b/examples/dhf5-custom-hook/input/customers/customers.csv
@@ -1,0 +1,7 @@
+id,first_name,last_name,email
+600,Jammie,Darko,jdarko0@adobe.com
+47,Cammy,Birkbeck,cbirkbeck1@pen.io
+481,Ethyl,Dean,edean2@miitbeian.gov.cn
+963,Theodora,Pfeffer,tpfeffer3@parallels.com
+74,Lynsey,Fishlee,lfishlee4@digg.com
+673,Kaylil,McIlreavy,kmcilreavy5@tumblr.com

--- a/examples/dhf5-custom-hook/mappings/LoadCustomers-MapCustomers/LoadCustomers-MapCustomers-0.mapping.json
+++ b/examples/dhf5-custom-hook/mappings/LoadCustomers-MapCustomers/LoadCustomers-MapCustomers-0.mapping.json
@@ -1,0 +1,24 @@
+{
+  "lang": "zxx",
+  "name": "LoadCustomers-MapCustomers",
+  "description": "",
+  "version": 0,
+  "targetEntityType": "http://example.org/Customer-0.0.1/Customer",
+  "sourceContext": "/",
+  "sourceURI": "/customers/4625344f-03e4-4bfb-a7b6-7fe69842c372.json",
+  "properties": {
+    "firstName": {
+      "sourcedFrom": "first_name"
+    },
+    "lastName": {
+      "sourcedFrom": "last_name"
+    },
+    "id": {
+      "sourcedFrom": "id"
+    },
+    "email": {
+      "sourcedFrom": "email"
+    }
+  },
+  "namespaces": {}
+}

--- a/examples/dhf5-custom-hook/src/main/ml-modules/root/custom-modules/mapping/MapCustomers/custom-uri-hook.sjs
+++ b/examples/dhf5-custom-hook/src/main/ml-modules/root/custom-modules/mapping/MapCustomers/custom-uri-hook.sjs
@@ -1,0 +1,29 @@
+/**
+ * This is a simple example (not prescriptive, just an example), of a custom hook to override the document URI.
+ */
+declareUpdate();
+
+// A custom hook receives the following parameters via DHF. Each can be optionally declared.
+var uris; // an array of URIs (may only be one) being processed
+var content; // an array of objects for each document being processed
+var options; // the options object passed to the step by DHF
+var flowName; // the name of the flow being processed
+var stepNumber; // the index of the step within the flow being processed; the first step has a step number of 1
+var step; // the step definition object
+
+content.forEach(c => {
+  let value = c.value.toObject();
+  // Validate the ID property is in the instance
+  if (value.envelope &&
+    value.envelope.instance &&
+    value.envelope.instance.Customer &&
+    value.envelope.instance.Customer.id) {
+
+    // Extract the id and construct a new URI
+    let id = value.envelope.instance.Customer.id;
+    let newUri = '/customers/' + id + '.json';
+
+    // Set the contents new URI
+    c.uri = newUri;
+  }
+})


### PR DESCRIPTION
### Description

This example builds upon the DHF5-custom-hook example to show
how a user can create a custom hook on a mapping step to set
the uri of a document.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

