### PR TITLE
DHFPROD-5240: Fixing the order of loading hub and user artifacts

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadHubArtifactsCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadHubArtifactsCommand.java
@@ -47,6 +47,12 @@ import java.util.*;
 @Component
 public class LoadHubArtifactsCommand extends AbstractCommand {
 
+    /**
+     * Hub artifacts are deployed after triggers for no particular reason yet other than that user artifacts must be
+     * deployed after both triggers (because of entity models) and after hub artifacts.
+     */
+    public static int SORT_ORDER = SortOrderConstants.DEPLOY_TRIGGERS + 10;
+
     @Autowired
     private HubConfig hubConfig;
 
@@ -54,9 +60,7 @@ public class LoadHubArtifactsCommand extends AbstractCommand {
 
     public LoadHubArtifactsCommand() {
         super();
-
-        // Sort order for this command must be more than LoadUserArtifactsCommand
-        setExecuteSortOrder(SortOrderConstants.DEPLOY_TRIGGERS + 10);
+        setExecuteSortOrder(SORT_ORDER);
     }
 
     /**

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommand.java
@@ -79,7 +79,7 @@ public class LoadUserArtifactsCommand extends AbstractCommand {
     public LoadUserArtifactsCommand() {
         super();
         this.objectMapper = ObjectMapperFactory.getObjectMapper();
-        setExecuteSortOrder(SortOrderConstants.DEPLOY_TRIGGERS + 1);
+        setExecuteSortOrder(LoadHubArtifactsCommand.SORT_ORDER + 1);
     }
 
     /**
@@ -130,9 +130,6 @@ public class LoadUserArtifactsCommand extends AbstractCommand {
 
             ArtifactService artifactService = ArtifactService.on(stagingClient);
 
-            // Then load steps
-            loadSteps(stagingClient);
-
             // TODO Can simplify this to just having a method for flows and a method for step definitions once
             // we're no longer creating matching settings
             ArtifactManager artifactManager = ArtifactManager.on(hubConfig.newHubClient());
@@ -181,6 +178,9 @@ public class LoadUserArtifactsCommand extends AbstractCommand {
                     loadArtifactsWithDataService(artifactPath, modulesFinder, artifactService, typeInfo);
                 }
             }
+
+            // Then load steps
+            loadSteps(stagingClient);
         }
         catch (IOException e) {
             throw new RuntimeException("Unable to load user artifacts, cause: " + e.getMessage(), e);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/step/saveStep.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/step/saveStep.sjs
@@ -50,13 +50,15 @@ if (existingStep) {
   stepProperties.stepId = stepName + "-" + stepDefinitionType;
 
   const stepDef = new Step().getStepByNameAndType(stepDefinitionName, stepDefinitionType);
-  const stepDefOptions = stepDef.options;
-  Object.keys(stepDefOptions).forEach(key => {
-    // Step artifact libraries are expected to apply their own concept of default collections
-    if (!stepProperties[key] && key !== "collections") {
-      stepProperties[key] = stepDefOptions[key];
-    }
-  });
+  if (stepDef != null && stepDef.options != null) {
+    const stepDefOptions = stepDef.options;
+    Object.keys(stepDefOptions).forEach(key => {
+      // Step artifact libraries are expected to apply their own concept of default collections
+      if (!stepProperties[key] && key !== "collections") {
+        stepProperties[key] = stepDefOptions[key];
+      }
+    });
+  }
 
   Artifacts.setArtifact(stepDefinitionType, stepName, stepProperties);
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommandTest.java
@@ -155,6 +155,10 @@ public class LoadUserArtifactsCommandTest extends AbstractHubCoreTest {
 
     @Test
     void scaffoldedIngestionStep() {
+        assertTrue(new LoadUserArtifactsCommand().getExecuteSortOrder() > new LoadHubArtifactsCommand().getExecuteSortOrder(),
+            "Hub artifacts must be loaded before user artifacts so that OOTB step definitions are present when " +
+                "user steps are loaded");
+
         final String stepName = "testIngester";
         final String stepType = "INGESTION"; // use uppercase to verify it gets converted to lowercase
 


### PR DESCRIPTION
This fixes an issue introduced by 5240 where loading steps failed because the OOTB step definitions didn't exist yet

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

