### PR TITLE
DHFPROD-5081: Hub Central header and toolbar should be sticky

### DIFF
--- a/marklogic-data-hub-central/ui/src/App.scss
+++ b/marklogic-data-hub-central/ui/src/App.scss
@@ -8,6 +8,17 @@
 
 body {
   font-family: "Helvetica Neue";
+  overflow: hidden;
+}
+
+
+.contentContainer{
+  top: 70px;
+  position: relative;
+  margin-right: 70px;
+  overflow-y: auto;
+  height: 100vh;
+  max-height: 92vh;
 }
 
 .ant-layout-header {

--- a/marklogic-data-hub-central/ui/src/App.tsx
+++ b/marklogic-data-hub-central/ui/src/App.tsx
@@ -100,46 +100,48 @@ const App: React.FC<Props> = ({history, location}) => {
       <Header environment={getEnvironment()} />
       <ModalStatus/>
       <main>
-      <Switch>
-        <Route path="/" exact component={Login}/>
-        <PrivateRoute path="/home" exact>
-          <Home/>
-        </PrivateRoute>
-        <PrivateRoute path="/load" exact>
-          <Load/>
-        </PrivateRoute>
-        <PrivateRoute path="/curate" exact>
-          <Curate/>
-        </PrivateRoute>
-        <PrivateRoute path="/run" exact>
-          <Run/>
-        </PrivateRoute>
-        <SearchProvider>
-          <PrivateRoute path="/view" exact>
-              <View/>
-          </PrivateRoute>
-          <PrivateRoute path="/browse" exact>
-              <Browse/>
-          </PrivateRoute>
-          <PrivateRoute path="/detail/:pk/:uri">
-            <Detail/>
-          </PrivateRoute>
-          <ModelingProvider>
-            <PrivateRoute path="/model" exact>
-              <Modeling/>
+        <div className="contentContainer">
+          <Switch>
+            <Route path="/" exact component={Login}/>
+            <PrivateRoute path="/home" exact>
+              <Home/>
             </PrivateRoute>
-            <PrivateRoute path="/tiles" exact>
-              <TilesView/>
+            <PrivateRoute path="/load" exact>
+              <Load/>
             </PrivateRoute>
-            <PrivateRoute path="/tiles-run" exact>
-              <TilesView id='run'/>
+            <PrivateRoute path="/curate" exact>
+              <Curate/>
             </PrivateRoute>
-          </ModelingProvider>
-        </SearchProvider>
-        <Route component={NoMatchRedirect}/>
-      </Switch>
+            <PrivateRoute path="/run" exact>
+              <Run/>
+            </PrivateRoute>
+            <SearchProvider>
+              <PrivateRoute path="/view" exact>
+                  <View/>
+              </PrivateRoute>
+              <PrivateRoute path="/browse" exact>
+                  <Browse/>
+              </PrivateRoute>
+              <PrivateRoute path="/detail/:pk/:uri">
+                <Detail/>
+              </PrivateRoute>
+              <ModelingProvider>
+                <PrivateRoute path="/model" exact>
+                  <Modeling/>
+                </PrivateRoute>
+                <PrivateRoute path="/tiles" exact>
+                  <TilesView/>
+                </PrivateRoute>
+                <PrivateRoute path="/tiles-run" exact>
+                  <TilesView id='run'/>
+                </PrivateRoute>
+              </ModelingProvider>
+            </SearchProvider>
+            <Route component={NoMatchRedirect}/>
+          </Switch>
+          <Footer pageTheme={pageTheme}/>
+        </div>
       </main>
-      <Footer pageTheme={pageTheme}/>
     </div>
   );
 }

--- a/marklogic-data-hub-central/ui/src/components/header/header.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/header/header.module.scss
@@ -1,4 +1,7 @@
 header.container {
+  position: fixed;
+  z-index: 1;
+  width: 100%;
   div.logoContainer {
     height: 0px;
     width: 240px;

--- a/marklogic-data-hub-central/ui/src/components/tiles/toolbar.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/tiles/toolbar.module.scss
@@ -2,7 +2,7 @@
     display: flex;
     justify-content: flex-start;
     flex-direction: column;
-    position: absolute;
+    position: fixed;
     top: 64px;
     right: 0;
     width: 70px;

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.module.scss
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.module.scss
@@ -1,8 +1,8 @@
 .tilesViewContainer {
-    height: 100%;
+    height: 95%;
     width: 100%;
     margin: 0;
-    padding: 10px 80px 0 10px;
+    padding: 10px 10px 0 10px;
 }
 
 #toolbar {

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.scss
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.scss
@@ -14,6 +14,10 @@
     padding-left: 10px;
 }
 
+div.mosaic-container{
+    z-index: 0;
+}
+
 
 div.mosaic-container div.mosaic-tile {
     border: solid 1px;


### PR DESCRIPTION
### Description

- Added inner container wrapping footer and main content so users can scroll while header/toolbar remain fixed.
- Disabled browser scrollbar that was located inside the toolbar.
- New scrollbar is to the left of toolbar and outside of inner tile.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

