### PR TITLE
DHFPROD-5269: Getting rid of all compiler warnings

### DIFF
--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/EntitySearchController.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/EntitySearchController.java
@@ -126,7 +126,7 @@ public class EntitySearchController extends BaseController {
     @Secured("ROLE_savedQueryUser")
     public ResponseEntity<Void> deleteQueryDocument(@RequestParam String id) {
         getEntitySearchService().deleteSavedQuery(id);
-        return new ResponseEntity(HttpStatus.NO_CONTENT);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
     /*

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/environment/DownloadProjectFilesMvcTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/environment/DownloadProjectFilesMvcTest.java
@@ -36,7 +36,7 @@ public class DownloadProjectFilesMvcTest extends AbstractMvcTest {
 
                 // We trust the zip to be constructed correctly based on DownloadConfigurationFilesTest, so just
                 // doing a quick sanity check here
-                List<String> entryNames = new ArrayList();
+                List<String> entryNames = new ArrayList<>();
                 try (ZipInputStream zipStream = new ZipInputStream(new ByteArrayInputStream(response.getContentAsByteArray()))) {
                     ZipEntry entry;
                     while ((entry = zipStream.getNextEntry()) != null) {

--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -11,6 +11,10 @@ plugins {
     id 'com.marklogic.ml-development-tools' version '5.1.0'
 }
 
+// Disabling javadoc warnings, as we have hundreds of them, and until we want to do something about them,
+// seeing them when running a Gradle task (like publishToMavenLocal) is just useless noise
+javadoc.options.addStringOption('Xdoclint:none', '-quiet')
+
 mainClassName='com.marklogic.hub.ApplicationConfig'
 repositories {
     jcenter()

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/DataHub.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/DataHub.java
@@ -21,6 +21,7 @@ import com.marklogic.hub.error.ServerValidationException;
 import com.marklogic.hub.flow.FlowRunner;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Handles creation and orchastration of DHF with a MarkLogic server.
@@ -74,7 +75,7 @@ public interface DataHub {
      * Must be run as a user with sufficient privileges to install a data hub.
      * @return - a hashmap of the results of the preinstall check
      */
-    HashMap runPreInstallCheck();
+    Map<String, Object> runPreInstallCheck();
 
     /**
      * Installs the data hub configuration and server-side config files into MarkLogic

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/collector/DiskQueue.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/collector/DiskQueue.java
@@ -45,7 +45,7 @@ import java.util.logging.Logger;
  *
  * @param <E> - A Serializable Class
  */
-public class DiskQueue<E extends Serializable> extends AbstractQueue<String> {
+public class DiskQueue<E extends Serializable> extends AbstractQueue<String> implements AutoCloseable {
 
     private static final Logger LOG = Logger.getLogger(DiskQueue.class.getName());
 
@@ -109,17 +109,11 @@ public class DiskQueue<E extends Serializable> extends AbstractQueue<String> {
         refillMemoryRatio = DEFAULT_REFILL_RATIO;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#finalize()
-     *
-     * Close down streams, and toss the temp file.
-     */
     @Override
-    protected void finalize() throws Throwable {
+    public void close() {
         if (closeFile()) {
-            LOG.warning(MessageFormat.format("{0} still had open file in finalize", DiskQueue.class.getSimpleName()));
+            LOG.warning(MessageFormat.format("{0} still had open file", com.marklogic.hub.legacy.collector.DiskQueue.class.getSimpleName()));
         }
-        super.finalize();
     }
 
     /**

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateHubTDETemplateCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateHubTDETemplateCommand.java
@@ -47,6 +47,7 @@ public class GenerateHubTDETemplateCommand extends GenerateModelArtifactsCommand
     private Path userFinalSchemasTDEs;
 
     private String entityNames;
+    @SuppressWarnings("unchecked")
     private List<String> entityNamesList = Collections.EMPTY_LIST;
 
     public GenerateHubTDETemplateCommand(HubConfig hubConfig) {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/FlowInputs.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/FlowInputs.java
@@ -32,7 +32,8 @@ public class FlowInputs {
         if (stepConfig == null) {
             stepConfig = new HashMap<>();
         }
-        Map<String, Object> fileLocations = (Map<String, Object>)stepConfig.get("fileLocations");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> fileLocations = (Map)stepConfig.get("fileLocations");
         if (fileLocations == null) {
             fileLocations = new HashMap<>();
             stepConfig.put("fileLocations", fileLocations);

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -413,7 +413,7 @@ public class DataHubImpl implements DataHub, InitializingBean {
     }
 
     @Override
-    public HashMap<String, Boolean> runPreInstallCheck() {
+    public Map<String, Object> runPreInstallCheck() {
         return runPreInstallCheck(constructServerManager(hubConfig));
     }
 
@@ -423,14 +423,14 @@ public class DataHubImpl implements DataHub, InitializingBean {
      * @param serverManager
      * @return
      */
-    protected HashMap<String, Boolean> runPreInstallCheck(ServerManager serverManager) {
+    protected Map<String, Object> runPreInstallCheck(ServerManager serverManager) {
         Map<Integer, String> portsInUse;
 
         try {
             portsInUse = getServerPortsInUse(serverManager);
         } catch (HttpClientErrorException e) {
             logger.warn("Used non-existing user to verify data hub.  Usually this means a fresh system, ready to install.");
-            HashMap response = new HashMap();
+            Map<String, Object> response = new HashMap<>();
             response.put("serverVersion", serverVersion);
             // no server means give it a shot.
             response.put("serverVersionOk", true);
@@ -466,7 +466,7 @@ public class DataHubImpl implements DataHub, InitializingBean {
 
         serverVersion = versions.getMarkLogicVersion();
         serverVersionOk = isServerVersionValid(serverVersion);
-        HashMap response = new HashMap();
+        Map<String, Object> response = new HashMap<>();
         response.put("serverVersion", serverVersion);
         response.put("serverVersionOk", serverVersionOk);
         response.put("stagingPortInUse", stagingPortInUse);
@@ -708,7 +708,7 @@ public class DataHubImpl implements DataHub, InitializingBean {
      * @param commandsMap
      */
     private void updateModuleCommandList(Map<String, List<Command>> commandsMap) {
-        List<Command> commands = new ArrayList();
+        List<Command> commands = new ArrayList<>();
         commands.add(loadHubModulesCommand);
         commands.add(loadUserModulesCommand);
         commands.add(loadUserArtifactsCommand);

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
@@ -211,10 +211,12 @@ public class HubProjectImpl implements HubProject {
         return this.projectDir.resolve("flows");
     }
 
+    @Deprecated
     @Override public Path getHubStagingModulesDir() {
         return this.projectDir.resolve(MODULES_DIR);
     }
 
+    @Deprecated
     @Override public Path getUserStagingModulesDir() {
         return this.projectDir.resolve(MODULES_DIR);
     }
@@ -223,6 +225,7 @@ public class HubProjectImpl implements HubProject {
         return this.projectDir.resolve(MODULES_DIR);
     }
 
+    @Deprecated
     @Override public Path getUserFinalModulesDir() {
         return this.projectDir.resolve(MODULES_DIR);
     }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/legacy/collector/DiskQueue.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/legacy/collector/DiskQueue.java
@@ -45,7 +45,7 @@ import java.util.logging.Logger;
  *
  * @param <E> - A Serializable Class
  */
-public class DiskQueue<E extends Serializable> extends AbstractQueue<String> {
+public class DiskQueue<E extends Serializable> extends AbstractQueue<String> implements AutoCloseable {
 
     private static final Logger LOG = Logger.getLogger(DiskQueue.class.getName());
 
@@ -109,18 +109,13 @@ public class DiskQueue<E extends Serializable> extends AbstractQueue<String> {
         refillMemoryRatio = DEFAULT_REFILL_RATIO;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#finalize()
-     *
-     * Close down streams, and toss the temp file.
-     */
     @Override
-    protected void finalize() throws Throwable {
+    public void close() {
         if (closeFile()) {
-            LOG.warning(MessageFormat.format("{0} still had open file in finalize", DiskQueue.class.getSimpleName()));
+            LOG.warning(MessageFormat.format("{0} still had open file", DiskQueue.class.getSimpleName()));
         }
-        super.finalize();
     }
+
 
     /**
      * Make sure the file streams are all closed down, the temp file is closed,

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/legacy/collector/impl/LegacyCollectorImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/legacy/collector/impl/LegacyCollectorImpl.java
@@ -105,6 +105,7 @@ public class LegacyCollectorImpl implements LegacyCollector {
     }
 
     @Override
+    @Deprecated
     public DiskQueue<String> run(String jobId, String entity, String flow, int threadCount, Map<String, Object> options) {
         try {
             DiskQueue<String> results = new DiskQueue<>(5000);
@@ -158,6 +159,7 @@ public class LegacyCollectorImpl implements LegacyCollector {
         }
     }
 
+    @Deprecated
     private RestTemplate newRestTemplate(String username, String password) {
         DatabaseClientFactory.SecurityContext securityContext = client.getSecurityContext();
 
@@ -192,7 +194,7 @@ public class LegacyCollectorImpl implements LegacyCollector {
                     @Override
                     public void verify(String host, String[] cns, String[] subjectAlts) throws SSLException {}
                 };
-                
+
             } else if (verifier == SSLHostnameVerifier.COMMON) {
                 hostnameVerifier = null;
             } else if (verifier == SSLHostnameVerifier.STRICT) {
@@ -210,13 +212,14 @@ public class LegacyCollectorImpl implements LegacyCollector {
         return rt;
     }
 
+    @Deprecated
     static private class HostnameVerifierAdapter implements X509HostnameVerifier {
         private DatabaseClientFactory.SSLHostnameVerifier verifier;
 
         protected HostnameVerifierAdapter(DatabaseClientFactory.SSLHostnameVerifier verifier) {
           this.verifier = verifier;
         }
-        
+
         public void verify(String hostname, X509Certificate cert) throws SSLException {
           ArrayList<String> cnArray = new ArrayList<>();
           try {
@@ -254,12 +257,12 @@ public class LegacyCollectorImpl implements LegacyCollector {
         @Override
         public void verify(String hostname, SSLSocket ssl) throws IOException {
             Certificate[] certificates = ssl.getSession().getPeerCertificates();
-            verify(hostname, (X509Certificate) certificates[0]);             
+            verify(hostname, (X509Certificate) certificates[0]);
         }
 
         @Override
         public void verify(String hostname, String[] cns, String[] subjectAlts) throws SSLException {
-            verifier.verify(hostname, cns, subjectAlts);            
+            verifier.verify(hostname, cns, subjectAlts);
         }
 
         @Override
@@ -268,7 +271,7 @@ public class LegacyCollectorImpl implements LegacyCollector {
               Certificate[] certificates = session.getPeerCertificates();
               verify(hostname, (X509Certificate) certificates[0]);
               return true;
-              } 
+              }
             catch(SSLException e) {
               return false;
             }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/legacy/flow/impl/LegacyFlowRunnerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/legacy/flow/impl/LegacyFlowRunnerImpl.java
@@ -159,6 +159,7 @@ public class LegacyFlowRunnerImpl implements LegacyFlowRunner {
     }
 
     @Override
+    @Deprecated
     public JobTicket run() {
         String jobId = UUID.randomUUID().toString();
         LegacyJobManager jobManager = LegacyJobManager.create(hubConfig.newJobDbClient());
@@ -411,6 +412,7 @@ public class LegacyFlowRunnerImpl implements LegacyFlowRunner {
         }
     }
 
+    @Deprecated
     protected RunFlowResponse handleFlowRunnerException (Exception e) {
         ObjectMapper objectMapper = new ObjectMapper();
         RunFlowResponse resp = null;

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/mapping/MappingImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/mapping/MappingImpl.java
@@ -76,6 +76,7 @@ public class MappingImpl implements Mapping {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Mapping deserialize(JsonNode json) {
         ObjectMapper mapper = new ObjectMapper();
         HashMap<String, ObjectNode> jsonProperties = new HashMap<>();

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
@@ -132,6 +132,7 @@ public class QueryStepRunner implements StepRunner {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public StepRunner withOptions(Map<String, Object> options) {
         if(flow == null){
             throw new DataHubConfigurationException("Flow has to be set before setting options");
@@ -290,7 +291,7 @@ public class QueryStepRunner implements StepRunner {
     }
 
     @Override
-    public RunStepResponse run(Collection uris) {
+    public RunStepResponse run(Collection<String> uris) {
         runningThread = null;
         RunStepResponse runStepResponse = StepRunnerUtil.createStepResponse(flow, step, jobId);
         try {
@@ -329,7 +330,7 @@ public class QueryStepRunner implements StepRunner {
         return uris;
     }
 
-    private RunStepResponse runHarmonizer(RunStepResponse runStepResponse, Collection uris) {
+    private RunStepResponse runHarmonizer(RunStepResponse runStepResponse, Collection<String> uris) {
         StepMetrics stepMetrics = new StepMetrics();
 
         stepStatusListeners.forEach((StepStatusListener listener) -> {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
@@ -178,6 +178,7 @@ public class WriteStepRunner implements StepRunner {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public StepRunner withOptions(Map<String, Object> options) {
         if(flow == null){
             throw new DataHubConfigurationException("Flow has to be set before setting options");
@@ -335,6 +336,7 @@ public class WriteStepRunner implements StepRunner {
         }
     }
 
+    @SuppressWarnings("unchecked")
     protected void loadStepRunnerParameters(){
         JsonNode comboOptions = null;
         try {

--- a/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/SSLsetup.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/SSLsetup.java
@@ -73,14 +73,14 @@ public class SSLsetup {
 
         ObjectNode node = ObjectMapperFactory.getObjectMapper().createObjectNode();
         if (certAuth) {
-            node.put("authentication", "certificate");            
+            node.put("authentication", "certificate");
             ArrayNode certnode = node.arrayNode();
             certnode.add(cacert);
-            node.put("ssl-client-certificate-pem", certnode );
+            node.set("ssl-client-certificate-pem", certnode );
 
         }
         node.put("ssl-certificate-template", "dhf-cert");
-        
+
         try {
             FileUtils.writeStringToFile(new File(System.getProperty("java.io.tmpdir") + "/ssl-server.json"),
                     node.toString());

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/CustomStepE2E.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/CustomStepE2E.java
@@ -2,6 +2,7 @@ package com.marklogic.hub;
 
 import com.marklogic.bootstrap.Installer;
 import com.marklogic.hub.flow.Flow;
+import com.marklogic.hub.flow.FlowInputs;
 import com.marklogic.hub.flow.FlowRunner;
 import com.marklogic.hub.flow.RunFlowResponse;
 import com.marklogic.hub.step.RunStepResponse;
@@ -93,7 +94,7 @@ public class CustomStepE2E extends HubTestBase{
             throw new Exception("Admissions Flow Not Found");
         }
         //Running all three ingestion steps here for E2E, but its the 3rd step that is of type custom ingestion
-        RunFlowResponse flowResponse = flowRunner.runFlow("Admissions", Arrays.asList("1","2","3"));
+        RunFlowResponse flowResponse = flowRunner.runFlow(new FlowInputs("Admissions", "1", "2", "3"));
         flowRunner.awaitCompletion();
         RunStepResponse ingestionJob = flowResponse.getStepResponses().get("3");
         assertTrue(ingestionJob.isSuccess(), "Custom ingestion job failed: "+ingestionJob.stepOutput);
@@ -110,7 +111,7 @@ public class CustomStepE2E extends HubTestBase{
             throw new Exception("Admissions Flow Not Found");
         }
         //Running custom mapping step
-        RunFlowResponse flowResponse = flowRunner.runFlow("Admissions", Arrays.asList("4"));
+        RunFlowResponse flowResponse = flowRunner.runFlow(new FlowInputs("Admissions", "4"));
         flowRunner.awaitCompletion();
         RunStepResponse mappingJob = flowResponse.getStepResponses().get("4");
         assertTrue(mappingJob.isSuccess(), "Custom mapping job failed: "+mappingJob.stepOutput);
@@ -127,7 +128,7 @@ public class CustomStepE2E extends HubTestBase{
             throw new Exception("Admissions Flow Not Found");
         }
         //Running custom mastering step
-        RunFlowResponse flowResponse = flowRunner.runFlow("Admissions", Arrays.asList("5"));
+        RunFlowResponse flowResponse = flowRunner.runFlow(new FlowInputs("Admissions", "5"));
         flowRunner.awaitCompletion();
         RunStepResponse masteringJob = flowResponse.getStepResponses().get("5");
         assertTrue(masteringJob.isSuccess(), "Custom mastering job failed: "+masteringJob.stepOutput);

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/PiiE2E.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/PiiE2E.java
@@ -116,9 +116,9 @@ public class PiiE2E extends HubTestBase
         // Hardcoding to "digest" auth for now
         // needs to be final db
         clerkClient = DatabaseClientFactory.newClient(finalClient.getHost(), finalPort, HubConfig.DEFAULT_FINAL_NAME,
-            "SydneyGardner", "x", Authentication.DIGEST);
+            new DatabaseClientFactory.DigestAuthContext("SydneyGardner", "x"));
         officerClient = DatabaseClientFactory.newClient(finalClient.getHost(), finalPort, HubConfig.DEFAULT_FINAL_NAME,
-            "GiannaEmerson", "x", Authentication.DIGEST);
+            new DatabaseClientFactory.DigestAuthContext("GiannaEmerson", "x"));
 
         try {
             runInputFLow();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/client/CommandLineFlowInputsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/cli/client/CommandLineFlowInputsTest.java
@@ -53,6 +53,7 @@ public class CommandLineFlowInputsTest {
         assertEquals(3, stepConfig.get("threadCount"));
         assertEquals(50, stepConfig.get("batchSize"));
 
+        @SuppressWarnings("unchecked")
         Map<String, Object> fileLocations = (Map<String, Object>) stepConfig.get("fileLocations");
         assertEquals("CSV", fileLocations.get("inputFileType"));
         assertEquals(";", fileLocations.get("separator"));
@@ -77,6 +78,7 @@ public class CommandLineFlowInputsTest {
         Map<String, Object> options = pair.getLeft().getOptions();
         assertEquals("world", options.get("hello"));
 
+        @SuppressWarnings("unchecked")
         List<String> values = (List<String>) options.get("values");
         assertEquals("red", values.get(0));
         assertEquals("green", values.get(1));

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/core/HubConfigTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/core/HubConfigTest.java
@@ -54,7 +54,7 @@ public class HubConfigTest extends HubTestBase {
 
         AppConfig config = adminHubConfig.getAppConfig();
 
-        assertEquals(new Integer(8011), config.getRestPort(),
+        assertEquals((Integer)8011, config.getRestPort(),
             "The final port should be used as restPort so that any ml-gradle feature that depends on mlRestPost " +
                 "ends up talking to the final app server");
         if (!(isCertAuth() || isSslRun())) {
@@ -84,7 +84,7 @@ public class HubConfigTest extends HubTestBase {
         config = adminHubConfig.getAppConfig();
 
         assertEquals(SecurityContextType.BASIC, config.getRestSecurityContextType());
-        assertEquals(new Integer(8123), config.getRestPort());
+        assertEquals((Integer)8123, config.getRestPort());
         assertEquals("/path/to/file", config.getRestCertFile());
         assertEquals("changeme", config.getRestCertPassword());
         assertEquals("somename", config.getRestExternalName());

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/ConstrainSourceQueryToJobTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/ConstrainSourceQueryToJobTest.java
@@ -44,7 +44,7 @@ public class ConstrainSourceQueryToJobTest extends HubTestBase {
 
     @Test
     public void test() {
-        RunFlowResponse flowResponse = flowRunner.runFlow("testFlow", Arrays.asList("1"), "job1", null, null);
+        RunFlowResponse flowResponse = flowRunner.runFlow(new FlowInputs("testFlow", "1").withJobId("job1"));
         flowRunner.awaitCompletion();
         RunStepResponse stepResponse = flowResponse.getStepResponses().get("1");
         assertEquals("job1", stepResponse.getJobId());
@@ -55,13 +55,13 @@ public class ConstrainSourceQueryToJobTest extends HubTestBase {
         final Map<String, Object> options = new HashMap<>();
         options.put("constrainSourceQueryToJob", true);
 
-        flowResponse = flowRunner.runFlow("testFlow", Arrays.asList(mapXmlStep), "job2", options, null);
+        flowResponse = flowRunner.runFlow(new FlowInputs("testFlow", mapXmlStep).withJobId("job2").withOptions(options));
         flowRunner.awaitCompletion();
         stepResponse = flowResponse.getStepResponses().get(mapXmlStep);
         assertEquals(0, stepResponse.getSuccessfulBatches(), "Since the sourceQuery was constrained to job2, and " +
             "no documents have that value for their datahubCreatedByJob metadata key, then nothing should have been processed");
 
-        flowResponse = flowRunner.runFlow("testFlow", Arrays.asList(mapXmlStep), "job1", options, null);
+        flowResponse = flowRunner.runFlow(new FlowInputs("testFlow", mapXmlStep).withJobId("job1"));
         flowRunner.awaitCompletion();
         stepResponse = flowResponse.getStepResponses().get(mapXmlStep);
         assertEquals(1, stepResponse.getSuccessfulBatches(), "Since the sourceQuery was constrained to job1, and the " +

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowInputsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowInputsTest.java
@@ -14,11 +14,13 @@ public class FlowInputsTest {
         FlowInputs inputs = new FlowInputs("anyflow");
         inputs.setInputFilePath("/path/to/data");
 
+        @SuppressWarnings("unchecked")
         Map<String, Object> fileLocations = (Map<String, Object>) inputs.getStepConfig().get("fileLocations");
         assertEquals("/path/to/data", fileLocations.get("inputFilePath"));
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void setInputFilePathWithExistingStepConfig() {
         FlowInputs inputs = new FlowInputs("anyflow");
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/impl/FlowRunnerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/impl/FlowRunnerTest.java
@@ -215,10 +215,12 @@ public class FlowRunnerTest extends HubTestBase {
         }
      }
 
-     protected RunFlowResponse runFlow(String flowName, String commaDelimitedSteps, String jobId, Map<String,Object> options, Map<String, Object> stepConfig) {
+    @SuppressWarnings("deprecation")
+    protected RunFlowResponse runFlow(String flowName, String commaDelimitedSteps, String jobId, Map<String, Object> options, Map<String, Object> stepConfig) {
         List<String> steps = commaDelimitedSteps != null ? Arrays.asList(commaDelimitedSteps.split(",")) : null;
-         return flowRunner.runFlow(flowName, steps, jobId, options, stepConfig);
-     }
+        // This is intentionally being used to ensure that the deprecated approach still works
+        return flowRunner.runFlow(flowName, steps, jobId, options, stepConfig);
+    }
 
     @Test
     public void testIngestCSVasXMLCustomDelimiter(){

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/GenerateIndexesTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/GenerateIndexesTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @ContextConfiguration(classes = ApplicationConfig.class)
 public class GenerateIndexesTest extends HubTestBase {
 
-    private List<JsonNode> entities = new ArrayList();
+    private List<JsonNode> entities = new ArrayList<>();
     private ObjectNode indexes;
 
     @Test

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/legacy/collector/DiskQueueTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/legacy/collector/DiskQueueTest.java
@@ -84,7 +84,7 @@ public class DiskQueueTest {
         instance.add("second");
         instance.add("third");
         assertEquals(3, instance.size());
-        instance.finalize();
+        instance.close();
     }
 
     @Test
@@ -113,7 +113,7 @@ public class DiskQueueTest {
     public void testFinalize() throws Exception {
         DiskQueue<String> instance = new DiskQueue<String>(1);
         try {
-            instance.finalize();
+            instance.close();
         } catch (Throwable ex) {
             fail();
         }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/legacy/flow/impl/LegacyFlowRunnerImplTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/legacy/flow/impl/LegacyFlowRunnerImplTest.java
@@ -6,6 +6,7 @@ import com.marklogic.hub.legacy.flow.RunFlowResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+@Deprecated
 class LegacyFlowRunnerImplTest  {
 
     @Test

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/mapping/MappingTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/mapping/MappingTest.java
@@ -12,6 +12,7 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.hub.ApplicationConfig;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.HubTestBase;
+import com.marklogic.hub.flow.FlowInputs;
 import com.marklogic.hub.flow.FlowRunner;
 import com.marklogic.hub.flow.RunFlowResponse;
 import com.marklogic.hub.step.RunStepResponse;
@@ -391,7 +392,7 @@ public class MappingTest extends HubTestBase {
     }
 
     protected RunFlowResponse runFlow(String flowName, String... stepIds) {
-        RunFlowResponse flowResponse = flowRunner.runFlow(flowName, Arrays.asList(stepIds));
+        RunFlowResponse flowResponse = flowRunner.runFlow(new FlowInputs(flowName, stepIds));
         flowRunner.awaitCompletion();
         return flowResponse;
     }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/master/MasterTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/master/MasterTest.java
@@ -122,7 +122,7 @@ public class MasterTest extends HubTestBase {
 
     @Test
     public void testMasterStep() {
-        RunFlowResponse flowResponse = flowRunner.runFlow("myNewFlow", Arrays.asList("1","2","3"));
+        RunFlowResponse flowResponse = flowRunner.runFlow(new FlowInputs("myNewFlow", "1","2","3"));
         flowRunner.awaitCompletion();
         RunStepResponse masterJob = flowResponse.getStepResponses().get("3");
         assertTrue(masterJob.isSuccess(), "Mastering job failed!");
@@ -164,7 +164,7 @@ public class MasterTest extends HubTestBase {
             "))";
         assertTrue(existsByQuery(summaryQueryText, HubConfig.DEFAULT_FINAL_NAME), "Missing valid matching summary document!");
 
-        RunFlowResponse flowMergeResponse = flowRunner.runFlow("myMatchMergeFlow", Collections.singletonList("4"));
+        RunFlowResponse flowMergeResponse = flowRunner.runFlow(new FlowInputs("myMatchMergeFlow", "4"));
         flowRunner.awaitCompletion();
         RunStepResponse mergeJob = flowMergeResponse.getStepResponses().get("4");
         assertTrue(mergeJob.isSuccess(), "Merging job failed!");

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubDeveloperTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubDeveloperTest.java
@@ -219,9 +219,9 @@ public class DataHubDeveloperTest extends AbstractSecurityTest {
 
         ObjectNode alertRuleNode = ObjectMapperFactory.getObjectMapper().createObjectNode();
         ObjectNode ctsQuery = ObjectMapperFactory.getObjectMapper().createObjectNode();
-        ctsQuery.put("wordQuery", ObjectMapperFactory.getObjectMapper().createObjectNode().put("text", "MarkLogic"));
+        ctsQuery.set("wordQuery", ObjectMapperFactory.getObjectMapper().createObjectNode().put("text", "MarkLogic"));
         alertRuleNode.put("name", "my-rule");
-        alertRuleNode.put("query", ctsQuery);
+        alertRuleNode.set("query", ctsQuery);
         alertRuleNode.put("description", "my-rule");
 
         try {

--- a/web/src/main/java/com/marklogic/hub/web/service/AsyncFlowService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/AsyncFlowService.java
@@ -226,6 +226,7 @@ public class AsyncFlowService implements InitializingBean, DisposableBean {
             threadCnt++;
         }
 
+        @SuppressWarnings("unchecked")
         ExecutorCompletionService<FlowStepsWithThreadInfo> ecs = new ExecutorCompletionService(
             executor);
         Future[] futures = IntStream.range(0, threadCnt)

--- a/web/src/main/java/com/marklogic/hub/web/service/DataHubService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/DataHubService.java
@@ -129,7 +129,7 @@ public class DataHubService {
         dataHub.deleteDocument(uri, databaseKind);
     }
 
-    public HashMap preInstallCheck(HubConfig config) {
+    public Map<String, Object> preInstallCheck(HubConfig config) {
         return dataHub.runPreInstallCheck();
     }
 

--- a/web/src/main/java/com/marklogic/hub/web/service/FlowManagerService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/FlowManagerService.java
@@ -319,6 +319,7 @@ public class FlowManagerService {
      * @param steps
      * @return
      */
+    @Deprecated
     public synchronized FlowStepModel runFlow(String flowName, List<String> steps) {
         if (steps == null || steps.size() == 0) {
             flowRunner.runFlow(flowName);

--- a/web/src/main/java/com/marklogic/hub/web/service/LegacyFlowManagerService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/LegacyFlowManagerService.java
@@ -122,19 +122,6 @@ public class LegacyFlowManagerService {
         return destFolder.resolve(entityName + "-harmonize-" + flowName + ".txt");
     }
 
-    public Map<String, Object> getHarmonizeFlowOptionsFromFile(String entityName, String flowName) throws IOException {
-        Path destFolder = hubConfig.getHubProjectDir().resolve(PROJECT_TMP_FOLDER);
-        Path filePath = getHarmonizeOptionsFilePath(destFolder, entityName, flowName);
-        File file = filePath.toFile();
-        if(file.exists()) {
-            return new ObjectMapper().readValue(file, Map.class);
-        }
-
-        Map<String, Object> result = new HashMap<>();
-        result.put("harmonize_file_path", hubConfig.getHubConfigDir());
-        return result;
-    }
-
     public void saveOrUpdateHarmonizeFlowOptionsToFile(String entityName, String flowName, String harmonizeOptionsFileContent) throws IOException {
         Path destFolder = hubConfig.getHubProjectDir().resolve(PROJECT_TMP_FOLDER);
         File destFolderFile = destFolder.toFile();
@@ -166,6 +153,7 @@ public class LegacyFlowManagerService {
         }
     }
 
+    @SuppressWarnings("unchecked")
     public Map<String, Object> getFlowMlcpOptionsFromFile(String entityName, String flowName) throws IOException {
         Path destFolder = hubConfig.getHubProjectDir().resolve(PROJECT_TMP_FOLDER);
         Path filePath = getMlcpOptionsFilePath(destFolder, entityName, flowName);

--- a/web/src/main/java/com/marklogic/hub/web/service/ProjectManagerService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/ProjectManagerService.java
@@ -39,6 +39,7 @@ public class ProjectManagerService {
 
     public ProjectManagerService() {}
 
+    @SuppressWarnings("unchecked")
     public synchronized Map<Integer, ProjectInfo> getProjects() {
         Map<Integer, ProjectInfo> projects;
         byte[] bytes = prefs.getByteArray("projects", null);

--- a/web/src/main/java/com/marklogic/hub/web/web/CurrentProjectController.java
+++ b/web/src/main/java/com/marklogic/hub/web/web/CurrentProjectController.java
@@ -220,7 +220,7 @@ public class CurrentProjectController implements FileSystemEventListener, Valida
     @RequestMapping(value = "/preinstall-check", method = RequestMethod.GET, produces = {MediaType.APPLICATION_JSON_VALUE})
     @ResponseBody
     public String preInstallCheck() {
-        HashMap response = dataHubService.preInstallCheck(hubConfig);
+        Map<String, Object> response = dataHubService.preInstallCheck(hubConfig);
         String jsonResponse = null;
         try {
             jsonResponse = new ObjectMapper().writeValueAsString(response);

--- a/web/src/main/java/com/marklogic/hub/web/web/EntitiesController.java
+++ b/web/src/main/java/com/marklogic/hub/web/web/EntitiesController.java
@@ -70,6 +70,7 @@ class EntitiesController {
 
     @RequestMapping(value = "/entities/", method = RequestMethod.POST)
     @ResponseBody
+    @Deprecated
     public ResponseEntity<?> saveEntities(@RequestBody List<EntityModel> entities) throws ClassNotFoundException, IOException {
 
         for (EntityModel entity : entities) {
@@ -92,6 +93,7 @@ class EntitiesController {
 
     @RequestMapping(value = "/entities/{entityName}", method = RequestMethod.PUT)
     @ResponseBody
+    @Deprecated
     public EntityModel saveEntity(@RequestBody EntityModel entity) throws ClassNotFoundException, IOException {
         entityManagerService.saveEntityUiData(entity);
         EntityModel m = entityManagerService.saveEntity(entity);

--- a/web/src/main/java/com/marklogic/hub/web/web/FlowController.java
+++ b/web/src/main/java/com/marklogic/hub/web/web/FlowController.java
@@ -158,6 +158,7 @@ public class FlowController {
 
     @RequestMapping(value = "/{flowName}/run", method = RequestMethod.POST)
     @ResponseBody
+    @Deprecated
     public ResponseEntity<?> runFlow(@PathVariable String flowName, @RequestBody(required = false) List<String> steps) {
         FlowStepModel flow = flowManagerService.runFlow(flowName, steps);
         return new ResponseEntity<>(flow, HttpStatus.OK);

--- a/web/src/test/java/com/marklogic/hub/web/service/EntityManagerServiceTest.java
+++ b/web/src/test/java/com/marklogic/hub/web/service/EntityManagerServiceTest.java
@@ -137,6 +137,7 @@ public class EntityManagerServiceTest extends AbstractServiceTest implements Ini
     }
 
     @Test
+    @Deprecated
     public void saveEntity() throws IOException {
         Path entityDir = projectDir.resolve("entities");
         String entityFilename = ENTITY2 + EntityManagerService.ENTITY_FILE_EXTENSION;
@@ -228,6 +229,7 @@ public class EntityManagerServiceTest extends AbstractServiceTest implements Ini
      * Addresses https://github.com/marklogic/marklogic-data-hub/issues/558.
      */
     @Test
+    @Deprecated
     public void changeEntityName() throws IOException {
         final String RENAMED_ENTITY = "renamed-entity";
 

--- a/web/src/test/java/com/marklogic/hub/web/web/ProjectsControllerTest.java
+++ b/web/src/test/java/com/marklogic/hub/web/web/ProjectsControllerTest.java
@@ -70,6 +70,7 @@ public class ProjectsControllerTest extends BaseTestController {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void getProjects() {
         assertEquals(0, ((Collection<ProjectInfo>)pc.getProjects().get("projects")).size());
         assertEquals(false, pc.getProjects().keySet().contains("lastProject"));
@@ -80,6 +81,7 @@ public class ProjectsControllerTest extends BaseTestController {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void addProject() throws IOException {
         assertEquals(0, ((Collection<ProjectInfo>)pc.getProjects().get("projects")).size());
 
@@ -90,6 +92,7 @@ public class ProjectsControllerTest extends BaseTestController {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void getProject() {
         assertEquals(0, ((Collection<ProjectInfo>)pc.getProjects().get("projects")).size());
         assertEquals(false, pc.getProjects().keySet().contains("lastProject"));
@@ -103,6 +106,7 @@ public class ProjectsControllerTest extends BaseTestController {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void removeProject() {
         assertEquals(0, ((Collection<ProjectInfo>)pc.getProjects().get("projects")).size());
 
@@ -115,6 +119,7 @@ public class ProjectsControllerTest extends BaseTestController {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void initializeProject() {
         assertEquals(0, ((Collection<ProjectInfo>)pc.getProjects().get("projects")).size());
 
@@ -129,6 +134,7 @@ public class ProjectsControllerTest extends BaseTestController {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void getDefaults() {
         assertEquals(0, ((Collection<ProjectInfo>)pc.getProjects().get("projects")).size());
 


### PR DESCRIPTION
Most of these involve deprecation and unchecked warnings. 

Also turned off javadoc warnings for ./marklogic-data-hub, as we don't care about those yet and there are hundreds of them, which amounts to noise. 

Really made just two significant changes:

- DataHub.runPreInstallCheck now returns a Map<String, Object> instead of a HashMap
- Both DiskQueue classes implement "AutoCloseable" (the replacement for "finalize()") instead of the deprecated "finalize" method

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

