### PR TITLE
DHFPROD-5077: Remove gray background from Expand/Collapse headers

### DIFF
--- a/marklogic-data-hub-central/ui/src/pages/TilesView.scss
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.scss
@@ -21,6 +21,11 @@ div.mosaic-container div.mosaic-tile {
     margin: 0;
 }
 
+div.ant-collapse-item{
+    background: white;
+}
+
+
 div.mosaic-container-explore div.mosaic-tile {
     border-color: #00474F;
 }


### PR DESCRIPTION
### Description

- Changed gray background of Expand/Collapse headers inside Curate and Run Tile.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

