### PR TITLE
DHFPROD-4713: hubDeployAsDeveloper now calls mlPrepareBundles

### DIFF
--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -230,7 +230,10 @@ class DataHubPlugin implements Plugin<Project> {
 
         project.task("hubDeployAsDeveloper", group: deployGroup, type: DeployAsDeveloperTask,
             description: "Deploy project configuration as a user with the data-hub-developer role"
-        ).finalizedBy(["hubGenerateExplorerOptions"]).mustRunAfter("hubDeployAsSecurityAdmin")
+        )
+            .dependsOn("mlPrepareBundles") // Needed for https://github.com/marklogic-community/ml-gradle/wiki/Bundles
+            .finalizedBy(["hubGenerateExplorerOptions"])
+            .mustRunAfter("hubDeployAsSecurityAdmin")
 
         project.task("hubDeploy", group: deployGroup, dependsOn: ["hubDeployAsDeveloper", "hubDeployAsSecurityAdmin"],
             description: "Deploy project configuration as a user with the data-hub-security-admin and data-hub-developer roles")


### PR DESCRIPTION
No good way to do an automated test for this; just verified manually by adding the following to the reference project's build.gradle file:

repositories {
    jcenter()
}
dependencies {
    mlBundle "com.marklogic:marklogic-unit-test-modules:1.0.beta"
}

### Description

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
