### PR TITLE
DHFPROD-5076: Fix hover color for Mapping Step Details and other places

### DIFF
--- a/marklogic-data-hub-central/ui/src/App.scss
+++ b/marklogic-data-hub-central/ui/src/App.scss
@@ -89,6 +89,10 @@ div#error-list div.ant-collapse div.ant-collapse-item div.ant-collapse-content d
   padding: 0 16px;
 }
 
+tr.ant-table-row:hover > td {
+  background: #E9F7FE !important;
+}
+
 .ant-upload.ant-upload-select {
   display: block;
 }


### PR DESCRIPTION
### Description
- Override for ant design table row hover color to the requested '#E9F7FE' color. 
- Applies to all instances of table rows across Hub Central.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

