### PR TITLE
DHFPROD-4801: data-hub-security-admin can now inherit some roles...

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesCommand.java
@@ -11,6 +11,8 @@ import com.marklogic.mgmt.api.API;
 import com.marklogic.mgmt.api.security.Privilege;
 import com.marklogic.mgmt.mapper.DefaultResourceMapper;
 import com.marklogic.mgmt.resource.security.PrivilegeManager;
+import com.marklogic.mgmt.resource.security.RoleManager;
+import com.marklogic.rest.util.ResourcesFragment;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,6 +25,48 @@ public class CreateGranularPrivilegesCommand implements Command, UndoableCommand
 
     private HubConfig hubConfig;
     private List<String> groupNames;
+
+    /**
+     * Defines the roles that can be inherited when a data-hub-security-admin creates or edits a custom role.
+     */
+    public final static List<String> ROLES_THAT_CAN_BE_INHERITED = Arrays.asList(
+        "data-hub-admin",
+        "data-hub-developer",
+        "data-hub-monitor",
+        "data-hub-operator",
+        "hub-central-clear-user-data",
+        "hub-central-downloader",
+        "hub-central-entity-exporter",
+        "hub-central-entity-model-reader",
+        "hub-central-entity-model-writer",
+        "hub-central-flow-writer",
+        "hub-central-load-reader",
+        "hub-central-load-writer",
+        "hub-central-mapping-reader",
+        "hub-central-mapping-writer",
+        "hub-central-saved-query-user",
+        "hub-central-step-runner",
+        "hub-central-user",
+        "data-hub-common",
+        "data-hub-common-writer",
+        "data-hub-custom-reader",
+        "data-hub-entity-model-reader",
+        "data-hub-entity-model-writer",
+        "data-hub-flow-reader",
+        "data-hub-flow-writer",
+        "data-hub-ingestion-reader",
+        "data-hub-ingestion-writer",
+        "data-hub-job-reader",
+        "data-hub-mapping-reader",
+        "data-hub-mapping-writer",
+        "data-hub-match-merge-reader",
+        "data-hub-match-merge-writer",
+        "data-hub-module-reader",
+        "data-hub-module-writer",
+        "data-hub-saved-query-user",
+        "data-hub-step-definition-reader",
+        "data-hub-step-definition-writer"
+    );
 
     public CreateGranularPrivilegesCommand(HubConfig hubConfig) {
         this.hubConfig = hubConfig;
@@ -86,6 +130,8 @@ public class CreateGranularPrivilegesCommand implements Command, UndoableCommand
         mgr.save(p.getJson());
 
         buildScheduledTaskPrivileges().forEach(privilege -> mgr.save(privilege.getJson()));
+
+        addRolePrivilegesToDataHubSecurityAdmin(context.getManageClient());
     }
 
     @Override
@@ -116,6 +162,12 @@ public class CreateGranularPrivilegesCommand implements Command, UndoableCommand
         getGroupNamesForScheduledTaskPrivileges().forEach(groupName -> {
             mgr.deleteAtPath("/manage/v2/privileges/admin-group-scheduled-task-" + groupName + "?kind=execute");
         });
+
+        List<Privilege> privileges = buildPrivilegesForRolesThatCanBeInherited(context.getManageClient());
+        for (Privilege privilege : privileges) {
+            String path = "/manage/v2/privileges/" + privilege.getPrivilegeName() + "?kind=execute";
+            mgr.deleteAtPath(path);
+        }
     }
 
     /**
@@ -154,11 +206,10 @@ public class CreateGranularPrivilegesCommand implements Command, UndoableCommand
     }
 
     /**
-     *
      * @param client
-     * @param name The name of the privilege to create if a privilege with the given dhsName does not exist. This name
-     *             is not the same as the dhsName, as the initial goal was to have a consistent naming convention for
-     *             all granular privileges, and the DHS privilege names are not consistent with that convention.
+     * @param name                   The name of the privilege to create if a privilege with the given dhsName does not exist. This name
+     *                               is not the same as the dhsName, as the initial goal was to have a consistent naming convention for
+     *                               all granular privileges, and the DHS privilege names are not consistent with that convention.
      * @param action
      * @param dhsName
      * @param existingPrivilegeNames
@@ -203,6 +254,45 @@ public class CreateGranularPrivilegesCommand implements Command, UndoableCommand
         return (groupNames != null && !groupNames.isEmpty()) ?
             groupNames :
             Arrays.asList(hubConfig.getAppConfig().getGroupName());
+    }
+
+    /**
+     * As an optimization, this first checks to see if a privilege with the given name exists. This is safe to do until
+     * we need to change the definition of these privileges, of course. The optimization is done because deploying the
+     * privileges - whether via RMA or CMA - is a bit slower if the privileges already exist. And since we know we're
+     * not going to be making any updates to the privileges, the optimization check is performed.
+     *
+     * @param manageClient
+     */
+    private void addRolePrivilegesToDataHubSecurityAdmin(ManageClient manageClient) {
+        PrivilegeManager privilegeManager = new PrivilegeManager(manageClient);
+        ResourcesFragment existingPrivileges = privilegeManager.getAsXml();
+        buildPrivilegesForRolesThatCanBeInherited(manageClient).forEach(privilege -> {
+            if (!existingPrivileges.resourceExists(privilege.getPrivilegeName())) {
+                privilegeManager.save(privilege.getJson());
+            }
+        });
+    }
+
+    /**
+     * @param manageClient
+     * @return a list of Privilege objects, one for which each role that can be inherited when a data-hub-security-admin
+     * is creating a role. Each privilege has a name of the form "data-role-inherit-(roleId)"; while that format is not
+     * required, and its the privilege action that matters, this format is the same as what the ML security API uses,
+     * so it's being adopted for consistency
+     */
+    protected List<Privilege> buildPrivilegesForRolesThatCanBeInherited(ManageClient manageClient) {
+        ResourcesFragment existingRoles = new RoleManager(manageClient).getAsXml();
+        List<Privilege> privileges = new ArrayList<>();
+        ROLES_THAT_CAN_BE_INHERITED.forEach(roleName -> {
+            String roleId = existingRoles.getIdForNameOrId(roleName);
+            Privilege p = new Privilege(null, "data-role-inherit-" + roleId);
+            p.setKind("execute");
+            p.setAction("http://marklogic.com/xdmp/privileges/role/inherit/" + roleId);
+            p.addRole("data-hub-security-admin");
+            privileges.add(p);
+        });
+        return privileges;
     }
 
     public List<String> getGroupNames() {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesTest.java
@@ -1,8 +1,7 @@
 package com.marklogic.hub.deploy.commands;
 
 import com.marklogic.appdeployer.command.CommandContext;
-import com.marklogic.hub.ApplicationConfig;
-import com.marklogic.hub.HubTestBase;
+import com.marklogic.hub.AbstractHubCoreTest;
 import com.marklogic.mgmt.api.API;
 import com.marklogic.mgmt.api.security.Privilege;
 import com.marklogic.mgmt.api.security.Role;
@@ -15,18 +14,13 @@ import com.marklogic.rest.util.ResourcesFragment;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = ApplicationConfig.class)
-public class CreateGranularPrivilegesTest extends HubTestBase {
+public class CreateGranularPrivilegesTest extends AbstractHubCoreTest {
 
     @BeforeEach
     public void setUp() {
@@ -111,6 +105,9 @@ public class CreateGranularPrivilegesTest extends HubTestBase {
 
     @Test
     void deletePrivilegesOnUndeploy() {
+        final CreateGranularPrivilegesCommand command = new CreateGranularPrivilegesCommand(adminHubConfig);
+        final CommandContext context = new CommandContext(adminHubConfig.getAppConfig(), adminHubConfig.getManageClient(), null);
+
         PrivilegeManager mgr = new PrivilegeManager(adminHubConfig.getManageClient());
         ResourcesFragment privileges = mgr.getAsXml();
         assertTrue(privileges.resourceExists("admin-database-clear-data-hub-STAGING"));
@@ -127,8 +124,9 @@ public class CreateGranularPrivilegesTest extends HubTestBase {
         assertTrue(privileges.resourceExists("admin-database-alerts-data-hub-FINAL"));
         assertTrue(privileges.resourceExists("admin-group-scheduled-task-" + adminHubConfig.getAppConfig().getGroupName()));
 
-        final CreateGranularPrivilegesCommand command = new CreateGranularPrivilegesCommand(adminHubConfig);
-        final CommandContext context = new CommandContext(adminHubConfig.getAppConfig(), adminHubConfig.getManageClient(), null);
+        for (Privilege privilege : command.buildPrivilegesForRolesThatCanBeInherited(adminHubConfig.getManageClient())) {
+            assertTrue(privileges.resourceExists(privilege.getPrivilegeName()));
+        }
 
         try {
             assertEquals(adminHubConfig.getAppConfig().getGroupName(), command.getGroupNamesForScheduledTaskPrivileges().get(0));
@@ -149,6 +147,10 @@ public class CreateGranularPrivilegesTest extends HubTestBase {
             assertFalse(privileges.resourceExists("admin-database-alerts-data-hub-STAGING"));
             assertFalse(privileges.resourceExists("admin-database-alerts-data-hub-FINAL"));
             assertFalse(privileges.resourceExists("admin-group-scheduled-task-" + adminHubConfig.getAppConfig().getGroupName()));
+
+            for (Privilege privilege : command.buildPrivilegesForRolesThatCanBeInherited(adminHubConfig.getManageClient())) {
+                assertFalse(privileges.resourceExists(privilege.getPrivilegeName()));
+            }
         } finally {
             // Need to deploy these privileges back so the lack of them doesn't impact other tests
             command.execute(context);


### PR DESCRIPTION
... when creating a new role. Uses the "data-role-inherit-" privilege.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

