### PR TITLE
DHFPROD-5156: Save all entity models

### DIFF
--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/SwaggerConfig.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/SwaggerConfig.java
@@ -85,6 +85,7 @@ public class SwaggerConfig {
                 ModelController.CreateModelInput.class,
                 ModelController.LatestJobInfo.class,
                 ModelController.ModelReferencesInfo.class,
+                ModelController.UpdateModelInput.class,
                 ModelDefinitions.class,
                 ModelDescriptor.class,
                 PrimaryEntityType.class,

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/ModelController.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/ModelController.java
@@ -24,6 +24,7 @@ import com.marklogic.client.admin.QueryOptionsManager;
 import com.marklogic.client.io.Format;
 import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.central.managers.ModelManager;
+import com.marklogic.hub.central.schemas.ModelDefinitions;
 import com.marklogic.hub.central.schemas.ModelDescriptor;
 import com.marklogic.hub.central.schemas.PrimaryEntityType;
 import com.marklogic.hub.dataservices.ModelsService;
@@ -112,12 +113,12 @@ public class ModelController extends BaseController {
         return ResponseEntity.ok(newService().getModelReferences(modelName));
     }
 
-    @RequestMapping(value = "/{modelName}/entityTypes", method = RequestMethod.PUT)
-    @ApiImplicitParam(required = true, paramType = "body", dataType = "ModelDefinitions")
+    @RequestMapping(value = "/entityTypes", method = RequestMethod.PUT)
+    @ApiImplicitParam(required = true, paramType = "body", allowMultiple = true, dataType = "UpdateModelInput")
     @Secured("ROLE_writeEntityModel")
-    public ResponseEntity<Void> updateModelEntityTypes(@ApiParam(hidden = true) @RequestBody JsonNode entityTypes, @PathVariable String modelName) {
+    public ResponseEntity<Void> updateModelEntityTypes(@ApiParam(hidden = true) @RequestBody JsonNode entityTypes) {
         // update the model
-        newService().updateModelEntityTypes(modelName, entityTypes);
+        newService().updateModelEntityTypes(entityTypes);
 
         //deploy updated configs
         deployModelConfigs();
@@ -279,5 +280,10 @@ public class ModelController extends BaseController {
     public static class ModelReferencesInfo {
         public List<String> stepAndMappingNames;
         public List<String> entityNames;
+    }
+
+    public static class UpdateModelInput {
+        public String entityName;
+        public ModelDefinitions modelDefinition;
     }
 }

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/ModelMvcTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/ModelMvcTest.java
@@ -22,7 +22,7 @@ public class ModelMvcTest extends AbstractMvcTest {
 
         verifyRequestIsForbidden(buildJsonPost("/api/models", "{}"));
         verifyRequestIsForbidden(buildJsonPut("/api/models/doesntMatter/info", "{}"));
-        verifyRequestIsForbidden(buildJsonPut("/api/models/doesntMatter/entityTypes", "{}"));
+        verifyRequestIsForbidden(buildJsonPut("/api/models/entityTypes", "{}"));
         delete("/api/models/doesntMatter").andExpect(status().isForbidden());
     }
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/ModelsService.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/ModelsService.java
@@ -75,7 +75,7 @@ public interface ModelsService {
                 this.req_getModelReferences = this.baseProxy.request(
                     "getModelReferences.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC);
                 this.req_updateModelEntityTypes = this.baseProxy.request(
-                    "updateModelEntityTypes.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_MIXED);
+                    "updateModelEntityTypes.sjs", BaseProxy.ParameterValuesKind.SINGLE_NODE);
             }
 
             @Override
@@ -175,19 +175,16 @@ public interface ModelsService {
             }
 
             @Override
-            public com.fasterxml.jackson.databind.JsonNode updateModelEntityTypes(String name, com.fasterxml.jackson.databind.JsonNode input) {
-                return updateModelEntityTypes(
-                    this.req_updateModelEntityTypes.on(this.dbClient), name, input
+            public void updateModelEntityTypes(com.fasterxml.jackson.databind.JsonNode input) {
+                updateModelEntityTypes(
+                    this.req_updateModelEntityTypes.on(this.dbClient), input
                     );
             }
-            private com.fasterxml.jackson.databind.JsonNode updateModelEntityTypes(BaseProxy.DBFunctionRequest request, String name, com.fasterxml.jackson.databind.JsonNode input) {
-              return BaseProxy.JsonDocumentType.toJsonNode(
-                request
+            private void updateModelEntityTypes(BaseProxy.DBFunctionRequest request, com.fasterxml.jackson.databind.JsonNode input) {
+              request
                       .withParams(
-                          BaseProxy.atomicParam("name", false, BaseProxy.StringType.fromString(name)),
                           BaseProxy.documentParam("input", false, BaseProxy.JsonDocumentType.fromJsonNode(input))
-                          ).responseSingle(false, Format.JSON)
-                );
+                          ).responseNone();
             }
         }
 
@@ -254,10 +251,9 @@ public interface ModelsService {
   /**
    * Invokes the updateModelEntityTypes operation on the database server
    *
-   * @param name	The name of the model
    * @param input	provides input
-   * @return	as output
+   * 
    */
-    com.fasterxml.jackson.databind.JsonNode updateModelEntityTypes(String name, com.fasterxml.jackson.databind.JsonNode input);
+    void updateModelEntityTypes(com.fasterxml.jackson.databind.JsonNode input);
 
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesCommand.java
@@ -134,6 +134,7 @@ public class CreateGranularPrivilegesCommand implements Command, UndoableCommand
         final String adminRole = "data-hub-admin";
         final String clearUserDataRole = "hub-central-clear-user-data";
         final String developerRole = "data-hub-developer";
+        final String hubCentralEntityModelWriterRole = "hub-central-entity-model-writer";
 
         List<Privilege> list = new ArrayList<>();
         list.add(buildPrivilege(client, "admin-database-clear-" + stagingDbName, "http://marklogic.com/xdmp/privileges/admin/database/clear/$$database-id(" + stagingDbName + ")",
@@ -144,9 +145,9 @@ public class CreateGranularPrivilegesCommand implements Command, UndoableCommand
             "clear-data-hub-JOBS", existingPrivilegeNames, adminRole, clearUserDataRole));
 
         list.add(buildPrivilege(client, "admin-database-index-" + stagingDbName, "http://marklogic.com/xdmp/privileges/admin/database/index/$$database-id(" + stagingDbName + ")",
-            "STAGING-index-editor", existingPrivilegeNames, developerRole));
+            "STAGING-index-editor", existingPrivilegeNames, developerRole, hubCentralEntityModelWriterRole));
         list.add(buildPrivilege(client, "admin-database-index-" + finalDbName, "http://marklogic.com/xdmp/privileges/admin/database/index/$$database-id(" + finalDbName + ")",
-            "FINAL-index-editor", existingPrivilegeNames, developerRole));
+            "FINAL-index-editor", existingPrivilegeNames, developerRole, hubCentralEntityModelWriterRole));
         list.add(buildPrivilege(client, "admin-database-index-" + jobsDbName, "http://marklogic.com/xdmp/privileges/admin/database/index/$$database-id(" + jobsDbName + ")",
             "JOBS-index-editor", existingPrivilegeNames, developerRole));
 

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-entity-model-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-entity-model-writer.json
@@ -23,6 +23,21 @@
       "privilege-name": "xdmp:eval",
       "action": "http://marklogic.com/xdmp/privileges/xdmp-eval",
       "kind": "execute"
+    },
+    {
+      "privilege-name": "manage",
+      "action": "http://marklogic.com/xdmp/privileges/manage",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "protect-path",
+      "action": "http://marklogic.com/xdmp/privileges/protect-path",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "add-query-rolesets",
+      "action": "http://marklogic.com/xdmp/privileges/add-query-rolesets",
+      "kind": "execute"
     }
   ]
 }

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelEntityTypes.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelEntityTypes.api
@@ -1,19 +1,10 @@
 {
-  "functionName" : "updateModelEntityTypes",
-  "params" : [ {
-    "name" : "name",
-    "datatype" : "string",
-    "desc" : "The name of the model"
-  }, {
-    "name" : "input",
-    "datatype" : "jsonDocument",
-    "$javaClass" : "com.fasterxml.jackson.databind.JsonNode",
-    "schema" : {
-      "$ref" : "../../models/ModelDefinitions.v1.json"
+  "functionName": "updateModelEntityTypes",
+  "params": [
+    {
+      "name": "input",
+      "datatype": "jsonDocument",
+      "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
     }
-  } ],
-  "return" : {
-    "datatype" : "jsonDocument",
-    "$javaClass" : "com.fasterxml.jackson.databind.JsonNode"
-  }
+  ]
 }

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelEntityTypes.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelEntityTypes.sjs
@@ -18,16 +18,29 @@
 const ds = require("/data-hub/5/data-services/ds-utils.sjs");
 const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
 
-var name;
-var input = fn.head(xdmp.fromJSON(input));
+var input = JSON.parse(input);
 
-const uri = entityLib.getModelUri(name);
-if (!fn.docAvailable(uri)) {
-  ds.throwBadRequest("Could not find model with name: " + name);
+if (!input || !Array.isArray(input)) {
+  ds.throwBadRequest("Valid array input required.");
 }
 
-const model = cts.doc(uri).toObject();
-model.definitions = input;
-entityLib.writeModel(name, model);
+input.forEach(entry => {
+  const entityName = entry["entityName"];
+  if (!entityName) {
+    ds.throwBadRequest("Must specify an entity name.");
+  }
 
-model;
+  const modelDefinition = entry["modelDefinition"];
+  if (!modelDefinition) {
+    ds.throwBadRequest(`Must specify a model definition for entity: ${entityName}`);
+  }
+
+  const uri = entityLib.getModelUri(entityName);
+  if (!fn.docAvailable(uri)) {
+    ds.throwBadRequest("Could not find model with name: " + entityName);
+  }
+
+  const model = cts.doc(uri).toObject();
+  model.definitions = modelDefinition;
+  entityLib.writeModel(entityName, model);
+});

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesTest.java
@@ -68,10 +68,12 @@ public class CreateGranularPrivilegesTest extends HubTestBase {
         p = resourceMapper.readResource(mgr.getAsJson("admin-database-index-data-hub-STAGING", "kind", "execute"), Privilege.class);
         assertEquals("http://marklogic.com/xdmp/privileges/admin/database/index/" + stagingDbId, p.getAction());
         assertEquals("data-hub-developer", p.getRole().get(0));
+        assertEquals("hub-central-entity-model-writer", p.getRole().get(1));
 
         p = resourceMapper.readResource(mgr.getAsJson("admin-database-index-data-hub-FINAL", "kind", "execute"), Privilege.class);
         assertEquals("http://marklogic.com/xdmp/privileges/admin/database/index/" + finalDbId, p.getAction());
         assertEquals("data-hub-developer", p.getRole().get(0));
+        assertEquals("hub-central-entity-model-writer", p.getRole().get(1));
 
         p = resourceMapper.readResource(mgr.getAsJson("admin-database-index-data-hub-JOBS", "kind", "execute"), Privilege.class);
         assertEquals("http://marklogic.com/xdmp/privileges/admin/database/index/" + jobsDbId, p.getAction());


### PR DESCRIPTION
### Description
* Changed updateModelEntityTypes endpoint from
`PUT /{modelName}/entityTypes to PUT /entityTypes` with request body
```
[
   {
      "entityName":"string",
      "modelDefinition":{}
   }
]
```
* hub-central-entity-model-writer role can now deploy protected-paths, query-rolesets and database indexes.
* Updated Model Controller test to use hub-central-entity-model-writer role.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

