### PR TITLE
DHFPROD-5204: backend - adding tests to creating primaryKey value

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/entities/entity-search-lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/entities/entity-search-lib.sjs
@@ -68,7 +68,7 @@ function addPropertiesToSearchResponse(entityName, searchResponse, propertiesToD
             result.entityProperties.push(getPropertyValues(parentProperty, entityInstance));
             result.primaryKey = getPrimaryValue(entityInstance, entityDef);
 
-            // no primaryKey in entity instance, so use URI
+            // no primaryKey in entityInst / entityDef, so use URI
             if (result.primaryKey === null) {
               result.primaryKey = {
                 "propertyPath": "uri",
@@ -298,9 +298,9 @@ function getPrimaryValue(entityInstance, entityDefinition) {
     let primaryKey = entityDefinition.primaryKey;
 
     if (entityInstance.hasOwnProperty(primaryKey)) {
-      let primaryKeyValue = entityInstance[primaryKey]
+      let primaryKeyValue = entityInstance[primaryKey];
 
-      if (primaryKeyValue === null || primaryKeyValue === "") {
+      if (primaryKeyValue === null || String(primaryKeyValue).trim().length === 0) {
         return null;
       } else {
         primaryKeyData.propertyPath = primaryKey;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/addPropertiesToSearchResponse.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/addPropertiesToSearchResponse.sjs
@@ -422,6 +422,10 @@ function verifyPrimaryKeyWithDefinedEntities() {
       {
         "index": 2,
         "uri": "/content/sally.json",
+      },
+      {
+        "index": 3,
+        "uri": "/content/tim.json",
       }
     ]
   };
@@ -430,7 +434,9 @@ function verifyPrimaryKeyWithDefinedEntities() {
     test.assertEqual(101, response.results[0].primaryKey.propertyValue),
     test.assertEqual("customerId", response.results[0].primaryKey.propertyPath),
     test.assertEqual(101, response.results[1].primaryKey.propertyValue),
-    test.assertEqual("customerId", response.results[1].primaryKey.propertyPath)
+    test.assertEqual("customerId", response.results[1].primaryKey.propertyPath),
+    test.assertEqual("uri", response.results[2].primaryKey.propertyPath, "primaryKey is an empty string, so use uri"),
+    test.assertEqual("/content/tim.json", response.results[2].primaryKey.propertyValue)
   ];
 }
 

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/test-data/content/tim.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/test-data/content/tim.json
@@ -1,0 +1,13 @@
+{
+  "envelope": {
+    "instance": {
+      "Customer": {
+        "customerId": " ",
+        "name": "Tim Lee",
+        "nicknames": [
+          "timmy"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description
Adds handling for empty and null primaryKeys in the backend. Also added an empty primaryKey test. This is in addition to merged PR https://github.com/marklogic/marklogic-data-hub/pull/4132


#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

