### PR TITLE
DHFPROD-5112: Display default properties for "all entities" search results

### DIFF
--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/EntitySearchManager.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/EntitySearchManager.java
@@ -104,7 +104,9 @@ public class EntitySearchManager {
                 // We have some awkwardness here where the input is 'entityName', but as of 5.3.0, the "entityTypeIds"
                 // property is capturing entity names, which are expected to double as collection names as well
                 ServerTransform searchResultsTransform = new ServerTransform("hubEntitySearchTransform");
-                searchResultsTransform.put("entityName", entityTypeCollections[0]);
+                if(entityTypeCollections.length == 1) {
+                    searchResultsTransform.put("entityName", entityTypeCollections);
+                }
                 searchResultsTransform.put("propertiesToDisplay", searchQuery.getPropertiesToDisplay());
                 rcQueryDef.setResponseTransform(searchResultsTransform);
             }

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/entity-search.js
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/entity-search.js
@@ -8,6 +8,10 @@ export const entitySearch = {
     {
       "index": 1,
       "uri": "/Customer/Cust1.json",
+      "primaryKey": {
+        "propertyPath": "customerId",
+        "propertyValue": 101
+      },
       "path": "fn:doc(\"/Customer/Cust1.json\")",
       "score": 0,
       "confidence": 0,
@@ -230,6 +234,10 @@ export const entitySearch = {
     {
       "index": 2,
       "uri": "/Customer/Cust2.json",
+      "primaryKey": {
+        "propertyPath": "customerId",
+        "propertyValue": 102
+      },
       "path": "fn:doc(\"/Customer/Cust2.json\")",
       "score": 0,
       "confidence": 0,
@@ -452,6 +460,10 @@ export const entitySearch = {
     {
       "index": 3,
       "uri": "/Customer/Cust3.json",
+      "primaryKey": {
+        "propertyPath": "customerId",
+        "propertyValue": 103
+      },
       "path": "fn:doc(\"/Customer/Cust3.json\")",
       "score": 0,
       "confidence": 0,
@@ -674,6 +686,10 @@ export const entitySearch = {
     {
       "index": 4,
       "uri": "/Customer/Cust4.json",
+      "primaryKey": {
+        "propertyPath": "customerId",
+        "propertyValue": 104
+      },
       "path": "fn:doc(\"/Customer/Cust4.json\")",
       "score": 0,
       "confidence": 0,
@@ -898,6 +914,10 @@ export const entitySearch = {
     {
       "index": 5,
       "uri": "/Customer/Cust5.json",
+      "primaryKey": {
+        "propertyPath": "customerId",
+        "propertyValue": 105
+      },
       "path": "fn:doc(\"/Customer/Cust5.json\")",
       "score": 0,
       "confidence": 0,
@@ -1695,6 +1715,200 @@ export const entityPropertyDefinitions =  [
   }
 ]
 
+export const entitySearchAllEntities = {
+  "snippet-format": "snippet",
+  "total": 5,
+  "start": 1,
+  "page-length": 10,
+  "selected": "include",
+  "results": [
+    {
+      "index": 1,
+      "identifier": {
+        "propertyPath": "identifier",
+        "propertyValue": 101
+      },
+      "primaryKey": {
+        "propertyPath": "customerId",
+        "propertyValue": 101
+      },
+      "uri": "/Customer/Cust1.json",
+      "entityName": "Customer",
+      "createdOn": "2020-06-21T23:44:46.225063-07:00",
+      "path": "fn:doc(\"/Customer/Cust1.json\")",
+      "score": 0,
+      "confidence": 0,
+      "fitness": 0,
+      "href": "/v1/documents?uri=%2FCustomer%2FCust1.json",
+      "mimetype": "application/json",
+      "format": "json",
+      "matches": [
+        {
+          "path": "fn:doc(\"/Customer/Cust1.json\")/object-node()",
+          "match-text": [
+            "Customer 0.0.1 http://example.org/ Carmella Hardin Carm din Whitwell Place Ellerslie Georgia 52239 1718 Whitwell Place2 Ellerslie2 Georgia 52239 1718 Anna Court Stewart Kansas 62601"
+          ]
+        }
+      ],
+      "extracted": {
+        "kind": "array",
+        "content": [
+          {
+            "headers": {}
+          },
+          {
+            "Customer": {
+              "customerId": 101,
+              "name": "Carmella Hardin",
+              "nicknames": [
+                "Carm",
+                "din"
+              ],
+              "shipping": [
+                {
+                  "Address": {
+                    "street": "Whitwell Place",
+                    "city": "Ellerslie",
+                    "state": "Georgia",
+                    "zip": {
+                      "Zip": {
+                        "fiveDigit": "52239",
+                        "plusFour": "1718"
+                      }
+                    }
+                  }
+                },
+                {
+                  "Address": {
+                    "street": "Whitwell Place2",
+                    "city": "Ellerslie2",
+                    "state": "Georgia",
+                    "zip": {
+                      "Zip": {
+                        "fiveDigit": "52239",
+                        "plusFour": "1718"
+                      }
+                    }
+                  }
+                }
+              ],
+              "billing": {
+                "Address": {
+                  "street": "Anna Court",
+                  "city": "Stewart",
+                  "state": "Kansas",
+                  "zip": {
+                    "Zip": {
+                      "fiveDigit": "62601",
+                      "plusFour": "6783"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "Address": {
+              "Shipping": {
+                "Street": "Whitwell Place",
+                "City": "Ellerslie",
+                "State": "Georgia",
+                "Postal": "52239-1718"
+              }
+            }
+          },
+          {
+            "Address": {
+              "Shipping": {
+                "Street": "Whitwell Place2",
+                "City": "Ellerslie2",
+                "State": "Georgia",
+                "Postal": "52239-1718"
+              }
+            }
+          },
+          {
+            "Address": {
+              "Billing": {
+                "Street": "Anna Court",
+                "City": "Stewart",
+                "State": "Kansas",
+                "Postal": "62601-6783"
+              }
+            }
+          }
+        ]
+      }
+    }]}
+
+
+export const entityDefArray = [{
+  info: {
+    baseUri: "http://example.org/",
+    title: "Customer",
+    version: "0.0.1"
+  },
+  name: "Customer",
+  pathIndex: [],
+  primaryKey: "customerId",
+  properties: [
+    {
+      collation: undefined,
+      datatype: "integer",
+      name: "customerId",
+      ref: ""
+    },
+    {
+      collation: "http://marklogic.com/collation/codepoint",
+      datatype: "string",
+      name: "name",
+      ref: ""
+    },
+    {
+      collation: undefined,
+      datatype: "array",
+      name: "nicknames",
+      ref: ""
+    },
+    {
+      collation: undefined,
+      datatype: "array",
+      name: "shipping",
+      ref: "Address"
+    },
+    {
+      collation: undefined,
+      datatype: "entity",
+      name: "billing",
+      ref: "Address"
+    },
+    {
+      collation: undefined,
+      datatype: "date",
+      name: "birthDate",
+      ref: ""
+    },
+    {
+      collation: undefined,
+      datatype: "string",
+      name: "status",
+      ref: ""
+    },
+    {
+      collation: undefined,
+      datatype: "date",
+      name: "customerSince",
+      ref: ""
+    },
+    {
+      collation: undefined,
+      datatype: "array",
+      name: "orders",
+      ref: "Order"
+    }],
+  rangeIndex: []
+}]
+  
 
 
 

--- a/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.module.scss
@@ -22,3 +22,12 @@
   
   
   
+.nestedTable{
+    padding: 30px;
+    margin: 0px;
+  }
+
+.redirectIcons a {
+  padding: 8px;
+  color: #44499C;
+}

--- a/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.test.tsx
@@ -1,19 +1,24 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import {entitySearch, entityPropertyDefinitions, selectedPropertyDefinitions} from "../../assets/mock-data/entity-search";
+import { render, fireEvent, waitForElement } from '@testing-library/react';
+import {entitySearch, entityPropertyDefinitions, selectedPropertyDefinitions, entityDefArray, entitySearchAllEntities} from "../../assets/mock-data/entity-search";
 import ResultsTabularView from "./results-tabular-view";
 import userEvent from "@testing-library/user-event";
+import { BrowserRouter as Router } from 'react-router-dom';
 
 describe("Results Table view component", () => {
-    test('Results table with data renders', () => {
-        const {  getByText } = render(
+    test('Results table with data renders', async () => {
+        const {  getByText, getByTestId } = render(
+            <Router>
                 <ResultsTabularView
                     data={entitySearch.results}
                     entityPropertyDefinitions={entityPropertyDefinitions}
                     selectedPropertyDefinitions={selectedPropertyDefinitions}
+                    entityDefArray={entityDefArray}
                     columns={[]}
                     hasStructured={false}
+                    selectedEntities={['Customer']}
                 />
+                </Router>
         )
         // Check table column headers are rendered
         expect(getByText('customerId')).toBeInTheDocument();
@@ -21,7 +26,7 @@ describe("Results Table view component", () => {
         expect(getByText('nicknames')).toBeInTheDocument();
         expect(getByText('shipping')).toBeInTheDocument();
         expect(getByText('billing')).toBeInTheDocument();
-
+        expect(getByText('Detail View')).toBeInTheDocument();
 
         //check table data is rendered correctly
         expect(getByText('101')).toBeInTheDocument();
@@ -31,17 +36,33 @@ describe("Results Table view component", () => {
         expect(getByText('Whitwell Place2')).toBeInTheDocument();
         expect(getByText('Ellerslie')).toBeInTheDocument();
         expect(getByText('Ellerslie2')).toBeInTheDocument();
+        expect(getByTestId('101-detailOnSeparatePage')).toBeInTheDocument();
+        expect(getByTestId('101-sourceOnSeparatePage')).toBeInTheDocument();
+        
+        //Check if the tooltip on 'Detail on separate page' icon works fine.
+        fireEvent.mouseOver(getByTestId('101-detailOnSeparatePage'))
+        await(waitForElement(() => (getByText('Show detail on a separate page'))))
+
+        //Check if the tooltip on 'source on separate page' icon works fine.
+        fireEvent.mouseOver(getByTestId('101-sourceOnSeparatePage'))
+        await(waitForElement(() => (getByText('Show source on a separate page'))))
+
+        //Validation of routing to detail page needs to be done in e2e tests
+
     });
 
     test('Result table with no data renders', () => {
         const { getByText } = render(
+            <Router>
                  <ResultsTabularView
                     data={[]}
                     entityPropertyDefinitions={[]}
                     selectedPropertyDefinitions={[]}
+                    entityDefArray={[]}
                     columns={[]}
                     hasStructured={false}
                 />
+                </Router>
         )
         // Check for Empty Table
         expect(getByText(/No Data/i)).toBeInTheDocument();
@@ -49,13 +70,16 @@ describe("Results Table view component", () => {
 
     test('Array data renders properly', () => {
         const {  getByText, queryByText } = render(
+            <Router>
                 <ResultsTabularView
                     data={entitySearch.results}
                     entityPropertyDefinitions={entityPropertyDefinitions}
                     selectedPropertyDefinitions={selectedPropertyDefinitions}
                     columns={[]}
                     hasStructured={false}
+                    selectedEntities={['Customer']}
                 />
+            </Router>
         )
 
         expect(queryByText('Carmdin')).toBeNull();
@@ -65,5 +89,47 @@ describe("Results Table view component", () => {
         expect(getByText('Carm')).toContainHTML('<div style="text-overflow: ellipsis; overflow: hidden;">Carm</div>');
         expect(getByText('din')).toContainHTML('<div style="text-overflow: ellipsis; overflow: hidden;">din</div>');
         expect(getByText('Carm').closest('td')).toEqual(getByText('din').closest('td'))
+    });
+
+    test('Results table with data renders when All Entities option is selected', async () => {
+        const {  getByText, getByTestId } = render(
+            <Router>
+                <ResultsTabularView
+                    data={entitySearchAllEntities.results}
+                    entityPropertyDefinitions={[]}
+                    selectedPropertyDefinitions={[]}
+                    entityDefArray={entityDefArray}
+                    columns={[]}
+                    hasStructured={false}
+                    selectedEntities={[]}
+                />
+                </Router>
+        )
+
+        // Check table column headers are rendered
+        expect(getByText('Identifier')).toBeInTheDocument();
+        expect(getByText('Entity')).toBeInTheDocument();
+        expect(getByText('File Type')).toBeInTheDocument();
+        expect(getByText('Created')).toBeInTheDocument();
+        expect(getByText('Detail View')).toBeInTheDocument();
+
+        //check table data is rendered correctly
+        expect(getByText('101')).toBeInTheDocument();
+        expect(getByTestId('Customer-101')).toBeInTheDocument();
+        expect(getByTestId('json-101')).toBeInTheDocument();
+        expect(getByText('2020-06-21 23:44')).toBeInTheDocument();
+        expect(getByTestId('101-detailOnSeparatePage')).toBeInTheDocument();
+        expect(getByTestId('101-sourceOnSeparatePage')).toBeInTheDocument();
+        
+        //Check if the tooltip on 'Detail on separate page' icon works fine.
+        fireEvent.mouseOver(getByTestId('101-detailOnSeparatePage'))
+        await(waitForElement(() => (getByText('Show detail on a separate page'))))
+
+        //Check if the tooltip on 'source on separate page' icon works fine.
+        fireEvent.mouseOver(getByTestId('101-sourceOnSeparatePage'))
+        await(waitForElement(() => (getByText('Show source on a separate page'))))
+
+        //Validation of routing to detail page needs to be done in e2e tests
+
     });
 })

--- a/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.tsx
+++ b/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.tsx
@@ -6,6 +6,11 @@ import styles from './results-tabular-view.module.scss';
 import ColumnSelector from '../../components/column-selector/column-selector';
 import { Tooltip } from 'antd';
 import { SearchContext } from '../../util/search-context';
+import { tableParser } from '../../util/data-conversion';
+import { Link } from 'react-router-dom';
+import { faExternalLinkAlt, faCode } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { dateConverter } from '../../util/date-conversion';
 
 interface Props {
     data: any;
@@ -14,6 +19,44 @@ interface Props {
     columns: any;
     hasStructured: boolean;
 }
+
+const DEFAULT_ALL_ENTITIES_HEADER = [
+    {
+        title: 'Identifier',
+        dataIndex: 'identifier',
+        key: '0-i',
+        visible: true,
+        width: 150
+    },
+    {
+        title: 'Entity',
+        dataIndex: 'entityName',
+        key: '0-1',
+        visible: true,
+        width: 150
+    },
+    {
+        title: 'File Type',
+        key: '0-2',
+        dataIndex: 'fileType',
+        visible: true,
+        width: 150
+    },
+    {
+        title: 'Created',
+        dataIndex: 'createdOn',
+        key: '0-c',
+        visible: true,
+        width: 150
+    },
+    {
+        title: 'Detail View',
+        dataIndex: 'detailView',
+        key: '0-d',
+        visible: true,
+        width: 150
+    }
+];
 
 const ResultsTabularView = (props) => {
     const [popoverVisibility, setPopoverVisibility] = useState<boolean>(false);
@@ -25,6 +68,8 @@ const ResultsTabularView = (props) => {
 
     const authorityService = useContext(AuthoritiesContext);
     const canExportQuery = authorityService.canExportEntityInstances();
+    let counter = 0;
+    let parsedPayload = tableParser(props);
 
     let selectedTableColumns = props.selectedPropertyDefinitions;
 
@@ -86,10 +131,72 @@ const ResultsTabularView = (props) => {
         return columns;
     }
 
-    const tableHeaders = tableHeaderRender(selectedTableColumns);
+
+    const updatedTableHeader = () => {
+        let header = tableHeaderRender(selectedTableColumns);
+        let detailView = {
+            title: 'Detail View',
+            dataIndex: 'detailView',
+            key: '0-d'
+        }
+        header.push(detailView);
+        return header;
+    }
+
+    const tableHeaders = props.selectedEntities?.length === 0 ? DEFAULT_ALL_ENTITIES_HEADER : updatedTableHeader();
+
 
     const tableDataRender = (item) => {
         let dataObj = {};
+        let primaryKeyValue = item.primaryKey?.propertyValue;
+        let isUri = item.primaryKey?.propertyPath === 'uri';
+        let uri = encodeURIComponent(item.uri);
+        let path = { pathname: `/detail/${isUri ? '-' : primaryKeyValue}/${uri}` };
+        let options = {};
+        let detailView =
+            <div className={styles.redirectIcons}>
+                <Link to={{ pathname: `${path.pathname}`, state: { selectedValue: 'instance' } }} id={'instance'}
+                    data-cy='instance'>
+                    <Tooltip title={'Show detail on a separate page'}><FontAwesomeIcon icon={faExternalLinkAlt} size="sm" data-testid={`${primaryKeyValue}-detailOnSeparatePage`} /></Tooltip>
+                </Link>
+                <Link to={{ pathname: `${path.pathname}`, state: { selectedValue: 'source' } }} id={'source'}
+                    data-cy='source'>
+                    <Tooltip title={'Show source on a separate page'}><FontAwesomeIcon icon={faCode} size="sm" data-testid={`${primaryKeyValue}-sourceOnSeparatePage`} /></Tooltip>
+                </Link>
+            </div>
+        if (props.selectedEntities?.length === 0) {
+            let itemIdentifier = item.identifier?.propertyValue;
+            let itemEntityName = item.entityName;
+            let document = item.uri.split('/')[item.uri.split('/').length - 1];
+            let createdOn = item.createdOn;
+            options = {
+                primaryKey: primaryKeyValue,
+                identifier: <Tooltip title={isUri && item.uri}>{isUri ? '.../' + document : itemIdentifier}</Tooltip>,
+                entityName: <span data-testid={`${itemEntityName}-${primaryKeyValue}`}>{itemEntityName}</span>,
+                fileType: <span data-testid={`${item.format}-${primaryKeyValue}`}>{item.format}</span>,
+                createdOn: dateConverter(createdOn),
+                uri: item.uri,
+                primaryKeyPath: path,
+                detailView: detailView
+            }
+        } else {
+            options = {
+                primaryKey: primaryKeyValue,
+                uri: item.uri,
+                primaryKeyPath: path,
+                detailView: detailView
+            }
+        }
+
+        dataObj = { ...dataObj, ...options };
+        if (item?.hasOwnProperty('entityProperties')) {
+            generateTableData(item.entityProperties, dataObj)
+        }
+
+        return dataObj;
+    }
+
+    const generateTableData = (item, dataObj = {}) => {
         for (let subItem of item) {
             if (!Array.isArray(subItem)) {
                 if (!Array.isArray(subItem.propertyValue) || typeof (subItem.propertyValue[0]) === 'string') {
@@ -97,19 +204,20 @@ const ResultsTabularView = (props) => {
                 } else {
                     let dataObjArr: any[] = [];
                     for (let el of subItem.propertyValue) {
-                        dataObjArr.push(tableDataRender(el));
+                        dataObjArr.push(generateTableData(el));
                     }
                     dataObj[subItem.propertyPath] = dataObjArr;
                 }
             } else {
-                return tableDataRender(subItem)
+                return generateTableData(subItem)
             }
         }
+
         return dataObj;
     }
 
     const dataSource = props.data.map((item) => {
-        return tableDataRender(item.entityProperties);
+        return tableDataRender(item);
     });
 
     useEffect(() => {
@@ -117,6 +225,58 @@ const ResultsTabularView = (props) => {
             setSelectedTableProperties(props.columns)
         }
     }, [props.columns])
+    const expandedRowRender = (rowId) => {
+
+        const nestedColumns = [
+            { title: 'Property', dataIndex: 'property', width: '33%' },
+            { title: 'Value', dataIndex: 'value', width: '34%' },
+            { title: 'View', dataIndex: 'view', width: '33%' },
+        ];
+
+        let nestedData: any[] = [];
+        const parseJson = (obj: Object) => {
+            let parsedData = new Array();
+            for (var i in obj) {
+                if (obj[i] !== null && typeof (obj[i]) === "object") {
+                    parsedData.push({
+                        key: counter++,
+                        property: i,
+                        children: parseJson(obj[i]),
+                        view: <Link to={{ pathname: `${rowId.primaryKeyPath.pathname}`, state: { id: obj[i] } }}
+                            data-cy='nested-instance'>
+                            <Tooltip title={'Show nested detail on a separate page'}><FontAwesomeIcon icon={faExternalLinkAlt}
+                                size="sm" /></Tooltip>
+                        </Link>
+                    });
+                } else {
+                    parsedData.push({
+                        key: counter++,
+                        property: i,
+                        value: typeof obj[i] === 'boolean' ? obj[i].toString() : obj[i],
+                        view: null
+                    });
+                }
+            }
+            return parsedData;
+        }
+
+        let index: string = '';
+        for (let i in parsedPayload.data) {
+            if (parsedPayload.data[i].primaryKey == rowId.primaryKey) {
+                index = i;
+            }
+        }
+
+        nestedData = parseJson(parsedPayload.data[index].itemEntityProperties[0]);
+
+        return <MLTable
+            rowKey="key"
+            columns={nestedColumns}
+            dataSource={nestedData}
+            pagination={false}
+            className={styles.nestedTable}
+        />
+    }
 
     return (
         <>
@@ -124,17 +284,20 @@ const ResultsTabularView = (props) => {
                 <div className={styles.queryExport}>
                     {canExportQuery && <QueryExport hasStructured={props.hasStructured} columns={props.columns} />}
                 </div>
-                <div className={styles.columnSelector} data-cy="column-selector">
+                {props.selectedEntities?.length !== 0 ? <div className={styles.columnSelector} data-cy="column-selector">
                     <ColumnSelector popoverVisibility={popoverVisibility} setPopoverVisibility={setPopoverVisibility} entityPropertyDefinitions={props.entityPropertyDefinitions} selectedPropertyDefinitions={props.selectedPropertyDefinitions} setColumnSelectorTouched={props.setColumnSelectorTouched} columns={props.columns} />
-                </div>
+                </div> : ''}
+                
             </div>
             <div className={styles.tabular}>
-                <MLTable bordered
-                    data-testid='result-table'
-                    dataSource={dataSource}
-                    columns={tableHeaders}
-                    pagination={false}
-                />
+        <MLTable bordered
+           data-testid='result-table'
+           rowKey='uri'
+           dataSource={dataSource}
+           columns={tableHeaders}
+           expandedRowRender={expandedRowRender}
+           pagination={false}
+        />
             </div>
         </>
     )

--- a/marklogic-data-hub-central/ui/src/pages/Browse.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Browse.tsx
@@ -282,13 +282,15 @@ const Browse: React.FC<Props> = ({ location }) => {
               <div className={styles.fixedView} >
                 {tableView ?
                   <div>
-                    <ResultsTabularView
-                      data={data}
-                      entityPropertyDefinitions={entityPropertyDefinitions}
-                      selectedPropertyDefinitions={selectedPropertyDefinitions}
-                      columns={columns}
-                      setColumnSelectorTouched={setColumnSelectorTouched}
-                    />
+                      <ResultsTabularView
+                          data={data}
+                          entityPropertyDefinitions = {entityPropertyDefinitions}
+                          selectedPropertyDefinitions = {selectedPropertyDefinitions}
+                          entityDefArray={entityDefArray}
+                          columns={columns}
+                          selectedEntities={searchOptions.entityTypeIds}
+                          setColumnSelectorTouched={setColumnSelectorTouched}
+                      />
                   </div>
                   : <SearchResults data={data} entityDefArray={entityDefArray} />
                 }

--- a/marklogic-data-hub-central/ui/src/util/data-conversion.tsx
+++ b/marklogic-data-hub-central/ui/src/util/data-conversion.tsx
@@ -306,12 +306,12 @@ export const tableParser = (props) => {
 
       // Parameters for both JSON and XML.
       //Get entity definition.
-      if (itemEntityName.length && props.entityDefArray.length) {
+      if (itemEntityName.length && props.entityDefArray?.length) {
         entityDef = props.entityDefArray.find(entity => entity.name === itemEntityName[0]);
       }
 
       //Get primary key if exists or set it to undefined.
-      if (entityDef.primaryKey.length !== 0) {
+      if (entityDef.primaryKey?.length !== 0) {
         primaryKeyValue = encodeURIComponent(itemEntityProperties[0][entityDef.primaryKey]);
         primaryKeys.indexOf(entityDef.primaryKey) === -1 && primaryKeys.push(entityDef.primaryKey);
       } else {

--- a/marklogic-data-hub/src/main/resources/ml-modules/transforms/hubEntitySearchTransform.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/transforms/hubEntitySearchTransform.sjs
@@ -20,10 +20,10 @@ const entitySearchLib = require("/data-hub/5/entities/entity-search-lib.sjs");
 
 // Expects JSON content
 function transform(context, params, content) {
-  if(!params.entityName) {
-    ds.throwBadRequest("entityName is required to generate search results containing entity properties");
+  let entityName = null;
+  if(params.entityName) {
+    entityName = params.entityName;
   }
-  const entityName = params.entityName;
   const propertiesToDisplay = params.propertiesToDisplay;
 
   const contentObject = content.toObject();

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/addPropertiesToSearchResponse.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/addPropertiesToSearchResponse.sjs
@@ -464,10 +464,69 @@ function verifyPrimaryKeyWithoutDefinedEntities() {
   ];
 }
 
+function verifyPropertiesForAllEntitiesOption() {
+  const response = {
+    "snippet-format": "snippet",
+    "total": 2,
+    "results": [
+      {
+        "index": 1,
+        "uri": "/content/jane.json",
+      },
+      {
+        "index": 2,
+        "uri": "/content/sally.json",
+      }
+    ]
+  };
+  const entityName = null; //Indicates that user has chosen 'All Entities' option
+  
+  entitySearchLib.addPropertiesToSearchResponse(entityName, response);
+  const allEntitiesProps = response.results[0];
+  return([
+  test.assertEqual(true, allEntitiesProps.hasOwnProperty('identifier')),
+  test.assertEqual(true, allEntitiesProps.hasOwnProperty('primaryKey')),
+  test.assertEqual(true, allEntitiesProps.hasOwnProperty('entityName')),
+  test.assertEqual(true, allEntitiesProps.hasOwnProperty('createdOn')),
+  test.assertEqual("identifier", allEntitiesProps.identifier.propertyPath),
+  test.assertEqual(101, allEntitiesProps.identifier.propertyValue),
+  test.assertEqual("Customer", allEntitiesProps.entityName)
+  ]);
+}
+
+function verifyIdentifierWithoutDefinedPrimaryKey() {
+  const response = {
+    "snippet-format": "snippet",
+    "total": 2,
+    "results": [
+      {
+        "index": 1,
+        "uri": "/content/sallyAddress.json",
+      },
+      {
+        "index": 2,
+        "uri": "/content/janeAddress.json",
+      }
+    ]
+  };
+  const entityName = null;  //Indicates that user has chosen 'All Entities' option
+  entitySearchLib.addPropertiesToSearchResponse(entityName, response);
+  return([
+    test.assertEqual("/content/sallyAddress.json", response.results[0].identifier.propertyValue),
+    test.assertEqual("identifier", response.results[0].identifier.propertyPath),
+    test.assertEqual("uri", response.results[0].primaryKey.propertyPath),
+    test.assertEqual("/content/janeAddress.json", response.results[1].identifier.propertyValue),
+    test.assertEqual("identifier", response.results[1].identifier.propertyPath),
+    test.assertEqual("uri", response.results[1].primaryKey.propertyPath)
+  ]);
+}
+
 []
   .concat(verifySimpleSelectedPropertiesResults())
   .concat(verifyStructuredFirstLevelSelectedPropertiesResults())
   .concat(verifyStructuredSelectedPropertiesResults())
   .concat(verifyResultsWithoutSelectedProperties())
   .concat(verifyPrimaryKeyWithDefinedEntities())
-  .concat(verifyPrimaryKeyWithoutDefinedEntities());
+  .concat(verifyPrimaryKeyWithoutDefinedEntities())
+  .concat(verifyPropertiesForAllEntitiesOption())
+  .concat(verifyIdentifierWithoutDefinedPrimaryKey());


### PR DESCRIPTION
#### Description
This PR contains changes for the tickets mentioned below.
DHFPROD-5112: Display default properties for "all entities" search results
DHFPROD-5152: Detail view column in the tabular view is missing
DHFPROD-5101: Expanded row render in the table view is missing after changes to the new table

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

