### PR TITLE
DHFPROD-4997:Fix deployment of non-ootb ingestion steps

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/customStep.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/customStep.sjs
@@ -21,7 +21,7 @@ const dataHub = DataHubSingleton.instance();
 const collections = ['http://marklogic.com/data-hub/steps/custom', 'http://marklogic.com/data-hub/steps'];
 const databases = [dataHub.config.STAGINGDATABASE, dataHub.config.FINALDATABASE];
 const permissions = [xdmp.permission(dataHub.consts.DATA_HUB_CUSTOM_WRITE_ROLE, 'update'), xdmp.permission(dataHub.consts.DATA_HUB_CUSTOM_READ_ROLE, 'read')];
-const requiredProperties = ['name', 'selectedSource', 'stepDefinitionName'];
+const requiredProperties = ['name', 'selectedSource'];
 
 function getNameProperty() {
   return 'name';

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/step/saveStep.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/step/saveStep.sjs
@@ -47,16 +47,22 @@ if (existingStep) {
   if("mapping" === stepDefinitionType){
     stepDefinitionName = "entity-services-mapping";
   }
-  else if("ingestion" === stepDefinitionType){
-    stepDefinitionName = "default-ingestion";
-  }
   else {
-    stepDefinitionName = stepProperties.stepDefinitionName;
+    //if 'stepDefinitionName' is not set for ingestion step, it will be set to 'default-ingestion'
+    if("ingestion" === stepDefinitionType && !stepProperties.stepDefinitionName){
+      stepDefinitionName = "default-ingestion";
+    }
+    else {
+      stepDefinitionName = stepProperties.stepDefinitionName;
+    }
   }
-
   stepProperties.stepDefinitionName = stepDefinitionName;
   stepProperties.stepDefinitionType = stepDefinitionType;
   stepProperties.stepId = stepName + "-" + stepDefinitionType;
+
+  if(!stepProperties.stepDefinitionName){
+    throw new Error(`Missing required property 'stepDefinitionName' for step: ${stepName}`);
+  }
 
   const stepDef = new Step().getStepByNameAndType(stepDefinitionName, stepDefinitionType);
   if (stepDef != null && stepDef.options != null) {

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/step/manageIngestionStep.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/step/manageIngestionStep.sjs
@@ -28,6 +28,7 @@ expectedStep.provenanceGranularityLevel = "coarse";
 expectedStep.permissions = "data-hub-common,read,data-hub-common,update";
 expectedStep.outputURIReplacement= "abc,'def'";
 expectedStep.batchSize = 100;
+expectedStep.stepDefinitionName = "default-ingestion";
 
 hubJsTest.verifyJson(expectedStep, serviceResponse, assertions);
 hubJsTest.verifyJson(expectedStep, stepService.getStep(stepDefinitionType, stepName), assertions);
@@ -41,10 +42,12 @@ assertions = assertions
 //Remove 'outputURIReplacement' from payload
 info.outputURIPrefix = '/prefix/';
 delete info.outputURIReplacement;
+info.stepDefinitionName = 'custom-ingestion';
 serviceResponse = stepService.saveStep(stepDefinitionType, info);
 
 delete expectedStep.outputURIReplacement;
 expectedStep.outputURIPrefix = '/prefix/';
+expectedStep.stepDefinitionName = 'custom-ingestion';
 
 hubJsTest.verifyJson(expectedStep, serviceResponse, assertions);
 hubJsTest.verifyJson(expectedStep, stepService.getStep(stepDefinitionType, stepName), assertions);


### PR DESCRIPTION
### Description
Fix deployment of non-ootb ingestion steps. Setting the stepDefinitionName to 'default-ingestion' if it is not specified else use the one specified. Currently, the stepDefinitionName is set to 'default-ingestion' no matter the value of 'stepDefinitionName' in the request payload

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

