### PR TITLE
DHFPROD-5286: Processing URIs for a step now uses DS endpoint

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/StepRunnerService.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/StepRunnerService.java
@@ -1,0 +1,131 @@
+package com.marklogic.hub.dataservices;
+
+// IMPORTANT: Do not edit. This file is generated.
+
+import com.marklogic.client.io.Format;
+import java.io.Reader;
+import com.marklogic.client.SessionState;
+import java.util.stream.Stream;
+
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.io.marker.JSONWriteHandle;
+
+import com.marklogic.client.impl.BaseProxy;
+
+/**
+ * Provides a set of operations on the database server
+ */
+public interface StepRunnerService {
+    /**
+     * Creates a StepRunnerService object for executing operations on the database server.
+     *
+     * The DatabaseClientFactory class can create the DatabaseClient parameter. A single
+     * client object can be used for any number of requests and in multiple threads.
+     *
+     * @param db	provides a client for communicating with the database server
+     * @return	an object for executing database operations
+     */
+    static StepRunnerService on(DatabaseClient db) {
+      return on(db, null);
+    }
+    /**
+     * Creates a StepRunnerService object for executing operations on the database server.
+     *
+     * The DatabaseClientFactory class can create the DatabaseClient parameter. A single
+     * client object can be used for any number of requests and in multiple threads.
+     *
+     * The service declaration uses a custom implementation of the same service instead
+     * of the default implementation of the service by specifying an endpoint directory
+     * in the modules database with the implementation. A service.json file with the
+     * declaration can be read with FileHandle or a string serialization of the JSON
+     * declaration with StringHandle.
+     *
+     * @param db	provides a client for communicating with the database server
+     * @param serviceDeclaration	substitutes a custom implementation of the service
+     * @return	an object for executing database operations
+     */
+    static StepRunnerService on(DatabaseClient db, JSONWriteHandle serviceDeclaration) {
+        final class StepRunnerServiceImpl implements StepRunnerService {
+            private DatabaseClient dbClient;
+            private BaseProxy baseProxy;
+
+            private BaseProxy.DBFunctionRequest req_processUris;
+            private BaseProxy.DBFunctionRequest req_runSteps;
+
+            private StepRunnerServiceImpl(DatabaseClient dbClient, JSONWriteHandle servDecl) {
+                this.dbClient  = dbClient;
+                this.baseProxy = new BaseProxy("/data-hub/5/data-services/stepRunner/", servDecl);
+
+                this.req_processUris = this.baseProxy.request(
+                    "processUris.sjs", BaseProxy.ParameterValuesKind.SINGLE_NODE);
+                this.req_runSteps = this.baseProxy.request(
+                    "runSteps.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_NODES);
+            }
+            @Override
+            public SessionState newSessionState() {
+              return baseProxy.newSessionState();
+            }
+
+            @Override
+            public com.fasterxml.jackson.databind.JsonNode processUris(com.fasterxml.jackson.databind.JsonNode inputs) {
+                return processUris(
+                    this.req_processUris.on(this.dbClient), inputs
+                    );
+            }
+            private com.fasterxml.jackson.databind.JsonNode processUris(BaseProxy.DBFunctionRequest request, com.fasterxml.jackson.databind.JsonNode inputs) {
+              return BaseProxy.JsonDocumentType.toJsonNode(
+                request
+                      .withParams(
+                          BaseProxy.documentParam("inputs", false, BaseProxy.JsonDocumentType.fromJsonNode(inputs))
+                          ).responseSingle(false, Format.JSON)
+                );
+            }
+
+            @Override
+            public Stream<Reader> runSteps(Reader endpointState, SessionState session, Reader workUnit) {
+                return runSteps(
+                    this.req_runSteps.on(this.dbClient), endpointState, session, workUnit
+                    );
+            }
+            private Stream<Reader> runSteps(BaseProxy.DBFunctionRequest request, Reader endpointState, SessionState session, Reader workUnit) {
+              return BaseProxy.JsonDocumentType.toReader(
+                request
+                      .withSession("session", session, true)
+                      .withParams(
+                          BaseProxy.documentParam("endpointState", true, BaseProxy.JsonDocumentType.fromReader(endpointState)),
+                          BaseProxy.documentParam("workUnit", false, BaseProxy.JsonDocumentType.fromReader(workUnit))
+                          ).responseMultiple(true, Format.JSON)
+                );
+            }
+        }
+
+        return new StepRunnerServiceImpl(db, serviceDeclaration);
+    }
+    /**
+     * Creates an object to track a session for a set of operations
+     * that require session state on the database server.
+     *
+     * @return	an object for session state
+     */
+    SessionState newSessionState();
+
+  /**
+   * Replacement for the mlRunFlow REST extension; processes the given URIs against the given flow and step
+   *
+   * @param inputs	provides input
+   * @return	as output
+   */
+    com.fasterxml.jackson.databind.JsonNode processUris(com.fasterxml.jackson.databind.JsonNode inputs);
+
+  /**
+   * This is intended to be used by Bulk IO, but a functionName is required to generate a Java interface
+   *
+   * @param endpointState	provides input
+   * @param session	provides input
+   * @param workUnit	provides input
+   * @return	as output
+   */
+    Stream<Reader> runSteps(Reader endpointState, SessionState session, Reader workUnit);
+
+}

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/StepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/StepRunner.java
@@ -67,13 +67,6 @@ public interface StepRunner {
     StepRunner withThreadCount(int threadCount);
 
     /**
-     * Sets the database where flow output data will be persisted to
-     * @param destinationDatabase - the name of the destination database
-     * @return the step runner object
-     */
-    StepRunner withDestinationDatabase(String destinationDatabase);
-
-    /**
      * Sets the options to be passed into the xqy or sjs flow in the $options or options variables of main.
      * @param options - the object map of options as string/object pair
      * @return the step runner object

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/StepRunnerFactory.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/StepRunnerFactory.java
@@ -76,39 +76,21 @@ public class StepRunnerFactory {
 
         stepRunner.withThreadCount(threadCount);
 
-        final String stagingDbName = theHubClient.getDbName(DatabaseKind.STAGING);
-
-
-        if (stepRunner instanceof QueryStepRunner) {
-            String sourceDatabase;
-            if(step.getOptions().get("sourceDatabase") != null) {
-                sourceDatabase = ((TextNode)step.getOptions().get("sourceDatabase")).asText();
+        if (stepRunner instanceof WriteStepRunner) {
+            String targetDatabase;
+            if (step.getOptions().get("targetDatabase") != null) {
+                targetDatabase = ((TextNode) step.getOptions().get("targetDatabase")).asText();
+            } else if (stepDef.getOptions().get("targetDatabase") != null) {
+                targetDatabase = ((TextNode) stepDef.getOptions().get("targetDatabase")).asText();
+            } else {
+                if (StepDefinition.StepDefinitionType.INGESTION.equals(step.getStepDefinitionType())) {
+                    targetDatabase = theHubClient.getDbName(DatabaseKind.STAGING);
+                } else {
+                    targetDatabase = theHubClient.getDbName(DatabaseKind.FINAL);
+                }
             }
-            else if(stepDef.getOptions().get("sourceDatabase") != null) {
-                sourceDatabase = ((TextNode)stepDef.getOptions().get("sourceDatabase")).asText();
-            }
-            else {
-                sourceDatabase = stagingDbName;
-            }
-            ((QueryStepRunner)stepRunner).setSourceDatabase(sourceDatabase);
+            ((WriteStepRunner)stepRunner).withDestinationDatabase(targetDatabase);
         }
-
-        String targetDatabase;
-        if(step.getOptions().get("targetDatabase") != null) {
-            targetDatabase = ((TextNode)step.getOptions().get("targetDatabase")).asText();
-        }
-        else if(stepDef.getOptions().get("targetDatabase") != null) {
-            targetDatabase = ((TextNode)stepDef.getOptions().get("targetDatabase")).asText();
-        }
-        else {
-            if(StepDefinition.StepDefinitionType.INGESTION.equals(step.getStepDefinitionType())) {
-                targetDatabase = theHubClient.getDbName(DatabaseKind.STAGING);
-            }
-            else {
-                targetDatabase = theHubClient.getDbName(DatabaseKind.FINAL);
-            }
-        }
-        stepRunner.withDestinationDatabase(targetDatabase);
 
         //For ingest flow, set stepDef.
         if(StepDefinition.StepDefinitionType.INGESTION.equals(step.getStepDefinitionType())) {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
@@ -165,7 +165,6 @@ public class WriteStepRunner implements StepRunner {
         return this;
     }
 
-    @Override
     public StepRunner withDestinationDatabase(String destinationDatabase) {
         this.destinationDatabase = destinationDatabase;
         return this;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepRunner/processUris.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepRunner/processUris.api
@@ -1,0 +1,15 @@
+{
+    "functionName": "processUris",
+    "desc": "Replacement for the mlRunFlow REST extension; processes the given URIs against the given flow and step",
+    "params": [
+        {
+            "name": "inputs",
+            "datatype": "jsonDocument",
+            "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+        }
+    ],
+    "return": {
+        "datatype": "jsonDocument",
+        "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+    }
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepRunner/processUris.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepRunner/processUris.sjs
@@ -1,0 +1,38 @@
+/*
+  Copyright (c) 2020 MarkLogic Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+'use strict';
+
+const ds = require("/data-hub/5/data-services/ds-utils.sjs");
+const DataHubSingleton = require("/data-hub/5/datahub-singleton.sjs");
+
+var inputs;
+inputs = fn.head(xdmp.fromJSON(inputs));
+
+const flowName = inputs.flowName;
+if (!fn.exists(flowName)) {
+  ds.throwBadRequest(`Invalid request - must specify a flowName`);
+}
+
+const stepNumber = inputs.stepNumber;
+const jobId = inputs.jobId;
+const options = inputs.options;
+
+const datahub = DataHubSingleton.instance({
+  performanceMetrics: !!options.performanceMetrics
+});
+
+const content = datahub.flow.findMatchingContent(flowName, stepNumber, options, null);
+datahub.flow.runFlow(flowName, jobId, content, options, stepNumber);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepRunner/runSteps.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepRunner/runSteps.api
@@ -1,5 +1,7 @@
 {
     "endpoint": "/data-hub/5/data-services/stepRunner/runSteps.sjs",
+    "functionName": "runSteps",
+    "desc": "This is intended to be used by Bulk IO, but a functionName is required to generate a Java interface",
     "params": [
         {
             "name": "endpointState",

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepRunner/runSteps.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepRunner/runSteps.sjs
@@ -1,3 +1,18 @@
+/*
+  Copyright (c) 2020 MarkLogic Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 'use strict';
 
 const StepRunner = require("/data-hub/5/impl/step-runner.sjs");

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepRunner/service.json
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepRunner/service.json
@@ -1,0 +1,4 @@
+{
+  "endpointDirectory": "/data-hub/5/data-services/stepRunner/",
+  "$javaClass": "com.marklogic.hub.dataservices.StepRunnerService"
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/services/mlRunFlow.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/services/mlRunFlow.sjs
@@ -16,6 +16,13 @@
 'use strict';
 const DataHubSingleton = require("/data-hub/5/datahub-singleton.sjs");
 
+/**
+ * DO NOT USE THIS; it is deprecated as of DHF 5.3.0.
+ *
+ * Use the processUris.sjs DS endpoint in StepRunnerService instead.
+ */
+
+
 function get(context, params) {
   return post(context, params, null);
 }


### PR DESCRIPTION
All inputs are passed in a JSON object to the DS endpoint. This fixes an issue where the mlRunFlow endpoint fails when the string of request parameters is too long (mostly due to the length of each URI and the batch size). 

Cleaned up a few other things while I was at it:

- The sourceDatabase field wasn't used in QueryStepRunner, so removed it from QSR and from StepRunnerFactory (as it doesn't apply to WriteStepRunner either)
- The destinationDatabase field was actually never used in QSR either; the "target-database" param passed by FlowResource to mlRunFlow was never used. 
- Modified StepRunnerFactory to only set destinationDatabase on WriteStepRunner and removed it from the StepRunner interface

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

