### PR TITLE
DHFPROD-5066: Add routes and links for handling tile view

### DIFF
--- a/marklogic-data-hub-central/ui/src/App.test.tsx
+++ b/marklogic-data-hub-central/ui/src/App.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { Router } from 'react-router'
+import { createMemoryHistory } from 'history'
+const history = createMemoryHistory()
 import { render, fireEvent, waitForElement, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import { AuthoritiesContext } from './util/authorities';
@@ -26,7 +28,9 @@ describe('App component', () => {
 
   test('Verify header title links return to overview', async () => {
       const firstTool = Object.keys(tiles)[0];
-      const { getByLabelText, queryByText } = render(<Router>
+      // App defaults to pathname "/" which renders Login page. So setting the path to /tiles when App is rendered
+      history.push('/tiles');
+      const { getByLabelText, queryByText } = render(<Router history = {history}>
           <AuthoritiesContext.Provider value={mockDevRolesService}>
             <UserContext.Provider value={userAuthenticated}><App/></UserContext.Provider>
           </AuthoritiesContext.Provider>

--- a/marklogic-data-hub-central/ui/src/App.tsx
+++ b/marklogic-data-hub-central/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext, useState } from 'react';
+import React, { useEffect, useContext } from 'react';
 import { Switch } from 'react-router';
 import { Route, Redirect, RouteComponentProps, withRouter } from 'react-router-dom';
 import { UserContext } from './util/user-context';
@@ -9,21 +9,15 @@ import Header from './components/header/header';
 import Footer from './components/footer/footer';
 import Login from './pages/Login';
 import Home from './pages/Home';
-import Load from './pages/Load';
-import Run from './pages/Run';
 import TilesView from './pages/TilesView';
-import NoMatchRedirect from './pages/noMatchRedirect';
-import View from './pages/View';
 import Browse from './pages/Browse';
-
 import Detail from './pages/Detail';
-import Modeling from './pages/Modeling';
+import NoMatchRedirect from './pages/noMatchRedirect';
 
 import './App.scss';
 import { Application } from './config/application.config';
 import { themes, themeMap } from './config/themes.config';
 import axios from 'axios';
-import Curate from './pages/Curate';
 import ModalStatus from './components/modal-status/modal-status';
 import { getEnvironment } from './util/environment';
 
@@ -33,10 +27,8 @@ interface Props extends RouteComponentProps<any> {}
 const App: React.FC<Props> = ({history, location}) => {
   const {
     user,
-    clearRedirect,
     handleError
   } = useContext(UserContext);
-  let environment: any = {};
 
   const PrivateRoute = ({ children, ...rest }) => (
     <Route {...rest} render={ props => (
@@ -49,35 +41,25 @@ const App: React.FC<Props> = ({history, location}) => {
         }}/>
       )
     )}/>
-  )
+  );
 
   useEffect(() => {
     if (user.authenticated){
-      if (user.redirect) {
-        clearRedirect();
+      if (location.pathname === '/') {
+        history.push(user.pageRoute);
+      } else {
+        history.push(location.pathname);
       }
-      if (location.state && !user.redirect && user.error.type === '') {
-        if (location.state.hasOwnProperty('from')) {
-          history.push(location.state['from'].pathname);
-        }
-      }
-      if (user.redirect || location.pathname === '/') {
-        if (location.state && location.state.hasOwnProperty('from')) {
-            history.push(location.state['from'].pathname);
-        } else {
-            history.push('/tiles');
-        }
-      }
-    }
-    if (user.redirect) {
+    } else {
       if (user.error.type !== '') {
-        clearRedirect();
         history.push('/error');
-      } else if (!user.authenticated) {
+      } else {
+        if (location.pathname !== '/') {
+          user.pageRoute = location.pathname;
+        }
         history.push('/');
       }
     }
-
   }, [user]);
 
   useEffect(() => {
@@ -101,45 +83,45 @@ const App: React.FC<Props> = ({history, location}) => {
       <ModalStatus/>
       <main>
         <div className="contentContainer">
-          <Switch>
-            <Route path="/" exact component={Login}/>
-            <PrivateRoute path="/home" exact>
-              <Home/>
+        <Switch>
+          <Route path="/" exact component={Login}/>
+          <PrivateRoute path="/home" exact>
+            <Home/>
+          </PrivateRoute>
+          <SearchProvider>
+            <PrivateRoute path="/browse" exact>
+                <Browse/>
             </PrivateRoute>
-            <PrivateRoute path="/load" exact>
-              <Load/>
+            <PrivateRoute path="/detail/:pk/:uri">
+              <Detail/>
             </PrivateRoute>
-            <PrivateRoute path="/curate" exact>
-              <Curate/>
-            </PrivateRoute>
-            <PrivateRoute path="/run" exact>
-              <Run/>
-            </PrivateRoute>
-            <SearchProvider>
-              <PrivateRoute path="/view" exact>
-                  <View/>
+            <ModelingProvider>
+              <PrivateRoute path="/tiles" exact>
+                <TilesView/>
               </PrivateRoute>
-              <PrivateRoute path="/browse" exact>
-                  <Browse/>
+              <PrivateRoute path="/tiles/load" exact>
+                <TilesView id='load'/>
               </PrivateRoute>
-              <PrivateRoute path="/detail/:pk/:uri">
-                <Detail/>
+              <PrivateRoute path="/tiles/model" exact>
+                <TilesView id='model'/>
               </PrivateRoute>
-              <ModelingProvider>
-                <PrivateRoute path="/model" exact>
-                  <Modeling/>
-                </PrivateRoute>
-                <PrivateRoute path="/tiles" exact>
-                  <TilesView/>
-                </PrivateRoute>
-                <PrivateRoute path="/tiles-run" exact>
-                  <TilesView id='run'/>
-                </PrivateRoute>
-              </ModelingProvider>
-            </SearchProvider>
-            <Route component={NoMatchRedirect}/>
-          </Switch>
-          <Footer pageTheme={pageTheme}/>
+              <PrivateRoute path="/tiles/curate" exact>
+                <TilesView id='curate'/>
+              </PrivateRoute>
+              <PrivateRoute path="/tiles/run" exact>
+                <TilesView id='run'/>
+              </PrivateRoute>
+              <PrivateRoute path="/tiles/run/add" exact>
+                <TilesView id='run' addingStepToFlow='true' />
+              </PrivateRoute>
+              <PrivateRoute path="/tiles/explore" exact>
+                <TilesView id='explore'/>
+              </PrivateRoute>
+            </ModelingProvider>
+          </SearchProvider>
+          <Route component={NoMatchRedirect}/>
+        </Switch>
+        <Footer pageTheme={pageTheme}/>
         </div>
       </main>
     </div>

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/user-context-mock.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/user-context-mock.ts
@@ -3,7 +3,6 @@ import { UserContextInterface, IUserContextInterface } from '../../types/user-ty
 const defaultUserData: UserContextInterface = {
   name: '',
   authenticated: false,
-  redirect: false,
   error : {
     title: '',
     message: '',
@@ -20,7 +19,6 @@ const defaultUserContext: IUserContextInterface = {
   userNotAuthenticated: jest.fn(),
   handleError: jest.fn(),
   clearErrorMessage: jest.fn(),
-  clearRedirect: jest.fn(),
   setPageRoute: jest.fn(),
   setAlertMessage: jest.fn(),
   resetSessionTime: jest.fn(),
@@ -33,7 +31,6 @@ export const userAuthenticated: IUserContextInterface = Object.assign(defaultUse
   user: {
     name: '',
     authenticated: true,
-    redirect: false,
     error : {
       type: ''
     },
@@ -46,7 +43,6 @@ export const userSessionWarning: IUserContextInterface = {
   user: {
     name: '',
     authenticated: true,
-    redirect: false,
     error : {
       title: '',
       message: '',
@@ -57,7 +53,6 @@ export const userSessionWarning: IUserContextInterface = {
   },
   loginAuthenticated: jest.fn(),
   sessionAuthenticated: jest.fn(),
-  clearRedirect: jest.fn(),
   setPageRoute: jest.fn(),
   setAlertMessage: jest.fn(),
   userNotAuthenticated: jest.fn(),
@@ -71,7 +66,6 @@ export const userModalError: IUserContextInterface = {
   user: {
     name: '',
     authenticated: false,
-    redirect: false,
     error : {
       title: '500 Internal Server Error',
       message: 'java.net.ConnectException: Failed to connect to localhost/0:0:0:0:0:0:0:1:8011',
@@ -82,7 +76,6 @@ export const userModalError: IUserContextInterface = {
   },
   loginAuthenticated: jest.fn(),
   sessionAuthenticated: jest.fn(),
-  clearRedirect: jest.fn(),
   setPageRoute: jest.fn(),
   setAlertMessage: jest.fn(),
   userNotAuthenticated: jest.fn(),
@@ -96,7 +89,6 @@ export const userNoErrorNoSessionWarning: IUserContextInterface = {
   user: {
     name: '',
     authenticated: false,
-    redirect: false,
     error : {
       title: '',
       message: '',
@@ -107,7 +99,6 @@ export const userNoErrorNoSessionWarning: IUserContextInterface = {
   },
   loginAuthenticated: jest.fn(),
   sessionAuthenticated: jest.fn(),
-  clearRedirect: jest.fn(),
   setPageRoute: jest.fn(),
   setAlertMessage: jest.fn(),
   userNotAuthenticated: jest.fn(),
@@ -121,7 +112,6 @@ export const userHasModalErrorHasSessionWarning: IUserContextInterface = {
   user: {
     name: '',
     authenticated: false,
-    redirect: false,
     error : {
       title: '500 Internal Server Error',
       message: 'java.net.ConnectException: Failed to connect to localhost/0:0:0:0:0:0:0:1:8011',
@@ -132,7 +122,6 @@ export const userHasModalErrorHasSessionWarning: IUserContextInterface = {
   },
   loginAuthenticated: jest.fn(),
   sessionAuthenticated: jest.fn(),
-  clearRedirect: jest.fn(),
   setPageRoute: jest.fn(),
   setAlertMessage: jest.fn(),
   userNotAuthenticated: jest.fn(),

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
@@ -218,9 +218,9 @@ describe("Mapping Card component", () => {
     //Click on 'Yes' button
     fireEvent.click(getByTestId('Mapping1-to-testFlow-Confirm'));
 
-    //Check if the tiles-run route has been called
+    //Check if the /tiles/run/add route has been called
     wait(() => {
-      expect(mockHistoryPush).toHaveBeenCalledWith('/tiles-run');
+      expect(mockHistoryPush).toHaveBeenCalledWith('/tiles/run/add');
     })
     //TODO- E2E test to check if the Run tile is loaded or not.
 
@@ -275,7 +275,7 @@ describe("Mapping Card component", () => {
 
     //Wait for the route to be pushed into History( which means that the route is working fine. Remaining can be verified in E2E test)
     wait(() => {
-      expect(mockHistoryPush).toHaveBeenCalledWith('/tiles-run');
+      expect(mockHistoryPush).toHaveBeenCalledWith('/tiles/run/add');
     })
 
   });

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
@@ -552,7 +552,7 @@ const MappingCard: React.FC<Props> = (props) => {
         setAddDialogVisible(false);
 
         history.push({
-            pathname: '/tiles-run',
+            pathname: '/tiles/run/add',
             state: {
                 flowName: fName,
                 flowsDefaultKey: [props.flows.findIndex(el => el.name === fName)],
@@ -614,8 +614,8 @@ const MappingCard: React.FC<Props> = (props) => {
                                 <p className={styles.lastUpdatedStyle}>Last Updated: {convertDateFromISO(elem.lastUpdated)}</p>
                                 <div className={styles.cardLinks} style={{display: showLinks === elem.name ? 'block' : 'none'}}>
                                     <div className={styles.cardLink} onClick={() => openSourceToEntityMapping(elem.name,index)}>Open step details</div>
-                                    { props.canWriteFlow ? <Link id="tiles-run" to={
-                                    {pathname: '/tiles-run',
+                                    { props.canWriteFlow ? <Link id="tiles-run-add" to={
+                                    {pathname: '/tiles/run/add',
                                     state: {
                                         stepToAdd : elem.name,
                                         stepDefinitionType : 'mapping'

--- a/marklogic-data-hub-central/ui/src/components/load/load-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-card.test.tsx
@@ -66,9 +66,9 @@ describe('Load Card component', () => {
     //Click on 'Yes' button
     fireEvent.click(getByTestId('testLoadXML-to-FlowA-Confirm'));
 
-    //Check if the tiles-run route has been called
+    //Check if the /tiles/run/add route has been called
     wait(() => {
-      expect(mockHistoryPush).toHaveBeenCalledWith('/tiles-run');
+      expect(mockHistoryPush).toHaveBeenCalledWith('/tiles/run/add');
     })
     //TODO- E2E test to check if the Run tile is loaded or not.
 
@@ -107,7 +107,7 @@ describe('Load Card component', () => {
 
     //Wait for the route to be pushed into History(which means that the route is working fine. Remaining can be verified in E2E test)
     wait(() => {
-      expect(mockHistoryPush).toHaveBeenCalledWith('/tiles-run');
+      expect(mockHistoryPush).toHaveBeenCalledWith('/tiles/run/add');
     })
     //TODO- E2E test to check if the Run tile is loaded or not.
 

--- a/marklogic-data-hub-central/ui/src/components/load/load-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-card.tsx
@@ -126,7 +126,7 @@ const LoadCard: React.FC<Props> = (props) => {
         setAddDialogVisible(false);
 
         history.push({
-            pathname: '/tiles-run',
+            pathname: '/tiles/run/add',
             state: {
                 flowName: fName,
                 flowsDefaultKey: [props.flows.findIndex(el => el.name === fName)],
@@ -204,8 +204,8 @@ const LoadCard: React.FC<Props> = (props) => {
                             <div className={styles.stepNameStyle}>{getInitialChars(elem.name, 25, '...')}</div>
                             <div className={styles.lastUpdatedStyle}>Last Updated: {convertDateFromISO(elem.lastUpdated)}</div>
                             <div className={styles.cardLinks} style={{display: showLinks === elem.name ? 'block' : 'none'}}>
-                                {props.canWriteFlow ? <Link id="tiles-run" to={
-                                    {pathname: '/tiles-run',
+                                {props.canWriteFlow ? <Link id="tiles-run-add" to={
+                                    {pathname: '/tiles/run/add',
                                     state: {
                                         stepToAdd : elem.name,
                                         stepDefinitionType : 'ingestion',

--- a/marklogic-data-hub-central/ui/src/components/tiles/tiles.tsx
+++ b/marklogic-data-hub-central/ui/src/components/tiles/tiles.tsx
@@ -86,39 +86,40 @@ const Tiles: React.FC<Props> = (props) => {
                         <div>
                             <Dropdown overlay={menu} trigger={['click']} placement="bottomLeft">
                                 <a className="ant-dropdown-link" onClick={e => e.preventDefault()}>
-                                    <Tooltip title={'Menu'} placement="top">
-                                        <i className={styles.faCog} aria-label={'menu'} style={{ color: options['color'] }}>
+                                    <i className={styles.faCog} aria-label={'menu'} style={{ color: options['color'] }}>
+                                        <Tooltip title={'Menu'} placement="top">
                                             <FontAwesomeIcon icon={faCog} />
-                                        </i>
-                                    </Tooltip>
+                                        </Tooltip>
+                                    </i> 
                                 </a>
                             </Dropdown>
                         </div>
                     ) : null}
                     {showControl('newTab') ? (
-                        <Tooltip title={'Open in New Tab'} placement="top">
-                            <i className={styles.fa} aria-label={'newTab'} style={{ color: options['color'] }} onClick={onClickNewTab}>
+                        <i className={styles.fa} aria-label={'newTab'} style={{ color: options['color'] }} onClick={onClickNewTab}>
+                            <Tooltip title={'Open in New Tab'} placement="top">
                                 <FontAwesomeIcon icon={faExternalLinkAlt} />
-                            </i>
-                        </Tooltip>) : null}
+                            </Tooltip>
+                        </i>) : null}
                     {showControl('maximize') ? (
-                        <Tooltip title={'Maximize'} placement="top">
-                            <i className={styles.ant} aria-label={'maximize'} style={{ color: options['color'] }} onClick={onClickMaximize}>
+                        <i className={styles.ant} aria-label={'maximize'} style={{ color: options['color'] }} onClick={onClickMaximize}>
+                            <Tooltip title={'Maximize'} placement="top">
                                 <ArrowsAltOutlined />
-                            </i>
-                        </Tooltip>) : null}
+                            </Tooltip>
+                        </i>) : null}
                     {showControl('minimize') ? (
-                        <Tooltip title={'Minimize'} placement="top">
-                            <i className={styles.ant} aria-label={'minimize'} style={{ color: options['color'] }} onClick={onClickMinimize}>
+                        <i className={styles.ant} aria-label={'minimize'} style={{ color: options['color'] }} onClick={onClickMinimize}>
+                            <Tooltip title={'Minimize'} placement="top">
                                 <ShrinkOutlined />
-                            </i>
-                        </Tooltip>) : null}
+                            </Tooltip>
+                        </i>) : null}
                     {showControl('close') ? (
-                        <Tooltip title={'Close'} placement="top">
-                            <i className={styles.close} aria-label={'close'} style={{ color: options['color'] }} onClick={onClickClose}>
+                        <i className={styles.close} aria-label={'close'} style={{ color: options['color'] }} onClick={onClickClose}>
+                            <Tooltip title={'Close'} placement="top">
                                 <CloseOutlined />
-                            </i>
-                        </Tooltip>) : null}
+                            </Tooltip>
+                        </i>
+                        ) : null}
                 </div>
             </div>
         )

--- a/marklogic-data-hub-central/ui/src/components/tiles/toolbar.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/tiles/toolbar.test.tsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import { Router } from 'react-router'
+import { createMemoryHistory } from 'history'
+const history = createMemoryHistory()
 import { render, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import Toolbar from './toolbar';
@@ -8,17 +11,15 @@ import tiles from '../../config/tiles.config'
 describe('Toolbar component', () => {
 
     it('renders with clickable tools', () => {
-        const mockClick = jest.fn()
         const tools = Object.keys(tiles);
-        const {getByLabelText} = render(<Toolbar tiles={tiles} onClick={mockClick} enabled={tools}/>);
+        const {getByLabelText} = render(<Router history={history}><Toolbar tiles={tiles} enabled={tools}/></Router>);
 
         expect(getByLabelText("toolbar")).toBeInTheDocument();
 
         tools.forEach((tool, i) => {
             expect(getByLabelText("tool-" + tool)).toBeInTheDocument();
             fireEvent.click(getByLabelText("tool-" + tool));
-            expect(mockClick.mock.calls.length).toBe(i+1);
-            expect(mockClick.mock.calls[i][0]).toBe(tool);
+            expect(history.location.pathname).toEqual(`/tiles/${tool}`);
         })
 
     });

--- a/marklogic-data-hub-central/ui/src/components/tiles/toolbar.tsx
+++ b/marklogic-data-hub-central/ui/src/components/tiles/toolbar.tsx
@@ -1,4 +1,5 @@
 import React, { CSSProperties } from 'react';
+import { Link } from 'react-router-dom';
 import { Tooltip } from 'antd';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
@@ -7,21 +8,12 @@ import './toolbar.scss';
 
 interface Props {
     tiles: any;
-    onClick: any;
     enabled: any;
 }
 
 const Toolbar: React.FC<Props>  = (props) => {
 
     const tiles = props.tiles; // config/tiles.config.ts
-
-    const onClick = (e, id) => {
-        if (props.enabled && props.enabled.includes(id)){
-            props.onClick(id);
-        } else {
-            e.preventDefault();
-        }
-    }
 
     const getTooltip = (id) => {
         if (props.enabled && props.enabled.includes(id)){
@@ -31,34 +23,44 @@ const Toolbar: React.FC<Props>  = (props) => {
         }
     }
 
-    const getIconStyle = (tileId) => {
+    const getIconStyle = (id) => {
         let disabled: CSSProperties = {
-                color: 'grey',
-                opacity: '0.5',
-                cursor: 'not-allowed'
+            color: 'grey',
+            opacity: '0.5',
+            cursor: 'not-allowed'
         }
         let enabled: CSSProperties = {
-            color: tiles[tileId]['color']
+            color: tiles[id]['color']
         }
-        return (props.enabled && props.enabled.includes(tileId)) ? enabled : disabled;
-    }    
+        return (props.enabled && props.enabled.includes(id)) ? enabled : disabled;
+    }
+
     return (
         <div id={styles.toolbar} aria-label={'toolbar'}>
             {Object.keys(tiles).map((id, i) => {
                 if (tiles[id]['iconType'] === 'custom') {
                     return (
-                        <Tooltip title={getTooltip(id)} placement="left" key={i}>
-                            <div className={tiles[id]['icon']} aria-label={'tool-' + id} style={getIconStyle(id)} 
-                            onClick={(e) => onClick(e,id)}></div>
-                        </Tooltip>
+                        <Link to={ '/tiles/' + id } aria-label={'tool-' + id + '-link'} key={i}>
+                            <Tooltip title={getTooltip(id)} placement="leftTop" key={i}>
+                                <div
+                                    className={tiles[id]['icon']}
+                                    aria-label={'tool-' + id}
+                                    style={getIconStyle(id)}
+                                />
+                            </Tooltip>
+                        </Link>
                     )
                 } else {
                     return (
-                        <Tooltip title={getTooltip(id)} placement="left" key={i}>
-                            <i className={styles.tool} aria-label={'tool-' + id} style={getIconStyle(id)}
-                            onClick={(e) => onClick(e,id)}>
-                                <FontAwesomeIcon icon={tiles[id]['icon']} size="lg" />
-                            </i>
+                        <Tooltip title={getTooltip(id)} placement="leftTop" key={i}>
+                            <Link to={ '/tiles/' + id } aria-label={'tool-' + id + '-link'} >
+                                <i
+                                    className={styles.tool}
+                                    aria-label={'tool-' + id}
+                                    style={getIconStyle(id)}
+                                ><FontAwesomeIcon icon={tiles[id]['icon']} size="lg" />
+                                </i>
+                            </Link>
                         </Tooltip>
                     )
                 }

--- a/marklogic-data-hub-central/ui/src/pages/Overview.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Overview.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import styles from './Overview.module.scss';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faLongArrowAltRight, faCube, faCubes, faObjectUngroup, faProjectDiagram } from "@fortawesome/free-solid-svg-icons";

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Router } from 'react-router'
 import { createMemoryHistory } from 'history'
 const history = createMemoryHistory()
-import { render, fireEvent, waitForElement, cleanup } from '@testing-library/react'
+import { render, fireEvent, waitForElement, cleanup, wait } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import TilesView from './TilesView';
 import {AuthoritiesContext, AuthoritiesService} from '../util/authorities';
@@ -35,10 +35,12 @@ describe('Tiles View component tests for Developer user', () => {
         cleanup();
     })
 
-    test('Verify TilesView renders with the toolbar', async () => {
+    test('Verify TilesView renders with the toolbar', () => {
         const { getByLabelText } = render(<Router history={history}>
-            <AuthoritiesContext.Provider value={mockDevRolesService}><TilesView/></AuthoritiesContext.Provider> />
-          </Router>);
+            <AuthoritiesContext.Provider value={mockDevRolesService}>
+                <TilesView/>
+            </AuthoritiesContext.Provider> />
+        </Router>);
 
         expect(getByLabelText("toolbar")).toBeInTheDocument();
 
@@ -57,7 +59,7 @@ describe('Tiles View component tests for Developer user', () => {
 
     });
 
-    test('Verify tiles can be closed', async () => {
+    test('Verify tiles can be closed', () => {
         const tools = Object.keys(tiles);
         const { getByLabelText } = render(<Router history={history}>
             <AuthoritiesContext.Provider value={mockDevRolesService}>
@@ -80,11 +82,11 @@ describe('Tiles View component tests for Developer user', () => {
     });
 
     test('Verify Curate tile displays from toolbar', async () => {
-        const {getByLabelText, getByText, queryByText, debug} = render(<Router history={history}>
+        const {getByLabelText, getByText, queryByText } = render(<Router history={history}>
             <AuthoritiesContext.Provider value={mockDevRolesService}>
                 <SearchContext.Provider value={setViewCurateFunction}>
-                <TilesView/>
-            </SearchContext.Provider>
+                    <TilesView id='curate'/>
+                </SearchContext.Provider>
             </AuthoritiesContext.Provider>
         </Router>);
 
@@ -95,11 +97,10 @@ describe('Tiles View component tests for Developer user', () => {
         fireEvent.click(getByLabelText("tool-curate"));
 
         // Curate tile shown with entityTypes after click
-        expect(await(waitForElement(() => getByLabelText("icon-curate")))).toBeInTheDocument();
+        await wait (() => expect(getByLabelText("icon-curate")).toBeInTheDocument());
         expect(getByLabelText("title-curate")).toBeInTheDocument();
 
         expect(getByText('Customer')).toBeInTheDocument();
-        //debug(getByText('Customer'));
 
         fireEvent.click(getByText('Customer'));
 
@@ -116,10 +117,10 @@ describe('Tiles View component tests for Developer user', () => {
         const {getByLabelText, getByText, queryByText} = render(<Router history={history}>
             <AuthoritiesContext.Provider value={authorityService}>
                 <SearchContext.Provider value={setViewLoadFunction}>
-                    <TilesView/>
+                    <TilesView id='load'/>
                 </SearchContext.Provider>
             </AuthoritiesContext.Provider>
-            </Router>);
+        </Router>);
 
         // Curate tile not shown initially
         expect(queryByText("icon-load")).not.toBeInTheDocument();
@@ -128,7 +129,7 @@ describe('Tiles View component tests for Developer user', () => {
         fireEvent.click(getByLabelText("tool-load"));
 
         // Load tile shown with entityTypes after click
-        expect(await(waitForElement(() => getByLabelText("icon-load")))).toBeInTheDocument();
+        await wait (() => expect(getByLabelText("icon-load")).toBeInTheDocument());
         expect(getByLabelText("title-load")).toBeInTheDocument();
         expect(getByText('testLoad')).toBeInTheDocument();
     });
@@ -137,10 +138,12 @@ describe('Tiles View component tests for Developer user', () => {
         const authorityService = new AuthoritiesService();
         authorityService.setAuthorities([]);
         const {getByLabelText, queryByLabelText, queryByText} = render(<Router history={history}>
-            <AuthoritiesContext.Provider value={authorityService}> <SearchContext.Provider value={setViewLoadFunction}>
-                <TilesView/>
-            </SearchContext.Provider></AuthoritiesContext.Provider>
-            </Router>);
+            <AuthoritiesContext.Provider value={authorityService}>
+                <SearchContext.Provider value={setViewLoadFunction}>
+                    <TilesView/>
+                </SearchContext.Provider>
+            </AuthoritiesContext.Provider>
+        </Router>);
 
         // Curate tile not shown initially
         expect(queryByText("icon-load")).not.toBeInTheDocument();
@@ -157,7 +160,9 @@ describe('Tiles View component tests for Developer user', () => {
         const authorityService = new AuthoritiesService();
         authorityService.setAuthorities(['readIngestion']);
         const {getByLabelText, queryByLabelText, queryByText} = render(<Router history={history}>
-            <AuthoritiesContext.Provider value={authorityService}><TilesView/></AuthoritiesContext.Provider>
+            <AuthoritiesContext.Provider value={authorityService}>
+                <TilesView/>
+            </AuthoritiesContext.Provider>
         </Router>);
 
         ['model', 'curate', 'run'].forEach((tileId) => {
@@ -176,10 +181,13 @@ describe('Tiles View component tests for Developer user', () => {
     test('Verify Curate tile with customRead authority', async () => {
         const authorityService = new AuthoritiesService();
         authorityService.setAuthorities(['readCustom']);
-        const { getByLabelText, queryByText, getByText } = render(<Router history={history}><AuthoritiesContext.Provider value={authorityService}>
-            <SearchContext.Provider value={setViewCurateFunction}>
-            <TilesView/>
-        </SearchContext.Provider></AuthoritiesContext.Provider></Router>);
+        const { getByLabelText, queryByText, getByText } = render(<Router history={history}>
+            <AuthoritiesContext.Provider value={authorityService}>
+                <SearchContext.Provider value={setViewCurateFunction}>
+                    <TilesView id='curate'/>
+                </SearchContext.Provider>
+            </AuthoritiesContext.Provider>
+        </Router>);
 
         // Curate tile not shown initially
         expect(queryByText("icon-curate")).not.toBeInTheDocument();
@@ -188,7 +196,7 @@ describe('Tiles View component tests for Developer user', () => {
         fireEvent.click(getByLabelText("tool-curate"));
 
         // Curate tile shown with entityTypes after click
-        expect(await(waitForElement(() => getByLabelText("icon-curate")))).toBeInTheDocument();
+        await wait(() => expect(getByLabelText("icon-curate")).toBeInTheDocument());
         expect(getByLabelText("title-curate")).toBeInTheDocument();
 
         // test cannot access Mapping tab
@@ -204,9 +212,10 @@ describe('Tiles View component tests for Developer user', () => {
         const {getByLabelText, getByText, queryByText, getByTestId} = await render(<Router history={history}>
             <AuthoritiesContext.Provider value={ authorityService}>
                 <SearchContext.Provider value={setViewRunFunction}>
-                <TilesView/>
-            </SearchContext.Provider></AuthoritiesContext.Provider>
-            </Router>);
+                    <TilesView id='run'/>
+                </SearchContext.Provider>
+            </AuthoritiesContext.Provider>
+        </Router>);
 
         // Run tile not shown initially
         expect(queryByText("icon-run")).not.toBeInTheDocument();
@@ -215,7 +224,7 @@ describe('Tiles View component tests for Developer user', () => {
         fireEvent.click(getByLabelText("tool-run"));
 
         // Run tile shown with entityTypes after click
-        expect(await(waitForElement(() => getByLabelText("icon-run")))).toBeInTheDocument();
+        await wait(() => expect(getByLabelText("icon-run")).toBeInTheDocument());
         expect(getByLabelText("title-run")).toBeInTheDocument();
         expect(document.querySelector('#flows-container')).toBeInTheDocument();
         expect(getByText('Create Flow')).toBeInTheDocument();
@@ -239,10 +248,12 @@ describe('Tiles View component tests for Developer user', () => {
         const authorityService = new AuthoritiesService();
         authorityService.setAuthorities(['readFlow']);
         const {getByLabelText, getByText, queryByText, getByTestId} = render(<Router history={history}>
-            <AuthoritiesContext.Provider value={authorityService}><SearchContext.Provider value={setViewRunFunction}>
-                <TilesView/>
-            </SearchContext.Provider>
-            </AuthoritiesContext.Provider></Router>);
+            <AuthoritiesContext.Provider value={authorityService}>
+                <SearchContext.Provider value={setViewRunFunction}>
+                    <TilesView id='run'/>
+                </SearchContext.Provider>
+            </AuthoritiesContext.Provider>
+        </Router>);
 
         // Run tile not shown initially
         expect(queryByText("icon-run")).not.toBeInTheDocument();
@@ -251,7 +262,7 @@ describe('Tiles View component tests for Developer user', () => {
         fireEvent.click(getByLabelText("tool-run"));
 
         // Run tile shown with entityTypes after click
-        expect(await(waitForElement(() => getByLabelText("icon-run")))).toBeInTheDocument();
+        await wait(() => expect(getByLabelText("icon-run")).toBeInTheDocument());
         expect(getByLabelText("title-run")).toBeInTheDocument();
         expect(document.querySelector('#flows-container')).toBeInTheDocument();
         expect(getByText('testFlow')).toBeInTheDocument();
@@ -276,11 +287,13 @@ describe('Tiles View component tests for Developer user', () => {
     test('Verify run tile can read/run with readFlow and runStep authority', async () => {
         const authorityService = new AuthoritiesService();
         authorityService.setAuthorities(['readFlow','runStep']);
-        const {getByLabelText, getByText, queryByText, getByTestId} = render(<Router history={history}><AuthoritiesContext.Provider value={authorityService}>
-            <SearchContext.Provider value={setViewRunFunction}>
-                <TilesView/>
-            </SearchContext.Provider>
-        </AuthoritiesContext.Provider></Router>);
+        const {getByLabelText, getByText, queryByText, getByTestId} = render(<Router history={history}>
+            <AuthoritiesContext.Provider value={authorityService}>
+                <SearchContext.Provider value={setViewRunFunction}>
+                    <TilesView id='run'/>
+                </SearchContext.Provider>
+            </AuthoritiesContext.Provider>
+        </Router>);
 
 
         // Run tile not shown initially
@@ -289,7 +302,7 @@ describe('Tiles View component tests for Developer user', () => {
 
         fireEvent.click(getByLabelText("tool-run"));
 
-        expect(await(waitForElement(() => getByLabelText("icon-run")))).toBeInTheDocument();
+        await wait(() => expect(getByLabelText("icon-run")).toBeInTheDocument());
         // test run
         fireEvent.click(getByLabelText('icon: right'));
         expect(getByTestId('runStep-1')).toBeInTheDocument();
@@ -303,11 +316,13 @@ describe('Tiles View component tests for Developer user', () => {
     test('Verify run tile does not load from toolbar without readFlow authority', async () => {
         const authorityService = new AuthoritiesService();
         authorityService.setAuthorities([]);
-        const {getByLabelText, queryByLabelText, queryByText} = render(<Router history={history}><AuthoritiesContext.Provider value={authorityService}>
-            <SearchContext.Provider value={setViewRunFunction}>
-                <TilesView/>
-            </SearchContext.Provider>
-        </AuthoritiesContext.Provider></Router>);
+        const {getByLabelText, queryByLabelText, queryByText} = render(<Router history={history}>
+            <AuthoritiesContext.Provider value={authorityService}>
+                <SearchContext.Provider value={setViewRunFunction}>
+                    <TilesView/>
+                </SearchContext.Provider>
+            </AuthoritiesContext.Provider>
+        </Router>);
 
         // Curate tile not shown initially
         expect(queryByText("icon-run")).not.toBeInTheDocument();
@@ -321,11 +336,13 @@ describe('Tiles View component tests for Developer user', () => {
     });
 
     test('Verify Load tile displays from toolbar', async () => {
-        const {getByLabelText, getByText, queryByText} = render(<Router history={history}><AuthoritiesContext.Provider value={mockDevRolesService}>
-            <SearchContext.Provider value={setViewLoadFunction}>
-                <TilesView/>
-            </SearchContext.Provider>
-        </AuthoritiesContext.Provider></Router>);
+        const {getByLabelText, getByText, queryByText} = render(<Router history={history}>
+            <AuthoritiesContext.Provider value={mockDevRolesService}>
+                <SearchContext.Provider value={setViewLoadFunction}>
+                    <TilesView id='load'/>
+                </SearchContext.Provider>
+            </AuthoritiesContext.Provider>
+        </Router>);
 
         // Load tile not shown initially
         expect(queryByText("icon-load")).not.toBeInTheDocument();
@@ -334,7 +351,7 @@ describe('Tiles View component tests for Developer user', () => {
         fireEvent.click(getByLabelText("tool-load"));
 
         // Load tile shown after click
-        expect(await(waitForElement(() => getByLabelText("icon-load")))).toBeInTheDocument();
+        await wait(() => expect(getByLabelText("icon-load")).toBeInTheDocument());
         expect(getByLabelText("title-load")).toBeInTheDocument();
         // Default list view
         expect(getByLabelText("switch-view")).toBeInTheDocument();
@@ -358,11 +375,13 @@ describe('Tiles View component tests for Operator user', () => {
     })
 
     test('Verify Curate tile', async () => {
-        const { getByLabelText, queryByText, getByText } = render(<Router history={history}><AuthoritiesContext.Provider value={testWithOperator}>
-            <SearchContext.Provider value={setViewCurateFunction}>
-                <TilesView/>
-            </SearchContext.Provider>
-        </AuthoritiesContext.Provider></Router>);
+        const { getByLabelText, queryByText, getByText } = render(<Router history={history}>
+            <AuthoritiesContext.Provider value={testWithOperator}>
+                <SearchContext.Provider value={setViewCurateFunction}>
+                    <TilesView id='curate'/>
+                </SearchContext.Provider>
+            </AuthoritiesContext.Provider>
+        </Router>);
 
         // Curate tile not shown initially
         expect(queryByText("icon-curate")).not.toBeInTheDocument();
@@ -371,7 +390,7 @@ describe('Tiles View component tests for Operator user', () => {
         fireEvent.click(getByLabelText("tool-curate"));
 
         // Curate tile shown with entityTypes after click
-        expect(await(waitForElement(() => getByLabelText("icon-curate")))).toBeInTheDocument();
+        await wait(() => expect(getByLabelText("icon-curate")).toBeInTheDocument());
         expect(getByLabelText("title-curate")).toBeInTheDocument();
 
         fireEvent.click(getByText('Customer'));

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.tsx
@@ -13,7 +13,7 @@ import Run from './Run';
 import Browse from './Browse';
 import { AuthoritiesContext } from "../util/authorities";
 import { SearchContext } from '../util/search-context';
-import { useLocation } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 
 export type TileId = 'load' | 'model' | 'curate' | 'run' | 'explore';
 export type IconType = 'fa' | 'custom';
@@ -41,6 +41,9 @@ const TilesView = (props) => {
     const [currentNode, setCurrentNode] = useState<any>(INITIAL_SELECTION);
     const [options, setOptions] = useState<TileItem|null>(null);
 
+    const history: any = useHistory();
+    const location: any = useLocation();
+
     const {
         setZeroState,
         setManageQueryModal,
@@ -57,6 +60,7 @@ const TilesView = (props) => {
         setCurrentNode(INITIAL_SELECTION); // TODO Handle multiple with nested objects
         setOptions(null);
         setView(null);
+        history.push('/tiles');
     }
 
     // For role-based privileges
@@ -72,25 +76,12 @@ const TilesView = (props) => {
     };
     const enabled = Object.keys(enabledViews).filter(key => enabledViews[key]);
 
-    const onSelect = (id) => {
-        id === 'explore' && setZeroState(true)
-        setSelection(id);
-        setCurrentNode(id); // TODO Handle multiple with nested objects
-        setOptions(tiles[id]);
-        if(id == 'explore')
-            setView(views[id], true)
-        else
-            setView(views[id])
-    }
-
-    const location: any = useLocation();
-
     useEffect(() => {
         if (props.id) {
             setSelection(props.id);
             setCurrentNode(props.id); // TODO Handle multiple with nested objects
             setOptions(tiles[props.id]);
-            setView(views[props.id]);
+            setView(views[props.id], true);
         }
         return (() => {
             setSelection(INITIAL_SELECTION);
@@ -100,17 +91,19 @@ const TilesView = (props) => {
         })
     }, [])
 
-    const [newStepToFlowOptions, setNewStepToFlowOptions] = useState(!props.id ? { addingStepToFlow: false } : {
-        addingStepToFlow: true,
-        newStepName: location.state?.stepToAdd,
-        stepDefinitionType: location.state?.stepDefinitionType,
-        existingFlow: location.state?.existingFlow || false,
-        flowsDefaultKey: location.state?.flowsDefaultKey || ['-1']
-    })
+    const getNewStepToFlowOptions = () => {
+        return !props.addingStepToFlow ? { addingStepToFlow: false } : {
+            addingStepToFlow: true,
+            newStepName: location.state?.stepToAdd,
+            stepDefinitionType: location.state?.stepDefinitionType,
+            existingFlow: location.state?.existingFlow || false,
+            flowsDefaultKey: location.state?.flowsDefaultKey || ['-1']
+        }
+    }
 
     return (
         <>
-            <Toolbar tiles={tiles} onClick={onSelect} enabled={enabled}/>
+            <Toolbar tiles={tiles} enabled={enabled}/>
             { (searchOptions.view !== null) ?  (
                 <div className={styles.tilesViewContainer}>
                     { (selection !== '') ?  (
@@ -121,7 +114,7 @@ const TilesView = (props) => {
                         options={options}
                         onMenuClick={onMenuClick}
                         onTileClose={onTileClose}
-                        newStepToFlowOptions={newStepToFlowOptions}
+                        newStepToFlowOptions={getNewStepToFlowOptions()}
                     />
                     ) : null }
                 </div> ) :

--- a/marklogic-data-hub-central/ui/src/services/user-preferences.tsx
+++ b/marklogic-data-hub-central/ui/src/services/user-preferences.tsx
@@ -6,7 +6,7 @@ interface UserPreferences {
   },
   pageLength: number,
   tableView: boolean,
-  pageRoute: string,
+  // pageRoute: string,
   resultTableColumns: any[],
   selectedQuery: string
 }
@@ -19,7 +19,7 @@ export const defaultUserPreferences = {
   },
   pageLength: 20,
   tableView: true,
-  pageRoute: '/view',
+  // pageRoute: '/view',
   resultTableColumns: [],
   selectedQuery: 'select a query'
 }

--- a/marklogic-data-hub-central/ui/src/types/user-types.ts
+++ b/marklogic-data-hub-central/ui/src/types/user-types.ts
@@ -1,7 +1,6 @@
 export interface UserContextInterface {
     name: string;
     authenticated: boolean;
-    redirect: boolean;
     error : any;
     pageRoute: string;
     maxSessionTime: number;
@@ -14,7 +13,6 @@ export interface IUserContextInterface {
     userNotAuthenticated: () => void;
     handleError: (error:any) => void;
     clearErrorMessage: () => void;
-    clearRedirect: () => void;
     setPageRoute: (route: string) => void;
     setAlertMessage: (title: string, message: string) => void;
     resetSessionTime: () => void;

--- a/marklogic-data-hub-central/ui/src/util/user-context.tsx
+++ b/marklogic-data-hub-central/ui/src/util/user-context.tsx
@@ -12,15 +12,13 @@ import { useInterval } from '../hooks/use-interval';
 
 const defaultUserData = {
   name: '',
-  // email: '',
   authenticated: false,
-  redirect: false,
   error : {
     title: '',
     message: '',
     type: ''
   },
-  pageRoute: '/view',
+  pageRoute: '/tiles',
   maxSessionTime: 300
 }
 
@@ -31,7 +29,6 @@ export const UserContext = React.createContext<IUserContextInterface>({
   userNotAuthenticated: () => {},
   handleError: () => {},
   clearErrorMessage: () => {},
-  clearRedirect: () => {},
   setPageRoute: () => {},
   setAlertMessage: () => {},
   resetSessionTime: () => {},
@@ -64,8 +61,8 @@ const UserProvider: React.FC<{ children: any }> = ({children}) => {
         ...user,
         name: username,
         authenticated: true,
-        redirect: true,
-        pageRoute: values.pageRoute,
+        // redirect: true,
+        // pageRoute: values.pageRoute,
         maxSessionTime: sessionCount
       });
     } else {
@@ -74,7 +71,7 @@ const UserProvider: React.FC<{ children: any }> = ({children}) => {
         ...user,
         name: username,
         authenticated: true,
-        redirect: true,
+        // redirect: true,
         maxSessionTime: sessionCount
       });
     }
@@ -89,7 +86,7 @@ const UserProvider: React.FC<{ children: any }> = ({children}) => {
         ...user,
         name: username,
         authenticated: true,
-        pageRoute: values.pageRoute,
+        // pageRoute: values.pageRoute,
         maxSessionTime: sessionCount
       });
     } else {
@@ -104,7 +101,7 @@ const UserProvider: React.FC<{ children: any }> = ({children}) => {
     localStorage.setItem('loginResp','');
     authoritiesService.setAuthorities([]);
     resetEnvironment();
-    setUser({ ...user,name: '', authenticated: false, redirect: true});
+    setUser({ ...user,name: '', authenticated: false}); //, redirect: true});
   };
 
   const handleError = (error) => {
@@ -140,7 +137,7 @@ const UserProvider: React.FC<{ children: any }> = ({children}) => {
       case 404: {
         setUser({
           ...user,
-          redirect: true,
+          // redirect: true,
           error: {
             title: error.response.data.error,
             message: error.response.data.message || DEFAULT_MESSAGE,
@@ -192,9 +189,6 @@ const UserProvider: React.FC<{ children: any }> = ({children}) => {
   const clearErrorMessage = () => {
     setUser({ ...user, error : { title:'', message: '', type: '' }});
   }
-  const clearRedirect = () => {
-    setUser({ ...user, redirect: false });
-  }
 
   const setPageRoute = (route: string) => {
     updateUserPreferences(user.name, { pageRoute: route });
@@ -243,7 +237,6 @@ const UserProvider: React.FC<{ children: any }> = ({children}) => {
       userNotAuthenticated,
       handleError,
       clearErrorMessage,
-      clearRedirect,
       setPageRoute,
       setAlertMessage,
       getSessionTime,


### PR DESCRIPTION
Make the different tile views "URL accessible," i.e.:

/tiles/load -> Load view
/tiles/model -> Model view
/tiles/curate -> Curate view
/tiles/run -> Run view
/tiles/explore -> Explore view

Notes:

- Refactored routing in Add.tsx to add routes for the different tile views.
- Made the tool buttons links to the new routes to enable "open in new window" clicking etc.
- Refactored user-context to remove props no longer needed (redirect, etc).
- Removed some routes that are no longer relevant.
- Refactored add-step-to-flow feature based on new routes (use /tiles/run/add for that).

Updated tests (with @bsrikan's help), all passing.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

