### PR TITLE
DHFPROD-5313: Fixing the bug where clicking on expanded row render breaks the UI when there is no primary key

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.tsx
+++ b/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.tsx
@@ -262,7 +262,7 @@ const ResultsTabularView = (props) => {
 
         let index: string = '';
         for (let i in parsedPayload.data) {
-            if (parsedPayload.data[i].primaryKey == rowId.primaryKey) {
+            if (parsedPayload.data[i].uri == rowId.uri) {
                 index = i;
             }
         }


### PR DESCRIPTION
### Description
This is a small bug fix so no test is required.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

