### PR TITLE
DHFPROD-5393: Can now run hubUpdate on DHF 4.3.x

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -869,6 +869,8 @@ public class DataHubImpl implements DataHub, InitializingBean {
         if (isHubInstalled) {
             final String minUpgradeVersion = "4.3.0";
             final String installedVersion = versions.getInstalledVersion();
+            // Warn is used so this appears when using Gradle without "-i"
+            logger.warn("Currently installed DHF version: " + installedVersion);
             if (Versions.compare(installedVersion, minUpgradeVersion) == -1) {
                 throw new RuntimeException("Cannot upgrade installed Data Hub; its version is " + installedVersion + ", and must be at least version " + minUpgradeVersion + " or higher");
             }

--- a/marklogic-data-hub/src/main/resources/scaffolding/gradle/wrapper/gradle-wrapper.properties
+++ b/marklogic-data-hub/src/main/resources/scaffolding/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/UpgradeProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/UpgradeProjectTest.java
@@ -177,7 +177,7 @@ public class UpgradeProjectTest extends AbstractHubCoreTest {
         Assumptions.assumingThat(versions.isVersionCompatibleWithES(), () -> {
             FileUtils.copyFileToDirectory(getResourceFile("mapping-test/flows/CustomerXML.flow.json"), adminHubConfig.getFlowsDir().toFile());
             FileUtils.copyDirectory(getResourceFile("flow-runner-test/flows"), adminHubConfig.getFlowsDir().toFile());
-            project.upgradeFlows();
+            project.updateStepDefinitionTypeForInlineMappingSteps();
             Assertions.assertEquals("entity-services-mapping", flowManager.getLocalFlow("testFlow").getStep("6").getStepDefinitionName());
             Assertions.assertEquals("entity-services-mapping", flowManager.getLocalFlow("CustomerXML").getStep("2").getStepDefinitionName());
         });


### PR DESCRIPTION
Added some logging and a try/catch on updating mapping steps, just in case the call to get the ML version bombs. 

The actual fix is in Versions - we now fallback to ml:hubversion if mlHubversion can't be hit. See the comments about the complexity/value of an automated test for this.

Finally, I bumped up the Gradle version in the scaffolded gradle-wrapper.properties to be 6.2.2. The user will really need to do this first (since it can't be done as part of "./gradlew hubUpdate), but I wanted to correct this here as I think not doing it was an oversight in the ticket for upgrading to Java Client 5.2.0.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

