### PR TITLE
DHFPROD-5407: Permission properties now work again

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -1408,6 +1408,9 @@ public class HubConfigImpl implements HubConfig
         }
 
         customTokens.put("%%mlJobPermissions%%", jobPermissions);
+        customTokens.put("%%mlFlowPermissions%%", flowPermissions);
+        customTokens.put("%%mlEntityModelPermissions%%", entityModelPermissions);
+        customTokens.put("%%mlStepDefinitionPermissions%%", stepDefinitionPermissions);
 
         customTokens.put("%%mlCustomForestPath%%", customForestPath);
 
@@ -1684,6 +1687,13 @@ public class HubConfigImpl implements HubConfig
 
         customForestPath = "forests";
 
+        applyDefaultPermissionPropertyValues();
+    }
+
+    /**
+     * This is called by applyDefaultPropertyValues, but is separate for testing purposes.
+     */
+    public void applyDefaultPermissionPropertyValues() {
         modulePermissions = "data-hub-module-reader,read,data-hub-module-reader,execute,data-hub-module-writer,update,rest-extension-user,execute";
         entityModelPermissions = "data-hub-entity-model-reader,read,data-hub-entity-model-writer,update";
         mappingPermissions = "data-hub-mapping-reader,read,data-hub-mapping-writer,update";

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.hub/config.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.hub/config.sjs
@@ -8,6 +8,5 @@ module.exports = {
   HUBLOGLEVEL: "%%mlHubLogLevel%%",
   FLOWOPERATORROLE: "%%mlFlowOperatorRole%%",
   FLOWDEVELOPERROLE: "%%mlFlowDeveloperRole%%",
-  JOBPERMISSIONS: "%%mlJobPermissions%%",
-  MODELPERMISSIONS: "%%mlEntityModelPermissions%%"
+  JOBPERMISSIONS: "%%mlJobPermissions%%"
 };

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/flow.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/flow.sjs
@@ -18,9 +18,10 @@
 const DataHubSingleton = require('/data-hub/5/datahub-singleton.sjs');
 const dataHub = DataHubSingleton.instance();
 
+const HubUtils = require("/data-hub/5/impl/hub-utils.sjs");
+
 const collections = ['http://marklogic.com/data-hub/flow'];
 const databases = [dataHub.config.STAGINGDATABASE, dataHub.config.FINALDATABASE];
-const permissions = [xdmp.permission(dataHub.consts.DATA_HUB_FLOW_WRITE_ROLE, 'update'), xdmp.permission(dataHub.consts.DATA_HUB_FLOW_READ_ROLE, 'read')];
 const requiredProperties = ['name'];
 
 function getNameProperty() {
@@ -40,7 +41,12 @@ function getStorageDatabases() {
 }
 
 function getPermissions() {
-    return permissions;
+  let permsString = "%%mlFlowPermissions%%";
+  // Default to the given string in case the above token has not been replaced
+  permsString = permsString.indexOf("%mlFlowPermissions%") > -1 ?
+    "data-hub-flow-reader,read,data-hub-flow-writer,update" :
+    permsString;
+  return new HubUtils().parsePermissions(permsString);
 }
 
 function getFileExtension() {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/stepDefinition.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/stepDefinition.sjs
@@ -18,9 +18,10 @@
 const DataHubSingleton = require('/data-hub/5/datahub-singleton.sjs');
 const dataHub = DataHubSingleton.instance();
 
+const HubUtils = require("/data-hub/5/impl/hub-utils.sjs");
+
 const collections = ['http://marklogic.com/data-hub/step-definition'];
 const databases = [dataHub.config.STAGINGDATABASE, dataHub.config.FINALDATABASE];
-const permissions = [xdmp.permission(dataHub.consts.DATA_HUB_STEP_DEFINITION_WRITE_ROLE, 'update'), xdmp.permission(dataHub.consts.DATA_HUB_STEP_DEFINITION_READ_ROLE, 'read')];
 const requiredProperties = ['name'];
 
 function getNameProperty() {
@@ -40,7 +41,12 @@ function getStorageDatabases() {
 }
 
 function getPermissions() {
-    return permissions;
+  let permsString = "%%mlStepDefinitionPermissions%%";
+  // Default to the given string in case the above token has not been replaced
+  permsString = permsString.indexOf("%mlStepDefinitionPermissions%") > -1 ?
+    "data-hub-step-definition-reader,read,data-hub-step-definition-writer,update" :
+    permsString;
+  return new HubUtils().parsePermissions(permsString);
 }
 
 function getArtifactNode(artifactName, artifactVersion) {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/entity-lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/entity-lib.sjs
@@ -326,11 +326,10 @@ function writeModel(entityName, model) {
 
   dataHub.hubUtils.replaceLanguageWithLang(model);
 
-  let permsString = dataHub.config.MODELPERMISSIONS;
-  if (!permsString || permsString.startsWith("%%ml")) {
-    // Safeguard, as the token is somehow not being replaced when tests are run in Jenkins
-    permsString = "data-hub-entity-model-reader,read,data-hub-entity-model-writer,update";
-  }
+  let permsString = "%%mlEntityModelPermissions%%";
+  permsString = permsString.indexOf("%mlEntityModelPermissions%") > -1 ?
+    "data-hub-entity-model-reader,read,data-hub-entity-model-writer,update" :
+    permsString;
   const permissions = dataHub.hubUtils.parsePermissions(permsString);
 
   [dataHub.config.STAGINGDATABASE, dataHub.config.FINALDATABASE].forEach(db => {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/AbstractHubCoreTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/AbstractHubCoreTest.java
@@ -2,6 +2,7 @@ package com.marklogic.hub;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +32,13 @@ public abstract class AbstractHubCoreTest extends HubTestBase {
     void beforeEachHubTest() {
         resetHubProject();
         runAsDataHubDeveloper();
+    }
+
+    protected DocumentMetadataHelper getMetadata(DatabaseClient client, String uri) {
+        return new DocumentMetadataHelper(
+            uri,
+            client.newDocumentManager().readMetadata(uri, new DocumentMetadataHandle())
+        );
     }
 
     protected void verifyJsonNodes(JsonNode expectedNode, JsonNode actualNode) {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/DocumentMetadataHelper.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/DocumentMetadataHelper.java
@@ -1,0 +1,34 @@
+package com.marklogic.hub;
+
+import com.marklogic.client.io.DocumentMetadataHandle;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * TODO Move this to testFixures once that configuration depends on JUnit 5.
+ */
+public class DocumentMetadataHelper {
+
+    private String uri;
+    private DocumentMetadataHandle metadata;
+
+    public DocumentMetadataHelper(String uri, DocumentMetadataHandle metadata) {
+        this.uri = uri;
+        this.metadata = metadata;
+    }
+
+    public void assertInCollection(String collection) {
+        assertTrue(metadata.getCollections().contains(collection),
+            String.format("Expected document with URI %s to be in collection %s", uri, collection));
+    }
+
+    public void assertHasPermission(String role, DocumentMetadataHandle.Capability capability) {
+        assertTrue(metadata.getPermissions().containsKey(role),
+            String.format("Expected document with URI %s to have permission with role %s", uri, role));
+        Set<DocumentMetadataHandle.Capability> capabilities = metadata.getPermissions().get(role);
+        assertTrue(capabilities.contains(capability),
+            String.format("Expected document with URI %s to have permission with role %s and capability %s", uri, role, capability));
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsWithCustomPermissionsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsWithCustomPermissionsTest.java
@@ -1,0 +1,81 @@
+package com.marklogic.hub.deploy.commands;
+
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.hub.AbstractHubCoreTest;
+import com.marklogic.hub.DocumentMetadataHelper;
+import com.marklogic.hub.impl.HubConfigImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Stream;
+
+public class LoadUserArtifactsWithCustomPermissionsTest extends AbstractHubCoreTest {
+
+    @AfterEach
+    void restoreDefaultPermissionsForFlowsAndStepDefinitions() {
+        getHubConfig().applyDefaultPermissionPropertyValues();
+        getHubConfig().setAppConfig(getHubConfig().getAppConfig());
+        installHubModules();
+    }
+
+    @Test
+    void customPermissionsForFlowsAndStepDefinitionsAndEntityModels() {
+        HubConfigImpl hubConfig = getHubConfig();
+        hubConfig.setFlowPermissions("data-hub-common,read,data-hub-common,update");
+        hubConfig.setStepDefinitionPermissions("data-hub-module-reader,read,data-hub-module-writer,update");
+        hubConfig.setEntityModelPermissions("data-hub-operator,read,data-hub-operator,update");
+
+        // Must call this to force the modified property values to be added to the AppConfig customTokens map
+        // In a Gradle context, this would have already happened when the Gradle properties were processed
+        hubConfig.setAppConfig(hubConfig.getAppConfig());
+        installHubModules();
+
+        installReferenceModelProject();
+
+        Stream.of(adminHubConfig.newStagingClient(), adminHubConfig.newFinalClient()).forEach(client -> {
+            DocumentMetadataHelper metadata = getMetadata(client, "/flows/echoFlow.flow.json");
+            metadata.assertInCollection("http://marklogic.com/data-hub/flow");
+            metadata.assertHasPermission("data-hub-common", DocumentMetadataHandle.Capability.READ);
+            metadata.assertHasPermission("data-hub-common", DocumentMetadataHandle.Capability.UPDATE);
+
+            metadata = getMetadata(client, "/step-definitions/custom/echoStep/echoStep.step.json");
+            metadata.assertInCollection("http://marklogic.com/data-hub/step-definition");
+            metadata.assertHasPermission("data-hub-module-reader", DocumentMetadataHandle.Capability.READ);
+            metadata.assertHasPermission("data-hub-module-writer", DocumentMetadataHandle.Capability.UPDATE);
+
+            metadata = getMetadata(client, "/entities/Customer.entity.json");
+            metadata.assertInCollection("http://marklogic.com/entity-services/models");
+            metadata.assertHasPermission("data-hub-operator", DocumentMetadataHandle.Capability.READ);
+            metadata.assertHasPermission("data-hub-operator", DocumentMetadataHandle.Capability.UPDATE);
+        });
+    }
+
+    /**
+     * Verifies that if the tokens are somehow not replaced in the modules that reference them, then the modules will
+     * fallback to default values that match the default values in HubConfigImpl.
+     */
+    @Test
+    void simulateTokensNotBeingReplaced() {
+        HubConfigImpl hubConfig = getHubConfig();
+        hubConfig.setFlowPermissions("%%mlFlowPermissions%%");
+        hubConfig.setStepDefinitionPermissions("%%mlStepDefinitionPermissions%%");
+        hubConfig.setEntityModelPermissions("%%mlEntityModelPermissions%%");
+        hubConfig.setAppConfig(hubConfig.getAppConfig());
+        installHubModules();
+        installReferenceModelProject();
+
+        Stream.of(adminHubConfig.newStagingClient(), adminHubConfig.newFinalClient()).forEach(client -> {
+            DocumentMetadataHelper metadata = getMetadata(client, "/flows/echoFlow.flow.json");
+            metadata.assertHasPermission("data-hub-flow-reader", DocumentMetadataHandle.Capability.READ);
+            metadata.assertHasPermission("data-hub-flow-writer", DocumentMetadataHandle.Capability.UPDATE);
+
+            metadata = getMetadata(client, "/step-definitions/custom/echoStep/echoStep.step.json");
+            metadata.assertHasPermission("data-hub-step-definition-reader", DocumentMetadataHandle.Capability.READ);
+            metadata.assertHasPermission("data-hub-step-definition-writer", DocumentMetadataHandle.Capability.UPDATE);
+
+            metadata = getMetadata(client, "/entities/Customer.entity.json");
+            metadata.assertHasPermission("data-hub-entity-model-reader", DocumentMetadataHandle.Capability.READ);
+            metadata.assertHasPermission("data-hub-entity-model-writer", DocumentMetadataHandle.Capability.UPDATE);
+        });
+    }
+}


### PR DESCRIPTION
The values of mlFlowPermissions, mlStepDefinitionPermissions, and mlEntityModelPermissions are now applied by the DS endpoints for these artifact types.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

