### PR TITLE
DHFPROD-5329: Close the resource only after running the job

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
@@ -255,14 +255,7 @@ public class QueryStepRunner implements StepRunner {
             return runStepResponse;
         }
 
-        try {
-            return this.runHarmonizer(runStepResponse, uris);
-        }
-        finally {
-            if (uris != null) {
-                uris.close();
-            }
-        }
+        return this.runHarmonizer(runStepResponse, uris);
     }
 
     @Override
@@ -470,6 +463,11 @@ public class QueryStepRunner implements StepRunner {
 
         runningThread = new Thread(() -> {
             queryBatcher.awaitCompletion();
+
+            // now that the job has completed we can close the resource
+            if (uris instanceof DiskQueue) {
+                ((DiskQueue<String>)uris).close();
+            }
 
             String stepStatus;
             if (stepMetrics.getFailedEventsCount() > 0 && stopOnFailure) {


### PR DESCRIPTION
### Description
Not changing `runHarmonizer` to accept a DiskQueue as runHarmonizer is also called by `run(Collection<String> uris)` which is part of our public API.
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [N/A] Added Tests
  

- ##### Reviewer:

- [N/A] Reviewed Tests

