### PR TITLE
DHFPROD-5461: Fixing generation of protected paths

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/util/QueryRolesetUtil.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/util/QueryRolesetUtil.java
@@ -22,29 +22,39 @@ import org.slf4j.LoggerFactory;
 import org.springframework.web.client.HttpClientErrorException;
 
 public class QueryRolesetUtil {
+
     private static final Logger logger = LoggerFactory.getLogger(QueryRolesetUtil.class);
 
+    /**
+     * Query rolesets have a bug in the Manage API in < 10.0-4 ML, and the Manage API no longer supports PUT requests
+     * (updates) on them in 10.0-4. Because DHF 5.3.0 requires ML 10.0-2.1 or higher, need to do some error handling here
+     * as some errors should just be logged and ignored.
+     *
+     * @param ex
+     */
     public static void handleSaveException(HttpClientErrorException ex) {
-        if (isPermissionDeniedException(ex)) {
-            logger.error("Received SEC-PERMDENIED error when deploying query roleset; this can be safely ignored if the " +
-                "query roleset already exists in MarkLogic.");
-        } else {
-            throw ex;
-        }
-    }
-
-    private static boolean isPermissionDeniedException(HttpClientErrorException ex) {
         try {
             JsonNode error = ObjectMapperFactory.getObjectMapper().readTree(ex.getResponseBodyAsString());
             if (error.has("errorResponse")) {
                 JsonNode errorResponse = error.get("errorResponse");
                 if (errorResponse.has("messageCode")) {
-                    return "SEC-PERMDENIED".equals(errorResponse.get("messageCode").asText());
+                    final String messageCode = errorResponse.get("messageCode").asText();
+                    if ("SEC-PERMDENIED".equals(messageCode)) {
+                        logger.error("Received SEC-PERMDENIED error when deploying query roleset; this can be safely ignored if the " +
+                            "query roleset already exists in MarkLogic.");
+                        return;
+                    } else if ("REST-UNSUPPORTEDMETHOD".equals(messageCode)) {
+                        // This won't occur when using a data-hub-developer user, but will when using an admin user, and
+                        // likely a user with manage-admin/security as well
+                        logger.info("Received REST-UNSUPPORTEDMETHOD error when updating query roleset; this can be safely ignored " +
+                            "when running against MarkLogic version 10.0-4 or higher, which no longer supports updates to query rolesets");
+                        return;
+                    }
                 }
             }
         } catch (Exception e) {
             logger.warn("Unexpected error when trying to parse error for deploying query rolesets: " + e.getMessage());
         }
-        return false;
+        throw ex;
     }
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/models/GenerateProtectedPathForXmlEntitiesTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/models/GenerateProtectedPathForXmlEntitiesTest.java
@@ -1,0 +1,107 @@
+package com.marklogic.hub.dataservices.models;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.appdeployer.AppConfig;
+import com.marklogic.appdeployer.command.CommandContext;
+import com.marklogic.appdeployer.command.security.DeployProtectedPathsCommand;
+import com.marklogic.appdeployer.command.security.DeployQueryRolesetsCommand;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.hub.AbstractHubCoreTest;
+import com.marklogic.hub.HubClient;
+import com.marklogic.hub.HubConfig;
+import com.marklogic.hub.impl.EntityManagerImpl;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GenerateProtectedPathForXmlEntitiesTest extends AbstractHubCoreTest {
+
+    @Test
+    void test() {
+        installProjectInFolder("test-projects/entity-with-indexes");
+        new EntityManagerImpl(getHubConfig()).savePii();
+
+        File pathsDir = getHubConfig().getHubProject().getUserSecurityDir().resolve("protected-paths").toFile();
+        assertTrue(pathsDir.exists());
+        File pathFile = new File(pathsDir, "01_" + HubConfig.PII_PROTECTED_PATHS_FILE);
+        assertTrue(pathFile.exists());
+        ObjectNode path = readJsonObject(pathFile);
+        assertEquals("/*:envelope//*:instance//*:Person/*:personId", path.get("path-expression").asText(),
+            "The path should account for both XML and JSON entities");
+        assertEquals("pii-reader", path.get("permission").get("role-name").asText());
+        assertEquals("read", path.get("permission").get("capability").asText());
+
+        // Verify that the path works on XML and JSON
+        runAsFlowDeveloper();
+        deployProtectedPathsAndQueryRolesets();
+        insertJsonAndXmlEntities();
+
+        runAsDataHubOperator();
+        verifyPersonIdIsHidden();
+    }
+
+    private void deployProtectedPathsAndQueryRolesets() {
+        AppConfig appConfig = getHubConfig().getAppConfig();
+        CommandContext context = new CommandContext(appConfig, getHubConfig().getManageClient(), null);
+        boolean originalCmaSetting = appConfig.getCmaConfig().isCombineRequests();
+        try {
+            appConfig.getCmaConfig().setCombineRequests(false);
+            new DeployQueryRolesetsCommand().execute(context);
+            new DeployProtectedPathsCommand().execute(context);
+        } finally {
+            appConfig.getCmaConfig().setCombineRequests(originalCmaSetting);
+        }
+    }
+
+    private void insertJsonAndXmlEntities() {
+        HubClient client = getHubClient();
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle()
+            .withPermission("data-hub-common", DocumentMetadataHandle.Capability.READ)
+            .withPermission("data-hub-common", DocumentMetadataHandle.Capability.UPDATE);
+
+        final String json = "{\n" +
+            "  \"envelope\": {\n" +
+            "    \"instance\": {\n" +
+            "      \"Person\": {\n" +
+            "        \"personId\": 101,\n" +
+            "        \"name\": \"JSON Person\"\n" +
+            "      }\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+        client.getFinalClient().newJSONDocumentManager().write("/fake/Person101.json", metadata,
+            new StringHandle(json).withFormat(Format.JSON));
+
+        final String xml = "<envelope xmlns=\"http://marklogic.com/entity-services\">\n" +
+            "  <instance>\n" +
+            "    <Person xmlns=\"\">\n" +
+            "      <personId>201</personId>\n" +
+            "      <name>XML Person</name>\n" +
+            "    </Person>\n" +
+            "  </instance>\n" +
+            "</envelope>";
+        client.getFinalClient().newXMLDocumentManager().write("/fake/Person201.xml", metadata,
+            new StringHandle(xml).withFormat(Format.XML));
+    }
+
+    private void verifyPersonIdIsHidden() {
+        HubClient client = getHubClient();
+        final String message = "personId should be hidden because it's PII-protected and the user " +
+            "doesn't have the pii-reader role";
+
+        JsonNode personDoc = client.getFinalClient().newJSONDocumentManager().read("/fake/Person101.json", new JacksonHandle()).get();
+        JsonNode person = personDoc.get("envelope").get("instance").get("Person");
+        assertEquals("JSON Person", person.get("name").asText());
+        assertFalse(person.has("personId"), message);
+
+        String xml = client.getFinalClient().newXMLDocumentManager().read("/fake/Person201.xml", new StringHandle()).get();
+        assertTrue(xml.contains("<name>XML Person</name"));
+        assertFalse(xml.contains("personId"), message);
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/hubcentral/AllArtifactsProject.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/hubcentral/AllArtifactsProject.java
@@ -57,9 +57,9 @@ public class AllArtifactsProject extends TestObject {
 
         // Verify PII stuff
         verifyEntryExists("/src/main/ml-config/security/protected-paths/1-pii-protected-paths.json",
-            "path-expression", "/envelope//instance//Order/orderID");
+            "path-expression", "/*:envelope//*:instance//*:Order/*:orderID");
         verifyEntryExists("/src/main/ml-config/security/protected-paths/2-pii-protected-paths.json",
-            "path-expression", "/envelope//instance//Order/orderName");
+            "path-expression", "/*:envelope//*:instance//*:Order/*:orderName");
         assertEquals("pii-reader", zipEntries.get("/src/main/ml-config/security/query-rolesets/pii-reader.json").get("role-name").iterator().next().asText());
 
         // Verify search options

--- a/marklogic-data-hub/src/test/resources/test-projects/entity-with-indexes/entities/Person.entity.json
+++ b/marklogic-data-hub/src/test/resources/test-projects/entity-with-indexes/entities/Person.entity.json
@@ -13,6 +13,9 @@
       "rangeIndex": [
         "personId"
       ],
+      "pii": [
+        "personId"
+      ],
       "properties": {
         "personId": {
           "datatype": "integer"


### PR DESCRIPTION
Also added more exception handling for query rolesets, as the Manage API endpoint for them changed in ML 10.0-4 such that "PUT" is no longer available.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

