### PR TITLE
DHFPROD-5187: Display mapping test results for arrays on separate lines

### DIFF
--- a/marklogic-data-hub-central/ui/src/assets/mock-data/common.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/common.data.ts
@@ -188,8 +188,8 @@ const testJSONResponse = {
 
 const truncatedJSONResponse = {
   properties: {
-    propName: { output: 'user1@marklogic.com,user2@marklogic.com, ... (300 more)', sourcedFrom: 'proteinId' },
-    propAttribute: { output: 'u@ml.com,v@ml.com, ... (30 more)', sourcedFrom: 'proteinType' },
+    propName: { output: 'extremelylongusername@marklogic.com', sourcedFrom: 'proteinId' },
+    propAttribute: { output: ['s@ml.com', 't@ml.com', 'u@ml.com' , 'v@ml.com' , 'w@ml.com' , 'x@ml.com' , 'y@ml.com', 'z@ml.com'], sourcedFrom: 'proteinType' },
   },
   targetEntityType: 'Person'
 };

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.module.scss
@@ -204,8 +204,8 @@ hr {
 
 .mapValue {
     margin-top: -6px;
-    margin-bottom: -8px;
-    white-space: nowrap;
+    margin-bottom: -20px;
+    white-space: pre-wrap;
     overflow: hidden;
     text-overflow: ellipsis;
     line-height: normal;

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { waitForElement, waitForElementToBeRemoved, render, cleanup, fireEvent, within } from '@testing-library/react';
+import { waitForElement, waitForElementToBeRemoved, render, cleanup, fireEvent, within, screen, wait, prettyDOM } from '@testing-library/react';
 import SourceToEntityMap from './source-to-entity-map';
 import data from '../../../../assets/mock-data/common.data';
 import { shallow } from 'enzyme';
@@ -447,7 +447,7 @@ describe('RTL Source-to-entity map tests', () => {
 
     test('Truncation in case of responses for Array datatype', async () => {
         axiosMock.post['mockImplementation'](jest.fn(() => Promise.resolve({ status: 200, data: data.truncatedJSONResponse })));
-        const { getByText, getByTestId, queryByTestId } = render(<SourceToEntityMap {...data.mapProps} mappingVisible={true} entityTypeProperties={data.truncatedEntityProps} />)
+        const { getByText, getAllByRole, getByTestId, queryByTestId } = render(<SourceToEntityMap {...data.mapProps} mappingVisible={true} entityTypeProperties={data.truncatedEntityProps} />)
         let propNameExpression = getByText('testNameInExp');
         let propAttributeExpression = getByText('placeholderAttribute')
 
@@ -471,8 +471,16 @@ describe('RTL Source-to-entity map tests', () => {
         //Verify Test button click
         fireEvent.click(getByText('Test'))
         await(waitForElement(() => getByTestId('propName-value')))
-        expect(getByTestId('propName-value')).toHaveTextContent('user1@marklogic.com,user2... (300 more)')
-        expect(getByTestId('propAttribute-value')).toHaveTextContent('u@ml.com,v@ml.com... (30 more)')
+        expect(getByTestId('propName-value')).toHaveTextContent('extremelylongusername@m...')
+        expect(getByTestId('propAttribute-value')).toHaveTextContent('s@ml.com t@ml.com (6 more)')
+
+        // Verify tooltip shows full value when hovering Test values
+        fireEvent.mouseOver(getByText('extremelylongusername@m...'))
+        await waitForElement(() => getByText('extremelylongusername@marklogic.com'));
+
+        //TODO: Verify tooltip shows all values when hovering Test values
+        // fireEvent.mouseOver(getByText())
+        // await waitForElement(() => getByText('s@ml.com, t@ml.com, u@ml.com, v@ml.com, w@ml.com, x@ml.com, y@ml.com z@ml.com'));
 
     })
 


### PR DESCRIPTION
### Description

- Mapping test results of arrays with multiple values are now displayed on separate lines
- Maximum of two values shown and then '(X more)' all on separate lines
- Refactored RTL tests and test data to accommodate new response from backend and how it is handled in the UI.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

