### PR TITLE
DHFPROD-4456: Handle no network response

### DIFF
--- a/marklogic-data-hub-central/ui/src/App.test.tsx
+++ b/marklogic-data-hub-central/ui/src/App.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Router } from 'react-router'
-import { createMemoryHistory } from 'history'
-const history = createMemoryHistory()
-import { render, fireEvent, waitForElement, cleanup } from '@testing-library/react'
+import { Router } from 'react-router';
+import { createMemoryHistory } from 'history';
+const history = createMemoryHistory();
+import { render, fireEvent, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect'
 import { AuthoritiesContext } from './util/authorities';
 import authorities from './assets/authorities.testutils';
@@ -30,7 +30,7 @@ describe('App component', () => {
       const firstTool = Object.keys(tiles)[0];
       // App defaults to pathname "/" which renders Login page. So setting the path to /tiles when App is rendered
       history.push('/tiles');
-      const { getByLabelText, queryByText } = render(<Router history = {history}>
+      const { getByLabelText, queryByText } = render(<Router history={history}>
           <AuthoritiesContext.Provider value={mockDevRolesService}>
             <UserContext.Provider value={userAuthenticated}><App/></UserContext.Provider>
           </AuthoritiesContext.Provider>
@@ -41,14 +41,14 @@ describe('App component', () => {
 
       // After switching to non-default, click MarkLogic logo to return to overview
       fireEvent.click(getByLabelText("tool-" + firstTool));
-      expect(await(waitForElement(() => getByLabelText("icon-" + firstTool)))).toBeInTheDocument();
+      await expect(getByLabelText("icon-" + firstTool)).toBeInTheDocument();
       expect(queryByText("overview")).not.toBeInTheDocument();
       fireEvent.click(getByLabelText("header-logo"));
       expect(getByLabelText("overview")).toBeInTheDocument();
 
       // After switching to non-default, click application name to return to overview
       fireEvent.click(getByLabelText("tool-" + firstTool));
-      expect(await(waitForElement(() => getByLabelText("icon-" + firstTool)))).toBeInTheDocument();
+      await expect(getByLabelText("icon-" + firstTool)).toBeInTheDocument();
       expect(queryByText("overview")).not.toBeInTheDocument();
       fireEvent.click(getByLabelText("header-title"));
       expect(getByLabelText("overview")).toBeInTheDocument();

--- a/marklogic-data-hub-central/ui/src/App.tsx
+++ b/marklogic-data-hub-central/ui/src/App.tsx
@@ -13,6 +13,7 @@ import TilesView from './pages/TilesView';
 import Browse from './pages/Browse';
 import Detail from './pages/Detail';
 import NoMatchRedirect from './pages/noMatchRedirect';
+import NoResponse from './pages/NoResponse';
 
 import './App.scss';
 import { Application } from './config/application.config';
@@ -54,7 +55,7 @@ const App: React.FC<Props> = ({history, location}) => {
       if (user.error.type !== '') {
         history.push('/error');
       } else {
-        if (location.pathname !== '/') {
+        if (location.pathname !== '/' && location.pathname !== '/noresponse') {
           user.pageRoute = location.pathname;
         }
         history.push('/');
@@ -68,7 +69,11 @@ const App: React.FC<Props> = ({history, location}) => {
         .then(res => {})
         // Timeouts throw 401s and are caught here
         .catch(err => {
-            handleError(err);
+            if (err.response) {
+              handleError(err);
+            } else {
+              history.push('/noresponse');
+            }
         })
   }, [location.pathname]);
 
@@ -85,6 +90,7 @@ const App: React.FC<Props> = ({history, location}) => {
         <div className="contentContainer">
         <Switch>
           <Route path="/" exact component={Login}/>
+          <Route path="/noresponse" exact component={NoResponse} />
           <PrivateRoute path="/home" exact>
             <Home/>
           </PrivateRoute>

--- a/marklogic-data-hub-central/ui/src/api/__mocks__/mocks.data.ts
+++ b/marklogic-data-hub-central/ui/src/api/__mocks__/mocks.data.ts
@@ -2,6 +2,7 @@ import loadData from "../../assets/mock-data/ingestion.data";
 import curateData from "../../assets/mock-data/flows.data";
 import advancedData from "../../assets/mock-data/advanced-settings.data";
 import commonData from "../../assets/mock-data/common.data";
+import systemInfoData from "../../assets/mock-data/system-info.data";
 
 const loadAPI = (axiosMock) => {
   axiosMock.delete['mockImplementation']((url) => {
@@ -199,6 +200,28 @@ const advancedAPI = (axiosMock) => {
   })
 };
 
+const systemInfoAPI = (axiosMock) => {
+  return axiosMock.get['mockImplementation']((url) => {
+    switch (url) {
+      case '/api/environment/systemInfo':
+        return Promise.resolve(systemInfoData.environment);
+      default:
+        return Promise.reject(new Error('not found'));
+    }
+  })
+};
+
+const noResponseAPI = (axiosMock) => {
+  return axiosMock.get['mockImplementation']((url) => {
+    switch (url) {
+      case '/api/environment/systemInfo':
+        return Promise.reject(new Error());
+      default:
+        return Promise.reject(new Error('not found'));
+    }
+  })
+};
+
 const mocks = {
   loadAPI: loadAPI,
   curateAPI: curateAPI,
@@ -208,6 +231,8 @@ const mocks = {
   runFailedAPI: runFailedAPI,
   runXMLAPI: runXMLAPI,
   advancedAPI: advancedAPI,
+  systemInfoAPI: systemInfoAPI,
+  noResponseAPI: noResponseAPI,
 };
 
 export default mocks;

--- a/marklogic-data-hub-central/ui/src/components/header/header.tsx
+++ b/marklogic-data-hub-central/ui/src/components/header/header.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { RouteComponentProps, withRouter, useHistory } from 'react-router-dom';
 import axios from 'axios';
 import { Layout, Icon, Avatar, Menu, Tooltip, Dropdown } from 'antd';
 import { UserContext } from '../../util/user-context';
@@ -16,10 +16,10 @@ interface Props extends RouteComponentProps<any> {
 const Header:React.FC<Props> = (props) => {
   const { user, userNotAuthenticated, handleError } = useContext(UserContext);
   const [systemInfoVisible, setSystemInfoVisible] = useState(false);
+  const history = useHistory();
 
   const handleLogout = async () => {
     try {
-      console.log('logging out');
       let response = await axios(`/api/logout`);
       if (response.status === 200 ) {
         userNotAuthenticated();
@@ -30,7 +30,18 @@ const Header:React.FC<Props> = (props) => {
   };
 
   const handleSystemInfoDisplay = () => {
-    setSystemInfoVisible(true);
+    axios.get('/api/environment/systemInfo')
+        .then(res => {
+          setSystemInfoVisible(true);
+        })
+        // Timeouts throw 401s and are caught here
+        .catch(err => {
+            if (err.response) {
+              handleError(err);
+            } else {
+              history.push('/noresponse');
+            }
+        })
   }
 
   let userMenu = <div className={styles.userMenu}>

--- a/marklogic-data-hub-central/ui/src/pages/NoResponse.module.scss
+++ b/marklogic-data-hub-central/ui/src/pages/NoResponse.module.scss
@@ -1,0 +1,17 @@
+.noResponseContainer {
+    
+    padding: 80px 60px 150px;
+
+    .title {
+        font-size: 28px;
+        font-weight: bold;
+        margin-bottom: 30px;
+    }
+    
+    .subtitle {
+        font-size: 16px;
+        font-weight: bold;
+    }
+
+}
+

--- a/marklogic-data-hub-central/ui/src/pages/NoResponse.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/NoResponse.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import {render } from "@testing-library/react";
+import NoResponse from './NoResponse';
+
+describe('NoResponse component', () => {
+
+    test('Verify static display', async () => {
+
+        const { getByText, getByLabelText } = render(<NoResponse/>);
+
+        expect(getByLabelText('noResponse')).toBeInTheDocument();
+
+        expect(getByText('No response from MarkLogic Server.')).toBeInTheDocument();
+        expect(getByText('Contact your administrator.')).toBeInTheDocument();
+
+    });
+
+});

--- a/marklogic-data-hub-central/ui/src/pages/NoResponse.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/NoResponse.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styles from './NoResponse.module.scss';
+
+const NoResponse: React.FC = () => {
+
+  return (
+    <div className={styles.noResponseContainer} aria-label="noResponse">
+      <div className={styles.title}>No response from MarkLogic Server.</div>
+      <div className={styles.subtitle}>Contact your administrator.</div>
+    </div>
+  );
+}
+
+export default NoResponse;


### PR DESCRIPTION
Display error page when middle tier goes down.
Display of error view will happen upon:
- Switching tile tools or other route-changing navigation
- Opening system info dialog
- Clicking buttons in session dialog

Update modal-status tests to handle async systemInfo check.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

