### PR TITLE
DHFPROD-5504: Generating function metadata now regenerates transforms

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/MappingService.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/MappingService.java
@@ -48,6 +48,7 @@ public interface MappingService {
             private BaseProxy baseProxy;
 
             private BaseProxy.DBFunctionRequest req_testMapping;
+            private BaseProxy.DBFunctionRequest req_generateMappingTransforms;
             private BaseProxy.DBFunctionRequest req_getMappingFunctions;
 
             private MappingServiceImpl(DatabaseClient dbClient, JSONWriteHandle servDecl) {
@@ -56,6 +57,8 @@ public interface MappingService {
 
                 this.req_testMapping = this.baseProxy.request(
                     "testMapping.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_MIXED);
+                this.req_generateMappingTransforms = this.baseProxy.request(
+                    "generateMappingTransforms.sjs", BaseProxy.ParameterValuesKind.NONE);
                 this.req_getMappingFunctions = this.baseProxy.request(
                     "getMappingFunctions.sjs", BaseProxy.ParameterValuesKind.NONE);
             }
@@ -75,6 +78,16 @@ public interface MappingService {
                           BaseProxy.documentParam("jsonMapping", false, BaseProxy.JsonDocumentType.fromJsonNode(jsonMapping))
                           ).responseSingle(false, Format.JSON)
                 );
+            }
+
+            @Override
+            public void generateMappingTransforms() {
+                generateMappingTransforms(
+                    this.req_generateMappingTransforms.on(this.dbClient)
+                    );
+            }
+            private void generateMappingTransforms(BaseProxy.DBFunctionRequest request) {
+              request.responseNone();
             }
 
             @Override
@@ -102,6 +115,14 @@ public interface MappingService {
    * @return	as output
    */
     com.fasterxml.jackson.databind.JsonNode testMapping(String uri, String database, com.fasterxml.jackson.databind.JsonNode jsonMapping);
+
+  /**
+   * Generates a transform in the modules database for each legacy mapping or mapping step
+   *
+   * 
+   * 
+   */
+    void generateMappingTransforms();
 
   /**
    * Invokes the getMappingFunctions operation on the database server

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateFunctionMetadataCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateFunctionMetadataCommand.java
@@ -10,10 +10,13 @@ import com.marklogic.client.document.ServerTransform;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.HubConfig;
+import com.marklogic.hub.dataservices.MappingService;
 import com.marklogic.hub.impl.Versions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Component
@@ -22,12 +25,9 @@ public class GenerateFunctionMetadataCommand extends AbstractCommand {
     @Autowired
     private HubConfig hubConfig;
 
-    private Versions versions;
-    private Throwable caughtException;
-    private DatabaseClient modulesClient;
-
     private boolean isCompatibleWithES;
 
+    // Need no-arg constructor for Spring
     public GenerateFunctionMetadataCommand() {
         super();
 
@@ -36,31 +36,19 @@ public class GenerateFunctionMetadataCommand extends AbstractCommand {
         setExecuteSortOrder(new LoadUserModulesCommand().getExecuteSortOrder() + 1);
     }
 
+    public GenerateFunctionMetadataCommand(HubConfig hubConfig) {
+        this();
+        this.hubConfig = hubConfig;
+    }
+
     /**
      * @param hubConfig
      * @param isCompatibleWithES if it's known that the version of ML supports mapping based on Entity Services, then
      *                           can set this to true
      */
     public GenerateFunctionMetadataCommand(HubConfig hubConfig, boolean isCompatibleWithES) {
-        this.hubConfig = hubConfig;
+        this(hubConfig);
         this.isCompatibleWithES = isCompatibleWithES;
-    }
-
-    public GenerateFunctionMetadataCommand(DatabaseClient modulesClient, Versions versions) {
-        this();
-        this.modulesClient = modulesClient;
-        this.versions = versions;
-    }
-
-    public GenerateFunctionMetadataCommand(HubConfig hubConfig, DatabaseClient modulesClient, Versions versions) {
-        this(modulesClient, versions);
-        this.hubConfig = hubConfig;
-    }
-
-    public GenerateFunctionMetadataCommand(HubConfig hubConfig) {
-        this();
-        this.hubConfig = hubConfig;
-        this.versions = new Versions(hubConfig);
     }
 
     @Override
@@ -69,30 +57,19 @@ public class GenerateFunctionMetadataCommand extends AbstractCommand {
     }
 
     public void generateFunctionMetadata() {
-        if (isCompatibleWithES || getVersions().isVersionCompatibleWithES()) {
-            if (modulesClient == null) {
-                if (hubConfig == null) {
-                    throw new IllegalStateException("Unable to create a DatabaseClient for the modules database because hubConfig is null");
-                }
-                modulesClient = hubConfig.newStagingClient(hubConfig.getDbName(DatabaseKind.MODULES));
-            }
-
+        if (isCompatibleWithES || new Versions(hubConfig).isVersionCompatibleWithES()) {
+            DatabaseClient modulesClient = hubConfig.newStagingClient(hubConfig.getDbName(DatabaseKind.MODULES));
             DataMovementManager dataMovementManager = modulesClient.newDataMovementManager();
+            final List<Throwable> caughtExceptions = new ArrayList<>();
 
             StructuredQueryBuilder sb = modulesClient.newQueryManager().newStructuredQueryBuilder();
-
-            // This transform needs to be the camelcase prefix instead of the ml: prefix since it is run as part of modules load.
             ServerTransform serverTransform = new ServerTransform("mlGenerateFunctionMetadata");
-
             ApplyTransformListener transformListener = new ApplyTransformListener()
                 .withTransform(serverTransform)
                 .withApplyResult(ApplyTransformListener.ApplyResult.IGNORE)
                 .onFailure((batch, throwable) -> {
-                    logger.error(throwable.getMessage());
-                    // throw the first exception
-                    if (caughtException == null) {
-                        caughtException = throwable;
-                    }
+                    logger.error("Caught error while generating function metadata: " + throwable.getMessage());
+                    caughtExceptions.add(throwable);
                 });
 
             // Query for uris "/data-hub/5/mapping-functions/" and "/custom-modules/mapping-functions/" which are reserved for mapping functions
@@ -111,22 +88,25 @@ public class GenerateFunctionMetadataCommand extends AbstractCommand {
             }
             dataMovementManager.stopJob(queryBatcher);
 
-            if (caughtException != null) {
-                throw new RuntimeException(caughtException);
+            // Trigger regeneration of mapping transforms, as they are now out-of-date and will not work
+            // Do this before throwing an exception, as the exception may only impact one mapping, and we don't
+            // want none of them to work
+            DatabaseClient stagingClient = hubConfig.newStagingClient(null);
+            try {
+                MappingService.on(stagingClient).generateMappingTransforms();
+            } finally {
+                stagingClient.release();
+            }
+
+            if (!caughtExceptions.isEmpty()) {
+                throw new RuntimeException(caughtExceptions.get(0));
             }
         } else {
-            logger.warn("GenerateFunctionMetadataCommand is not supported on this MarkLogic server version ");
+            logger.info("Not generating function metadata for mapping libraries, as it's not supported by this version of MarkLogic");
         }
     }
 
     public void setHubConfig(HubConfig hubConfig) {
         this.hubConfig = hubConfig;
-    }
-
-    private Versions getVersions() {
-        if (this.versions == null) {
-            this.versions = new Versions(this.hubConfig);
-        }
-        return this.versions;
     }
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -236,9 +236,12 @@ public class HubConfigImpl implements HubConfig
      */
     public HubConfigImpl(String host, String mlUsername, String mlPassword) {
         this();
-        setHost(host);
-        setMlUsername(mlUsername);
-        setMlPassword(mlPassword);
+
+        Properties props = new Properties();
+        props.setProperty("mlHost", host);
+        props.setProperty("mlUsername", mlUsername);
+        props.setProperty("mlPassword", mlPassword);
+        applyProperties(new SimplePropertySource(props));
     }
 
     /**

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/Versions.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/Versions.java
@@ -17,7 +17,6 @@ package com.marklogic.hub.impl;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marklogic.appdeployer.AppConfig;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.eval.EvalResultIterator;
@@ -42,8 +41,6 @@ import java.util.GregorianCalendar;
 
 @Component
 public class Versions extends LoggingObject {
-
-    private AppConfig appConfig;
 
     @Autowired
     private HubConfig hubConfig;
@@ -81,22 +78,8 @@ public class Versions extends LoggingObject {
         }
     }
 
-    /**
-     * Needed for the Gradle tasks.
-     *
-     * @param hubConfig HubConfig
-     */
     public Versions(HubConfig hubConfig) {
         this.hubConfig = hubConfig;
-    }
-
-    /**
-     * Needed for the Gradle tasks.
-     *
-     * @param appConfig AppConfig
-     */
-    public Versions(AppConfig appConfig) {
-        this.appConfig = appConfig;
     }
 
     /**
@@ -109,7 +92,6 @@ public class Versions extends LoggingObject {
     }
 
     /**
-     *
      * @param fallbackToLocalProject if true, and the version cannot be determined from the installed DH, will try to
      *                               determine the version of the local project
      * @return
@@ -133,7 +115,7 @@ public class Versions extends LoggingObject {
      * We have to account for both ml:hubversion (DHF 4.3.x) and mlHubversion (DHF 5) because this method may be used
      * as part of updating a DHF 4.3.x instance. So in case we fail when using mlHubversion due to that endpoint not
      * existing, we use ml:hubversion instead.
-     *
+     * <p>
      * Unfortunately, we don't have a way to write an automated test for this without removing mlHubversion and adding
      * ml:hubversion to the test modules database. So we are relying on manual testing for each new minor release,
      * which is reasonable as we know we have to support a 4.3.x to 5.x upgrade (at least as of 5.3.0).
@@ -202,7 +184,7 @@ public class Versions extends LoggingObject {
         // this call specifically needs to access marklogic without a known database
         DatabaseClient client = hubClient != null ?
             hubClient.getStagingClient() :
-            getAppConfig().newAppServicesDatabaseClient(null);
+            hubConfig.getAppConfig().newAppServicesDatabaseClient(null);
         ServerEvaluationCall eval = client.newServerEval();
         String xqy = "xdmp:version()";
         try (EvalResultIterator result = eval.xquery(xqy).eval()) {
@@ -323,13 +305,6 @@ public class Versions extends LoggingObject {
             }
         }
         return 0;
-    }
-
-    private AppConfig getAppConfig() {
-        if (this.appConfig == null && this.hubConfig != null) {
-            this.appConfig = this.hubConfig.getAppConfig();
-        }
-        return this.appConfig;
     }
 }
 

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mapping/generateMappingTransforms.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mapping/generateMappingTransforms.api
@@ -1,0 +1,4 @@
+{
+    "functionName": "generateMappingTransforms",
+    "desc": "Generates a transform in the modules database for each legacy mapping or mapping step"
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mapping/generateMappingTransforms.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mapping/generateMappingTransforms.sjs
@@ -1,0 +1,21 @@
+/**
+ Copyright (c) 2020 MarkLogic Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+declareUpdate();
+
+cts.uris(null, null, cts.collectionQuery("http://marklogic.com/data-hub/mappings")).toArray().forEach(uri => {
+  const doc = cts.doc(uri);
+  // "Touch" the document to force the trigger to run
+  xdmp.nodeReplace(cts.doc(uri), doc);
+});

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/LoadTestModules.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/LoadTestModules.java
@@ -5,6 +5,7 @@ import com.marklogic.appdeployer.DefaultAppConfigFactory;
 import com.marklogic.appdeployer.command.modules.LoadModulesCommand;
 import com.marklogic.appdeployer.impl.SimpleAppDeployer;
 import com.marklogic.hub.deploy.commands.GenerateFunctionMetadataCommand;
+import com.marklogic.hub.impl.HubConfigImpl;
 import com.marklogic.hub.impl.Versions;
 import com.marklogic.mgmt.util.SimplePropertySource;
 
@@ -18,13 +19,9 @@ import java.util.Properties;
 public class LoadTestModules {
 
     public static void loadTestModules(String host, int finalPort, String username, String password, String modulesDatabaseName, String modulePermissions) {
-        Properties props = new Properties();
-        props.setProperty("mlUsername", username);
-        props.setProperty("mlPassword", password);
-        props.setProperty("mlHost", host);
-        props.setProperty("mlRestPort", finalPort + "");
-
-        AppConfig config = new DefaultAppConfigFactory(new SimplePropertySource(props)).newAppConfig();
+        HubConfigImpl hubConfig = new HubConfigImpl(host, username, password);
+        AppConfig config = hubConfig.getAppConfig();
+        config.setRestPort(finalPort);
         config.setModuleTimestampsPath(null);
         config.setModulesDatabaseName(modulesDatabaseName);
         config.setModulePermissions(modulePermissions);
@@ -54,7 +51,7 @@ public class LoadTestModules {
         // core mapping functions and custom functions under src/test/ml-modules/root/custom-modules.
         new SimpleAppDeployer(
             new LoadModulesCommand(),
-            new GenerateFunctionMetadataCommand(config.newAppServicesDatabaseClient("data-hub-MODULES"), new Versions(config))
+            new GenerateFunctionMetadataCommand(hubConfig)
         ).deploy(config);
     }
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/DeployAsDeveloperTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/DeployAsDeveloperTest.java
@@ -185,11 +185,13 @@ public class DeployAsDeveloperTest extends AbstractHubCoreTest {
         Collections.sort(commands, Comparator.comparing(Command::getExecuteSortOrder));
 
         int index = 0;
+        System.out.println(commands);
         assertTrue(commands.get(index++) instanceof DeployHubQueryRolesetsCommand);
         assertTrue(commands.get(index++) instanceof DeployOtherDatabasesCommand);
         assertTrue(commands.get(index++) instanceof DeployDatabaseFieldCommand);
         assertTrue(commands.get(index++) instanceof LoadSchemasCommand);
         assertTrue(commands.get(index++) instanceof LoadUserModulesCommand);
+        assertTrue(commands.get(index++) instanceof GenerateFunctionMetadataCommand);
         assertTrue(commands.get(index++) instanceof DeployTriggersCommand);
         assertTrue(commands.get(index++) instanceof LoadUserArtifactsCommand);
         assertTrue(commands.get(index++) instanceof DeployTemporalAxesCommand);
@@ -199,7 +201,6 @@ public class DeployAsDeveloperTest extends AbstractHubCoreTest {
         assertTrue(commands.get(index++) instanceof DeployAlertConfigsCommand);
         assertTrue(commands.get(index++) instanceof DeployAlertActionsCommand);
         assertTrue(commands.get(index++) instanceof DeployAlertRulesCommand);
-        assertTrue(commands.get(index++) instanceof GenerateFunctionMetadataCommand);
         assertTrue(commands.get(index++) instanceof DeployProtectedPathsCommand);
 
         assertEquals(16, commands.size(), "Per DHFPROD-5037, DeployDatabaseFieldsCommand now exists");

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/installer/command/InstallIntoDhsCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/installer/command/InstallIntoDhsCommandTest.java
@@ -106,11 +106,11 @@ public class InstallIntoDhsCommandTest extends HubTestBase {
         assertTrue(commands.get(index++) instanceof LoadHubModulesCommand);
         assertTrue(commands.get(index++) instanceof UpdateDhsModulesPermissionsCommand);
         assertTrue(commands.get(index++) instanceof DeployAmpsCommand);
+        assertTrue(commands.get(index++) instanceof GenerateFunctionMetadataCommand);
         assertTrue(commands.get(index++) instanceof CopyQueryOptionsCommand);
         assertTrue(commands.get(index++) instanceof DeployTriggersCommand);
         assertTrue(commands.get(index++) instanceof DeployHubTriggersCommand);
         assertTrue(commands.get(index++) instanceof LoadHubArtifactsCommand);
-        assertTrue(commands.get(index++) instanceof GenerateFunctionMetadataCommand);
         assertTrue(commands.get(index++) instanceof CreateGranularPrivilegesCommand);
         assertEquals(14, commands.size());
 

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/flows/simpleMapping.flow.json
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/flows/simpleMapping.flow.json
@@ -1,0 +1,23 @@
+{
+  "name": "simpleMapping",
+  "steps": {
+    "1": {
+      "name": "simpleMapper",
+      "stepDefinitionName": "entity-services-mapping",
+      "stepDefinitionType": "MAPPING",
+      "options": {
+        "sourceQuery": "cts.collectionQuery('customer-input')",
+        "sourceDatabase": "data-hub-STAGING",
+        "targetDatabase": "data-hub-FINAL",
+        "collections": [
+          "Customer"
+        ],
+        "permissions": "data-hub-common,read,data-hub-common,update",
+        "mapping": {
+          "name": "SimpleCustomerMapping",
+          "version": 1
+        }
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/mappings/SimpleCustomerMapping/SimpleCustomerMapping-1.mapping.json
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/mappings/SimpleCustomerMapping/SimpleCustomerMapping-1.mapping.json
@@ -8,6 +8,9 @@
   "properties" : {
     "customerId" : {
       "sourcedFrom" : "CustomerID"
+    },
+    "name": {
+      "sourcedFrom": "echo(name)"
     }
   }
 }

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/modules/root/custom-modules/mapping-functions/echoFunction.sjs
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/modules/root/custom-modules/mapping-functions/echoFunction.sjs
@@ -1,0 +1,7 @@
+function echo(input) {
+  return input != null ? "You said: " + input : null;
+}
+
+module.exports = {
+  echo
+};


### PR DESCRIPTION
Did a little cleanup too:

- LoadTestModules can now construct a HubConfigImpl using host/username/password, which means it can pass a HubConfig to GenerateFunctionMetadataCommand
- So got rid of obsolete constructors in GFMC
- And LoadTestModules doesn't need to call Versions(appConfig), so got rid of that from Versions

This was some overdue cleanup - I had created the above stuff before HubConfig(host,username,password) existed. But now that we have that constructor (which I realized needs to call applyProperties too, though that wasn't previously causing any problems), LoadTestModules doesn't need the stuff that existed in GFMC and Versions only for it.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

