### PR TITLE
DHFPROD-5186: Display multi-value property of simple values as a list in source table

### DIFF
--- a/marklogic-data-hub-central/ui/src/assets/mock-data/common.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/common.data.ts
@@ -194,6 +194,11 @@ const truncatedJSONResponse = {
   targetEntityType: 'Person'
 };
 
+const JSONSourceDataToTruncate = [
+  { rowKey: 1, key: 'proteinId', val: 'extremelylongusername@marklogic.com' },
+  { rowKey: 2, key: 'proteinType', val: 's@ml.com, t@ml.com, u@ml.com, v@ml.com, w@ml.com, x@ml.com, y@ml.com, z@ml.com'}
+];
+
 const truncatedEntityProps = [
   { key: 1, name: 'propId', type: 'int' },
   { key: 2, name: 'propName', type: 'string [ ]' },
@@ -380,6 +385,7 @@ const data = {
   entityTypePropertiesMultipleSiblings: entityTypePropertiesMultipleSiblings,
   jsonSourceDataMultipleSiblings: jsonSourceDataMultipleSiblings,
   truncatedJSONResponse: truncatedJSONResponse,
+  JSONSourceDataToTruncate: JSONSourceDataToTruncate,
   truncatedEntityProps: truncatedEntityProps,
   customData: customData,
   viewCustom: viewCustom

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
@@ -367,32 +367,31 @@ const MappingCard: React.FC<Props> = (props) => {
                         parentNamespace = tempNS;
                     }
                 } else if (val.constructor.name === "Array") {
-                    val.forEach(obj => {
-                        if(obj){
-                            if (obj.constructor.name == "String") {
-                                sourceTableKeyIndex = sourceTableKeyIndex + 1;
-                                let propty = {
-                                    rowKey: sourceTableKeyIndex,
-                                    key: key,
-                                    val: obj
-                                };
-                                nestedDoc.push(propty);
-                            } else {
-                                let tempNS = parentNamespace;
-                                if(obj.constructor.name === "Object" && obj.hasOwnProperty('@xmlns')){
-                                    parentNamespace = updateParentNamespace(obj);
-                                }
-                                let finalKey = getNamespace(key, obj, parentNamespace);
-                                let propty = getPropertyObject(finalKey, obj);
-
-                                generateNestedDataSource(obj, propty.children, parentNamespace);
-                                nestedDoc.push(propty);
-                                if(parentNamespace !== tempNS){
-                                    parentNamespace = tempNS;
-                                }
+                    if (val[0].constructor.name == "String") {
+                            let stringValues = val.join(', ')
+                            sourceTableKeyIndex = sourceTableKeyIndex + 1;
+                            let propty = {
+                                rowKey: sourceTableKeyIndex,
+                                key: key,
+                                val: stringValues
+                            };
+                            nestedDoc.push(propty);
+                    } else {
+                        val.forEach(obj => {
+                            let tempNS = parentNamespace;
+                            if(obj.constructor.name === "Object" && obj.hasOwnProperty('@xmlns')){
+                                parentNamespace = updateParentNamespace(obj);
                             }
-                        }
-                    });
+                            let finalKey = getNamespace(key, obj, parentNamespace);
+                            let propty = getPropertyObject(finalKey, obj);
+
+                            generateNestedDataSource(obj, propty.children, parentNamespace);
+                            nestedDoc.push(propty);
+                            if(parentNamespace !== tempNS){
+                                parentNamespace = tempNS;
+                            }
+                        });
+                    };
 
                 } else {
 

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.module.scss
@@ -244,6 +244,15 @@ hr {
     color: #7F86B5;
 }
 
+.sourceValue{
+    margin-top: -6px;
+    margin-bottom: -20px;
+    white-space: pre-wrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: normal;
+}
+
 .namespace{
     color: #5B69AF;
     cursor: pointer;

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
@@ -447,7 +447,7 @@ describe('RTL Source-to-entity map tests', () => {
 
     test('Truncation in case of responses for Array datatype', async () => {
         axiosMock.post['mockImplementation'](jest.fn(() => Promise.resolve({ status: 200, data: data.truncatedJSONResponse })));
-        const { getByText, getAllByRole, getByTestId, queryByTestId } = render(<SourceToEntityMap {...data.mapProps} mappingVisible={true} entityTypeProperties={data.truncatedEntityProps} />)
+        const { getByText, getAllByRole, getByTestId, queryByTestId } = render(<SourceToEntityMap {...data.mapProps} mappingVisible={true} entityTypeProperties={data.truncatedEntityProps} sourceData = {data.JSONSourceDataToTruncate}/>)
         let propNameExpression = getByText('testNameInExp');
         let propAttributeExpression = getByText('placeholderAttribute')
 
@@ -465,10 +465,23 @@ describe('RTL Source-to-entity map tests', () => {
             await (waitForElementToBeRemoved(() => (queryByTestId('successMessage'))))
         }
 
+        //Verify truncated text in Source table
+        await(waitForElement(() => getByTestId('proteinId-srcValue')))
+        expect(getByTestId('proteinId-srcValue')).toHaveTextContent('extremelylonguse...')
+        expect(getByTestId('proteinType-srcValue')).toHaveTextContent('s@ml.com t@ml.com (6 more)')
+
+        //Verify tooltip shows full value when hovering Source values
+        fireEvent.mouseOver(getByText('extremelylonguse...'))
+        await waitForElement(() => getByText('extremelylongusername@marklogic.com'));
+
+        //Verify tooltip shows all values in a list when hovering values with multiple items
+        fireEvent.mouseOver(getByText((_, node) => node.textContent == '(6 more)'))
+        await waitForElement(() => getByText('s@ml.com, t@ml.com, u@ml.com, v@ml.com, w@ml.com, x@ml.com, y@ml.com, z@ml.com'));
+
         // Test button should be enabled after mapping expression is saved
         expect(document.querySelector('#Test-btn')).toBeEnabled()
 
-        //Verify Test button click
+        //Verify Test button click and truncated text in Entity table
         fireEvent.click(getByText('Test'))
         await(waitForElement(() => getByTestId('propName-value')))
         expect(getByTestId('propName-value')).toHaveTextContent('extremelylongusername@m...')
@@ -477,11 +490,6 @@ describe('RTL Source-to-entity map tests', () => {
         // Verify tooltip shows full value when hovering Test values
         fireEvent.mouseOver(getByText('extremelylongusername@m...'))
         await waitForElement(() => getByText('extremelylongusername@marklogic.com'));
-
-        //TODO: Verify tooltip shows all values when hovering Test values
-        // fireEvent.mouseOver(getByText())
-        // await waitForElement(() => getByText('s@ml.com, t@ml.com, u@ml.com, v@ml.com, w@ml.com, x@ml.com, y@ml.com z@ml.com'));
-
     })
 
     test('Verify evaluation of valid expression for mapping reader user', async () => {

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
@@ -575,7 +575,7 @@ const SourceToEntityMap = (props) => {
             ellipsis: true,
             sorter: (a: any, b: any) => a.val?.localeCompare(b.val),
             width: '40%',
-            render: (text) => <span>{text ? String(text).substr(0, 20) : ''}{text && text.length > 20 ? <MLTooltip title={text}><span className={styles.toolTipForValues}>...</span></MLTooltip> : ''}</span>
+            render: (text, row) => (<div data-testid = {row.key +'-srcValue'} className = {styles.sourceValue}>{text ? <MLTooltip title={text}>{getTextforSourceValue(text)}</MLTooltip> : ''}</div>)
         }
     ];
 
@@ -651,6 +651,23 @@ const SourceToEntityMap = (props) => {
             render: (text, row) => (<div data-testid={row.name.split('/').pop()+'-value'} className={styles.mapValue}><MLTooltip title={getTextForTooltip(row.name)}>{getTextForValueField(row)}</MLTooltip></div>)
         }
     ]
+
+    const getTextforSourceValue = (text) => {
+        let arr = text.split(', ')
+        if (arr.length >= 2){
+            let xMore = '(' + (arr.length - 2) + ' more)';
+            let itemOne = arr[0].length > 16 ? getInitialChars(arr[0], 16, '...\n') : arr[0] + '\n';
+            let itemTwo = arr[1].length > 16 ? getInitialChars(arr[1], 16, '...\n') : arr[1] + '\n';
+            let fullItem = itemOne.concat(itemTwo);            
+            if(arr.length == 2){
+                return <p>{fullItem}</p>;
+            }else{
+                return <p>{fullItem}<span style= {{color: 'grey'}}>{xMore}</span></p>;
+            } 
+        }else{
+            return getInitialChars(arr[0],16,'...')
+        }           
+    }
 
     //Response from server already is an array for multiple values, string for single value
     //truncation in case array values


### PR DESCRIPTION
### Description

- Arrays of multi-values no longer show up in separate rows with duplicate names in 'Name' column.
- Multi values are now displayed as a list in a single row under a single 'Name'. 
- Hovering over values (truncated or not) in Source table now shows full text inside tooltip.
- Added tests for verifying truncated values and tooltip displaying all values on hover.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

