### PR TITLE
DHFPROD-5017: Enable sorting for entity properties marked sortable via modeling

### DIFF
--- a/examples/reference-entity-model/.gitignore
+++ b/examples/reference-entity-model/.gitignore
@@ -6,6 +6,6 @@ src/main/ml-modules
 src/main/ml-config/database-fields
 src/main/ml-config/databases
 src/main/ml-config/servers
-src/main/entity-config
+src/main/entity-config/*.xml
 
 step-definitions

--- a/examples/reference-entity-model/entities/Customer.entity.json
+++ b/examples/reference-entity-model/entities/Customer.entity.json
@@ -12,7 +12,8 @@
       "primaryKey": "customerId",
       "properties": {
         "customerId": {
-          "datatype": "integer"
+          "datatype": "integer",
+          "sortable": true
         },
         "name": {
           "datatype": "string",
@@ -38,7 +39,8 @@
         },
         "birthDate": {
           "datatype": "date",
-          "facetable": true
+          "facetable": true,
+          "sortable": true
         },
         "status": {
           "datatype": "string",

--- a/examples/reference-entity-model/src/main/entity-config/databases/final-database.json
+++ b/examples/reference-entity-model/src/main/entity-config/databases/final-database.json
@@ -1,0 +1,26 @@
+{
+  "lang" : "zxx",
+  "path-namespace" : [ {
+    "prefix" : "es",
+    "namespace-uri" : "http://marklogic.com/entity-services"
+  } ],
+  "range-path-index" : [ {
+    "invalid-values" : "reject",
+    "path-expression" : "//*:instance/Customer/customerId",
+    "range-value-positions" : false,
+    "scalar-type" : "decimal"
+  }, {
+    "invalid-values" : "reject",
+    "path-expression" : "//*:instance/Customer/birthDate",
+    "range-value-positions" : false,
+    "scalar-type" : "date"
+  }, {
+    "invalid-values" : "reject",
+    "path-expression" : "//*:instance/Customer/status",
+    "range-value-positions" : false,
+    "scalar-type" : "string",
+    "collation" : "http://marklogic.com/collation/"
+  } ],
+  "range-element-index" : [ ],
+  "database-name" : "%%mlFinalDbName%%"
+}

--- a/examples/reference-entity-model/src/main/entity-config/databases/staging-database.json
+++ b/examples/reference-entity-model/src/main/entity-config/databases/staging-database.json
@@ -1,0 +1,26 @@
+{
+  "lang" : "zxx",
+  "path-namespace" : [ {
+    "prefix" : "es",
+    "namespace-uri" : "http://marklogic.com/entity-services"
+  } ],
+  "range-path-index" : [ {
+    "invalid-values" : "reject",
+    "path-expression" : "//*:instance/Customer/customerId",
+    "range-value-positions" : false,
+    "scalar-type" : "decimal"
+  }, {
+    "invalid-values" : "reject",
+    "path-expression" : "//*:instance/Customer/birthDate",
+    "range-value-positions" : false,
+    "scalar-type" : "date"
+  }, {
+    "invalid-values" : "reject",
+    "path-expression" : "//*:instance/Customer/status",
+    "range-value-positions" : false,
+    "scalar-type" : "string",
+    "collation" : "http://marklogic.com/collation/"
+  } ],
+  "range-element-index" : [ ],
+  "database-name" : "%%mlStagingDbName%%"
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/DeployEntityIndexesTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/DeployEntityIndexesTest.java
@@ -69,12 +69,13 @@ public class DeployEntityIndexesTest extends AbstractHubCoreTest {
 
             ArrayNode indexes = (ArrayNode) db.get("range-path-index");
             if (databaseKind.equals(DatabaseKind.STAGING)) {
-                assertEquals(1, indexes.size());
+                assertEquals(2, indexes.size());
             } else {
-                assertEquals(3, indexes.size(), "Expecting the Person/personId index and then two path range indexes " +
-                    "that are added to Final for mastering purposes");
+                assertEquals(4, indexes.size(), "Expecting the Person/personId, Person/name indexes and " +
+                        "then two path range indexes that are added to Final for mastering purposes");
             }
             assertEquals("//*:instance/Person/personId", indexes.get(0).get("path-expression").asText());
+            assertEquals("//*:instance/Person/name", indexes.get(1).get("path-expression").asText());
         });
     }
 }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/com/marklogic/hub/impl/generate-indexes.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/com/marklogic/hub/impl/generate-indexes.sjs
@@ -247,6 +247,34 @@ function generateIndexConfigWithStructuredProperties() {
   ];
 }
 
+function generateIndexConfigWithSortableProperties() {
+  const indexes = generateRangeIndexConfig([
+    {
+      "info": {
+        "title": "Book"
+      },
+      "definitions": {
+        "Book": {
+          "properties": {
+            "title": {"datatype": "string", "facetable": true, "collation": "http://marklogic.com/collation/"},
+            "authors": {"datatype": "array", "sortable": true, "items": {"datatype": "string"}},
+            "rating": {"datatype": "integer", "facetable": true, "sortable": true, "items": {"datatype": "string"}},
+            "id": {"datatype": "string", "collation": "http://marklogic.com/collation/"},
+            "customer": {"datatype": "array", "items": {"$ref": "#/definitions/Address"}, "sortable": true},
+            "address": {"$ref": "#/definitions/Address", "facetable": true}
+          }
+        }
+      }
+    }
+  ]);
+  return [
+    test.assertEqual(3, indexes.length),
+    test.assertEqual("//*:instance/Book/title", indexes[0]["path-expression"]),
+    test.assertEqual("//*:instance/Book/authors", indexes[1]["path-expression"]),
+    test.assertEqual("//*:instance/Book/rating", indexes[2]["path-expression"])
+  ];
+}
+
 []
   .concat(sharedPropertyWithNullNamespace())
   .concat(sharedPropertyWithSameNamespaces())

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/generateSearchOptions.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/generateSearchOptions.sjs
@@ -1,98 +1,129 @@
 const hent = require("/data-hub/5/impl/hub-entities.xqy");
 const test = require("/test/test-helper.xqy");
 
-let input =
-  [{
+function generateOptionsWithElementRangeIndex() {
+  const input =
+      [{
+        "info" : {
+          "title": "Book"
+        },
+        "definitions": {
+          "Book": {
+            "elementRangeIndex": ["title"],
+            "properties": {"title": {"datatype": "string", "collation": "http://marklogic.com/collation/codepoint"}}
+          }
+        }
+      }];
+  const options = hent.dumpSearchOptions(input, false);
+
+  return [
+    test.assertEqual("limit=25", xs.string(fn.head(options.xpath("/*:constraint[@name = 'title']/*:range/*:facet-option/text()"))),
+        "To avoid displaying large numbers of values in facets in QuickStart, range constraints default to a max of 25 values"
+    ),
+    test.assertExists(options.xpath("/*:values[@name = 'Book']/*:range/*:element[@name = 'title']")),
+    test.assertExists(options.xpath("/*:transform-results[@apply = 'empty-snippet']")),
+    test.assertNotExists(options.xpath("/*:values[@name = 'Book']/*:range/*:facet-option"),
+        "A facet option does not need to be set on the values element")
+  ];
+}
+
+function generateExplorerOptionsWithElementRangeIndex() {
+  const input =
+      [{
+        "info" : {
+          "title": "Book"
+        },
+        "definitions": {
+          "Book": {
+            "elementRangeIndex": ["title"],
+            "properties": {"title": {"datatype": "string", "collation": "http://marklogic.com/collation/codepoint"}}
+          }
+        }
+      }];
+
+  const expOptions = hent.dumpSearchOptions(input, true);
+  return [
+    test.assertEqual("limit=25", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'title']/*:range/*:facet-option[1]/text()"))),
+        "To avoid displaying large numbers of values in facets in Explorer, range constraints default to a max of 25 values"
+    ),
+    test.assertEqual("frequency-order", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'title']/*:range/*:facet-option[2]/text()"))),
+        "To sort the facets based on frequency order"
+    ),
+    test.assertEqual("descending", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'Collection']/*:collection/*:facet-option[3]/text()"))),
+        "To sort the facets in decreasing order of frequency on search"
+    ),
+    test.assertEqual("limit=25", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'createdByStep']/*:range/*:facet-option[1]/text()"))),
+        "To avoid displaying large numbers of values in facets in Explorer, range constraints default to a max of 25 values"
+    ),
+    test.assertEqual("frequency-order", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'createdByStep']/*:range/*:facet-option[2]/text()"))),
+        "To sort the facets based on frequency order"
+    ),
+    test.assertEqual("descending", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'createdByStep']/*:range/*:facet-option[3]/text()"))),
+        "To sort the facets in decreasing order of frequency on search"
+    ),
+    test.assertEqual("limit=25", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'createdInFlowRange']/*:range/*:facet-option[1]/text()"))),
+        "To avoid displaying large numbers of values in facets in Explorer, range constraints default to a max of 25 values"
+    ),
+    test.assertEqual("frequency-order", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'createdInFlowRange']/*:range/*:facet-option[2]/text()"))),
+        "To sort the facets based on frequency order"
+    ),
+    test.assertEqual("descending", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'createdInFlowRange']/*:range/*:facet-option[3]/text()"))),
+        "To sort the facets in decreasing order of frequency on search"
+    ),
+    test.assertExists(expOptions.xpath("/*:constraint[@name = 'createdByJob', @facet = 'false']")),
+    test.assertExists(expOptions.xpath("/*:constraint[@name = 'createdByJobWord']")),
+    test.assertExists(expOptions.xpath("/*:constraint[@name = 'createdOnRange', @facet = 'false']")),
+    test.assertExists(expOptions.xpath("/*:values[@name = 'Book']/*:range/*:element[@name = 'title']")),
+    test.assertNotExists(expOptions.xpath("/*:values[@name = 'Book']/*:range/*:facet-option"),
+        "A facet option does not need to be set on the values element"),
+    test.assertEqual("/*:envelope/*:headers", xs.string(fn.head(expOptions.xpath("/*:extract-document-data/*:extract-path[2]/text()"))),
+        "To see the sourced From, created on and created by information on the search snippet"
+    ),
+    test.assertNotExists(expOptions.xpath("/*:transform-results"), "Enabling the snippet information by disabling empty-snippet")
+  ];
+}
+
+function generateExplorerWithFacetableAndSortableProperties() {
+  const input = [{
     "info" : {
       "title": "Book"
     },
     "definitions": {
       "Book": {
-        "elementRangeIndex": ["title"],
-        "properties": {"title": {"datatype": "string", "collation": "http://marklogic.com/collation/codepoint"}}
+        "elementRangeIndex": ["bookId"],
+        "properties": {
+          "title": {"datatype": "string", "facetable": true, "sortable": true, "collation": "http://marklogic.com/collation/"},
+          "authors": {"datatype": "array", "sortable": true, "items": {"datatype": "string"}},
+          "rating": {"datatype": "integer", "sortable": true, "items": {"datatype": "string"}},
+          "bookId": {"datatype": "string", "collation": "http://marklogic.com/collation/"},
+          "completedDate": {"datatype": "dateTime", "facetable": true},
+          "publishedDate": {"datatype": "date", "sortable": true}
+        }
       }
     }
   }];
 
-const params = false;
-const options = hent.dumpSearchOptions(input, params);
+  const expOptions = hent.dumpSearchOptions(input, true);
 
-let assertions = [
-  test.assertEqual("limit=25", xs.string(fn.head(options.xpath("/*:constraint[@name = 'title']/*:range/*:facet-option/text()"))),
-    "To avoid displaying large numbers of values in facets in QuickStart, range constraints default to a max of 25 values"
-  ),
-  test.assertExists(options.xpath("/*:values[@name = 'Book']/*:range/*:element[@name = 'title']")),
-  test.assertExists(options.xpath("/*:transform-results[@apply = 'empty-snippet']")),
-  test.assertNotExists(options.xpath("/*:values[@name = 'Book']/*:range/*:facet-option"),
-    "A facet option does not need to be set on the values element")
-];
+  return [
+    test.assertEqual("limit=25", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'Book.title']/*:range/*:facet-option/text()"))),
+        "To avoid displaying large numbers of values in facets in QuickStart, range constraints default to a max of 25 values"
+    ),
+    test.assertEqual("//*:instance/Book/title", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'Book.title']/*:range/*:path-index/text()")))),
+    test.assertEqual("//*:instance/Book/authors", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'Book.authors']/*:range/*:path-index/text()")))),
+    test.assertEqual("//*:instance/Book/rating", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'Book.rating']/*:range/*:path-index/text()")))),
+    test.assertEqual("//*:instance/Book/completedDate", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'Book.completedDate']/*:range/*:path-index/text()")))),
+    test.assertEqual("//*:instance/Book/publishedDate", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'Book.publishedDate']/*:range/*:path-index/text()")))),
+    test.assertEqual("true", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'Book.title']/*:range/@facet")))),
+    test.assertEqual("false", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'Book.authors']/*:range/@facet")))),
+    test.assertEqual("false", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'Book.rating']/*:range/@facet")))),
+    test.assertEqual("true", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'Book.completedDate']/*:range/@facet")))),
+    test.assertEqual("false", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'Book.publishedDate']/*:range/@facet")))),
+    test.assertNotExists(expOptions.xpath("/*:constraint[@name = 'Book.bookId']"))
+  ];
+}
 
-const expParams = true;
-let expOptions = hent.dumpSearchOptions(input, expParams);
-assertions.concat([
-  test.assertEqual("limit=25", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'title']/*:range/*:facet-option[1]/text()"))),
-    "To avoid displaying large numbers of values in facets in Explorer, range constraints default to a max of 25 values"
-  ),
-  test.assertEqual("frequency-order", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'title']/*:range/*:facet-option[2]/text()"))),
-    "To sort the facets based on frequency order"
-  ),
-  test.assertEqual("descending", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'Collection']/*:collection/*:facet-option[3]/text()"))),
-    "To sort the facets in decreasing order of frequency on search"
-  ),
-  test.assertEqual("limit=25", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'createdByStep']/*:range/*:facet-option[1]/text()"))),
-    "To avoid displaying large numbers of values in facets in Explorer, range constraints default to a max of 25 values"
-  ),
-  test.assertEqual("frequency-order", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'createdByStep']/*:range/*:facet-option[2]/text()"))),
-    "To sort the facets based on frequency order"
-  ),
-  test.assertEqual("descending", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'createdByStep']/*:range/*:facet-option[3]/text()"))),
-    "To sort the facets in decreasing order of frequency on search"
-  ),
-  test.assertEqual("limit=25", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'createdInFlowRange']/*:range/*:facet-option[1]/text()"))),
-    "To avoid displaying large numbers of values in facets in Explorer, range constraints default to a max of 25 values"
-  ),
-  test.assertEqual("frequency-order", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'createdInFlowRange']/*:range/*:facet-option[2]/text()"))),
-    "To sort the facets based on frequency order"
-  ),
-  test.assertEqual("descending", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'createdInFlowRange']/*:range/*:facet-option[3]/text()"))),
-    "To sort the facets in decreasing order of frequency on search"
-  ),
-  test.assertExists(expOptions.xpath("/*:constraint[@name = 'createdByJob', @facet = 'false']")),
-  test.assertExists(expOptions.xpath("/*:constraint[@name = 'createdByJobWord']")),
-  test.assertExists(expOptions.xpath("/*:constraint[@name = 'createdOnRange', @facet = 'false']")),
-  test.assertExists(expOptions.xpath("/*:values[@name = 'Book']/*:range/*:element[@name = 'title']")),
-  test.assertNotExists(expOptions.xpath("/*:values[@name = 'Book']/*:range/*:facet-option"),
-    "A facet option does not need to be set on the values element"),
-  test.assertEqual("/*:envelope/*:headers", xs.string(fn.head(expOptions.xpath("/*:extract-document-data/*:extract-path[2]/text()"))),
-    "To see the sourced From, created on and created by information on the search snippet"
-  ),
-  test.assertNotExists(expOptions.xpath("/*:transform-results"), "Enabling the snippet information by disabling empty-snippet")
-]);
-
-input = [{
-  "info" : {
-    "title": "Book"
-  },
-  "definitions": {
-    "Book": {
-      "properties": {
-         "title": {"datatype": "string", "facetable": true, "collation": "http://marklogic.com/collation/"},
-         "authors": {"datatype": "array", "facetable": true, "items": {"datatype": "string"}},
-         "rating": {"datatype": "integer", "facetable": true, "items": {"datatype": "string"}},
-         "bookId": {"datatype": "string", "facetable": false, "collation": "http://marklogic.com/collation/"}
-       }
-    }
-  }
-}];
-
-expOptions = hent.dumpSearchOptions(input, expParams);
-
-assertions.concat([
-  test.assertEqual("limit=25", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'Book.title']/*:range/*:facet-option/text()"))),
-      "To avoid displaying large numbers of values in facets in QuickStart, range constraints default to a max of 25 values"
-  ),
-  test.assertEqual("//*:instance/Book/title", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'Book.title']/*:range/*:path-index/text()")))),
-  test.assertEqual("//*:instance/Book/authors", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'Book.authors']/*:range/*:path-index/text()")))),
-  test.assertEqual("//*:instance/Book/rating", xs.string(fn.head(expOptions.xpath("/*:constraint[@name = 'Book.rating']/*:range/*:path-index/text()")))),
-  test.assertNotExists(expOptions.xpath("/*:constraint[@name = 'Book.bookId']"))
-]);
+[]
+    .concat(generateOptionsWithElementRangeIndex())
+    .concat(generateExplorerOptionsWithElementRangeIndex())
+    .concat(generateExplorerWithFacetableAndSortableProperties());

--- a/marklogic-data-hub/src/test/resources/test-projects/entity-with-indexes/entities/Person.entity.json
+++ b/marklogic-data-hub/src/test/resources/test-projects/entity-with-indexes/entities/Person.entity.json
@@ -20,7 +20,8 @@
         },
         "name": {
           "datatype": "string",
-          "collation": "http://marklogic.com/collation/codepoint"
+          "collation": "http://marklogic.com/collation/codepoint",
+          "sortable": true
         }
       }
     }


### PR DESCRIPTION
### Description

- Enable sorting for entity properties marked sortable via modeling
- removing src/main/entity-config/databases reference from gitignore in reference-entity-model
- Adding sortable properties to the Customer entity model

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

