### PR TITLE
DHFPROD-5497: Creating granular privileges will now reuse existing ones

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesTest.java
@@ -4,7 +4,6 @@ import com.marklogic.appdeployer.command.CommandContext;
 import com.marklogic.hub.AbstractHubCoreTest;
 import com.marklogic.mgmt.api.API;
 import com.marklogic.mgmt.api.security.Privilege;
-import com.marklogic.mgmt.api.security.Role;
 import com.marklogic.mgmt.mapper.DefaultResourceMapper;
 import com.marklogic.mgmt.mapper.ResourceMapper;
 import com.marklogic.mgmt.resource.databases.DatabaseManager;
@@ -16,7 +15,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -50,14 +52,17 @@ public class CreateGranularPrivilegesTest extends AbstractHubCoreTest {
         Privilege p = resourceMapper.readResource(mgr.getAsJson("admin-database-clear-data-hub-STAGING", "kind", "execute"), Privilege.class);
         assertEquals("http://marklogic.com/xdmp/privileges/admin/database/clear/" + stagingDbId, p.getAction());
         assertEquals("data-hub-admin", p.getRole().get(0));
+        assertEquals("hub-central-clear-user-data", p.getRole().get(1));
 
         p = resourceMapper.readResource(mgr.getAsJson("admin-database-clear-data-hub-FINAL", "kind", "execute"), Privilege.class);
         assertEquals("http://marklogic.com/xdmp/privileges/admin/database/clear/" + finalDbId, p.getAction());
         assertEquals("data-hub-admin", p.getRole().get(0));
+        assertEquals("hub-central-clear-user-data", p.getRole().get(1));
 
         p = resourceMapper.readResource(mgr.getAsJson("admin-database-clear-data-hub-JOBS", "kind", "execute"), Privilege.class);
         assertEquals("http://marklogic.com/xdmp/privileges/admin/database/clear/" + jobsDbId, p.getAction());
         assertEquals("data-hub-admin", p.getRole().get(0));
+        assertEquals("hub-central-clear-user-data", p.getRole().get(1));
 
         p = resourceMapper.readResource(mgr.getAsJson("admin-database-index-data-hub-STAGING", "kind", "execute"), Privilege.class);
         assertEquals("http://marklogic.com/xdmp/privileges/admin/database/index/" + stagingDbId, p.getAction());
@@ -106,53 +111,68 @@ public class CreateGranularPrivilegesTest extends AbstractHubCoreTest {
     }
 
     @Test
+    void existingPrivilegeHasSameAction() {
+        ResourcesFragment databasesXml = new DatabaseManager(adminHubConfig.getManageClient()).getAsXml();
+        final String finalDbId = databasesXml.getIdForNameOrId("data-hub-FINAL");
+
+        // Setup a test privilege that we want to create via the command's logic; it has the same action as one of the
+        // privileges that we know the command creates
+        Privilege p = new Privilege(null, "aaa-test-privilege");
+        p.setKind("execute");
+        p.addRole("qconsole-user");
+        p.setAction("http://marklogic.com/xdmp/privileges/admin/database/index/" + finalDbId);
+        Map<String, Privilege> privileges = new HashMap<>();
+        privileges.put(p.getAction(), p);
+
+        final ResourceMapper resourceMapper = new DefaultResourceMapper(new API(adminHubConfig.getManageClient()));
+        final PrivilegeManager privilegeManager = new PrivilegeManager(adminHubConfig.getManageClient());
+
+        try {
+            // Now apply the logic in the command for saving this test privilege
+            CreateGranularPrivilegesCommand command = new CreateGranularPrivilegesCommand(adminHubConfig);
+            command.saveGranularPrivileges(adminHubConfig.getManageClient(), privileges);
+
+            assertFalse(privilegeManager.exists("aaa-test-privilege"), "The test privilege should not have been created " +
+                "since there's an existing DHF granular privilege with the same action");
+            assertTrue(privilegeManager.exists("admin-database-index-data-hub-FINAL"));
+
+            String privilegeJson = privilegeManager.getAsJson("admin-database-index-data-hub-FINAL", "kind", "execute");
+            Privilege privilege = resourceMapper.readResource(privilegeJson, Privilege.class);
+            assertEquals(3, privilege.getRole().size(), "Expecting the 2 existing roles plus the qconsole one; roles: " + privilege.getRole());
+            Stream.of("data-hub-developer", "hub-central-entity-model-writer", "qconsole-user").forEach(role -> {
+                assertTrue(privilege.getRole().contains(role), "Did not find role: " + role + " in privilege roles: " + privilege.getRole());
+            });
+        } finally {
+            // Ensure qconsole-user is removed from the role
+            String privilegeJson = privilegeManager.getAsJson("admin-database-index-data-hub-FINAL", "kind", "execute");
+            Privilege privilege = resourceMapper.readResource(privilegeJson, Privilege.class);
+            privilege.getRole().remove("qconsole-user");
+            privilege.save();
+        }
+    }
+
+    @Test
     void deletePrivilegesOnUndeploy() {
         final CreateGranularPrivilegesCommand command = new CreateGranularPrivilegesCommand(adminHubConfig);
         final CommandContext context = new CommandContext(adminHubConfig.getAppConfig(), adminHubConfig.getManageClient(), null);
 
-        PrivilegeManager mgr = new PrivilegeManager(adminHubConfig.getManageClient());
-        ResourcesFragment privileges = mgr.getAsXml();
-        assertTrue(privileges.resourceExists("admin-database-clear-data-hub-STAGING"));
-        assertTrue(privileges.resourceExists("admin-database-clear-data-hub-FINAL"));
-        assertTrue(privileges.resourceExists("admin-database-clear-data-hub-JOBS"));
-        assertTrue(privileges.resourceExists("admin-database-index-data-hub-STAGING"));
-        assertTrue(privileges.resourceExists("admin-database-index-data-hub-FINAL"));
-        assertTrue(privileges.resourceExists("admin-database-index-data-hub-JOBS"));
-        assertTrue(privileges.resourceExists("admin-database-triggers-data-hub-staging-TRIGGERS"));
-        assertTrue(privileges.resourceExists("admin-database-triggers-data-hub-final-TRIGGERS"));
-        assertTrue(privileges.resourceExists("admin-database-temporal-data-hub-STAGING"));
-        assertTrue(privileges.resourceExists("admin-database-temporal-data-hub-FINAL"));
-        assertTrue(privileges.resourceExists("admin-database-alerts-data-hub-STAGING"));
-        assertTrue(privileges.resourceExists("admin-database-alerts-data-hub-FINAL"));
-        assertTrue(privileges.resourceExists("admin-group-scheduled-task-" + adminHubConfig.getAppConfig().getGroupName()));
+        PrivilegeManager privilegeManager = new PrivilegeManager(context.getManageClient());
+        ResourcesFragment existingPrivileges = privilegeManager.getAsXml();
 
-        for (Privilege privilege : command.buildPrivilegesForRolesThatCanBeInherited(adminHubConfig.getManageClient())) {
-            assertTrue(privileges.resourceExists(privilege.getPrivilegeName()));
-        }
+        final Map<String, Privilege> granularPrivileges = command.buildGranularPrivileges(adminHubConfig.getManageClient());
+        granularPrivileges.values().forEach(priv -> {
+            assertTrue(existingPrivileges.resourceExists(priv.getPrivilegeName()));
+        });
 
         try {
             assertEquals(adminHubConfig.getAppConfig().getGroupName(), command.getGroupNamesForScheduledTaskPrivileges().get(0));
 
             command.undo(context);
 
-            privileges = mgr.getAsXml();
-            assertFalse(privileges.resourceExists("admin-database-clear-data-hub-STAGING"));
-            assertFalse(privileges.resourceExists("admin-database-clear-data-hub-FINAL"));
-            assertFalse(privileges.resourceExists("admin-database-clear-data-hub-JOBS"));
-            assertFalse(privileges.resourceExists("admin-database-index-data-hub-STAGING"));
-            assertFalse(privileges.resourceExists("admin-database-index-data-hub-FINAL"));
-            assertFalse(privileges.resourceExists("admin-database-index-data-hub-JOBS"));
-            assertFalse(privileges.resourceExists("admin-database-triggers-data-hub-staging-TRIGGERS"));
-            assertFalse(privileges.resourceExists("admin-database-triggers-data-hub-final-TRIGGERS"));
-            assertFalse(privileges.resourceExists("admin-database-temporal-data-hub-STAGING"));
-            assertFalse(privileges.resourceExists("admin-database-temporal-data-hub-FINAL"));
-            assertFalse(privileges.resourceExists("admin-database-alerts-data-hub-STAGING"));
-            assertFalse(privileges.resourceExists("admin-database-alerts-data-hub-FINAL"));
-            assertFalse(privileges.resourceExists("admin-group-scheduled-task-" + adminHubConfig.getAppConfig().getGroupName()));
-
-            for (Privilege privilege : command.buildPrivilegesForRolesThatCanBeInherited(adminHubConfig.getManageClient())) {
-                assertFalse(privileges.resourceExists(privilege.getPrivilegeName()));
-            }
+            ResourcesFragment updatedPrivileges = privilegeManager.getAsXml();
+            granularPrivileges.values().forEach(priv -> {
+                assertFalse(updatedPrivileges.resourceExists(priv.getPrivilegeName()));
+            });
         } finally {
             // Need to deploy these privileges back so the lack of them doesn't impact other tests
             command.execute(context);
@@ -161,98 +181,7 @@ public class CreateGranularPrivilegesTest extends AbstractHubCoreTest {
     }
 
     /**
-     * Verifies that if the DHS privileges - clear-data-hub-FINAL and clear-data-hub-STAGING - already exist, then those
-     * are reused and the data-hub-admin role is added to them. This avoids errors in trying to create privileges with
-     * the same action.
-     */
-    @Test
-    void createDatabasePrivilegesInSimulatedDhsEnvironment() {
-        final API api = new API(adminHubConfig.getManageClient());
-        Role dhsDbaRole = new Role(api, "dba");
-
-        Privilege dhsFinalPriv = new Privilege(api, "clear-data-hub-FINAL");
-        dhsFinalPriv.setKind("execute");
-        dhsFinalPriv.setAction("not-the-real-privilege-final");
-        dhsFinalPriv.addRole("dba");
-
-        Privilege dhsStagingPriv = new Privilege(api, "clear-data-hub-STAGING");
-        dhsStagingPriv.setKind("execute");
-        dhsStagingPriv.setAction("not-the-real-privilege-staging");
-        dhsStagingPriv.addRole("dba");
-
-        Privilege dhsJobsPriv = new Privilege(api, "clear-data-hub-JOBS");
-        dhsJobsPriv.setKind("execute");
-        dhsJobsPriv.setAction("not-the-real-privilege-jobs");
-        dhsJobsPriv.addRole("dba");
-
-        Privilege dhsStagingIndexPriv = new Privilege(api, "STAGING-index-editor");
-        dhsStagingIndexPriv.setKind("execute");
-        dhsStagingIndexPriv.setAction("not-the-real-index-staging");
-        dhsStagingIndexPriv.addRole("dba");
-
-        Privilege dhsFinalIndexPriv = new Privilege(api, "FINAL-index-editor");
-        dhsFinalIndexPriv.setKind("execute");
-        dhsFinalIndexPriv.setAction("not-the-real-index-final");
-        dhsFinalIndexPriv.addRole("dba");
-
-        Privilege dhsJobsIndexPriv = new Privilege(api, "JOBS-index-editor");
-        dhsJobsIndexPriv.setKind("execute");
-        dhsJobsIndexPriv.setAction("not-the-real-index-jobs");
-        dhsJobsIndexPriv.addRole("dba");
-
-        try {
-            dhsDbaRole.save();
-            dhsStagingPriv.save();
-            dhsFinalPriv.save();
-            dhsJobsPriv.save();
-            dhsStagingIndexPriv.save();
-            dhsFinalIndexPriv.save();
-            dhsJobsIndexPriv.save();
-
-            List<Privilege> list = new CreateGranularPrivilegesCommand(adminHubConfig).buildPrivilegesThatDhsMayHaveCreated(adminHubConfig.getManageClient());
-            Privilege stagingPriv = list.get(0);
-            assertEquals("clear-data-hub-STAGING", stagingPriv.getPrivilegeName());
-            assertEquals("dba", stagingPriv.getRole().get(0));
-            assertEquals("data-hub-admin", stagingPriv.getRole().get(1));
-
-            Privilege finalPriv = list.get(1);
-            assertEquals("clear-data-hub-FINAL", finalPriv.getPrivilegeName());
-            assertEquals("dba", finalPriv.getRole().get(0));
-            assertEquals("data-hub-admin", finalPriv.getRole().get(1));
-
-            Privilege jobsPriv = list.get(2);
-            assertEquals("clear-data-hub-JOBS", jobsPriv.getPrivilegeName());
-            assertEquals("dba", jobsPriv.getRole().get(0));
-            assertEquals("data-hub-admin", jobsPriv.getRole().get(1));
-
-            Privilege stagingIndexPriv = list.get(3);
-            assertEquals("STAGING-index-editor", stagingIndexPriv.getPrivilegeName());
-            assertEquals("dba", stagingIndexPriv.getRole().get(0));
-            assertEquals("data-hub-developer", stagingIndexPriv.getRole().get(1));
-
-            Privilege finalIndexPriv = list.get(4);
-            assertEquals("FINAL-index-editor", finalIndexPriv.getPrivilegeName());
-            assertEquals("dba", finalIndexPriv.getRole().get(0));
-            assertEquals("data-hub-developer", finalIndexPriv.getRole().get(1));
-
-            Privilege finalJobsPriv = list.get(5);
-            assertEquals("JOBS-index-editor", finalJobsPriv.getPrivilegeName());
-            assertEquals("dba", finalJobsPriv.getRole().get(0));
-            assertEquals("data-hub-developer", finalJobsPriv.getRole().get(1));
-        } finally {
-            dhsDbaRole.delete();
-            PrivilegeManager mgr = new PrivilegeManager(adminHubConfig.getManageClient());
-            mgr.deleteAtPath("/manage/v2/privileges/clear-data-hub-FINAL?kind=execute");
-            mgr.deleteAtPath("/manage/v2/privileges/clear-data-hub-STAGING?kind=execute");
-            mgr.deleteAtPath("/manage/v2/privileges/clear-data-hub-JOBS?kind=execute");
-            mgr.deleteAtPath("/manage/v2/privileges/FINAL-index-editor?kind=execute");
-            mgr.deleteAtPath("/manage/v2/privileges/STAGING-index-editor?kind=execute");
-            mgr.deleteAtPath("/manage/v2/privileges/JOBS-index-editor?kind=execute");
-        }
-    }
-
-    /**
-     * Verify that the correct privileges are built (but not yet saved) for an arbitrary set of groups.
+     * Just verifies that the command uses the correct group names when it tries to build scheduled task privileges.
      */
     @Test
     void buildScheduledTaskPrivilegesForMultipleGroups() {
@@ -265,13 +194,7 @@ public class CreateGranularPrivilegesTest extends AbstractHubCoreTest {
         assertEquals("B", groupNames.get(1));
         assertEquals("C", groupNames.get(2));
 
-        List<Privilege> privileges = command.buildScheduledTaskPrivileges();
-        assertEquals(3, privileges.size());
-        assertEquals("admin-group-scheduled-task-A", privileges.get(0).getPrivilegeName());
-        assertEquals("http://marklogic.com/xdmp/privileges/admin/group/scheduled-task/$$group-id(A)", privileges.get(0).getAction());
-        assertEquals("admin-group-scheduled-task-B", privileges.get(1).getPrivilegeName());
-        assertEquals("http://marklogic.com/xdmp/privileges/admin/group/scheduled-task/$$group-id(B)", privileges.get(1).getAction());
-        assertEquals("admin-group-scheduled-task-C", privileges.get(2).getPrivilegeName());
-        assertEquals("http://marklogic.com/xdmp/privileges/admin/group/scheduled-task/$$group-id(C)", privileges.get(2).getAction());
+        command = new CreateGranularPrivilegesCommand(adminHubConfig);
+        assertEquals("Default", command.getGroupNamesForScheduledTaskPrivileges().get(0));
     }
 }

--- a/marklogic-data-hub/src/test/resources/logback.xml
+++ b/marklogic-data-hub/src/test/resources/logback.xml
@@ -20,6 +20,11 @@
     <appender-ref ref="STDOUT" />
   </logger>
 
+  <!-- Quieting this down as it logs frequently at "info" with stuff that's rarely relevant to tests -->
+  <logger name="com.marklogic.hub.impl.HubConfigImpl" level="WARN" additivity="false">
+    <appender-ref ref="STDOUT" />
+  </logger>
+
   <!-- Helps verifies that test modules are loaded correctly -->
   <logger name="com.marklogic.client.ext" level="INFO" additivity="false">
     <appender-ref ref="STDOUT" />


### PR DESCRIPTION
This is close to a re-write of the command. All privileges are now built in memory before any are saved. Each is then saved via the same process, which checks for an existing privilege with the same action.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

