### PR TITLE
DHFPROD-5190: include environment property when saving indexes and move readme to e2e

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/README.md
+++ b/marklogic-data-hub-central/ui/e2e/README.md
@@ -10,11 +10,11 @@ Boot up HC application from `marklogic-data-hub-central` directory either via bo
  
     For DHS –
         * ./gradlew bootRun -PmlHost=<curationEndpoint>
-        * java -jar <HC.war> --mlHost=<curationEndpoint>
+        * java -jar <HC.war> --mlHost=<curationEndpoint> --spring.profiles.active=dev
         
     For local - 
         * ./gradlew bootRun -PhubUseLocalDefaults=true
-        * java -jar <HC.war> --hubUseLocalDefaults=true
+        * java -jar <HC.war> --hubUseLocalDefaults=true --spring.profiles.active=dev
 
  
 Then run the Cypress tests. Use appropriate run scripts defined in package.json to run on different browsers:

--- a/marklogic-data-hub-central/ui/e2e/setup.sh
+++ b/marklogic-data-hub-central/ui/e2e/setup.sh
@@ -18,9 +18,9 @@ if $DHS
 then
         env=dhs
         perl -i -pe"s/mlHost=/mlHost=$mlHost/g" gradle-dhs.properties
-        ./gradlew hubSaveIndexes --info --stacktrace
+        ./gradlew hubSaveIndexes -PenvironmentName=$env --info --stacktrace
         ./gradlew hubGeneratePII -PenvironmentName=$env --info --stacktrace
-        ./gradlew hubDeployAsDeveloper  --info --stacktrace -PenvironmentName=$env
+        ./gradlew hubDeployAsDeveloper -PenvironmentName=$env --info --stacktrace
 else
         cp ../cypress/fixtures/users/* src/main/ml-config/security/users/
 


### PR DESCRIPTION

### Description
Changes to setup script
Moving README to e2e

No tests needed. This is so pipeline can run Cypress tests successfully.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [ NA] Added Tests
  

- ##### Reviewer:

- [NA] Reviewed Tests

