### PR TITLE
DHFPROD-5493: entity-config files now have tokens replaced

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/DeployHubDatabaseCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/DeployHubDatabaseCommandTest.java
@@ -2,8 +2,13 @@ package com.marklogic.hub.deploy.commands;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.hub.AbstractHubCoreTest;
+import com.marklogic.hub.DatabaseKind;
+import com.marklogic.hub.impl.EntityManagerImpl;
+import com.marklogic.mgmt.api.database.Database;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -24,7 +29,7 @@ public class DeployHubDatabaseCommandTest extends AbstractHubCoreTest {
     void payloadHasValidLanguageProperty() {
         payload.put("language", "en");
 
-        ObjectNode updatedPayload = readJsonObject(command.preparePayloadBeforeSubmitting(payload.toString(), getHubConfig().getManageClient()));
+        ObjectNode updatedPayload = readJsonObject(command.preparePayloadBeforeSubmitting(newCommandContext(), payload.toString()));
         assertEquals("test", updatedPayload.get("database-name").asText());
         assertTrue(updatedPayload.has("language"), "language should still be present since it's a valid database property");
     }
@@ -33,7 +38,7 @@ public class DeployHubDatabaseCommandTest extends AbstractHubCoreTest {
     void payloadHasLanguageOfZxx() {
         payload.put("language", "zxx");
 
-        ObjectNode updatedPayload = readJsonObject(command.preparePayloadBeforeSubmitting(payload.toString(), getHubConfig().getManageClient()));
+        ObjectNode updatedPayload = readJsonObject(command.preparePayloadBeforeSubmitting(newCommandContext(), payload.toString()));
         assertEquals("test", updatedPayload.get("database-name").asText());
         assertFalse(updatedPayload.has("language"), "A language with a value of 'zxx' should have been removed; this " +
             "should be very unusual, as it likely was not added by a user (who in theory would have selected a valid " +
@@ -49,12 +54,27 @@ public class DeployHubDatabaseCommandTest extends AbstractHubCoreTest {
             payload.put("schema-database", "test1");
             payload.put("triggers-database", "test2");
 
-            ObjectNode updatedPayload = readJsonObject(command.preparePayloadBeforeSubmitting(payload.toString(), getHubConfig().getManageClient()));
+            ObjectNode updatedPayload = readJsonObject(command.preparePayloadBeforeSubmitting(newCommandContext(), payload.toString()));
             assertEquals("test", updatedPayload.get("database-name").asText());
             assertFalse(updatedPayload.has("schema-database"));
             assertFalse(updatedPayload.has("triggers-database"));
         } finally {
             getHubConfig().setIsProvisionedEnvironment(originalValue);
         }
+    }
+
+    @Test
+    void mergeEntityConfigFile() throws IOException {
+        installOnlyReferenceModelEntities();
+        new EntityManagerImpl(getHubConfig()).saveDbIndexes();
+
+        DeployHubDatabaseCommand command = new DeployHubDatabaseCommand(getHubConfig(), null, "final-database.json");
+
+        final String dbName = getHubConfig().getDbName(DatabaseKind.FINAL);
+        Database db = new Database(null, dbName);
+        ObjectNode result = command.mergePayloadWithEntityConfigFileIfItExists(newCommandContext(), db.toObjectNode());
+        assertEquals(dbName, result.get("database-name").asText(),
+            "The tokens in the entity-config file should have been replaced so that the result of merging its " +
+                "payload in does not contain any tokens");
     }
 }


### PR DESCRIPTION
This isn't an issue yet, but it could be in the future. This ensures that after we merge an entity-config file with another database file, the output does not have any tokens in it that still need to be replaced.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

