### PR TITLE
DHFPROD-5223:Replace data-hub-operator with data-hub-common for certain default permissions

### DIFF
--- a/examples/reference-entity-model/steps/ingestion/loadCustomersJSON.step.json
+++ b/examples/reference-entity-model/steps/ingestion/loadCustomersJSON.step.json
@@ -13,7 +13,7 @@
   "outputURIReplacement": ".*input/json,'/Customer'",
   "sourceDatabase": null,
   "targetDatabase": "data-hub-STAGING",
-  "permissions": "data-hub-common,read,data-hub-common-writer,update",
+  "permissions": "data-hub-common,read,data-hub-common,update",
   "provenanceGranularityLevel": "coarse",
   "lastUpdated": "2020-06-04T23:01:35.540012Z"
 }

--- a/examples/reference-entity-model/steps/ingestion/loadCustomersXML.step.json
+++ b/examples/reference-entity-model/steps/ingestion/loadCustomersXML.step.json
@@ -13,7 +13,7 @@
   "outputURIReplacement": ".*input/xml,'/Customer'",
   "sourceDatabase": null,
   "targetDatabase": "data-hub-STAGING",
-  "permissions": "data-hub-common,read,data-hub-common-writer,update",
+  "permissions": "data-hub-common,read,data-hub-common,update",
   "provenanceGranularityLevel": "coarse",
   "lastUpdated": "2020-06-04T23:01:35.525384Z"
 }

--- a/examples/step-processors/flows/orderFlow.flow.json
+++ b/examples/step-processors/flows/orderFlow.flow.json
@@ -9,7 +9,7 @@
         "collections": [
           "order-input"
         ],
-        "permissions": "data-hub-operator,read,data-hub-operator,update",
+        "permissions": "data-hub-common,read,data-hub-common,update",
         "outputFormat": "json",
         "targetDatabase": "data-hub-STAGING"
       },

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestion.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestion.spec.tsx
@@ -63,7 +63,7 @@ describe('Default ingestion ', () => {
         loadPage.targetCollectionInput().type('e2eTestCollection{enter}test1{enter}test2{enter}');
         cy.findByText('Default Collections').click();
         loadPage.defaultCollections(stepName).should('be.visible');
-        loadPage.appendTargetPermissions('data-hub-common-writer,update');
+        loadPage.appendTargetPermissions('data-hub-common,update');
         loadPage.selectProvGranularity('Off');
         loadPage.setBatchSize('200');
         //Verify JSON error
@@ -137,7 +137,7 @@ describe('Default ingestion ', () => {
         loadPage.targetCollectionInput().type('e2eTestCollection{enter}test1{enter}test2{enter}');
         cy.findByText('Default Collections').click();
         loadPage.defaultCollections(stepName).should('be.visible');
-        loadPage.setTargetPermissions('data-hub-common,read,data-hub-common-writer,update');
+        loadPage.setTargetPermissions('data-hub-common,read,data-hub-common,update');
         loadPage.selectProvGranularity('Off');
         loadPage.setBatchSize('200');
         //Verify JSON error

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/build.gradle
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/build.gradle
@@ -42,7 +42,7 @@ task loadThesaurus(type: com.marklogic.gradle.task.MlcpTask) {
     database = "data-hub-FINAL"
     input_file_path = "input/thesaurus"
     output_collections = "http://marklogic.com/xdmp/thesaurus,http://marklogic.com/xdmp/documents"
-    output_permissions = "data-hub-common,read,data-hub-common-writer,update"
+    output_permissions = "data-hub-common,read,data-hub-common,update"
     output_uri_replace = ".*input,''"
     host = project.findProperty("mlHost")
     ssl = project.findProperty("hubSsl")

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/flows/testCustomFlow.flow.json
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/flows/testCustomFlow.flow.json
@@ -15,7 +15,7 @@
         "targetEntity" : "Customer",
         "sourceDatabase" : "data-hub-FINAL",
         "collections" : [ "customMatching" ],
-        "permissions" : "data-hub-common,read,data-hub-common-writer,update",
+        "permissions" : "data-hub-common,read,data-hub-common,update",
         "matchOptions" : {
           "dataFormat" : "json",
           "propertyDefs" : {
@@ -58,7 +58,7 @@
         "targetEntity" : "Customer",
         "sourceDatabase" : "data-hub-FINAL",
         "collections" : [ "customMerging", "mastered" ],
-        "permissions" : "data-hub-common,read,data-hub-common-writer,update",
+        "permissions" : "data-hub-common,read,data-hub-common,update",
         "mergeOptions" : {
           "propertyDefs" : {
             "properties" : [ ],

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/step-definitions/custom/customCustom/customCustom.step.json
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/step-definitions/custom/customCustom/customCustom.step.json
@@ -7,7 +7,7 @@
   "options" : {
     "collections" : [ "customMapping" ],
     "sourceDatabase" : "data-hub-STAGING",
-    "permissions" : "data-hub-common,read,data-hub-common-writer,update",
+    "permissions" : "data-hub-common,read,data-hub-common,update",
     "outputFormat" : "json",
     "targetDatabase" : "data-hub-FINAL"
   },

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/step-definitions/custom/customMapping/customMapping.step.json
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/step-definitions/custom/customMapping/customMapping.step.json
@@ -7,7 +7,7 @@
   "options" : {
     "collections" : [ "customMapping" ],
     "sourceDatabase" : "data-hub-STAGING",
-    "permissions" : "data-hub-common,read,data-hub-common-writer,update",
+    "permissions" : "data-hub-common,read,data-hub-common,update",
     "outputFormat" : "json",
     "targetDatabase" : "data-hub-FINAL"
   },

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/step-definitions/custom/customMastering/customMastering.step.json
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/step-definitions/custom/customMastering/customMastering.step.json
@@ -7,7 +7,7 @@
   "options" : {
     "collections" : [ "customMastetring" ],
     "sourceDatabase" : "data-hub-STAGING",
-    "permissions" : "data-hub-common,read,data-hub-common-writer,update",
+    "permissions" : "data-hub-common,read,data-hub-common,update",
     "outputFormat" : "json",
     "targetDatabase" : "data-hub-FINAL"
   },

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/step-definitions/custom/customMatching/customMatching.step.json
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/step-definitions/custom/customMatching/customMatching.step.json
@@ -7,7 +7,7 @@
   "options" : {
     "collections" : [ "customMatching" ],
     "sourceDatabase" : "data-hub-STAGING",
-    "permissions" : "data-hub-common,read,data-hub-common-writer,update",
+    "permissions" : "data-hub-common,read,data-hub-common,update",
     "outputFormat" : "json",
     "targetDatabase" : "data-hub-FINAL"
   },

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/step-definitions/custom/customMerging/customMerging.step.json
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/step-definitions/custom/customMerging/customMerging.step.json
@@ -7,7 +7,7 @@
   "options" : {
     "collections" : [ "customMerging" ],
     "sourceDatabase" : "data-hub-STAGING",
-    "permissions" : "data-hub-common,read,data-hub-common-writer,update",
+    "permissions" : "data-hub-common,read,data-hub-common,update",
     "outputFormat" : "json",
     "targetDatabase" : "data-hub-FINAL"
   },

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/step-definitions/ingestion/cusIngTest/cusIngTest.step.json
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/step-definitions/ingestion/cusIngTest/cusIngTest.step.json
@@ -7,7 +7,7 @@
   "options" : {
     "sourceQuery" : "cts.collectionQuery([])",
     "collections" : [ "cusIngTest" ],
-    "permissions" : "data-hub-common,read,data-hub-common-writer,update",
+    "permissions" : "data-hub-common,read,data-hub-common,update",
     "outputFormat" : "json",
     "targetDatabase" : "data-hub-STAGING"
   },

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/step-definitions/ingestion/customIngestion/customIngestion.step.json
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/step-definitions/ingestion/customIngestion/customIngestion.step.json
@@ -7,7 +7,7 @@
   "options" : {
     "sourceQuery" : "cts.collectionQuery([])",
     "collections" : [ "customIngestion" ],
-    "permissions" : "data-hub-common,read,data-hub-common-writer,update",
+    "permissions" : "data-hub-common,read,data-hub-common,update",
     "outputFormat" : "json",
     "targetDatabase" : "data-hub-STAGING"
   },

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/steps/custom/mapping-step.step.json
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/steps/custom/mapping-step.step.json
@@ -13,7 +13,7 @@
   "sourceDatabase" : "data-hub-STAGING",
   "collections" : [ "customMapping", "mdm-content", "mapping-step", "Customer" ],
   "targetEntityType" : "http://example.org/Customer-0.0.1/Customer",
-  "permissions" : "data-hub-common,read,data-hub-common-writer,update",
+  "permissions" : "data-hub-common,read,data-hub-common,update",
   "validateEntity" : false,
   "targetDatabase" : "data-hub-FINAL",
   "targetFormat" : "json",

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/steps/ingestion/ingest-orders.step.json
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/steps/ingestion/ingest-orders.step.json
@@ -3,7 +3,7 @@
   "stepDefinitionName" : "default-ingestion",
   "stepDefinitionType" : "INGESTION",
   "collections" : [ "order-input", "ingest-orders" ],
-  "permissions" : "data-hub-common,read,data-hub-common-writer,update",
+  "permissions" : "data-hub-common,read,data-hub-common,update",
   "targetDatabase" : "data-hub-STAGING",
   "targetFormat" : "json",
   "inputFilePath" : "input/json/orders",

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/steps/ingestion/ingestion-step.step.json
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/steps/ingestion/ingestion-step.step.json
@@ -13,7 +13,7 @@
     "createdBy" : "currentUser"
   },
   "collections" : [ "cusIngTest", "ingestion-step" ],
-  "permissions" : "data-hub-common,read,data-hub-common-writer,update",
+  "permissions" : "data-hub-common,read,data-hub-common,update",
   "targetDatabase" : "data-hub-STAGING",
   "targetFormat" : "json",
   "inputFilePath" : "/input/json",

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/steps/ingestion/loadCustomersJSON.step.json
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/steps/ingestion/loadCustomersJSON.step.json
@@ -13,7 +13,7 @@
   "outputURIReplacement": ".*input,''",
   "sourceDatabase": null,
   "targetDatabase": "data-hub-STAGING",
-  "permissions": "data-hub-common,read,data-hub-common-writer,update",
+  "permissions": "data-hub-common,read,data-hub-common,update",
   "batchSize": 100,
   "provenanceGranularityLevel": "coarse",
   "lastUpdated": "2020-06-24T21:12:22.492316-07:00",

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/steps/ingestion/loadCustomersXML.step.json
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/steps/ingestion/loadCustomersXML.step.json
@@ -13,7 +13,7 @@
   "outputURIReplacement": ".*input,''",
   "sourceDatabase": null,
   "targetDatabase": "data-hub-STAGING",
-  "permissions": "data-hub-common,read,data-hub-common-writer,update",
+  "permissions": "data-hub-common,read,data-hub-common,update",
   "batchSize": 100,
   "provenanceGranularityLevel": "coarse",
   "lastUpdated": "2020-06-24T21:12:22.481031-07:00",

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/AbstractStepDefinition.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/AbstractStepDefinition.java
@@ -48,7 +48,7 @@ public abstract class AbstractStepDefinition implements StepDefinition {
         version = 1;
 
         options = new HashMap<>();
-        options.put("permissions", "data-hub-common,read,data-hub-common-writer,update");
+        options.put("permissions", "data-hub-common,read,data-hub-common,update");
 
         customHook = new JSONObject().jsonNode();
         retryLimit = 0;

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/triggers/ml-dh-entity-create.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/triggers/ml-dh-entity-create.json
@@ -32,7 +32,7 @@
       "capability": "update"
     },
     {
-      "role-name": "data-hub-operator",
+      "role-name": "data-hub-common",
       "capability": "read"
     }
   ]

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/triggers/ml-dh-entity-delete.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/triggers/ml-dh-entity-delete.json
@@ -32,7 +32,7 @@
       "capability": "update"
     },
     {
-      "role-name": "data-hub-operator",
+      "role-name": "data-hub-common",
       "capability": "read"
     }
   ]

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/triggers/ml-dh-entity-modify.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/triggers/ml-dh-entity-modify.json
@@ -32,7 +32,7 @@
       "capability": "update"
     },
     {
-      "role-name": "data-hub-operator",
+      "role-name": "data-hub-common",
       "capability": "read"
     }
   ]

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/triggers/ml-dh-entity-validate-create.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/triggers/ml-dh-entity-validate-create.json
@@ -32,7 +32,7 @@
       "capability": "update"
     },
     {
-      "role-name": "data-hub-operator",
+      "role-name": "data-hub-common",
       "capability": "read"
     }
   ]

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/triggers/ml-dh-entity-validate-modify.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/triggers/ml-dh-entity-validate-modify.json
@@ -32,7 +32,7 @@
       "capability": "update"
     },
     {
-      "role-name": "data-hub-operator",
+      "role-name": "data-hub-common",
       "capability": "read"
     }
   ]

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/triggers/ml-dh-json-mapping-create.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/triggers/ml-dh-json-mapping-create.json
@@ -32,7 +32,7 @@
       "capability": "update"
     },
     {
-      "role-name": "data-hub-operator",
+      "role-name": "data-hub-common",
       "capability": "read"
     }
   ]

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/triggers/ml-dh-json-mapping-delete.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/triggers/ml-dh-json-mapping-delete.json
@@ -32,7 +32,7 @@
       "capability": "update"
     },
     {
-      "role-name": "data-hub-operator",
+      "role-name": "data-hub-common",
       "capability": "read"
     }
   ]

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/triggers/ml-dh-json-mapping-modify.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/triggers/ml-dh-json-mapping-modify.json
@@ -32,7 +32,7 @@
       "capability": "update"
     },
     {
-      "role-name": "data-hub-operator",
+      "role-name": "data-hub-common",
       "capability": "read"
     }
   ]

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.hub/config.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.hub/config.xqy
@@ -13,7 +13,7 @@ declare variable $HUB-VERSION := "%%mlHubVersion%%";
 declare variable $HUB-LOG-LEVEL := "%%mlHubLogLevel%%";
 declare variable $FLOW-OPERATOR-ROLE := "%%mlFlowOperatorRole%%";
 declare variable $FLOW-DEVELOPER-ROLE := "%%mlFlowDeveloperRole%%";
-declare variable $DEFAULT-DATA-HUB-PERMISSIONS := "data-hub-common,read,data-hub-common-writer,update";
+declare variable $DEFAULT-DATA-HUB-PERMISSIONS := "data-hub-common,read,data-hub-common,update";
 
 (:
 This function is intended for usage where Data Hub must insert a document, and there's not yet a way for a user to

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/lib.sjs
@@ -20,9 +20,9 @@ const xsltPermissions = [
   xdmp.permission(datahub.config.FLOWDEVELOPERROLE,'execute'),
   xdmp.permission(datahub.config.FLOWOPERATORROLE,'read'),
   xdmp.permission(datahub.config.FLOWDEVELOPERROLE,'read'),
-  xdmp.permission(datahub.consts.DATA_HUB_OPERATOR_ROLE,'execute'),
+  xdmp.permission("data-hub-common",'execute'),
+  xdmp.permission("data-hub-common",'read'),
   xdmp.permission(datahub.consts.DATA_HUB_DEVELOPER_ROLE,'execute'),
-  xdmp.permission(datahub.consts.DATA_HUB_OPERATOR_ROLE,'read'),
   xdmp.permission(datahub.consts.DATA_HUB_DEVELOPER_ROLE,'read'),
   xdmp.permission("data-hub-module-reader", "execute"),
   // In the absence of this, ML will report an error about standard-library.xqy not being found. This is misleading; the

--- a/marklogic-data-hub/src/main/resources/scaffolding/defaultFlow.flow.json
+++ b/marklogic-data-hub/src/main/resources/scaffolding/defaultFlow.flow.json
@@ -18,7 +18,7 @@
       },
       "options": {
         "targetDatabase": "%%mlStagingDbName%%",
-        "permissions": "data-hub-common,read,data-hub-common-writer,update",
+        "permissions": "data-hub-common,read,data-hub-common,update",
         "outputFormat": "json",
         "collections": [
           "default-ingestion"
@@ -41,7 +41,7 @@
         "sourceDatabase": "%%mlStagingDbName%%",
         "targetDatabase": "%%mlFinalDbName%%",
         "sourceQuery": "cts.collectionQuery('default-ingestion')",
-        "permissions": "data-hub-common,read,data-hub-common-writer,update",
+        "permissions": "data-hub-common,read,data-hub-common,update",
         "outputFormat": "json",
         "collections": [
           "default-mapping",
@@ -70,7 +70,7 @@
         "collections": [
           "mastering-summary"
         ],
-        "permissions": "data-hub-common,read,data-hub-common-writer,update",
+        "permissions": "data-hub-common,read,data-hub-common,update",
         "outputFormat": "json",
         "matchOptions" : {
           "dataFormat": "json",
@@ -115,7 +115,7 @@
         "collections": [
           "default-merging","mastered"
         ],
-        "permissions": "data-hub-common,read,data-hub-common-writer,update",
+        "permissions": "data-hub-common,read,data-hub-common,update",
         "outputFormat": "json",
         "mergeOptions" : {
           "propertyDefs" : {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/mapping/MappingTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/mapping/MappingTest.java
@@ -353,10 +353,10 @@ public class MappingTest extends HubTestBase {
         BytesHandle handle = modMgr.read(uri, metadata, new BytesHandle());
         Assertions.assertNotEquals(0, handle.get().length);
         DocumentMetadataHandle.DocumentPermissions permissions = metadata.getPermissions();
-        Assertions.assertTrue(permissions.get("data-hub-operator").contains(DocumentMetadataHandle.Capability.READ));
+        Assertions.assertTrue(permissions.get("data-hub-common").contains(DocumentMetadataHandle.Capability.READ));
         Assertions.assertTrue(permissions.get("data-hub-developer").contains(DocumentMetadataHandle.Capability.READ));
         Assertions.assertTrue(permissions.get("data-hub-developer").contains(DocumentMetadataHandle.Capability.EXECUTE));
-        Assertions.assertTrue(permissions.get("data-hub-operator").contains(DocumentMetadataHandle.Capability.EXECUTE));
+        Assertions.assertTrue(permissions.get("data-hub-common").contains(DocumentMetadataHandle.Capability.EXECUTE));
     }
 
     private void installProject() throws IOException {

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/CreateFlowTaskTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/CreateFlowTaskTest.groovy
@@ -70,7 +70,7 @@ class CreateFlowTaskTest extends BaseTest {
         flowDir.isDirectory()
         def jsonSlurper = new JsonSlurper()
         def data = jsonSlurper.parse(Paths.get(testProjectDir.root.toString(), "flows", "myTestFlow.flow.json").toFile());
-        def expectedPermissions = 'data-hub-common,read,data-hub-common-writer,update'
+        def expectedPermissions = 'data-hub-common,read,data-hub-common,update'
         data.steps.'1'.name == 'ingestion-step'
         data.steps.'1'.options.permissions == expectedPermissions
         data.steps.'2'.name == 'mapping-step'

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/CreateStepDefinitionTaskTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/CreateStepDefinitionTaskTest.groovy
@@ -64,7 +64,7 @@ class CreateStepDefinitionTaskTest extends BaseTest {
         stepDir.isDirectory()
         def jsonSlurper = new JsonSlurper()
         def data = jsonSlurper.parse(Paths.get(testProjectDir.root.toString(), "step-definitions", "custom", "my-test-step", "my-test-step.step.json").toFile());
-        data.options.permissions == "data-hub-common,read,data-hub-common-writer,update";
+        data.options.permissions == "data-hub-common,read,data-hub-common,update";
     }
 
     def "create step with valid name and type"() {
@@ -87,7 +87,7 @@ class CreateStepDefinitionTaskTest extends BaseTest {
         stepDir.isDirectory()
         def jsonSlurper = new JsonSlurper()
         def data = jsonSlurper.parse(Paths.get(testProjectDir.root.toString(), "step-definitions", "ingestion", "my-new-step", "my-new-step.step.json").toFile());
-        data.options.permissions == "data-hub-common,read,data-hub-common-writer,update";
+        data.options.permissions == "data-hub-common,read,data-hub-common,update";
     }
 
     /**

--- a/web/e2e/specs/flows/steps/ingestion.ts
+++ b/web/e2e/specs/flows/steps/ingestion.ts
@@ -57,7 +57,7 @@ export default function (qaProjectDir) {
       await expect(ingestStepPage.mlcpCommand.getText()).toContain("json");
       await expect(ingestStepPage.mlcpCommand.getText()).toContain("-input_file_type \"documents\"");
       await expect(ingestStepPage.mlcpCommand.getText()).toContain("-output_collections \"json-ingestion\"");
-      await expect(ingestStepPage.mlcpCommand.getText()).toContain("-output_permissions \"data-hub-operator,read,data-hub-operator,update\"");
+      await expect(ingestStepPage.mlcpCommand.getText()).toContain("-output_permissions \"data-hub-common,read,data-hub-common,update\"");
       await expect(ingestStepPage.mlcpCommand.getText()).toContain("document_type \"json\"");
       await expect(ingestStepPage.mlcpCommand.getText()).toContain("-transform_param \"flow-name=TestFlow1,step=1\"");
     });
@@ -285,11 +285,11 @@ export default function (qaProjectDir) {
     });
 
     it('Should verify target permissions', async function () {
-      await expect(ingestStepPage.mlcpCommand.getText()).toContain("-output_permissions \"data-hub-operator,read,data-hub-operator,update\"");
+      await expect(ingestStepPage.mlcpCommand.getText()).toContain("-output_permissions \"data-hub-common,read,data-hub-common,update\"");
       await ingestStepPage.targetPermissions.clear();
-      await ingestStepPage.targetPermissions.sendKeys("data-hub-operator,read,data-hub-operator,update,user1,execute");
+      await ingestStepPage.targetPermissions.sendKeys("data-hub-common,read,data-hub-common,update,user1,execute");
       await ingestStepPage.targetPermissions.sendKeys(protractor.Key.ENTER);
-      await expect(ingestStepPage.mlcpCommand.getText()).toContain("-output_permissions \"data-hub-operator,read,data-hub-operator,update,user1,execute\"");
+      await expect(ingestStepPage.mlcpCommand.getText()).toContain("-output_permissions \"data-hub-common,read,data-hub-common,update,user1,execute\"");
     });
 
     it('Should verify target uri replacement', async function () {

--- a/web/src/main/ui/app/components/flows-new/edit-flow/custom/custom.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/custom/custom.component.ts
@@ -58,7 +58,7 @@ export class CustomComponent  implements OnInit {
     const options = {
       additionalCollections: this.step.options.additionalCollections || [],
       collections: this.step.options.collections || [`${this.step.name}`],
-      permissions: this.step.options.permissions || "data-hub-operator,read,data-hub-operator,update",
+      permissions: this.step.options.permissions || "data-hub-common,read,data-hub-common,update",
       outputFormat: this.step.options.outputFormat || 'json',
       sourceQuery: this.step.options.sourceQuery || '',
       targetDatabase: this.step.options.targetDatabase || '',
@@ -78,8 +78,8 @@ export class CustomComponent  implements OnInit {
 
     this.step.fileLocations = fileLocations;
     this.step.options = Object.assign(options, cOptions);
-    
-    
+
+
   }
 
 

--- a/web/src/main/ui/app/components/flows-new/edit-flow/custom/ui/custom-ui.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/custom/ui/custom-ui.component.ts
@@ -89,7 +89,7 @@ const settings = {
   outputPermissions: {
     label: 'Target Permissions',
     description: 'A comma separated list of (role,capability) pairs to apply to loaded documents.\nDefault: The default permissions associated with the user inserting the document.\n\nExample: role1,read,role2,update',
-    value: 'data-hub-operator,read,data-hub-operator,update',
+    value: 'data-hub-common,read,data-hub-common,update',
   },
   outputURIReplacement: {
     label: 'Target URI Replacement',

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ingest/ingest.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ingest/ingest.component.ts
@@ -61,7 +61,7 @@ export class IngestComponent implements OnInit {
     const options = {
       additionalCollections: additionalCollections || [],
       collections: collections || [`${this.step.name}`],
-      permissions: permissions || "data-hub-operator,read,data-hub-operator,update",
+      permissions: permissions || "data-hub-common,read,data-hub-common,update",
       outputFormat: outputFormat || 'json',
       sourceQuery: sourceQuery || '',
       targetDatabase: targetDatabase || '',
@@ -77,7 +77,7 @@ export class IngestComponent implements OnInit {
   }
   cmdCopied(): void {
     this.snackbar.open('MLCP command copied to the clipboard.', "", {
-        panelClass: ['snackbar'], 
+        panelClass: ['snackbar'],
         duration: 1200
       });
   }

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ingest/ui/ingest-ui.component.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ingest/ui/ingest-ui.component.ts
@@ -89,7 +89,7 @@ const settings = {
   outputPermissions: {
     label: 'Target Permissions',
     description: 'A comma separated list of (role,capability) pairs to apply to loaded documents.\nDefault: The default permissions associated with the user inserting the document.\n\nExample: role1,read,role2,update',
-    value: 'data-hub-operator,read,data-hub-operator,update',
+    value: 'data-hub-common,read,data-hub-common,update',
   },
   outputURIReplacement: {
     label: 'Target URI Replacement',

--- a/web/src/main/ui/app/components/flows-new/models/step.model.ts
+++ b/web/src/main/ui/app/components/flows-new/models/step.model.ts
@@ -61,7 +61,7 @@ export class Step {
     };
     step.fileLocations = fileLocations;
     step.options = new IngestionOptions();
-    step.options.permissions = 'data-hub-operator,read,data-hub-operator,update';
+    step.options.permissions = 'data-hub-common,read,data-hub-common,update';
     step.options.outputFormat = 'json';
     step.customHook = {"module" : "",
     "parameters" : {},
@@ -76,7 +76,7 @@ export class Step {
   static createMappingStep(): Step {
     const step = new Step();
     step.options = new MappingOptions();
-    step.options.permissions = 'data-hub-operator,read,data-hub-operator,update';
+    step.options.permissions = 'data-hub-common,read,data-hub-common,update';
     step.options.outputFormat = 'json';
     step.customHook = {"module" : "",
     "parameters" : {},
@@ -91,7 +91,7 @@ export class Step {
   static createMatchingStep(): Step {
     const step = new Step();
     step.options = new MatchingOptions();
-    step.options.permissions = 'data-hub-operator,read,data-hub-operator,update';
+    step.options.permissions = 'data-hub-common,read,data-hub-common,update';
     step.options.outputFormat = 'json';
     step.customHook = {"module" : "",
     "parameters" : {},
@@ -106,7 +106,7 @@ export class Step {
   static createMergingStep(): Step {
     const step = new Step();
     step.options = new MergingOptions();
-    step.options.permissions = 'data-hub-operator,read,data-hub-operator,update';
+    step.options.permissions = 'data-hub-common,read,data-hub-common,update';
     step.options.outputFormat = 'json';
     step.customHook = {"module" : "",
     "parameters" : {},
@@ -121,7 +121,7 @@ export class Step {
   static createMasteringStep(): Step {
     const step = new Step();
     step.options = new MasteringOptions();
-    step.options.permissions = 'data-hub-operator,read,data-hub-operator,update';
+    step.options.permissions = 'data-hub-common,read,data-hub-common,update';
     step.options.outputFormat = 'json';
     step.customHook = {"module" : "",
     "parameters" : {},
@@ -137,7 +137,7 @@ export class Step {
     const step = new Step();
     step.modulePath = '';
     step.options = new CustomOptions();
-    step.options.permissions = 'data-hub-operator,read,data-hub-operator,update';
+    step.options.permissions = 'data-hub-common,read,data-hub-common,update';
     step.options.outputFormat = 'json';
     step.customHook = {"module" : "",
     "parameters" : {},
@@ -148,7 +148,7 @@ export class Step {
     step.threadCount = 4;
     return step;
   }
-  
+
   static updateCustomStep(step: Step,customStepType: String,filePath: string) : Step {
     if(customStepType === StepType.INGESTION){
       const fileLocations = {
@@ -169,7 +169,7 @@ export class Step {
     }
     if (json.name) {
       newStep.name = json.name;
-    } 
+    }
     if (json.selectedSource) {
       newStep.selectedSource = json.selectedSource;
     }
@@ -203,7 +203,7 @@ export class Step {
     if (json.threadCount && isNumber(parseInt(json.threadCount))) {
       newStep.threadCount = json.threadCount;
     }
- 
+
     // Check options
     if (json.options) {
       // set defaults for each step type
@@ -254,7 +254,7 @@ export class Step {
             newStep.fileLocations = fileLocations;
           }
         }
-        
+
         newStep.options = new CustomOptions();
         newStep.options.sourceDatabase = databases.staging;
         newStep.options.targetDatabase = databases.final;
@@ -262,7 +262,7 @@ export class Step {
       const newOptions = Object.assign(newStep.options, json.options);
       newStep.options = newOptions;
     }
-    newStep.options.permissions = 'data-hub-operator,read,data-hub-operator,update';
+    newStep.options.permissions = 'data-hub-common,read,data-hub-common,update';
     return newStep;
   }
 }


### PR DESCRIPTION


### Description
Replace data-hub-operator with data-hub-common for certain default permissions

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

