### PR TITLE
DHFPROD-5553:Remove granular privileges before removing databases

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesCommand.java
@@ -95,9 +95,10 @@ public class CreateGranularPrivilegesCommand extends LoggingObject implements Co
         return Integer.MAX_VALUE;
     }
 
+    // Granular privileges should be removed before dbs as the 'granularPrivileges' map's key uses db id
     @Override
     public Integer getUndoSortOrder() {
-        return SortOrderConstants.DELETE_PRIVILEGES;
+        return SortOrderConstants.DELETE_OTHER_DATABASES - 1;
     }
 
     @Override


### PR DESCRIPTION
### Description
Remove granular privileges before removing databases. This fixes both DHFPROD-5535 and DHFPROD-5553. Tests in jenkins should run fine after this
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

