### PR TITLE
DHFPROD-5564: Stop createCustomRoleInheritingCertainDataHubRoles from…

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubSecurityAdminTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubSecurityAdminTest.java
@@ -92,6 +92,7 @@ public class DataHubSecurityAdminTest extends AbstractSecurityTest {
      */
     @Test
     void createCustomRoleInheritingCertainDataHubRoles() {
+        Assumptions.assumeTrue(isVersionCompatibleWith520Roles());
         final String roleName = "test-custom-role";
         Role customRole = new Role(userWithRoleBeingTestedApi, roleName);
         customRole.setRole(CreateGranularPrivilegesCommand.ROLES_THAT_CAN_BE_INHERITED);


### PR DESCRIPTION
… failing nightly ML-9 tests

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- N/A Added Tests
  

- ##### Reviewer:

- N/A Reviewed Tests

