### PR TITLE
DHFPROD-5466: Fix for windows and minor tweaks for consistent test results

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestion.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestion.spec.tsx
@@ -9,7 +9,7 @@ describe('Default ingestion ', () => {
         cy.contains(Application.title);
         cy.loginAsTestUserWithRoles("hub-central-load-writer", "hub-central-flow-writer").withRequest();
         cy.waitUntil(() => toolbar.getLoadToolbarIcon()).click();
-        tiles.waitForTableToLoad();
+        cy.waitUntil(() => loadPage.addNewButton('card').should('be.visible'));
     });
 
     afterEach(() => {
@@ -23,7 +23,7 @@ describe('Default ingestion ', () => {
     })
 
     it('Verifies CRUD functionality from list view', () => {
-        let stepName = 'cyTestName';
+        let stepName = 'cyListView';
         //Verify Cancel
         loadPage.loadView('table').click();
         loadPage.addNewButton('list').click();
@@ -98,7 +98,7 @@ describe('Default ingestion ', () => {
     })
 
     it('Verifies CRUD functionality from card view and run in a flow', () => {
-        let stepName = 'cyTestName';
+        let stepName = 'cyCardView';
         let flowName= 'newE2eFlow';
         //Verify Cancel
         loadPage.loadView('th-large').click();
@@ -186,7 +186,7 @@ describe('Default ingestion ', () => {
 
         //Verify Add to Existing Flow after changing source/target format to TEXT
         cy.waitUntil(() => toolbar.getLoadToolbarIcon()).click();
-        tiles.waitForTableToLoad();
+        cy.waitUntil(() => loadPage.addNewButton('card').should('be.visible'));
         loadPage.loadView('th-large').click();
         loadPage.editStepInCardView(stepName).click();
         loadPage.selectSourceFormat('TEXT');
@@ -211,7 +211,7 @@ describe('Default ingestion ', () => {
 
         //Verify Delete step
         cy.waitUntil(() => toolbar.getLoadToolbarIcon()).click();
-        tiles.waitForTableToLoad();
+        cy.waitUntil(() => loadPage.addNewButton('card').should('be.visible'));
         loadPage.deleteStep(stepName).click();
         loadPage.confirmationOptions("No").click();
         loadPage.stepName(stepName).should('be.visible');

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.queries.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.queries.tsx
@@ -14,6 +14,7 @@ describe('save/manage queries scenarios, developer role', () => {
         cy.loginAsDeveloper().withRequest();
         cy.waitUntil(() => toolbar.getExploreToolbarIcon()).click();
         cy.waitUntil(() => browsePage.getExploreButton(), {timeout: 10000}).click();
+        browsePage.waitForSpinnerToDisappear();
         browsePage.waitForTableToLoad();
     });
 

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/commands.js
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/commands.js
@@ -126,6 +126,7 @@ Cypress.Commands.add('uploadFile', (filePath) => {
   cy.get('#fileUpload').attachFile(filePath,{ subjectType: 'input', force: true });
   cy.waitUntil(() => cy.findByTestId('spinner').should('be.visible'));
   cy.waitUntil(() => cy.findByTestId('spinner').should('not.be.visible'));
+  cy.waitUntil(() => cy.get('span p'));
 })
 
 Cypress.Commands.add('verifyStepRunResult', (jobStatus, stepType, stepName) => {
@@ -182,16 +183,19 @@ Cypress.Commands.add('deleteSteps', (stepType, ...stepNames) => {
 })
 
 function setTestUserRoles(roles) {
-  //To get roles within quotes and comma separated
-  roles = '"' + roles.join('", "') + '"'
+  let role = roles.concat("hub-central-user");
+  cy.writeFile("cypress/support/body.json", {"role": role})
+  cy.readFile("cypress/support/body.json").then(content => {
+    expect(content.role).deep.equals(role);
+  });
   cy.exec(`curl -X PUT --anyauth -u test-admin-for-data-hub-tests:password -H "Content-Type:application/json" \
-  -d '{"role": [ "hub-central-user", ${roles} ]}' ${protocol}://${Cypress.env('mlHost')}:8002/manage/v2/users/hc-test-user/properties`)
+  -d @cypress/support/body.json ${protocol}://${Cypress.env('mlHost')}:8002/manage/v2/users/hc-test-user/properties`)
   cy.wait(500);
 }
 
 function resetTestUser() {
   cy.exec(`curl -X PUT --anyauth -u test-admin-for-data-hub-tests:password -H "Content-Type:application/json" \
-  -d '{"role": [ "hub-central-user" ]}' ${protocol}://${Cypress.env('mlHost')}:8002/manage/v2/users/hc-test-user/properties`)
+  -d @cypress/support/resetUser.json ${protocol}://${Cypress.env('mlHost')}:8002/manage/v2/users/hc-test-user/properties`)
 }
 
 Cypress.on('uncaught:exception', (err, runnable) => {

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/browse.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/browse.tsx
@@ -170,6 +170,7 @@ class BrowsePage {
     cy.get('[data-cy=search-bar]').type(str);
     cy.get('.ant-input-search-button').click();
     this.waitForTableToLoad();
+    this.waitForSpinnerToDisappear();
   }
 
   changeNumericSlider(val: string){

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/resetUser.json
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/resetUser.json
@@ -1,0 +1,5 @@
+{
+  "role": [
+    "hub-central-user"
+  ]
+}


### PR DESCRIPTION
### Description
Fixes set user with roles and reseting them on windows. Using a file based approach instead of passing data object directly to fix windows issue.
Also included fix to load test since Card view is the new default view.
Added little tweaks so tests run consistently in slower environments.

Verified to work in mac and windows.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

