### PR TITLE
DHFPROD-5055: stopOnError now works with step processors

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
@@ -238,6 +238,7 @@ public class QueryStepRunner implements StepRunner {
                 StepRunnerUtil.objectToString(options.get("sourceDatabase")) :
                 hubClient.getDbName(DatabaseKind.STAGING);
 
+            logger.info(String.format("Collecting items for step '%s' in flow '%s'", this.step, this.flow.getName()));
             uris = runCollector(sourceDatabase);
         } catch (Exception e) {
             runStepResponse.setCounts(0,0, 0, 0, 0)
@@ -457,12 +458,14 @@ public class QueryStepRunner implements StepRunner {
             });
 
         if(! isStopped.get()) {
+            logger.info(String.format("Starting processing of items for step '%s' in flow '%s'", this.step, this.flow.getName()));
             JobTicket jobTicket = dataMovementManager.startJob(queryBatcher);
             ticketWrapper.put("jobTicket", jobTicket);
         }
 
         runningThread = new Thread(() -> {
             queryBatcher.awaitCompletion();
+            logger.info(String.format("Finished processing of items for step '%s' in flow '%s'", this.step, this.flow.getName()));
 
             // now that the job has completed we can close the resource
             if (uris instanceof DiskQueue) {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow.sjs
@@ -347,7 +347,13 @@ class Flow {
     }
     flowInstance.globalContext.uri = null;
 
-    this.applyProcessorsBeforeContentPersisted(flowStep, contentArray, combinedOptions);
+    try {
+      this.applyProcessorsBeforeContentPersisted(flowStep, contentArray, combinedOptions);
+    } catch (e) {
+      // If a processor throws an error, we don't know if it was specific to a particular item or not. So we assume that
+      // all items failed; this is analogous to the behavior of acceptsBatch=true
+      this.handleStepError(flowInstance, e, items);
+    }
 
     // Add everything to the writeQueue
     contentArray.forEach(content => {

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/flows/stepProcessors.flow.json
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/flows/stepProcessors.flow.json
@@ -1,5 +1,6 @@
 {
   "name": "stepProcessors",
+  "stopOnError": true,
   "steps": {
     "1": {
       "name": "stepOne",
@@ -70,6 +71,20 @@
       "processors": [
         {
           "path": "/custom-modules/step-processors/onIngest.sjs",
+          "when": "beforeContentPersisted"
+        }
+      ]
+    },
+    "5": {
+      "name": "processorModuleThrowsError",
+      "stepDefinitionName": "echoStep",
+      "stepDefinitionType": "CUSTOM",
+      "options": {
+        "sourceQuery": "cts.collectionQuery('customer-input')"
+      },
+      "processors": [
+        {
+          "path": "/custom-modules/step-processors/moduleThrowsError.sjs",
           "when": "beforeContentPersisted"
         }
       ]

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/modules/root/custom-modules/step-processors/moduleThrowsError.sjs
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/modules/root/custom-modules/step-processors/moduleThrowsError.sjs
@@ -1,0 +1,4 @@
+var contentArray;
+var options;
+
+throw Error("This error is intentional");


### PR DESCRIPTION
Added some logging to QueryStepRunner so it's easier to see when a step starts and finishes too.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

