### PR TITLE
DHFPROD-5574:Removing "data-hub-clear-user-data" privilege as it's no longer used

### DIFF
--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/privileges/data-hub-clear-user-data.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/privileges/data-hub-clear-user-data.json
@@ -1,5 +1,0 @@
-{
-  "privilege-name": "data-hub-clear-user-data",
-  "action": "http://marklogic.com/data-hub/privileges/clear-user-data",
-  "kind": "execute"
-}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-developer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-developer.json
@@ -28,11 +28,6 @@
       "kind": "execute"
     },
     {
-      "privilege-name": "data-hub-clear-user-data",
-      "action": "http://marklogic.com/data-hub/privileges/clear-user-data",
-      "kind": "execute"
-    },
-    {
       "privilege-name": "data-hub-download-project-files",
       "action": "http://marklogic.com/data-hub/privileges/download-project-files",
       "kind": "execute"

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-clear-user-data.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-clear-user-data.json
@@ -10,12 +10,5 @@
     "data-hub-mapping-reader",
     "data-hub-match-merge-reader",
     "data-hub-step-definition-reader"
-  ],
-  "privilege": [
-    {
-      "privilege-name": "data-hub-clear-user-data",
-      "action": "http://marklogic.com/data-hub/privileges/clear-user-data",
-      "kind": "execute"
-    }
   ]
 }


### PR DESCRIPTION

### Description
Removing "data-hub-clear-user-data" privilege as it's no longer used. No tests required for this,
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [N/A ] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

