### PR TITLE
DHFPROD-5279: Tweaks to HC migration process

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/hubcentral/migration/FlowMigrator.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/hubcentral/migration/FlowMigrator.java
@@ -71,8 +71,8 @@ public class FlowMigrator extends LoggingObject {
      * converted to mapping steps. Fortunately, a delete trigger exists on these to also delete the xml/xslt documents
      * associated with them.
      */
-    public void deleteInstalledLegacyMappings() {
-        logger.info("Deleting installed legacy mappings in staging and final databases");
+    public void deleteLegacyMappings() {
+        logger.info("Deleting legacy mappings in staging and final databases");
         HubClient hubClient = hubConfig.newHubClient();
         Stream.of(hubClient.getStagingClient(), hubClient.getFinalClient()).forEach(client -> {
             DataMovementManager dmm = client.newDataMovementManager();

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/hubcentral/migration/HubCentralMigrator.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/hubcentral/migration/HubCentralMigrator.java
@@ -7,10 +7,12 @@ import com.marklogic.client.ext.helper.LoggingObject;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.HubProject;
 import com.marklogic.hub.impl.EntityManagerImpl;
+import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -51,6 +53,14 @@ public class HubCentralMigrator extends LoggingObject {
         }
 
         logger.warn("Beginning migration of entity models in entities directory");
+
+        Path migratedEntitiesPath = hubProject.getProjectDir().resolve("migrated-entities");
+        try {
+            migratedEntitiesPath.toFile().mkdirs();
+            FileUtils.copyDirectory(entityModelsDir, migratedEntitiesPath.toFile());
+        } catch (Exception e) {
+            throw new RuntimeException("Couldn't migrate entity models as backing up models failed : " + e.getMessage(), e);
+        }
 
         ObjectWriter writer = mapper.writerWithDefaultPrettyPrinter();
         boolean atLeastOneEntityModelWasMigrated = false;

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/hubcentral/migration/EntityModelMigratorTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/hubcentral/migration/EntityModelMigratorTest.java
@@ -138,6 +138,10 @@ public class EntityModelMigratorTest extends AbstractHubCoreTest {
         HubProject hubProject = getHubConfig().getHubProject();
         HubCentralMigrator hubCentralMigrator = new HubCentralMigrator(getHubConfig());
         hubCentralMigrator.migrateEntityModels();
+
+        File backupDir = hubProject.getProjectDir().resolve("migrated-entities").toFile();
+        assertTrue(backupDir.exists());
+
         verifyCustomerEntityModel(hubProject);
         verifyImproperEntityModels(hubProject);
         verifyNoIndexArraysEntityModel(hubProject);

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/hubcentral/migration/FlowMigratorTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/hubcentral/migration/FlowMigratorTest.java
@@ -82,7 +82,7 @@ class FlowMigratorTest extends AbstractHubCoreTest {
         verifyLegacyMappingsStillExistInMarkLogic();
         verifyFlowsWereMigrated();
 
-        flowMigrator.deleteInstalledLegacyMappings();
+        flowMigrator.deleteLegacyMappings();
         verifyLegacyMappingsWereDeletedFromMarkLogic();
     }
 

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -29,7 +29,7 @@ import com.marklogic.gradle.task.databases.UpdateIndexesTask
 import com.marklogic.gradle.task.deploy.DeployAsDeveloperTask
 import com.marklogic.gradle.task.deploy.DeployAsSecurityAdminTask
 import com.marklogic.hub.gradle.task.ApplyProjectZipTask
-import com.marklogic.hub.gradle.task.DeleteInstalledLegacyMappingsTask
+import com.marklogic.hub.gradle.task.DeleteLegacyMappingsTask
 import com.marklogic.hub.gradle.task.MigrateProjectForHubCentralTask
 import com.marklogic.hub.ApplicationConfig
 import com.marklogic.hub.deploy.commands.*
@@ -116,16 +116,12 @@ class DataHubPlugin implements Plugin<Project> {
                 " and the contents of the downloaded zip will then be extracted into the project directory.")
 
         String hubMigrationGroup = "Data Hub Migration"
-        project.task("hubDeleteInstalledLegacyMappings", group: hubMigrationGroup, type: DeleteInstalledLegacyMappingsTask,
+        project.task("hubDeleteLegacyMappings", group: hubMigrationGroup, type: DeleteLegacyMappingsTask,
             description: "Delete installed legacy mappings, which are mappings that have not been converted into the format required by Hub Central"
         ).mustRunAfter("hubDeployUserArtifacts")
         project.task("hubMigrateForHubCentral", group: hubMigrationGroup, type: MigrateProjectForHubCentralTask,
             description: "Migrate flows, mappings and entity models in the local project that were created before version 5.3.0 into the new format required for usage within Hub Central"
         ).finalizedBy(["hubSaveIndexes"])
-        project.task("hubMigrateInstalledFlows", group: hubMigrationGroup, type: DeleteInstalledLegacyMappingsTask,
-            dependsOn: ["hubDeployUserArtifacts", "hubDeleteInstalledLegacyMappings"],
-            description: "Deploys user artifacts and then deletes installed legacy mappings"
-        )
 
         String scaffoldGroup = "MarkLogic Data Hub Scaffolding"
         project.task("hubInit", group: scaffoldGroup, type: InitProjectTask)

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/hub/gradle/task/DeleteLegacyMappingsTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/hub/gradle/task/DeleteLegacyMappingsTask.groovy
@@ -3,11 +3,11 @@ package com.marklogic.hub.gradle.task
 import com.marklogic.gradle.task.AbstractConfirmableHubTask
 import com.marklogic.hub.hubcentral.migration.FlowMigrator
 
-class DeleteInstalledLegacyMappingsTask extends AbstractConfirmableHubTask {
+class DeleteLegacyMappingsTask extends AbstractConfirmableHubTask {
 
     @Override
     void executeIfConfirmed() {
-        new FlowMigrator(getProject().property("hubConfig")).deleteInstalledLegacyMappings()
+        new FlowMigrator(getProject().property("hubConfig")).deleteLegacyMappings()
     }
 
 }

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/hub/gradle/task/DeleteLegacyMappingsTaskTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/hub/gradle/task/DeleteLegacyMappingsTaskTest.groovy
@@ -5,7 +5,7 @@ import org.gradle.testkit.runner.UnexpectedBuildFailure
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
-class DeleteInstalledLegacyMappingsTaskTest extends BaseTest {
+class DeleteLegacyMappingsTaskTest extends BaseTest {
 
     def setupSpec() {
         createGradleFiles()
@@ -15,10 +15,10 @@ class DeleteInstalledLegacyMappingsTaskTest extends BaseTest {
     def "simple smoke test"() {
         when:
         def result
-        result = runTask("hubDeleteInstalledLegacyMappings", '-Pconfirm=true')
+        result = runTask("hubDeleteLegacyMappings", '-Pconfirm=true')
 
         then:
         notThrown(UnexpectedBuildFailure)
-        result.task(":hubDeleteInstalledLegacyMappings").outcome == SUCCESS
+        result.task(":hubDeleteLegacyMappings").outcome == SUCCESS
     }
 }


### PR DESCRIPTION
While writing docs for this, made these changes:

- Now backing up ./entities to ./migrated-entities
- Renamed "hubDeleteInstalledLegacyMappings" to "hubDeleteLegacyMappings" 
- Removed "hubMigratedInstalledFlows", which doesn't account for entity models; the docs will just tell the user to do a full deploy

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

