### PR TITLE
DHFPROD-5552: Tweaking codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,9 +8,9 @@ examples/* @rjrudin @srinathgit @bsrikan
 
 marklogic-data-hub/* @rjrudin @srinathgit @bsrikan @ryanjdew @fsnow @rahulvudutala @akshaysonvane
 
-marklogic-data-hub-central/src @rjrudin @srinathgit @bsrikan @ryanjdew @rahulvudutala @akshaysonvane
+marklogic-data-hub-central/src/* @rjrudin @srinathgit @bsrikan @ryanjdew @rahulvudutala @akshaysonvane
 
-marklogic-data-hub-central/ui @wooldridge @bsrikan @briantang @xnikhil08 @Sanjeevani19 @timur-isangulov @brucean52 @akshaysonvane @AkshayBajajML @rahulvudutala @saarimrahman
+marklogic-data-hub-central/ui/* @wooldridge @bsrikan @briantang @xnikhil08 @Sanjeevani19 @timur-isangulov @brucean52 @akshaysonvane @AkshayBajajML @rahulvudutala @saarimrahman
 
 ml-data-hub-plugin/* @rjrudin @srinathgit @bsrikan
 


### PR DESCRIPTION
I think "/*" is needed for matching files correctly.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

