### PR TITLE
DHFPROD-5047: Add Step menu for flows

### DIFF
--- a/marklogic-data-hub-central/ui/src/api/__mocks__/mocks.data.ts
+++ b/marklogic-data-hub-central/ui/src/api/__mocks__/mocks.data.ts
@@ -64,6 +64,8 @@ const curateAPI = (axiosMock) => {
     switch (url) {
       case '/api/flows':
         return Promise.resolve(curateData.flows);
+      case '/api/steps':
+        return Promise.resolve(curateData.steps);
       case '/api/models/primaryEntityTypes':
         return Promise.resolve(curateData.primaryEntityTypes);
       case '/api/steps/ingestion':
@@ -90,13 +92,17 @@ const runAPI = (axiosMock) => {
   return axiosMock.get['mockImplementation']((url) => {
     switch (url) {
       case '/api/flows':
-        return Promise.resolve(curateData.flows)
+        return Promise.resolve(curateData.flows);
+      case '/api/steps':
+        return Promise.resolve(curateData.steps);
+      case '/api/flows/testFlow/latestJobInfo':
+        return Promise.resolve({});
       case '/api/steps/ingestion':
         return Promise.resolve(curateData.loads);
       case '/api/steps/mapping':
         return Promise.resolve(curateData.mappings);
       case '/api/jobs/e4590649-8c4b-419c-b6a1-473069186592':
-        return Promise.resolve(curateData.jobRespSuccess)
+        return Promise.resolve(curateData.jobRespSuccess);
       default:
         return Promise.reject(new Error('not found'));
     }
@@ -133,11 +139,26 @@ const runAPI = (axiosMock) => {
     })
   };
 
+  const runAddStepAPI = (axiosMock) => {
+    // call Run API for the GET operations
+    runAPI(axiosMock);
+    axiosMock.post['mockImplementation']((url) => {
+      switch (url) {
+        case `/api/flows/${curateData.flows.data[0].name}/steps`:
+          return Promise.resolve({status: 200, data: {}});
+        default:
+          return Promise.reject(new Error('not found'));
+      }
+    })
+  };
+
   const runErrorsAPI = (axiosMock) => {
     return axiosMock.get['mockImplementation']((url) => {
       switch (url) {
         case '/api/flows':
-          return Promise.resolve(curateData.flows)
+          return Promise.resolve(curateData.flows);
+        case '/api/steps':
+          return Promise.resolve(curateData.steps);
         case '/api/steps/ingestion':
           return Promise.resolve(curateData.loads);
         case '/api/steps/mapping':
@@ -154,7 +175,9 @@ const runFailedAPI = (axiosMock) => {
   return axiosMock.get['mockImplementation']((url) => {
     switch (url) {
       case '/api/flows':
-        return Promise.resolve(curateData.flows)
+        return Promise.resolve(curateData.flows);
+      case '/api/steps':
+        return Promise.resolve(curateData.steps);
       case '/api/steps/ingestion':
         return Promise.resolve(curateData.loads);
       case '/api/steps/mapping':
@@ -173,8 +196,10 @@ const runXMLAPI = (axiosMock) => {
       case '/api/flows':
         return Promise.resolve(curateData.flowsXML);
       case '/api/flows/testFlow/latestJobInfo':
-          console.log(curateData.flowsXMLLatestJob)
+        console.log(curateData.flowsXMLLatestJob)
         return Promise.resolve(curateData.flowsXMLLatestJob);
+      case '/api/steps':
+        return Promise.resolve(curateData.steps);
       case '/api/steps/ingestion':
         return Promise.resolve(curateData.loadsXML);
       case '/api/steps/mapping':
@@ -231,6 +256,7 @@ const mocks = {
   loadAPI: loadAPI,
   curateAPI: curateAPI,
   runAPI: runAPI,
+  runAddStepAPI: runAddStepAPI,
   runCrudAPI: runCrudAPI,
   runErrorsAPI: runErrorsAPI,
   runFailedAPI: runFailedAPI,

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/flows.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/flows.data.ts
@@ -401,6 +401,33 @@ const flows = {
   "status" :200
 }
 
+const steps = {
+  "data": {
+    "ingestionSteps": [
+      {
+        "stepId": "step1-ingestion",
+        "name": "Step 1"
+      },
+      {
+        "stepId": "step2-ingestion",
+        "name": "Step 2"
+      }
+    ],
+    "mappingSteps": [
+      {
+        "stepId": "step3-mapping",
+        "name": "Step 3"
+      },
+      {
+        "stepId": "step4-mapping",
+        "name": "Step 4"
+      }
+    ]
+  }
+  ,
+  "status" :200
+}
+
 const jobRespSuccess = {
   "data": {
     "jobId": "e4590649-8c4b-419c-b6a1-473069186592",
@@ -550,6 +577,7 @@ const data = {
     primaryEntityTypes,
     flowProps,
     flows: flows,
+    steps: steps,
     entityTypes: entityTypes,
     response: response,
     loads: loads,

--- a/marklogic-data-hub-central/ui/src/components/flows/flows.scss
+++ b/marklogic-data-hub-central/ui/src/components/flows/flows.scss
@@ -1,0 +1,15 @@
+#panelActions {
+
+    .ant-dropdown-trigger {
+        margin-top: -4px;
+        height: 30px;
+        margin-right: 15px;
+    }
+
+}
+
+.stepMenu {
+    max-height: 50vh;
+    overflow: scroll;
+    border: solid 1px #ddd;
+}

--- a/marklogic-data-hub-central/ui/src/components/flows/flows.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/flows/flows.test.tsx
@@ -1,11 +1,46 @@
 import React from 'react';
-import Flows from './flows';
-import data from '../../assets/mock-data/flows.data';
-import { render } from '@testing-library/react';
+import { Router } from 'react-router';
+import { render, fireEvent, wait, within, cleanup, waitForElement, getByTestId } from '@testing-library/react';
 import userEvent from "@testing-library/user-event";
-import {BrowserRouter as Router} from "react-router-dom";
+import '@testing-library/jest-dom/extend-expect'
+import { createMemoryHistory } from 'history';
+const history = createMemoryHistory();
+import axiosMock from 'axios';
+import data from '../../assets/mock-data/flows.data';
+import Flows from './flows';
+
+jest.mock('axios');
 
 describe('Flows component', () => {
+
+    let flowsProps = {
+        flows: data.flows.data,
+        steps: data.steps.data,
+        deleteFlow: () => null,
+        createFlow: () => null,
+        updateFlow: () => null,
+        deleteStep: () => null,
+        runStep: () => null,
+        running: [],
+        uploadError: '',
+        newStepToFlowOptions: () => null,
+        addStepToFlow: () => null,
+        flowsDefaultActiveKey: [],
+        showStepRunResponse: () => null,
+        runEnded: {},
+    }
+    const flowName = data.flows.data[0].name;
+    const flowStepName = data.flows.data[0].steps[1].stepName;
+    const addStepName = data.steps.data['ingestionSteps'][0].name;
+
+    beforeEach(() => {
+        axiosMock.get['mockImplementationOnce'](jest.fn(() => Promise.resolve({})));
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        cleanup();
+    });
 
     it('Verifies input format names and type circles', () => {
         const allKindsOfIngestInAFlow = [{ name: 'allInputFormats', steps: [{
@@ -25,11 +60,115 @@ describe('Flows component', () => {
                 "sourceFormat": "xml"}
                 ]
         }];
-        const { getByText, getByLabelText } = render(<Router><Flows {...data.flowProps} flows={allKindsOfIngestInAFlow} /></Router>);
+        const { getByText, getByLabelText } = render(
+            <Router history={history}>
+                <Flows {...data.flowProps} flows={allKindsOfIngestInAFlow} />
+            </Router>);
         userEvent.click(getByLabelText('icon: right'));
         ["CSV", "BIN", "TXT", "JSON", "XML"].forEach(format => {
             expect(getByText(format)).toBeInTheDocument();
             expect(getByText(format)).toHaveStyle("height: 35px; width: 35px; line-height: 35px; text-align: center;");
         });
     })
+
+    it('user with flow read, write, and operator privileges can view, edit, and run', () => {
+        const {getByText, getByLabelText} = render(
+            <Router history={history}><Flows 
+                {...flowsProps}
+                canReadFlow={true}
+                canWriteFlow={true}
+                hasOperatorRole={true}
+            /></Router>
+        );
+
+        let flowButton = getByLabelText('icon: right');
+        expect(getByText(flowName)).toBeInTheDocument();
+        expect(getByLabelText('create-flow')).toBeInTheDocument();
+        expect(getByLabelText('deleteFlow-'+flowName)).toBeInTheDocument();
+
+        // Open flow
+        fireEvent.click(flowButton);
+        expect(getByText(flowStepName)).toBeInTheDocument();
+        expect(getByLabelText('runStep-'+flowStepName)).toBeInTheDocument();
+        expect(getByLabelText('deleteStep-'+flowStepName)).toBeInTheDocument();
+
+        // Open Add Step
+        let addStep = getByText('Add Step');
+        fireEvent.click(addStep);
+        expect(getByText(addStepName)).toBeInTheDocument();
+
+    });
+
+    it('user without flow write privileges cannot edit', () => {
+        const {getByText, getByLabelText, queryByLabelText} = render(
+            <Router history={history}><Flows 
+                {...flowsProps}
+                canReadFlow={true}
+                canWriteFlow={false}
+                hasOperatorRole={true}
+            /></Router>
+        );
+
+        let flowButton = getByLabelText('icon: right');
+        expect(getByText(flowName)).toBeInTheDocument();
+        expect(getByLabelText('create-flow-disabled')).toBeInTheDocument();
+        expect(getByLabelText('deleteFlowDisabled-'+flowName)).toBeInTheDocument();
+
+        // Open flow
+        fireEvent.click(flowButton);
+        expect(getByText(flowStepName)).toBeInTheDocument();
+        expect(getByLabelText('runStep-'+flowStepName)).toBeInTheDocument(); // Has operator priv's, can still run
+        expect(getByLabelText('deleteStepDisabled-'+flowStepName)).toBeInTheDocument();
+
+        // Open Add Step
+        let addStep = getByText('Add Step');
+        fireEvent.click(addStep);
+        expect(queryByLabelText(addStepName)).not.toBeInTheDocument();
+
+    });
+
+    it('user without flow write or operator privileges cannot edit or run', () => {
+        const {getByText, getByLabelText, queryByLabelText} = render(
+            <Router history={history}><Flows 
+                {...flowsProps}
+                canReadFlow={true}
+                canWriteFlow={false}
+                hasOperatorRole={false}
+            /></Router>
+        );
+
+        let flowButton = getByLabelText('icon: right');
+        expect(getByText(flowName)).toBeInTheDocument();
+        expect(getByLabelText('create-flow-disabled')).toBeInTheDocument();
+        expect(getByLabelText('deleteFlowDisabled-'+flowName)).toBeInTheDocument();
+
+        // Open flow
+        fireEvent.click(flowButton);
+        expect(getByText(flowStepName)).toBeInTheDocument();
+        expect(getByLabelText('runStepDisabled-'+flowStepName)).toBeInTheDocument();
+        expect(getByLabelText('deleteStepDisabled-'+flowStepName)).toBeInTheDocument();
+
+        // Open Add Step
+        let addStep = getByText('Add Step');
+        fireEvent.click(addStep);
+        expect(queryByLabelText(addStepName)).not.toBeInTheDocument();
+
+    });
+
+    it('user without flow read, write, or operator privileges cannot view, edit, or run', () => {
+        const {queryByText, queryByLabelText} = render(
+            <Router history={history}><Flows 
+                {...flowsProps}
+                canReadFlow={false}
+                canWriteFlow={false}
+                hasOperatorRole={false}
+            /></Router>
+        );
+
+        // Nothing shown, including Create button
+        expect(queryByLabelText('("icon: right')).not.toBeInTheDocument();
+        expect(queryByText(flowName)).not.toBeInTheDocument();
+
+    });
+
 });

--- a/marklogic-data-hub-central/ui/src/pages/Run.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Run.tsx
@@ -23,12 +23,13 @@ const Statuses = {
 }
 
 const Run = (props) => {
-   const { handleError } = useContext(UserContext);
+   const { handleError, resetSessionTime } = useContext(UserContext);
 
     const history: any = useHistory();
 
     const [isLoading, setIsLoading] = useState(false);
     const [flows, setFlows] = useState<any[]>([]);
+    const [steps, setSteps] = useState<any>({});
     const [runStarted, setRunStarted] = useState<any>({});
     const [runEnded, setRunEnded] = useState<any>({});
     const [running, setRunning] = useState<any[]>([]);
@@ -53,8 +54,10 @@ const Run = (props) => {
 
     useEffect(() => {
         getFlows();
+        getSteps();
         return (() => {
             setFlows([]);
+            setSteps([]);
         })
     }, [isLoading]);
 
@@ -81,6 +84,21 @@ const Run = (props) => {
         } catch (error) {
             console.error('Error getting flows', error);
             handleError(error)
+        }
+    }
+
+    const getSteps = async () => {
+        try {
+            let response = await axios.get('/api/steps');
+            if (response.status === 200) {
+                setSteps(response.data);
+            }
+        } catch (error) {
+            console.error('********* ERROR', error);
+            let message = error.response.data.message;
+            console.error('Error getting steps', message);
+        } finally {
+          resetSessionTime();
         }
     }
 
@@ -392,6 +410,7 @@ const Run = (props) => {
         <div className={styles.runContainer}>
             <Flows
                 flows={flows}
+                steps={steps}
                 deleteFlow={deleteFlow}
                 createFlow={createFlow}
                 updateFlow={updateFlow}

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.test.tsx
@@ -244,7 +244,7 @@ describe('Tiles View component tests for Developer user', () => {
         expect(getByTestId('runStep-1')).toBeInTheDocument();
     });
 
-    test('Verify run tile cannot edit or run with only readFlow authority', async () => {
+    test('Verify Run tile cannot edit or run with only readFlow authority', async () => {
         const authorityService = new AuthoritiesService();
         authorityService.setAuthorities(['readFlow']);
         const {getByLabelText, getByText, queryByText, getByTestId} = render(<Router history={history}>
@@ -284,7 +284,7 @@ describe('Tiles View component tests for Developer user', () => {
         expect(getByTestId('runStepDisabled-3')).toBeInTheDocument();
     });
 
-    test('Verify run tile can read/run with readFlow and runStep authority', async () => {
+    test('Verify Run tile can read/run with readFlow and runStep authority', async () => {
         const authorityService = new AuthoritiesService();
         authorityService.setAuthorities(['readFlow','runStep']);
         const {getByLabelText, getByText, queryByText, getByTestId} = render(<Router history={history}>
@@ -313,7 +313,7 @@ describe('Tiles View component tests for Developer user', () => {
         expect(getByTestId('runStep-6')).toBeInTheDocument();
     });
 
-    test('Verify run tile does not load from toolbar without readFlow authority', async () => {
+    test('Verify Run tile does not load from toolbar without readFlow authority', async () => {
         const authorityService = new AuthoritiesService();
         authorityService.setAuthorities([]);
         const {getByLabelText, queryByLabelText, queryByText} = render(<Router history={history}>


### PR DESCRIPTION
Implement "Add Step" dropdown menu in flow container that allows user to add a step to a flow.

Screencast (showing privileged and unprivileged views): 

https://drive.google.com/file/d/1QmtrBnJegwhzoVowwAC-cpfrK-BNGiT9/view

Also:
- Update existing tests to have /api/steps mocked
- Add new roles-based tests for flows component

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

