### PR TITLE
DHFPROD-5182: Migrate match steps so they are independent of flows

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -293,7 +293,7 @@ pipeline{
 		stage('code-review'){
 		when {
   			 allOf {
-    changeRequest author: '', authorDisplayName: '', authorEmail: '', branch: '', fork: '', id: '', target: 'develop', title: '', url: ''
+    changeRequest author: '', authorDisplayName: '', authorEmail: '', branch: '', fork: '', id: '', target: 'feature/5.4-develop', title: '', url: ''
   }
   			beforeAgent true
 		}
@@ -373,7 +373,7 @@ pipeline{
 		}
 		stage('Merge-PR'){
 		when {
-  			changeRequest author: '', authorDisplayName: '', authorEmail: '', branch: '', fork: '', id: '', target: 'develop', title: '', url: ''
+  			changeRequest author: '', authorDisplayName: '', authorEmail: '', branch: '', fork: '', id: '', target: 'feature/5.4-develop', title: '', url: ''
   			beforeAgent true
 		}
 		agent {label 'dhmaster'};

--- a/examples/dh-5-example/build.gradle
+++ b/examples/dh-5-example/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         if (project.hasProperty("testing")) {
-            classpath "com.marklogic:ml-data-hub:5.3-SNAPSHOT"
+            classpath "com.marklogic:ml-data-hub:5.4-SNAPSHOT"
         } else {
             classpath "gradle.plugin.com.marklogic:ml-data-hub:5.2.0"
         }
@@ -27,7 +27,7 @@ repositories {
 
 dependencies {
     if (project.hasProperty("testing")) {
-        compile "com.marklogic:marklogic-data-hub:5.3-SNAPSHOT"
+        compile "com.marklogic:marklogic-data-hub:5.4-SNAPSHOT"
     } else {
         compile "com.marklogic:marklogic-data-hub:5.2.0"
     }

--- a/examples/dhf5-custom-hook/build.gradle
+++ b/examples/dhf5-custom-hook/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath "net.saliman:gradle-properties-plugin:1.5.1"
         if (project.hasProperty("testing")) {
-            classpath "com.marklogic:ml-data-hub:5.3-SNAPSHOT"
+            classpath "com.marklogic:ml-data-hub:5.4-SNAPSHOT"
         } else {
             classpath "gradle.plugin.com.marklogic:ml-data-hub:5.2.0"
         }

--- a/examples/insurance/build.gradle
+++ b/examples/insurance/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath "net.saliman:gradle-properties-plugin:1.5.1"
         if (project.hasProperty("testing")) {
-            classpath "com.marklogic:ml-data-hub:5.3-SNAPSHOT"
+            classpath "com.marklogic:ml-data-hub:5.4-SNAPSHOT"
         } else {
             classpath "gradle.plugin.com.marklogic:ml-data-hub:5.2.0"
         }

--- a/examples/mapping-example/build.gradle
+++ b/examples/mapping-example/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath "net.saliman:gradle-properties-plugin:1.5.1"
         if (project.hasProperty("testing")) {
-            classpath "com.marklogic:ml-data-hub:5.3-SNAPSHOT"
+            classpath "com.marklogic:ml-data-hub:5.4-SNAPSHOT"
         } else {
             classpath "gradle.plugin.com.marklogic:ml-data-hub:5.2.0"
         }

--- a/examples/patient-hub/build.gradle
+++ b/examples/patient-hub/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath "net.saliman:gradle-properties-plugin:1.5.1"
         if (project.hasProperty("testing")) {
-            classpath "com.marklogic:ml-data-hub:5.3-SNAPSHOT"
+            classpath "com.marklogic:ml-data-hub:5.4-SNAPSHOT"
         } else {
             classpath "gradle.plugin.com.marklogic:ml-data-hub:5.2.0"
         }

--- a/examples/smart-mastering-complete/build.gradle
+++ b/examples/smart-mastering-complete/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath "net.saliman:gradle-properties-plugin:1.5.1"
         if (project.hasProperty("testing")) {
-            classpath "com.marklogic:ml-data-hub:5.3-SNAPSHOT"
+            classpath "com.marklogic:ml-data-hub:5.4-SNAPSHOT"
         } else {
             classpath "gradle.plugin.com.marklogic:ml-data-hub:5.2.0"
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=5.3-SNAPSHOT
+version=5.4-SNAPSHOT
 publishUrl=file:../marklogic-data-hub/releases
 systemProp.file.encoding=utf-8
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/MasteringService.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/MasteringService.java
@@ -48,6 +48,7 @@ public interface MasteringService {
             private BaseProxy baseProxy;
 
             private BaseProxy.DBFunctionRequest req_getDefaultCollections;
+            private BaseProxy.DBFunctionRequest req_updateMatchOptions;
 
             private MasteringServiceImpl(DatabaseClient dbClient, JSONWriteHandle servDecl) {
                 this.dbClient  = dbClient;
@@ -55,6 +56,8 @@ public interface MasteringService {
 
                 this.req_getDefaultCollections = this.baseProxy.request(
                     "getDefaultCollections.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC);
+                this.req_updateMatchOptions = this.baseProxy.request(
+                    "updateMatchOptions.sjs", BaseProxy.ParameterValuesKind.SINGLE_NODE);
             }
 
             @Override
@@ -71,6 +74,21 @@ public interface MasteringService {
                           ).responseSingle(false, Format.JSON)
                 );
             }
+
+            @Override
+            public com.fasterxml.jackson.databind.JsonNode updateMatchOptions(com.fasterxml.jackson.databind.JsonNode options) {
+                return updateMatchOptions(
+                    this.req_updateMatchOptions.on(this.dbClient), options
+                    );
+            }
+            private com.fasterxml.jackson.databind.JsonNode updateMatchOptions(BaseProxy.DBFunctionRequest request, com.fasterxml.jackson.databind.JsonNode options) {
+              return BaseProxy.JsonDocumentType.toJsonNode(
+                request
+                      .withParams(
+                          BaseProxy.documentParam("options", false, BaseProxy.JsonDocumentType.fromJsonNode(options))
+                          ).responseSingle(false, Format.JSON)
+                );
+            }
         }
 
         return new MasteringServiceImpl(db, serviceDeclaration);
@@ -83,5 +101,13 @@ public interface MasteringService {
    * @return	as output
    */
     com.fasterxml.jackson.databind.JsonNode getDefaultCollections(String entityType);
+
+  /**
+   * Invokes the updateMatchOptions operation on the database server
+   *
+   * @param options	provides input
+   * @return	as output
+   */
+    com.fasterxml.jackson.databind.JsonNode updateMatchOptions(com.fasterxml.jackson.databind.JsonNode options);
 
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/VersionInfo.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/VersionInfo.java
@@ -57,6 +57,6 @@ public class VersionInfo {
         }
 
         String version = properties.getProperty("version");
-        return "${project.version}".equals(version) ? "5.3-SNAPSHOT" : version;
+        return "${project.version}".equals(version) ? "5.4-SNAPSHOT" : version;
     }
 }

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-admin.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-admin.json
@@ -1,6 +1,6 @@
 {
   "role-name": "data-hub-admin",
-  "description": "5.3-SNAPSHOT: Permits developing and operating a Data Hub application, along with clearing databases",
+  "description": "5.4-SNAPSHOT: Permits developing and operating a Data Hub application, along with clearing databases",
   "role": [
     "data-hub-developer"
   ]

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/matching.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/matching.sjs
@@ -22,8 +22,11 @@ const dataHub = DataHubSingleton.instance();
 
 const collections = ['http://marklogic.com/data-hub/matching-artifact'];
 const databases = [dataHub.config.STAGINGDATABASE, dataHub.config.FINALDATABASE];
-const permissions = [xdmp.permission(dataHub.consts.DATA_HUB_MATCHING_WRITE_ROLE, 'update'), xdmp.permission(dataHub.consts.DATA_HUB_MATCHING_READ_ROLE, 'read')];
-const requiredProperties = ['name', 'targetEntityType', 'selectedSource'];
+const permissions = [
+  xdmp.permission(dataHub.consts.DATA_HUB_MATCHING_WRITE_ROLE, 'update'),
+  xdmp.permission(dataHub.consts.DATA_HUB_MATCHING_READ_ROLE, 'read')
+  ];
+const requiredProperties = ['name'];
 
 function getNameProperty() {
     return 'name';

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mastering/updateMatchOptions.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mastering/updateMatchOptions.api
@@ -1,0 +1,15 @@
+{
+    "functionName": "updateMatchOptions",
+    "params": [
+        {
+         "name": "options",
+         "datatype": "jsonDocument",
+         "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+        }
+    ],
+    "return": {
+        "datatype": "jsonDocument",
+        "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
+    }
+}
+

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mastering/updateMatchOptions.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mastering/updateMatchOptions.sjs
@@ -1,0 +1,24 @@
+/**
+ Copyright (c) 2020 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+const updateMatchOptionsLib = require("/data-hub/5/data-services/mastering/updateMatchOptionsLib.sjs");
+
+var options = fn.head(xdmp.fromJSON(options));
+
+let newOpts = updateMatchOptionsLib.updateMatchOptions(options);
+
+newOpts

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mastering/updateMatchOptionsLib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mastering/updateMatchOptionsLib.sjs
@@ -1,0 +1,230 @@
+'use strict';
+
+function updateMatchOptions(opt)
+{
+  let matchRulesets = [];
+  let thresholds = [];
+  let newOpt = {
+    matchRulesets: matchRulesets,
+    thresholds: thresholds
+  };
+
+  let maxWeight = maxWeightValue(opt);
+
+  // a lookup object for properties (name -> object)
+  let properties = {};
+  if (opt.propertyDefs && opt.propertyDefs.property) {
+    opt.propertyDefs.property.forEach((prop) => { properties[prop.name] = prop; });
+  }
+
+  // a lookup object for algorithms (name -> object)
+  let algorithms = {};
+  if (opt.algorithms && opt.algorithms.algorithm) {
+    opt.algorithms.algorithm.forEach((alg) => { algorithms[alg.name] = alg; });
+  }
+
+  // a lookup object for actions (name -> object)
+  let actions = {};
+  if (opt.actions && opt.actions.action) {
+    opt.actions.action.forEach((action) => { actions[action.name] = action; });
+  }
+
+  if (opt.scoring) {
+    if (opt.scoring.add) {
+      opt.scoring.add.forEach((item) => { matchRulesets.push(exactRuleset(item, properties, maxWeight)); });
+    }
+    if (opt.scoring.expand) {
+      opt.scoring.expand.forEach((item) =>
+        {
+          if (item.algorithmRef) {
+            if (item.algorithmRef === "zip-match") {
+              matchRulesets.push(zipRuleset(item, properties, maxWeight));
+            }
+            else if (item.algorithmRef === "double-metaphone") {
+              matchRulesets.push(doubleMetaphoneRuleset(item, properties, maxWeight));
+            }
+            else if (item.algorithmRef === "thesaurus") {
+              matchRulesets.push(synonymRuleset(item, properties, maxWeight));
+            }
+            // custom algorithm
+            else if (algorithms.hasOwnProperty(item.algorithmRef)) {
+              matchRulesets.push(customRuleset(item, properties, algorithms, maxWeight));
+            }
+          }
+        }
+      );
+    }
+    if (opt.scoring.reduce) {
+      opt.scoring.reduce.forEach((item) => { matchRulesets.push(reduceRuleset(item, properties, maxWeight)); });
+    }
+  }
+
+  if (opt.thresholds && opt.thresholds.threshold) {
+    opt.thresholds.threshold.forEach((thr) => { thresholds.push(threshold(thr, actions)); });
+  }
+
+  return newOpt;
+};
+
+function maxWeightValue(opt) {
+  let weights = [];
+  if (opt.scoring) {
+    if (opt.scoring.add) {
+      opt.scoring.add.forEach((item) => { weights.push(Number(item.weight)); });
+    }
+    if (opt.scoring.expand) {
+      opt.scoring.expand.forEach((item) => { weights.push(Number(item.weight)); });
+      if (opt.scoring.expand.zip) {
+        opt.scoring.expand.zip.forEach((item) => { weights.push(Number(item.weight)); });
+      }
+    }
+    if (opt.scoring.reduce) {
+      opt.scoring.reduce.forEach((item) => { weights.push(Math.abs(Number(item.weight))); });
+    }
+  }
+  return Math.max.apply(null, weights)
+};
+
+function exactRuleset(item, properties, maxWeight) {
+  let ruleset = {
+    "name": item.propertyName + " - Exact",
+    "weight": adjustWeight(item.weight, maxWeight),
+    "matchRules": [
+      {
+        "entityPropertyPath": properties[item.propertyName].localname,
+        "matchType": "exact",
+        "options": {}
+      }
+    ]
+  };
+  return ruleset
+};
+
+function zipRuleset(item, properties, maxWeight) {
+  // find the max of the origin weights
+  let weights = [];
+  if (item.zip) {
+    item.zip.forEach((z) => { weights.push(z.weight) });
+  }
+  let zipMaxWeight = Math.max.apply(null, weights);
+  let ruleset = {
+    "name": item.propertyName + " - Zip",
+    "weight": adjustWeight(zipMaxWeight, maxWeight),
+    "matchRules": [
+      {
+        "entityPropertyPath": properties[item.propertyName].localname,
+        "matchType": "zip",
+        "options": {}
+      }
+    ]
+  };
+  return ruleset
+};
+
+function reduceRuleset(item, properties, maxWeight) {
+  let ruleset = {
+    "name": item.propertyName + " - Reduce",
+    "weight": adjustWeight(Math.abs(Number(item.weight)), maxWeight),
+    "matchRules": [
+      {
+        "entityPropertyPath": properties[item.propertyName].localname,
+        "matchType": "exact",
+        "options": {}
+      }
+    ]
+  };
+  return ruleset
+};
+
+function doubleMetaphoneRuleset(item, properties, maxWeight)
+{
+  let ruleset = {
+    "name": item.propertyName + " - Double Metaphone",
+    "weight": adjustWeight(item.weight, maxWeight),
+    "matchRules": [
+      {
+        "entityPropertyPath": properties[item.propertyName].localname,
+        "matchType": "doubleMetaphone",
+        "options": {
+          "dictionaryURI": item.dictionary,
+          "distanceThreshold": Number(item.distanceThreshold)
+        }
+      }
+    ]
+  };
+  return ruleset
+};
+
+function synonymRuleset(item, properties, maxWeight) {
+  let ruleset = {
+    "name": item.propertyName + " - Synonym",
+    "weight": adjustWeight(item.weight, maxWeight),
+    "matchRules": [
+      {
+        "entityPropertyPath": properties[item.propertyName].localname,
+        "matchType": "synonym",
+        "options": {
+          "thesaurusURI": item.thesaurus,
+          "filter": item.filter
+        }
+      }
+    ]
+  };
+  return ruleset
+};
+
+function customRuleset(item, properties, algorithms, maxWeight) {
+  let algorithm = algorithms[item.algorithmRef];
+  let ruleset = {
+    "name": item.propertyName + " - Custom",
+    "weight": adjustWeight(item.weight, maxWeight),
+    "matchRules": [
+      {
+        "entityPropertyPath": properties[item.propertyName].localname,
+        "matchType": "custom",
+        "algorithmModuleNamespace": algorithm.namespace,
+        "algorithmModulePath": algorithm.at,
+        "algorithmFunction": algorithm.function,
+        "options": {}
+      }
+    ]
+  };
+  return ruleset
+};
+
+function threshold(thr, actions) {
+  let t = {
+    "thresholdName": thr.label,
+    "action": thr.action,
+    "score": Number(thr.above)
+  };
+
+  if (thr.action && thr.action !== "merge" && thr.action !== "notify") {
+    let action = actions[thr.action];
+    t.actionModulePath = action.at;
+    t.actionModuleNamespace = action.namespace;
+    t.actionModuleFunction = action.function;
+  }
+
+  return t
+};
+
+// returns a weight between 0 and 16
+function adjustWeight(weight, maxWeight) {
+  let w = Number(weight);
+
+  // We pass in the absolute value of the weight in the reduce case.
+  // For add or expand, make the minimum score 0
+  if (w < 0) w = 0;
+
+  // adjust weight if the max value in the options is greater than 16
+  if (maxWeight > 16) {
+    w = (w / (maxWeight / 16));
+  }
+  return w
+};
+
+
+module.exports = {
+  updateMatchOptions
+};

--- a/marklogic-data-hub/src/main/resources/scaffolding/build_gradle
+++ b/marklogic-data-hub/src/main/resources/scaffolding/build_gradle
@@ -19,7 +19,7 @@ plugins {
 
     // This gradle plugin extends the ml-gradle plugin with
     // commands that make Data Hub do its magic
-    id 'com.marklogic.ml-data-hub' version '5.3-SNAPSHOT'
+    id 'com.marklogic.ml-data-hub' version '5.4-SNAPSHOT'
 }
 
 repositories {
@@ -30,7 +30,7 @@ repositories {
 dependencies {
     // this allows you to write custom java code that depends
     // on the Data Hub library
-    compile 'com.marklogic:marklogic-data-hub:5.3-SNAPSHOT'
+    compile 'com.marklogic:marklogic-data-hub:5.4-SNAPSHOT'
     compile 'com.marklogic:marklogic-xcc:9.0.7'
 }
 

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mastering/updateMatchOptions.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mastering/updateMatchOptions.sjs
@@ -1,0 +1,364 @@
+const test = require("/test/test-helper.xqy");
+
+function invokeService(options) {
+  return fn.head(xdmp.invoke(
+    "/data-hub/5/data-services/mastering/updateMatchOptions.sjs",
+    {"options": options}
+  ));
+}
+
+// -----------------------------------------------
+// matchType exact
+// -----------------------------------------------
+const exactInput =
+  {
+    "dataFormat": "json",
+    "propertyDefs": {
+      "property": [
+        {
+          "localname": "localnameForName",
+          "name": "name"
+        }
+      ]
+    },
+    "scoring": {
+      "add": [
+        {
+          "propertyName": "name",
+          "weight": "3.5"
+        }
+      ]
+    }
+  };
+const exactExpected =
+  {
+    "matchRulesets": [
+      {
+        "name": "name - Exact",
+        "weight": 3.5,
+        "matchRules": [
+          {
+            "entityPropertyPath": "localnameForName",
+            "matchType": "exact",
+            "options": {}
+          }
+        ]
+      }
+    ],
+    "thresholds": []
+  };
+
+// -----------------------------------------------
+// matchType zip
+// -----------------------------------------------
+const zipInput =
+  {
+    "propertyDefs": {
+      "property": [
+        {
+          "namespace": "",
+          "localname": "LocationPostalCode",
+          "name": "zip"
+        }
+      ]
+    },
+    "scoring": {
+      "expand": [
+        {
+          "propertyName": "zip",
+          "algorithmRef": "zip-match",
+          "zip": [
+            {
+              "origin": "5",
+              "weight": "1.5"
+            },
+            {
+              "origin": "9",
+              "weight": "1"
+            }
+          ]
+        }
+      ]
+    }
+  };
+const zipExpected =
+  {
+    "matchRulesets": [
+      {
+        "name": "zip - Zip",
+        "weight": 1.5,
+        "matchRules": [
+          {
+            "entityPropertyPath": "LocationPostalCode",
+            "matchType": "zip",
+            "options": {}
+          }
+        ]
+      }
+    ],
+    "thresholds": []
+  };
+
+// -----------------------------------------------
+// normalize weights, 2 inputs with neg and pos weights, same output
+// -----------------------------------------------
+const normNegInput =
+  {
+    "propertyDefs": {
+      "property": [
+        {
+          "localname": "localnameForName",
+          "name": "name"
+        }
+      ]
+    },
+    "scoring": {
+      "add": [
+        {
+          "propertyName": "name",
+          "weight": "3.5"
+        }
+      ],
+      "reduce": [
+        {
+          "propertyName": "name",
+          "weight": "-20"
+        }
+      ]
+    }
+  };
+const normPosInput =
+  {
+    "propertyDefs": {
+      "property": [
+        {
+          "localname": "localnameForName",
+          "name": "name"
+        }
+      ]
+    },
+    "scoring": {
+      "add": [
+        {
+          "propertyName": "name",
+          "weight": "3.5"
+        }
+      ],
+      "reduce": [
+        {
+          "propertyName": "name",
+          "weight": "-20"
+        }
+      ]
+    }
+  };
+const normExpected =
+  {
+    "matchRulesets": [
+      {
+        "name": "name - Exact",
+        "weight": 2.8,
+        "matchRules": [
+          {
+            "entityPropertyPath": "localnameForName",
+            "matchType": "exact",
+            "options": {}
+          }
+        ]
+      },
+      {
+        "name": "name - Reduce",
+        "weight": 16,
+        "matchRules": [
+          {
+            "entityPropertyPath": "localnameForName",
+            "matchType": "exact",
+            "options": {}
+          }
+        ]
+      }
+    ],
+    "thresholds": []
+  };
+
+
+// -----------------------------------------------
+// large options, tests most cases
+// -----------------------------------------------
+const largeInput =
+  {
+    "dataFormat": "json",
+    "propertyDefs": {
+      "property": [
+        {
+          "localname": "localnameForName",
+          "name": "name"
+        }
+      ]
+    },
+    "algorithms": {
+      "algorithm": [
+        {
+          "name": "custom-name-match",
+          "function": "nameMatch",
+          "at": "/custom-modules/matching/nameMatch.xqy",
+          "namespace": "http://example.org/custom-modules/matching/nameMatch"
+        }
+      ]
+    },
+    "collections": {
+      "content": []
+    },
+    "scoring": {
+      "add": [
+        {
+          "propertyName": "name",
+          "weight": "3.5"
+        }
+      ],
+      "expand": [
+        {
+          "propertyName": "name",
+          "algorithmRef": "double-metaphone",
+          "weight": "2.5",
+          "dictionary": "/nameDictionary.json",
+          "distanceThreshold": "100"
+        },
+        {
+          "propertyName": "name",
+          "algorithmRef": "thesaurus",
+          "weight": "4.5",
+          "thesaurus": "/thesauri/name-synonyms.xml",
+          "filter": "<qualifier>english</qualifier>"
+        },
+        {
+          "propertyName": "name",
+          "algorithmRef": "custom-name-match",
+          "weight": "5.5"
+        }
+      ],
+      "reduce": [
+        {
+          "propertyName": "name",
+          "weight": "1.5"
+        }
+      ]
+    },
+    "actions": {
+      "action": [
+        {
+          "name": "household-action",
+          "function": "household-action",
+          "namespace": "http://marklogic.com/smart-mastering/action",
+          "at": "/custom-modules/matching/custom-action.xqy"
+        }
+      ]
+    },
+    "thresholds": {
+      "threshold": [
+        { "above": "6.5", "label": "similarThreshold", "action": "notify" },
+        { "above": "8.5", "label": "household", "action": "household-action" },
+        { "above": "12", "label": "sameThreshold", "action": "merge" }
+      ]
+    },
+    "tuning": {
+      "maxScan": 200
+    }
+  };
+
+const largeExpected =
+  {
+    "matchRulesets": [
+      {
+        "name": "name - Exact",
+        "weight": 3.5,
+        "matchRules": [
+          {
+            "entityPropertyPath": "localnameForName",
+            "matchType": "exact",
+            "options": {}
+          }
+        ]
+      },
+      {
+        "name": "name - Double Metaphone",
+        "weight": 2.5,
+        "matchRules": [
+          {
+            "entityPropertyPath": "localnameForName",
+            "matchType": "doubleMetaphone",
+            "options": {
+              "dictionaryURI": "/nameDictionary.json",
+              "distanceThreshold": 100
+            }
+          }
+        ]
+      },
+      {
+        "name": "name - Synonym",
+        "weight": 4.5,
+        "matchRules": [
+          {
+            "entityPropertyPath": "localnameForName",
+            "matchType": "synonym",
+            "options": {
+              "thesaurusURI": "/thesauri/name-synonyms.xml",
+              "filter": "<qualifier>english</qualifier>"
+            }
+          }
+        ]
+      },
+      {
+        "name": "name - Custom",
+        "weight": 5.5,
+        "matchRules": [
+          {
+            "entityPropertyPath": "localnameForName",
+            "matchType": "custom",
+            "algorithmModuleNamespace": "http://example.org/custom-modules/matching/nameMatch",
+            "algorithmModulePath": "/custom-modules/matching/nameMatch.xqy",
+            "algorithmFunction": "nameMatch",
+            "options": {}
+          }
+        ]
+      },
+      {
+        "name": "name - Reduce",
+        "weight": 1.5,
+        "matchRules": [
+          {
+            "entityPropertyPath": "localnameForName",
+            "matchType": "exact",
+            "options": {}
+          }
+        ]
+      }
+    ],
+    "thresholds": [
+      {
+        "thresholdName": "similarThreshold",
+        "action": "notify",
+        "score": 6.5
+      },
+      {
+        "thresholdName": "household",
+        "action": "household-action",
+        "score": 8.5,
+        "actionModulePath": "/custom-modules/matching/custom-action.xqy",
+        "actionModuleNamespace": "http://marklogic.com/smart-mastering/action",
+        "actionModuleFunction": "household-action"
+      },
+      {
+        "thresholdName": "sameThreshold",
+        "action": "merge",
+        "score": 12
+      }
+    ]
+  };
+[
+  test.assertEqualJson(exactExpected, invokeService(exactInput), "matchType exact"),
+  test.assertEqualJson(zipExpected, invokeService(zipInput), "matchType zip"),
+  test.assertEqualJson(normExpected, invokeService(normNegInput), "normalize weights, negative reduce"),
+  test.assertEqualJson(normExpected, invokeService(normPosInput), "normalize weights, positive reduce"),
+  test.assertEqualJson(largeExpected, invokeService(largeInput), "large options, most cases")
+];

--- a/marklogic-data-hub/src/test/resources/flow-migration-test/flows/customMaster.flow.json
+++ b/marklogic-data-hub/src/test/resources/flow-migration-test/flows/customMaster.flow.json
@@ -1,5 +1,5 @@
 {
-  "name": "custom-master",
+  "name": "customMaster",
   "steps": {
     "1": {
       "name": "generate-dictionary",

--- a/marklogic-data-hub/src/test/resources/flow-migration-test/flows/customOnlyFlow.flow.json
+++ b/marklogic-data-hub/src/test/resources/flow-migration-test/flows/customOnlyFlow.flow.json
@@ -1,5 +1,5 @@
 {
-  "name": "custom_only-flow",
+  "name": "customOnlyFlow",
   "steps": {
     "1": {
       "name": "custom-mapping-step",

--- a/marklogic-data-hub/src/test/resources/flow-migration-test/flows/ingestionMappingFlow.flow.json
+++ b/marklogic-data-hub/src/test/resources/flow-migration-test/flows/ingestionMappingFlow.flow.json
@@ -1,5 +1,5 @@
 {
-  "name": "ingestion_mapping-flow",
+  "name": "ingestionMappingFlow",
   "description": "This is the default flow containing all of the default steps",
   "batchSize": 100,
   "threadCount": 4,

--- a/marklogic-data-hub/src/test/resources/flow-migration-test/flows/ingestionMappingMasteringFlow.flow.json
+++ b/marklogic-data-hub/src/test/resources/flow-migration-test/flows/ingestionMappingMasteringFlow.flow.json
@@ -1,5 +1,5 @@
 {
-  "name": "ingestion_mapping_mastering-flow",
+  "name": "ingestionMappingMasteringFlow",
   "description": "This is the default flow containing all of the default steps",
   "batchSize": 100,
   "threadCount": 4,
@@ -62,6 +62,7 @@
     "3": {
       "name": "json-matching-step-json",
       "description": "matches the docs",
+      "targetEntityType": "http://example.org/Customer-0.0.1/Customer",
       "stepDefinitionName": "default-matching",
       "stepDefinitionType": "MATCHING",
       "options": {

--- a/pipeline.properties
+++ b/pipeline.properties
@@ -1,2 +1,2 @@
-ReleaseBranch:release/5.3.0
+ReleaseBranch:release/5.4.0
 ExecutionBranch:develop


### PR DESCRIPTION
### Description
Adding a library to convert matching steps to the new format, a data service that does that conversion and SJS unit tests.
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests




