### PR TITLE
DHFPROD-5484: Package hub-central as a RPM

### DIFF
--- a/marklogic-data-hub-central/build-rpm.gradle
+++ b/marklogic-data-hub-central/build-rpm.gradle
@@ -1,0 +1,59 @@
+ospackage {
+    packageName = 'hub-central'
+    version = "${project.version}"
+    release = 1
+    os = LINUX
+    type = BINARY
+    arch = NOARCH
+    summary = 'Hub Central Application Server'
+    url = 'http://marklogic.com/'
+    vendor = 'MarkLogic Corporation'
+
+    preInstall file('src/rpm/scripts/pre-install.sh')
+    postInstall file('src/rpm/scripts/post-install.sh')
+    preUninstall file('src/rpm/scripts/pre-uninstall.sh')
+    postUninstall file('src/rpm/scripts/post-uninstall.sh')
+
+    requires('systemd')
+
+    user 'hc-runner'
+    permissionGroup 'hc-runner'
+
+    from(war.outputs.files) {
+        rename { String fileName ->
+            fileName.replace("marklogic-data-hub-central-${project.version}", "hub-central")
+        }
+        fileMode 0755
+        into '/opt/hub-central'
+    }
+
+    from('src/rpm/services/hub-central.service') {
+        addParentDirs(false)
+        fileMode 0755
+        into '/etc/systemd/system'
+    }
+
+    from('src/rpm/configs/hub-central.conf') {
+        fileType CONFIG | NOREPLACE
+        fileMode 0644
+        into '/opt/hub-central'
+    }
+
+    from('src/rpm/configs/hub-central.properties') {
+        addParentDirs(false)
+        fileType CONFIG | NOREPLACE
+        fileMode 0644
+        into '/etc/opt/hub-central'
+    }
+}
+
+buildRpm {
+    user 'hc-runner'
+    permissionGroup 'hc-runner'
+
+    directory('/var/log/hub-central', 0755)
+
+    doLast {
+        println "RPM file written to './build/distributions'"
+    }
+}

--- a/marklogic-data-hub-central/build.gradle
+++ b/marklogic-data-hub-central/build.gradle
@@ -13,6 +13,7 @@ buildscript {
 plugins {
     id "net.saliman.properties" version "1.5.1"
     id "java"
+    id "nebula.ospackage" version "8.4.1"
 }
 
 apply plugin: "org.springframework.boot"
@@ -21,6 +22,7 @@ apply plugin: "io.spring.dependency-management"
 apply plugin: "war"
 apply plugin: "com.github.node-gradle.node"
 apply plugin: "jsonschema2pojo"
+apply from: 'build-rpm.gradle'
 
 mainClassName = "com.marklogic.hub.central.Application"
 
@@ -38,6 +40,10 @@ ext.junitJupiterVersion = '5.3.1'
 
 bootWar {
     baseName = springBootJarName
+    // Used for running hub-central as a system service
+    // Also allows us to customize options like JAVA_HOME using a config file
+    // https://docs.spring.io/spring-boot/docs/current/reference/html/deployment.html#deployment-script-customization-when-it-runs
+    launchScript()
 }
 
 // To pass Gradle properties for HubCentral to Spring Boot, copy them into the JVM environment
@@ -186,6 +192,7 @@ test {
 	useJUnitPlatform()
 }
 
+tasks.buildRpm.dependsOn(buildUi, copyUiFiles, bootWar)
 
 task testUI(type: NpmTask, dependsOn: installDependencies, group: taskGroup){
     description = "Runs the UI unit tests"

--- a/marklogic-data-hub-central/src/rpm/configs/hub-central.conf
+++ b/marklogic-data-hub-central/src/rpm/configs/hub-central.conf
@@ -1,0 +1,6 @@
+# The location of the java executable is discovered by using the PATH by default, 
+# but you can set it explicitly if there is an executable file at $JAVA_HOME/bin/java.
+#JAVA_HOME=
+
+# The arguments to pass to the program (the Spring Boot app).
+RUN_ARGS="--spring.config.additional-location=file:/etc/opt/hub-central/hub-central.properties"

--- a/marklogic-data-hub-central/src/rpm/configs/hub-central.properties
+++ b/marklogic-data-hub-central/src/rpm/configs/hub-central.properties
@@ -1,0 +1,2 @@
+# The location of the application log file
+log.path=/var/log/hub-central

--- a/marklogic-data-hub-central/src/rpm/scripts/post-install.sh
+++ b/marklogic-data-hub-central/src/rpm/scripts/post-install.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Enabling service: hub-central"
+systemctl enable hub-central

--- a/marklogic-data-hub-central/src/rpm/scripts/post-uninstall.sh
+++ b/marklogic-data-hub-central/src/rpm/scripts/post-uninstall.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Removing user: hc-runner"
+userdel hc-runner

--- a/marklogic-data-hub-central/src/rpm/scripts/pre-install.sh
+++ b/marklogic-data-hub-central/src/rpm/scripts/pre-install.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+STATUS="$(systemctl is-active hub-central)"
+if [ "${STATUS}" = "active" ]; then
+    echo "hub-central service is already running. Exiting installation."
+    exit 1
+fi
+
+echo "Creating group: hc-runner"
+groupadd -f -r hc-runner
+
+echo "Creating user: hc-runner"
+useradd -r -g hc-runner -c "hub-central user" hc-runner

--- a/marklogic-data-hub-central/src/rpm/scripts/pre-uninstall.sh
+++ b/marklogic-data-hub-central/src/rpm/scripts/pre-uninstall.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Disabling service: hub-central"
+systemctl --no-reload disable --now hub-central

--- a/marklogic-data-hub-central/src/rpm/services/hub-central.service
+++ b/marklogic-data-hub-central/src/rpm/services/hub-central.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=MarkLogic Data Hub Central Application Service
+After=syslog.target
+
+[Service]
+User=hc-runner
+ExecStart=/opt/hub-central/hub-central.war
+SuccessExitStatus=143
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -236,6 +236,7 @@ if (!(
         gradle.startParameter.taskNames*.toLowerCase().contains("generatefilesfordataservices") ||
         // Added for Hub Central
         gradle.startParameter.taskNames*.toLowerCase().contains("bootrun") ||
+        gradle.startParameter.taskNames*.toLowerCase().contains("buildrpm") ||
         project.hasProperty('skipui')
 )
 ) {


### PR DESCRIPTION
### Description
The package does not perform a dependency check on Java 11 because the java dependency could be satisfied by various packages (oracle java, openjdk java, etc). We can only add a dependency on one of the packages and if we change the java vendor or the package type in the future on DHS then the RPM will complain and not install. So I think its best not to include this dependency check.
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [N/A] Added Tests
  

- ##### Reviewer:

- [N/A] Reviewed Tests

