### PR TITLE
DHFPROD-5371: Navigate away prompt for modeling

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/reader.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/reader.spec.tsx
@@ -1,0 +1,102 @@
+/// <reference types="cypress"/>
+
+import modelPage from '../../support/pages/model';
+import {
+  entityTypeModal,
+  entityTypeTable,
+  propertyModal,
+  propertyTable,
+} from '../../support/components/model/index';
+import { confirmationModal, toolbar, tiles } from '../../support/components/common/index';
+import { Application } from '../../support/application.config';
+import browsePage from '../../support/pages/browse'
+import 'cypress-wait-until';
+
+describe('Entity Modeling: Reader Role', () => {
+
+  //login with valid account
+  beforeEach(() => {
+    cy.visit('/');
+    cy.contains(Application.title);
+    console.log(Cypress.env('mlHost'));
+    cy.loginAsTestUserWithRoles("hub-central-entity-model-reader", "hub-central-saved-query-user").withRequest()
+    cy.waitUntil(() => toolbar.getModelToolbarIcon()).click();
+    entityTypeTable.waitForTableToLoad();
+  });
+
+  after(() => {
+      //resetting the test user back to only have 'hub-central-user' role
+      cy.resetTestUser();
+  });
+
+  it('can navigate by clicking instance count and last processed, can not create, edit, or delete entity models', () => {
+    cy.waitUntil(() => entityTypeTable.getEntityLastProcessed('Person')).click();
+    tiles.getExploreTile().should('exist');
+    cy.waitUntil(() => browsePage.getSelectedEntity()).should('eq', 'Person');
+    browsePage.getClearAllButton().should('exist');
+    
+    toolbar.getModelToolbarIcon().click();
+    tiles.getModelTile().should('exist');
+
+    cy.waitUntil(() => entityTypeTable.getEntityInstanceCount('Order')).click();
+    tiles.getExploreTile().should('exist');
+    cy.waitUntil(() => browsePage.getSelectedEntity().should('eq', 'Order'));
+    browsePage.getClearAllButton().should('not.exist');
+
+    cy.go('back');
+    cy.url().should('include', '/tiles/model');
+    tiles.getModelTile().should('exist');
+
+    modelPage.getAddEntityButton().click({ force: true });
+    cy.wait(100);
+    entityTypeModal.getAddButton().should('not.be.visible');
+
+    modelPage.getSaveAllButton().click({ force: true });
+    cy.wait(100);
+    confirmationModal.getSaveAllEntityText().should('not.be.visible');
+
+    modelPage.getRevertAllButton().click({ force: true });
+    cy.wait(100);
+    confirmationModal.getRevertEntityText().should('not.be.visible');
+
+    entityTypeTable.getEntity('Customer').click({ force: true });
+    cy.wait(100);
+    propertyModal.getSubmitButton().should('not.be.visible');
+
+    entityTypeTable.getDeleteEntityIcon('Customer').click({ force: true });
+    cy.wait(100);
+    confirmationModal.getDeleteEntityStepText().should('not.be.visible');
+
+    entityTypeTable.getRevertEntityIcon('Customer').click({ force: true });
+    cy.wait(100);
+    confirmationModal.getRevertEntityText().should('not.be.visible');
+
+    entityTypeTable.getSaveEntityIcon('Customer').click({ force: true });
+    cy.wait(100);
+    confirmationModal.getSaveEntityText().should('not.be.visible');
+
+    entityTypeTable.getExpandEntityIcon('Customer').click();
+    propertyTable.getAddPropertyButton('Customer').should('be.visible').click({ force: true });
+    cy.wait(100);
+    propertyModal.getSubmitButton().should('not.be.visible');
+
+    propertyTable.getDeletePropertyIcon('Customer','pin').click({ force: true });
+    cy.wait(100);
+    confirmationModal.getDeletePropertyStepWarnText().should('not.be.visible');
+
+    propertyTable.getAddPropertyToStructureType('Address').click({ force: true });
+    cy.wait(100);
+    propertyModal.getStructuredTypeName().should('not.be.visible');
+
+    propertyTable.expandStructuredTypeIcon('shipping').click();
+    propertyTable.expandStructuredTypeIcon('zip').click();
+
+    propertyTable.getAddPropertyToStructureType('Zip').click({ force: true });
+    cy.wait(100);
+    propertyModal.getStructuredTypeName().should('not.be.visible');
+    
+    propertyTable.getDeleteStructuredPropertyIcon('Customer', 'Zip', 'fiveDigit').click({ force: true });
+    cy.wait(100);
+    confirmationModal.getDeletePropertyStepWarnText().should('not.be.visible');
+  });
+});

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/common/confirmation-modal.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/common/confirmation-modal.tsx
@@ -14,33 +14,36 @@ class ConfirmationModal {
     return cy.findByLabelText('toggle-steps');
   }
   getSaveEntityText() {
-    return cy.get('#save-text', {timeout: 25000});
+    return cy.findByLabelText('save-text', {timeout: 25000});
   }
   getSaveAllEntityText() {
-    return cy.get('#save-all-text', {timeout: 25000});
+    return cy.findByLabelText('save-all-text', {timeout: 25000});
   }
 
   getRevertEntityText() {
-    return cy.get('#revert-text', {timeout: 25000});
+    return cy.findByLabelText('revert-text', {timeout: 25000});
   }
 
   getRevertAllEntityText() {
-    return cy.get('#revert-all-text', {timeout: 25000});
+    return cy.findByLabelText('revert-all-text', {timeout: 25000});
   }
   getDeleteEntityText() {
-    return cy.get('#delete-text', {timeout: 15000});
+    return cy.findByLabelText('delete-text', {timeout: 15000});
   }
   getDeleteEntityRelationshipText() {
-    return cy.get('#delete-relationship-text', {timeout: 15000});
+    return cy.findByLabelText('delete-relationship-text', {timeout: 15000});
   }
   getDeleteEntityStepText() {
-    return cy.get('#delete-step-text', {timeout: 15000});
+    return cy.findByLabelText('delete-step-text', {timeout: 15000});
   }
   getDeletePropertyWarnText() {
-    return cy.get('#delete-property-text', {timeout: 15000});
+    return cy.findByLabelText('delete-property-text', {timeout: 15000});
   }
   getDeletePropertyStepWarnText() {
-    return cy.get('#delete-property-step-text', {timeout: 15000});
+    return cy.findByLabelText('delete-property-step-text', {timeout: 15000});
+  }
+  getNavigationWarnText() {
+    return cy.findByLabelText('navigation-warn-text');
   }
 }
 

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/property-table.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/property-table.tsx
@@ -43,7 +43,7 @@ class PropertyTable {
   }
 
   getAddPropertyToStructureType(structureTypeName: string) {
-    return cy.findByTestId(`add-struct-${structureTypeName}`);
+    return cy.findAllByTestId(`add-struct-${structureTypeName}`).eq(0);
   }
 
   editProperty(propertyName: string) {
@@ -59,7 +59,7 @@ class PropertyTable {
   }
 
   getDeleteStructuredPropertyIcon(entityName: string, structuredTypeName: string, propertyName: string) {
-    return cy.findByTestId(`delete-${entityName}-${structuredTypeName}-${propertyName}`);
+    return cy.findAllByTestId(`delete-${entityName}-${structuredTypeName}-${propertyName}`).eq(0);
   }
 }
 

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/model.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/model.tsx
@@ -11,6 +11,10 @@ class ModelPage {
   getRevertAllButton() {
     return cy.findByLabelText('revert-all');
   }
+
+  getEntityModifiedAlert() {
+    return cy.findByLabelText('entity-modified-alert');
+  }
 }
 
 const modelPage = new ModelPage();

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/types/modeling-types.ts
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/types/modeling-types.ts
@@ -8,5 +8,6 @@ export enum ConfirmationType {
   SaveEntity = 'saveEntity',
   SaveAll = 'saveAllEntity',
   RevertEntity = 'revertEntity',
-  RevertAll = 'revertAllEntity'
+  RevertAll = 'revertAllEntity',
+  NavigationWarn = 'navigationWarn'
 }

--- a/marklogic-data-hub-central/ui/package-lock.json
+++ b/marklogic-data-hub-central/ui/package-lock.json
@@ -1837,20 +1837,37 @@
       }
     },
     "@testing-library/dom": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.16.0.tgz",
-      "integrity": "sha512-lBD88ssxqEfz0wFL6MeUyyWZfV/2cjEZZV3YRpb2IoJRej/4f1jB0TzqIOznTpfR1r34CNesrubxwIlAQ8zgPA==",
+      "version": "7.21.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.21.6.tgz",
+      "integrity": "sha512-Xj6AMM9Xb24NSeann91fmXFuyJEzZ1lpVgiaPiy/KY2pNX9y4OeDrEm2ZYZt6mfZgFSGZW0eEWpF7YfcvRq5LQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.8.4",
-        "@sheerun/mutationobserver-shim": "^0.3.2",
-        "@types/testing-library__dom": "^6.12.1",
-        "aria-query": "^4.0.2",
-        "dom-accessibility-api": "^0.3.0",
-        "pretty-format": "^25.1.0",
-        "wait-for-expect": "^3.0.2"
+        "@babel/runtime": "^7.10.3",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "dom-accessibility-api": "^0.4.6",
+        "pretty-format": "^25.5.0"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
+          "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@babel/runtime-corejs3": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.5.tgz",
+          "integrity": "sha512-RMafpmrNB5E/bwdSphLr8a8++9TosnyJp98RZzI6VOx2R2CCMpsXXXRvmI700O9oEKpXdZat6oEK68/F0zjd4A==",
+          "dev": true,
+          "requires": {
+            "core-js-pure": "^3.0.0",
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
         "@jest/types": {
           "version": "25.5.0",
           "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
@@ -1889,13 +1906,13 @@
           }
         },
         "aria-query": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.0.2.tgz",
-          "integrity": "sha512-S1G1V790fTaigUSM/Gd0NngzEfiMy9uTUfMyHhKhVyy4cH5O/eTuR01ydhGL0z4Za1PXFTRGH3qL8VhUQuEO5w==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+          "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
           "dev": true,
           "requires": {
-            "@babel/runtime": "^7.7.4",
-            "@babel/runtime-corejs3": "^7.7.4"
+            "@babel/runtime": "^7.10.2",
+            "@babel/runtime-corejs3": "^7.10.2"
           }
         },
         "chalk": {
@@ -1940,6 +1957,12 @@
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
           }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.1.0",
@@ -2130,12 +2153,187 @@
         "@babel/runtime": "^7.8.4",
         "@testing-library/dom": "^6.15.0",
         "@types/testing-library__react": "^9.1.2"
+      },
+      "dependencies": {
+        "@babel/runtime-corejs3": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.5.tgz",
+          "integrity": "sha512-RMafpmrNB5E/bwdSphLr8a8++9TosnyJp98RZzI6VOx2R2CCMpsXXXRvmI700O9oEKpXdZat6oEK68/F0zjd4A==",
+          "dev": true,
+          "requires": {
+            "core-js-pure": "^3.0.0",
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@jest/types": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "@testing-library/dom": {
+          "version": "6.16.0",
+          "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.16.0.tgz",
+          "integrity": "sha512-lBD88ssxqEfz0wFL6MeUyyWZfV/2cjEZZV3YRpb2IoJRej/4f1jB0TzqIOznTpfR1r34CNesrubxwIlAQ8zgPA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.8.4",
+            "@sheerun/mutationobserver-shim": "^0.3.2",
+            "@types/testing-library__dom": "^6.12.1",
+            "aria-query": "^4.0.2",
+            "dom-accessibility-api": "^0.3.0",
+            "pretty-format": "^25.1.0",
+            "wait-for-expect": "^3.0.2"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "aria-query": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+          "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.10.2",
+            "@babel/runtime-corejs3": "^7.10.2"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.10.5",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
+              "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "dom-accessibility-api": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz",
+          "integrity": "sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@testing-library/user-event": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-10.3.1.tgz",
-      "integrity": "sha512-HozvWlr/xHmkoJrrDdZBbUOXAC/STAeXGyNU+g5KgEwWBpLJi1RPCHJKbTjwz8hp2jDFsk/jjfD0530eZjcFEg==",
+      "version": "12.0.17",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.0.17.tgz",
+      "integrity": "sha512-Et22bfgnLdowY0VSP8MQuCP9wdrqWMrm9OCXSi3q3rx7ctSvEsC/jYNbgK/MJdDSpVhNVnB+fqm1VhVlDDRN6A==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
+          "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        }
+      }
+    },
+    "@types/aria-query": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
+      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==",
       "dev": true
     },
     "@types/babel__core": {
@@ -5516,9 +5714,9 @@
       }
     },
     "dom-accessibility-api": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz",
-      "integrity": "sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.4.6.tgz",
+      "integrity": "sha512-qxFVFR/ymtfamEQT/AsYLe048sitxFCoCHiM+vuOdR3fE94i3so2SCFJxyz/RxV69PZ+9FgToYWOd7eqJqcbYw==",
       "dev": true
     },
     "dom-align": {
@@ -10610,35 +10808,6 @@
         "tslib": "^1.10.0"
       }
     },
-    "nock": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-12.0.3.tgz",
-      "integrity": "sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.0",
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.13",
-        "propagate": "^2.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
-      }
-    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -12642,12 +12811,6 @@
         "object.assign": "^4.1.0",
         "reflect.ownkeys": "^0.2.0"
       }
-    },
-    "propagate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
-      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
-      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.6",

--- a/marklogic-data-hub-central/ui/package.json
+++ b/marklogic-data-hub-central/ui/package.json
@@ -102,11 +102,11 @@
   "devDependencies": {
     "@iconify/icons-fa": "^1.0.3",
     "@iconify/react": "^1.1.3",
+    "@testing-library/dom": "^7.21.6",
     "@testing-library/jest-dom": "^5.1.1",
     "@testing-library/react": "^9.5.0",
-    "@testing-library/user-event": "^10.0.0",
+    "@testing-library/user-event": "^12.0.17",
     "customize-cra": "^0.9.1",
-    "nock": "^12.0.1",
     "path": "^0.12.7"
   }
 }

--- a/marklogic-data-hub-central/ui/src/App.tsx
+++ b/marklogic-data-hub-central/ui/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useContext } from 'react';
+import axios from 'axios';
 import { Switch } from 'react-router';
 import { Route, Redirect, RouteComponentProps, withRouter } from 'react-router-dom';
 import { UserContext } from './util/user-context';
@@ -10,18 +11,15 @@ import Footer from './components/footer/footer';
 import Login from './pages/Login';
 import Home from './pages/Home';
 import TilesView from './pages/TilesView';
-import Browse from './pages/Browse';
-import Detail from './pages/Detail';
 import NoMatchRedirect from './pages/noMatchRedirect';
 import NoResponse from './pages/NoResponse';
+import ModalStatus from './components/modal-status/modal-status';
+import NavigationPrompt from './components/navigation-prompt/navigation-prompt';
 
 import './App.scss';
 import { Application } from './config/application.config';
 import { themes, themeMap } from './config/themes.config';
-import axios from 'axios';
-import ModalStatus from './components/modal-status/modal-status';
 import { getEnvironment } from './util/environment';
-
 
 interface Props extends RouteComponentProps<any> {}
 
@@ -84,24 +82,19 @@ const App: React.FC<Props> = ({history, location}) => {
 
   return (
     <div id="background" style={pageTheme['background']}>
-      <Header environment={getEnvironment()} />
-      <ModalStatus/>
-      <main>
-        <div className="contentContainer">
-        <Switch>
-          <Route path="/" exact component={Login}/>
-          <Route path="/noresponse" exact component={NoResponse} />
-          <PrivateRoute path="/home" exact>
-            <Home/>
-          </PrivateRoute>
-          <SearchProvider>
-            <PrivateRoute path="/browse" exact>
-                <Browse/>
-            </PrivateRoute>
-            {/*<PrivateRoute path="/detail/:pk/:uri">
-              <Detail/>
-            </PrivateRoute>*/}
-            <ModelingProvider>
+      <SearchProvider>
+        <ModelingProvider>
+          <Header environment={getEnvironment()} />
+          <ModalStatus/>
+          <NavigationPrompt/>
+          <main>
+            <div className="contentContainer">
+            <Switch>
+              <Route path="/" exact component={Login}/>
+              <Route path="/noresponse" exact component={NoResponse} />
+              <PrivateRoute path="/home" exact>
+                <Home/>
+              </PrivateRoute>
               <PrivateRoute path="/tiles" exact>
                 <TilesView/>
               </PrivateRoute>
@@ -126,13 +119,13 @@ const App: React.FC<Props> = ({history, location}) => {
               <PrivateRoute path="/tiles/explore/detail/:pk/:uri" exact>
                  <TilesView id='explore'/>
               </PrivateRoute>
-            </ModelingProvider>
-          </SearchProvider>
-          <Route component={NoMatchRedirect}/>
-        </Switch>
-        <Footer pageTheme={pageTheme}/>
-        </div>
-      </main>
+              <Route component={NoMatchRedirect}/>
+            </Switch>
+              <Footer pageTheme={pageTheme}/>
+            </div>
+          </main>
+        </ModelingProvider>
+      </SearchProvider>
     </div>
   );
 }

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/modeling-context-mock.js
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/modeling-context-mock.js
@@ -4,9 +4,9 @@ export const isModified = {
     isModified: true,
     modifiedEntitiesArray: [
       {
-        "entityName": "Product",
+        "entityName": "Order",
         "modelDefinition": {
-          "Product": {
+          "Order": {
             "required": [],
             "pii": [
               "someProperty"
@@ -36,6 +36,7 @@ export const isModified = {
       }
     ]
   },
+  clearEntityModified: jest.fn(),
   toggleIsModified: jest.fn(),
   setEntityTypeNamesArray: jest.fn()
 }
@@ -44,6 +45,7 @@ export const notModified = {
   modelingOptions: {
     isModified: false
   },
+  clearEntityModified: jest.fn(),
   toggleIsModified: jest.fn(),
   setEntityTypeNamesArray: jest.fn()
 }

--- a/marklogic-data-hub-central/ui/src/components/confirmation-modal/confirmation-modal.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/confirmation-modal/confirmation-modal.module.scss
@@ -1,4 +1,5 @@
 .alert {
+  margin-top: 30px;
   margin-bottom: 20px;
 }
 
@@ -17,4 +18,8 @@
     content: "- ";
     margin-left: -15px;
   }
+}
+
+p:first-child {
+  margin-top: 30px;
 }

--- a/marklogic-data-hub-central/ui/src/components/confirmation-modal/confirmation-modal.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/confirmation-modal/confirmation-modal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, getByLabelText } from '@testing-library/react';
 import userEvent from "@testing-library/user-event";
 
 import ConfirmationModal from './confirmation-modal';
@@ -13,7 +13,7 @@ describe('Confirmation Modal Component', () => {
     let toggleModal = jest.fn();
     let confirmAction = jest.fn();
 
-    const { queryByText, getByText, getAllByText, rerender } =  render(
+    const { queryByLabelText, getByText, getAllByText, rerender } =  render(
       <ConfirmationModal 
         isVisible={false}
         type={ConfirmationType.Identifer}
@@ -23,7 +23,7 @@ describe('Confirmation Modal Component', () => {
       />
     );
 
-    expect(queryByText('Confirmation')).toBeNull();
+    expect(queryByLabelText('identifier-text')).toBeNull();
 
     rerender(<ConfirmationModal 
       isVisible={true}
@@ -33,7 +33,6 @@ describe('Confirmation Modal Component', () => {
       confirmAction={confirmAction}
     />);
 
-    expect(getByText('Confirmation')).toBeInTheDocument();
     expect(getAllByText(currentIdentifier)).toHaveLength(3);
     expect(getByText(newIdentifier)).toBeInTheDocument();
     expect(getByText(/Each entity type is allowed a maximum of one identifier/i)).toBeInTheDocument();
@@ -51,7 +50,7 @@ describe('Confirmation Modal Component', () => {
     let toggleModal = jest.fn();
     let confirmAction = jest.fn();
 
-    const { queryByText, getByText, getAllByText, rerender } =  render(
+    const { queryByLabelText, getByText, getAllByText, rerender } =  render(
       <ConfirmationModal 
         isVisible={false}
         type={ConfirmationType.DeleteEntity}
@@ -61,7 +60,7 @@ describe('Confirmation Modal Component', () => {
       />
     );
 
-    expect(queryByText('Confirmation')).toBeNull();
+    expect(queryByLabelText('delete-text')).toBeNull();
 
     rerender(<ConfirmationModal 
       isVisible={true}
@@ -71,7 +70,6 @@ describe('Confirmation Modal Component', () => {
       confirmAction={confirmAction}
     />);
 
-    expect(getByText('Confirmation')).toBeInTheDocument();
     expect(getByText(entityName)).toBeInTheDocument();
     expect(getByText(/Permanently delete/i)).toBeInTheDocument();
 
@@ -87,7 +85,7 @@ describe('Confirmation Modal Component', () => {
     let toggleModal = jest.fn();
     let confirmAction = jest.fn();
 
-    const { queryByText, getByText, getAllByText, rerender } =  render(
+    const { queryByLabelText, getByText, getAllByText, rerender } =  render(
       <ConfirmationModal 
         isVisible={false}
         type={ConfirmationType.DeleteEntityRelationshipWarn}
@@ -97,7 +95,7 @@ describe('Confirmation Modal Component', () => {
       />
     );
 
-    expect(queryByText('Confirmation')).toBeNull();
+    expect(queryByLabelText('delete-relationship-text')).toBeNull();
 
     rerender(<ConfirmationModal 
       isVisible={true}
@@ -107,7 +105,6 @@ describe('Confirmation Modal Component', () => {
       confirmAction={confirmAction}
     />);
 
-    expect(getByText('Confirmation')).toBeInTheDocument();
     expect(getAllByText(entityName)).toHaveLength(3);
     expect(getByText('Existing entity type relationships.')).toBeInTheDocument();
 
@@ -124,7 +121,7 @@ describe('Confirmation Modal Component', () => {
     let toggleModal = jest.fn();
     let confirmAction = jest.fn();
 
-    const { queryByText, getByText, getAllByText, rerender, getByLabelText } =  render(
+    const { queryByText, queryByLabelText, getByText, getAllByText, rerender, getByLabelText } =  render(
       <ConfirmationModal 
         isVisible={false}
         type={ConfirmationType.DeleteEntityStepWarn}
@@ -135,7 +132,7 @@ describe('Confirmation Modal Component', () => {
       />
     );
 
-    expect(queryByText('Delete: Entity Type in Use')).toBeNull();
+    expect(queryByLabelText('delete-step-text')).toBeNull();
 
     rerender(<ConfirmationModal 
       isVisible={true}
@@ -146,7 +143,6 @@ describe('Confirmation Modal Component', () => {
       confirmAction={confirmAction}
     />);
 
-    expect(getByText('Delete: Entity Type in Use')).toBeInTheDocument();
     expect(getAllByText(entityName)).toHaveLength(1);
     expect(getByText('Entity type is used in one or more steps.')).toBeInTheDocument();
     expect(getByText('Show Steps...')).toBeInTheDocument();
@@ -170,7 +166,7 @@ describe('Confirmation Modal Component', () => {
     let toggleModal = jest.fn();
     let confirmAction = jest.fn();
 
-    const { queryByText, getByText, getAllByText, rerender } =  render(
+    const { queryByLabelText, getByText, getAllByText, rerender } =  render(
       <ConfirmationModal 
         isVisible={false}
         type={ConfirmationType.SaveEntity}
@@ -180,7 +176,7 @@ describe('Confirmation Modal Component', () => {
       />
     );
 
-    expect(queryByText('Confirmation')).toBeNull();
+    expect(queryByLabelText('save-text')).toBeNull();
 
     rerender(<ConfirmationModal 
       isVisible={true}
@@ -190,7 +186,6 @@ describe('Confirmation Modal Component', () => {
       confirmAction={confirmAction}
     />);
 
-    expect(getByText('Confirmation')).toBeInTheDocument();
     expect(getByText(entityName)).toBeInTheDocument();
     expect(getByText(/Are you sure you want to save changes to /i)).toBeInTheDocument();
 
@@ -205,7 +200,7 @@ describe('Confirmation Modal Component', () => {
     let toggleModal = jest.fn();
     let confirmAction = jest.fn();
 
-    const { queryByText, getByText, rerender } =  render(
+    const { queryByLabelText, getByText, rerender } =  render(
       <ConfirmationModal 
         isVisible={false}
         type={ConfirmationType.SaveAll}
@@ -215,7 +210,7 @@ describe('Confirmation Modal Component', () => {
       />
     );
 
-    expect(queryByText('Confirmation')).toBeNull();
+    expect(queryByLabelText('save-all-text')).toBeNull();
 
     rerender(<ConfirmationModal 
       isVisible={true}
@@ -225,7 +220,6 @@ describe('Confirmation Modal Component', () => {
       confirmAction={confirmAction}
     />);
 
-    expect(getByText('Confirmation')).toBeInTheDocument();
     expect(getByText('Are you sure you want to save ALL changes to ALL entity types?')).toBeInTheDocument();
 
     userEvent.click(getByText('No'));
@@ -240,7 +234,7 @@ describe('Confirmation Modal Component', () => {
     let toggleModal = jest.fn();
     let confirmAction = jest.fn();
 
-    const { queryByText, getByText, rerender } =  render(
+    const { queryByLabelText, getByText, rerender } =  render(
       <ConfirmationModal
         isVisible={false}
         type={ConfirmationType.RevertEntity}
@@ -250,7 +244,7 @@ describe('Confirmation Modal Component', () => {
       />
     );
 
-    expect(queryByText('Confirmation')).toBeNull();
+    expect(queryByLabelText('revert-text')).toBeNull();
 
     rerender(<ConfirmationModal
       isVisible={true}
@@ -260,7 +254,6 @@ describe('Confirmation Modal Component', () => {
       confirmAction={confirmAction}
     />);
 
-    expect(getByText('Confirmation')).toBeInTheDocument();
     expect(getByText(entityName)).toBeInTheDocument();
     expect(getByText(/Are you sure you want to discard your changes to /i)).toBeInTheDocument();
 
@@ -275,7 +268,7 @@ describe('Confirmation Modal Component', () => {
     let toggleModal = jest.fn();
     let confirmAction = jest.fn();
 
-    const { queryByText, getByText, rerender } =  render(
+    const { queryByLabelText, getByText, rerender } =  render(
       <ConfirmationModal
         isVisible={false}
         type={ConfirmationType.RevertAll}
@@ -285,7 +278,7 @@ describe('Confirmation Modal Component', () => {
       />
     );
 
-    expect(queryByText('Confirmation')).toBeNull();
+    expect(queryByLabelText('revert-all-text')).toBeNull();
 
     rerender(<ConfirmationModal
       isVisible={true}
@@ -295,8 +288,41 @@ describe('Confirmation Modal Component', () => {
       confirmAction={confirmAction}
     />);
 
-    expect(getByText('Confirmation')).toBeInTheDocument();
     expect(getByText('Are you sure you want to discard all changes to all entity types?')).toBeInTheDocument();
+
+    userEvent.click(getByText('No'));
+    expect(toggleModal).toBeCalledTimes(1);
+
+    userEvent.click(getByText('Yes'));
+    expect(confirmAction).toBeCalledTimes(1);
+  });
+
+  test('can render navigation away confirmation', () => {
+    let toggleModal = jest.fn();
+    let confirmAction = jest.fn();
+
+    const { queryByLabelText, getByText, rerender, getByLabelText } =  render(
+      <ConfirmationModal
+        isVisible={false}
+        type={ConfirmationType.NavigationWarn}
+        boldTextArray={[]}
+        toggleModal={toggleModal}
+        confirmAction={confirmAction}
+      />
+    );
+
+    expect(queryByLabelText('navigation-warn-text')).toBeNull();
+
+    rerender(<ConfirmationModal
+      isVisible={true}
+      type={ConfirmationType.NavigationWarn}
+      boldTextArray={[]}
+      toggleModal={toggleModal}
+      confirmAction={confirmAction}
+    />);
+
+    expect(getByText('Unsaved Changes')).toBeInTheDocument();
+    expect(getByText('You have made changes to the properties of one or more entity types. If you exit now, you will lose those changes.')).toBeInTheDocument();
 
     userEvent.click(getByText('No'));
     expect(toggleModal).toBeCalledTimes(1);

--- a/marklogic-data-hub-central/ui/src/components/confirmation-modal/confirmation-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/confirmation-modal/confirmation-modal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Modal, Icon } from 'antd';
+import { Modal } from 'antd';
 import { MLAlert, MLButton } from '@marklogic/design-system';
 import styles from './confirmation-modal.module.scss'
 
@@ -15,18 +15,11 @@ type Props = {
 };
 
 const ConfirmationModal: React.FC<Props> = (props) => {
-  const [title, setTitle] = useState('Confirmation');
   const [showSteps, toggleSteps] = useState(false);
   const [loading, toggleLoading] = useState(false);
 
   useEffect(() => {
     if (props.isVisible) {
-      let title = 'Confirmation';
-      if (props.type === ConfirmationType.DeleteEntityStepWarn) {
-        title = 'Delete: Entity Type in Use'
-      }
-
-      setTitle(title);
       toggleSteps(false);
       toggleLoading(false);
     }
@@ -52,7 +45,9 @@ const ConfirmationModal: React.FC<Props> = (props) => {
       size="default"
       loading={loading}
       onClick={() => {
-        toggleLoading(true);
+        if (props.type !== ConfirmationType.NavigationWarn) {
+          toggleLoading(true);
+        }
         props.confirmAction();
       }}
     >Yes</MLButton>
@@ -70,21 +65,21 @@ const ConfirmationModal: React.FC<Props> = (props) => {
       visible={props.isVisible}
       destroyOnClose={true}
       closable={true}
-      title={title}
+      className={styles.confirmModal}
       onCancel={closeModal}
       maskClosable={false}
       footer={props.type === ConfirmationType.DeleteEntityStepWarn ? modalFooterClose : modalFooter}
     >
       {props.type === ConfirmationType.Identifer && (
         <>
-          <p id="identifier-text">Each entity type is allowed a maximum of one identifier. The current identifier is <b>{props.boldTextArray[0]}</b>.
+          <p aria-label="identifier-text">Each entity type is allowed a maximum of one identifier. The current identifier is <b>{props.boldTextArray[0]}</b>.
           Choosing a different identifier could affect custom applications and other code that uses <b>{props.boldTextArray[0]}</b> for searching.</p>
 
           <p>Are you sure you want to change the identifier from <b>{props.boldTextArray[0]}</b> to <b>{props.boldTextArray[1]}</b>?</p>
         </>
       )}
 
-      {props.type === ConfirmationType.DeleteEntity && <span id="delete-text">Permanently delete <b>{props.boldTextArray[0]}</b>?</span>}
+      {props.type === ConfirmationType.DeleteEntity && <p aria-label="delete-text">Permanently delete <b>{props.boldTextArray[0]}</b>?</p>}
 
       {props.type === ConfirmationType.DeleteEntityRelationshipWarn && (
         <>
@@ -95,7 +90,7 @@ const ConfirmationModal: React.FC<Props> = (props) => {
             showIcon
             type="warning"
           />
-          <p id="delete-relationship-text">The <b>{props.boldTextArray[0]}</b> entity type is related to one or more entity types. Deleting <b>{props.boldTextArray[0]}</b> will cause
+          <p aria-label="delete-relationship-text">The <b>{props.boldTextArray[0]}</b> entity type is related to one or more entity types. Deleting <b>{props.boldTextArray[0]}</b> will cause
           those relationships to be removed from all involved entity types.</p>
           <p>Are you sure you want to delete the <b>{props.boldTextArray[0]}</b> entity type?</p>
         </>
@@ -110,7 +105,7 @@ const ConfirmationModal: React.FC<Props> = (props) => {
             showIcon
             type="warning"
           />
-          <p id="delete-step-text">Edit these steps and choose a different entity type before deleting <b>{props.boldTextArray[0]}</b>, to correlate with your changes to this property.</p>
+          <p aria-label="delete-step-text">Edit these steps and choose a different entity type before deleting <b>{props.boldTextArray[0]}</b>, to correlate with your changes to this property.</p>
           <p
             aria-label="toggle-steps"
             className={styles.toggleSteps}
@@ -126,10 +121,8 @@ const ConfirmationModal: React.FC<Props> = (props) => {
       )}
 
       {props.type === ConfirmationType.DeletePropertyWarn && 
-        <span 
-          id="delete-property-text"
-          aria-label="delete-property-text"
-        >Are you sure you want to delete the <b>{props.boldTextArray[0]}</b> property?</span>
+        <p aria-label="delete-property-text"
+        >Are you sure you want to delete the <b>{props.boldTextArray[0]}</b> property?</p>
       }
 
       {props.type === ConfirmationType.DeletePropertyStepWarn && (
@@ -141,7 +134,7 @@ const ConfirmationModal: React.FC<Props> = (props) => {
             showIcon
             type="warning"
           />
-          <p id="delete-property-step-text" aria-label="delete-property-step-text">The <b>{props.boldTextArray[1]}</b> entity type is used in one or more steps,
+          <p aria-label="delete-property-step-text">The <b>{props.boldTextArray[1]}</b> entity type is used in one or more steps,
           so deleting this property may require editing the steps to make sure this deletion doesn't affect those steps.</p>
           <p
             aria-label="toggle-steps"
@@ -160,7 +153,7 @@ const ConfirmationModal: React.FC<Props> = (props) => {
 
       {props.type === ConfirmationType.SaveEntity && (
         <>
-          <p id="save-text">Are you sure you want to save changes to <b>{props.boldTextArray[0]}</b>?</p>
+          <p aria-label="save-text">Are you sure you want to save changes to <b>{props.boldTextArray[0]}</b>?</p>
 
           <p>Changes will be saved to the entity model, possibly including updating indexes.
             Any features enabled by the changes will not be available until this is complete.
@@ -170,7 +163,7 @@ const ConfirmationModal: React.FC<Props> = (props) => {
 
       {props.type === ConfirmationType.SaveAll && (
         <>
-          <p id="save-all-text">Are you sure you want to save ALL changes to ALL entity types?</p>
+          <p aria-label="save-all-text">Are you sure you want to save ALL changes to ALL entity types?</p>
 
           <p>Changes will be saved to the entity model, possibly including updating indexes.
             Any features enabled by the changes will not be available until this is complete.
@@ -180,7 +173,7 @@ const ConfirmationModal: React.FC<Props> = (props) => {
 
       {props.type === ConfirmationType.RevertEntity && (
         <>
-          <p id="revert-text">Are you sure you want to discard your changes to <b>{props.boldTextArray[0]}</b>?</p>
+          <p aria-label="revert-text">Are you sure you want to discard your changes to <b>{props.boldTextArray[0]}</b>?</p>
 
           <p>The settings from the last saved version of all properties will be restored.</p>
         </>
@@ -188,11 +181,28 @@ const ConfirmationModal: React.FC<Props> = (props) => {
 
       {props.type === ConfirmationType.RevertAll && (
         <>
-          <p id="revert-all-text">Are you sure you want to discard all changes to all entity types?</p>
+          <p aria-label="revert-all-text">Are you sure you want to discard all changes to all entity types?</p>
 
           <p>The settings from the last saved version of all properties of all
             entity types will be restored.
           </p>
+        </>
+      )}
+
+      {props.type === ConfirmationType.NavigationWarn && (
+        <>
+          <MLAlert
+            className={styles.alert}
+            closable={false}
+            description={"Unsaved Changes"}
+            showIcon
+            type="warning"
+          />
+          <p aria-label="navigation-warn-text">You have made changes to the properties of one or more entity types.
+          If you exit now, you will lose those changes.
+          </p>
+
+          <p>Are you sure you want to exit?</p>
         </>
       )}
     </Modal>

--- a/marklogic-data-hub-central/ui/src/components/modal-status/modal-status.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modal-status/modal-status.tsx
@@ -4,6 +4,7 @@ import { Modal } from 'antd';
 import axios from "axios";
 
 import { UserContext } from '../../util/user-context';
+import { ModelingContext} from '../../util/modeling-context';
 import { useInterval } from '../../hooks/use-interval';
 import { SESSION_WARNING_COUNTDOWN } from '../../config/application.config';
 
@@ -29,6 +30,7 @@ const ModalStatus: React.FC<Props> = (props) => {
     getSessionTime,
     resetSessionTime
   } = useContext(UserContext);
+  const { clearEntityModified } = useContext(ModelingContext);
   const [showModal, toggleModal] = useState(false);
   const [sessionTime, setSessionTime] = useState(SESSION_WARNING_COUNTDOWN);
   const [title, setTitle] = useState('Session Timeout');
@@ -131,6 +133,7 @@ const ModalStatus: React.FC<Props> = (props) => {
         setSessionWarning(false);
       }
     }
+    clearEntityModified();
     toggleModal(false);
   };
 

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-modal/entity-type-modal.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-modal/entity-type-modal.test.tsx
@@ -42,8 +42,8 @@ describe('EntityTypeModal Component', () => {
         description={''}
       />);
     expect(getByText('Add Entity Type')).toBeInTheDocument();
-    await userEvent.type(getByPlaceholderText('Enter name'), 'AnotherModel');
-    await userEvent.type(getByPlaceholderText('Enter description'), 'Testing');
+    userEvent.type(getByPlaceholderText('Enter name'), 'AnotherModel');
+    userEvent.type(getByPlaceholderText('Enter description'), 'Testing');
 
     await wait(() => {
       userEvent.click(getByText('Add'));
@@ -67,8 +67,8 @@ describe('EntityTypeModal Component', () => {
       />);
     expect(getByText(/Add Entity Type/i)).toBeInTheDocument();
 
-    await userEvent.type(getByPlaceholderText('Enter name'), '123-Box');
-    await userEvent.type(getByPlaceholderText('Enter description'), 'Product entity desription');;
+    userEvent.type(getByPlaceholderText('Enter name'), '123-Box');
+    userEvent.type(getByPlaceholderText('Enter description'), 'Product entity desription');;
 
     await wait(() => {
       userEvent.click(getByText('Add'));
@@ -92,8 +92,8 @@ describe('EntityTypeModal Component', () => {
       />);
     expect(getByText('Add Entity Type')).toBeInTheDocument();
 
-    await userEvent.type(getByPlaceholderText('Enter name'), 'Testing');
-    await userEvent.type(getByPlaceholderText('Enter description'), '');
+    userEvent.type(getByPlaceholderText('Enter name'), 'Testing');
+    userEvent.type(getByPlaceholderText('Enter description'), '');
 
     await wait(() => {
       userEvent.click(getByText('Add'));
@@ -151,8 +151,8 @@ describe('EntityTypeModal Component', () => {
         description={'Model description'}
       />);
 
-    await userEvent.clear(getByPlaceholderText('Enter description'));
-    await userEvent.type(getByPlaceholderText('Enter description'), 'Updated Description');
+    userEvent.clear(getByPlaceholderText('Enter description'));
+    userEvent.type(getByPlaceholderText('Enter description'), 'Updated Description');
 
     await wait(() => {
       userEvent.click(getByText('OK'));

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.test.tsx
@@ -18,6 +18,8 @@ import {
 } from '../../../assets/mock-data/modeling';
 
 import { ConfirmationType } from '../../../types/modeling-types';
+import { ModelingContext } from '../../../util/modeling-context';
+import { isModified } from '../../../assets/mock-data/modeling-context-mock';
 
 jest.mock('../../../api/modeling');
 
@@ -116,7 +118,7 @@ describe('EntityTypeModal Component', () => {
 
     // Add back once functionality is added
     expect(getByTestId('Order-save-icon')).not.toHaveClass('iconSave');
-    // expect(getByTestId('Order-revert-icon')).toHaveClass('iconRevert');
+    //expect(getByTestId('Order-revert-icon')).toHaveClass('iconRevert');
     expect(getByTestId('Order-trash-icon')).toHaveClass('iconTrash');
 
     userEvent.click(getByTestId('Order-span'));
@@ -151,9 +153,11 @@ describe('EntityTypeModal Component', () => {
       expect(mockEntityReferences).toBeCalledTimes(1);
 
       await wait(() =>
-        expect(screen.getByText('Confirmation')).toBeInTheDocument(),
+        expect(screen.getByLabelText('delete-text')).toBeInTheDocument(),
       )
+
       userEvent.click(screen.getByLabelText(`confirm-${ConfirmationType.DeleteEntity}-yes`));
+
       expect(mockDeleteEntity).toBeCalledTimes(1);
   });
 
@@ -185,7 +189,7 @@ describe('EntityTypeModal Component', () => {
       expect(mockEntityReferences).toBeCalledTimes(1);
 
       await wait(() =>
-        expect(screen.getByText('Confirmation')).toBeInTheDocument()
+        expect(screen.getByLabelText('delete-relationship-text')).toBeInTheDocument()
       )
       expect(screen.getByText('Existing entity type relationships.')).toBeInTheDocument();
       userEvent.click(screen.getByLabelText(`confirm-${ConfirmationType.DeleteEntityRelationshipWarn}-yes`));
@@ -220,7 +224,7 @@ describe('EntityTypeModal Component', () => {
       expect(mockEntityReferences).toBeCalledTimes(1);
 
       await wait(() =>
-        expect(screen.getByText('Delete: Entity Type in Use')).toBeInTheDocument()
+        expect(screen.getByLabelText('delete-step-text')).toBeInTheDocument()
       )
       expect(screen.getByText('Entity type is used in one or more steps.')).toBeInTheDocument();
       userEvent.click(screen.getByLabelText(`confirm-${ConfirmationType.DeleteEntityStepWarn}-close`));
@@ -232,25 +236,27 @@ describe('EntityTypeModal Component', () => {
 
     const { getByTestId, getByLabelText, getByText, debug } =  render(
       <Router>
-        <EntityTypeTable 
-          allEntityTypesData={getEntityTypes}
-          canReadEntityModel={true}
-          canWriteEntityModel={true}
-          autoExpand=''
-          editEntityTypeDescription={jest.fn()}
-          updateEntities={jest.fn()}
-          revertAllEntity={false}
-          toggleRevertAllEntity={jest.fn()}
-          modifiedEntityTypesData={[]}
-          useModifiedEntityTypesData={false}
-          toggleModifiedEntityTypesData={jest.fn()}
-        />
+        <ModelingContext.Provider value={isModified}>  
+          <EntityTypeTable 
+            allEntityTypesData={getEntityTypes}
+            canReadEntityModel={true}
+            canWriteEntityModel={true}
+            autoExpand=''
+            editEntityTypeDescription={jest.fn()}
+            updateEntities={jest.fn()}
+            revertAllEntity={false}
+            toggleRevertAllEntity={jest.fn()}
+            modifiedEntityTypesData={[]}
+            useModifiedEntityTypesData={false}
+            toggleModifiedEntityTypesData={jest.fn()}
+          />
+        </ModelingContext.Provider>
       </Router>);
 
       userEvent.click(getByTestId('Order-save-icon'));
 
       await wait(() =>
-        expect(screen.getByText('Confirmation')).toBeInTheDocument(),
+        expect(screen.getByLabelText('save-text')).toBeInTheDocument(),
       )
       userEvent.click(screen.getByLabelText(`confirm-${ConfirmationType.SaveEntity}-yes`));
       expect(mockUpdateEntityModels).toBeCalledTimes(1);
@@ -261,25 +267,27 @@ describe('EntityTypeModal Component', () => {
 
     const { getByTestId } =  render(
       <Router>
-        <EntityTypeTable
-          allEntityTypesData={getEntityTypes}
-          canReadEntityModel={true}
-          canWriteEntityModel={true}
-          autoExpand=''
-          editEntityTypeDescription={jest.fn()}
-          updateEntities={jest.fn()}
-          revertAllEntity={false}
-          toggleRevertAllEntity={jest.fn()}
-          modifiedEntityTypesData={[]}
-          useModifiedEntityTypesData={false}
-          toggleModifiedEntityTypesData={jest.fn()}
-        />
+        <ModelingContext.Provider value={isModified}>  
+          <EntityTypeTable
+            allEntityTypesData={getEntityTypes}
+            canReadEntityModel={true}
+            canWriteEntityModel={true}
+            autoExpand=''
+            editEntityTypeDescription={jest.fn()}
+            updateEntities={jest.fn()}
+            revertAllEntity={false}
+            toggleRevertAllEntity={jest.fn()}
+            modifiedEntityTypesData={[]}
+            useModifiedEntityTypesData={false}
+            toggleModifiedEntityTypesData={jest.fn()}
+          />
+        </ModelingContext.Provider>
       </Router>);
 
     userEvent.click(getByTestId('Order-revert-icon'));
 
     await wait(() =>
-      expect(screen.getByText('Confirmation')).toBeInTheDocument(),
+      expect(screen.getByLabelText('revert-text')).toBeInTheDocument(),
     )
   });
 });

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.tsx
@@ -184,13 +184,17 @@ const EntityTypeTable: React.FC<Props> = (props) => {
         let entityDescription = parseText[1];
 
         return (
-          <MLTooltip title={ModelingTooltips.entityTypeName}>
-            <span data-testid={parseText[0] + '-span'} className={styles.link}
-              onClick={() => {
-                props.editEntityTypeDescription(entityName, entityDescription);
-              }}>
-              {entityName}</span>
-          </MLTooltip>
+          <>
+            {props.canWriteEntityModel && props.canReadEntityModel ? (
+              <MLTooltip title={ModelingTooltips.entityTypeName}>
+                <span data-testid={parseText[0] + '-span'} className={styles.link}
+                  onClick={() => {
+                    props.editEntityTypeDescription(entityName, entityDescription);
+                  }}>
+                  {entityName}</span>
+              </MLTooltip>
+            ) : <span data-testid={parseText[0] + '-span'}>{entityName}</span>}
+          </>
         )
       },
       sorter: (a, b) => {
@@ -207,17 +211,22 @@ const EntityTypeTable: React.FC<Props> = (props) => {
         let instanceCount = numberConverter(parseInt(parseText[1]));
 
         return (
-          <MLTooltip title={ModelingTooltips.instanceNumber}>
-            <Link
-              to={{
-                pathname: "/tiles/explore",
-                state: { entity: parseText[0] }
-              }}
-              data-testid={parseText[0] + '-instance-count'}
-            >
-              {instanceCount}
-            </Link>
-          </MLTooltip>
+          <>
+            {instanceCount === '0' ? <span data-testid={parseText[0] + '-instance-count'}>{instanceCount}</span> : (
+              <MLTooltip title={ModelingTooltips.instanceNumber}>
+                <Link
+                  to={{
+                    pathname: "/tiles/explore",
+                    state: { entity: parseText[0] }
+                  }}
+                  data-testid={parseText[0] + '-instance-count'}
+                >
+                  {instanceCount}
+                </Link>
+              </MLTooltip>
+              )
+            }
+         </> 
         )
       },
       sorter: (a, b) => {
@@ -268,30 +277,41 @@ const EntityTypeTable: React.FC<Props> = (props) => {
       className: styles.actions,
       width: 100,
       render: text => {
-        return (
-          <div className={styles.iconContainer}>
+
+        const saveIcon = props.canWriteEntityModel ? (
           <MLTooltip title={ModelingTooltips.saveIcon}>
             <span
               data-testid={text + '-save-icon'}
-              className={(!props.canWriteEntityModel && props.canReadEntityModel) || !isAnyEntityModified || !isEntityModified(text) ? styles.iconSaveReadOnly : styles.iconSave}
-              onClick={() => confirmSaveEntity(text)}
-            />
-          </MLTooltip>
-          <MLTooltip title={ModelingTooltips.revertIcon}>
-            <FontAwesomeIcon
-              data-testid={text + '-revert-icon'} 
-              className={(!props.canWriteEntityModel && props.canReadEntityModel) || !isAnyEntityModified || !isEntityModified(text) ? styles.iconRevertReadOnly : styles.iconRevert}
-              icon={faUndo}
+              className={!isAnyEntityModified || !isEntityModified(text) ? styles.iconSaveReadOnly : styles.iconSave}
               onClick={(event) => {
-                if (!props.canWriteEntityModel && props.canReadEntityModel) {
+                if (!props.canWriteEntityModel && props.canReadEntityModel || !isEntityModified(text)) {
                   return event.preventDefault()
                 } else {
-                  confirmRevertEntity(text);
+                  confirmSaveEntity(text)
                 }
               }}
-              size="2x"
             />
           </MLTooltip>
+        ) : <span data-testid={text + '-save-icon'} className={styles.iconSaveReadOnly}/>
+
+        return (
+          <div className={styles.iconContainer}>
+            {saveIcon}
+            <MLTooltip title={ModelingTooltips.revertIcon}>
+              <FontAwesomeIcon
+                data-testid={text + '-revert-icon'} 
+                className={(!props.canWriteEntityModel && props.canReadEntityModel) || !isAnyEntityModified || !isEntityModified(text) ? styles.iconRevertReadOnly : styles.iconRevert}
+                icon={faUndo}
+                onClick={(event) => {
+                  if (!props.canWriteEntityModel && props.canReadEntityModel) {
+                    return event.preventDefault()
+                  } else {
+                    confirmRevertEntity(text);
+                  }
+                }}
+                size="2x"
+              />
+            </MLTooltip>
             <FontAwesomeIcon
               data-testid={text + '-trash-icon'}
               className={!props.canWriteEntityModel && props.canReadEntityModel ? styles.iconTrashReadOnly : styles.iconTrash}

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.test.tsx
@@ -68,7 +68,7 @@ describe('Property Modal Component', () => {
     expect(queryByText('Add Property')).toBeNull();
   });
 
-  test('Add a basic property type and duplicate name validation', async () => {
+  test('Add a basic property type and duplicate name validation', () => {
     let entityType = propertyTableEntities.find( entity => entity.entityName === 'Customer' );
     let entityDefninitionsArray = definitionsParser(entityType?.model.definitions);
     let mockAdd = jest.fn();
@@ -90,12 +90,12 @@ describe('Property Modal Component', () => {
       </ModelingContext.Provider>
     );
 
-    await userEvent.type(getByLabelText('input-name'), 'name');
+    userEvent.type(getByLabelText('input-name'), 'name');
     userEvent.click(getByText('Add'));
     expect(getByText('A property already exists with a name of name')).toBeInTheDocument();
 
     userEvent.clear(getByLabelText('input-name'));
-    await userEvent.type(getByLabelText('input-name'), 'new-property-name');
+    userEvent.type(getByLabelText('input-name'), 'new-property-name');
 
     userEvent.click(getByPlaceholderText('Select the property type'));
     userEvent.click(getByText('string'));
@@ -128,7 +128,7 @@ describe('Property Modal Component', () => {
     expect(mockAdd).toHaveBeenCalledTimes(1);
   });
 
-  test('Add a Property with relationship type', async () => {
+  test('Add a Property with relationship type', () => {
     let entityType = propertyTableEntities.find( entity => entity.entityName === 'Customer' );
     let entityDefninitionsArray = definitionsParser(entityType?.model.definitions);
     let mockAdd = jest.fn();
@@ -150,7 +150,7 @@ describe('Property Modal Component', () => {
       </ModelingContext.Provider>
     );
 
-    await userEvent.type(getByPlaceholderText('Enter the property name'), 'Entity-Property');
+    userEvent.type(getByPlaceholderText('Enter the property name'), 'Entity-Property');
 
     userEvent.click(getByPlaceholderText('Select the property type'));
     userEvent.click(getByText('Relationship'));
@@ -170,7 +170,7 @@ describe('Property Modal Component', () => {
     expect(mockAdd).toHaveBeenCalledTimes(1);
   });
 
-  test('can display error message for property name and type inputs and press cancel', async () => {
+  test('can display error message for property name and type inputs and press cancel', () => {
     let entityType = propertyTableEntities.find( entity => entity.entityName === 'Customer' );
     let entityDefninitionsArray = definitionsParser(entityType?.model.definitions);
     let mockAdd = jest.fn();
@@ -189,12 +189,12 @@ describe('Property Modal Component', () => {
         deletePropertyFromDefinition={jest.fn()}
       />);
 
-    await userEvent.type(getByLabelText('input-name'), '123-name');
+    userEvent.type(getByLabelText('input-name'), '123-name');
     userEvent.click(getByText('Add'));
     expect(getByText(ModelingTooltips.nameRegex)).toBeInTheDocument();
     userEvent.clear(getByLabelText('input-name'));
 
-    await userEvent.type(getByLabelText('input-name'), 'name2');
+    userEvent.type(getByLabelText('input-name'), 'name2');
     userEvent.click(getByText('Add'));
     expect(getByText('Type is required')).toBeInTheDocument();
 
@@ -206,7 +206,7 @@ describe('Property Modal Component', () => {
     expect(mockAdd).toHaveBeenCalledTimes(0);
   });
 
-  test('Add a Property with a structured type, no relationship type in dropdown', async () => {
+  test('Add a Property with a structured type, no relationship type in dropdown', () => {
     let entityType = propertyTableEntities.find( entity => entity.entityName === 'Customer' );
     let entityDefninitionsArray = definitionsParser(entityType?.model.definitions);
     let mockAdd = jest.fn();
@@ -228,7 +228,7 @@ describe('Property Modal Component', () => {
       </ModelingContext.Provider>
     );
 
-    await userEvent.type(getByPlaceholderText('Enter the property name'), 'alternate-address');
+    userEvent.type(getByPlaceholderText('Enter the property name'), 'alternate-address');
 
     userEvent.click(getByPlaceholderText('Select the property type'));
     userEvent.click(getByText('Structured'));
@@ -245,7 +245,7 @@ describe('Property Modal Component', () => {
     expect(mockAdd).toHaveBeenCalledTimes(1);
   });
 
-  test('Add a new property to a structured type definition', async () => {
+  test('Add a new property to a structured type definition', () => {
     let entityType = propertyTableEntities.find( entity => entity.entityName === 'Customer' );
     let entityDefninitionsArray = definitionsParser(entityType?.model.definitions);
     let addMock = jest.fn();
@@ -270,7 +270,7 @@ describe('Property Modal Component', () => {
     expect(getByText('Structured Type:')).toBeInTheDocument();
     expect(getByText('Employee')).toBeInTheDocument();
 
-    await userEvent.type(getByPlaceholderText('Enter the property name'), 'email');
+    userEvent.type(getByPlaceholderText('Enter the property name'), 'email');
 
     userEvent.click(getByPlaceholderText('Select the property type'));
     userEvent.click(getByText('string'));
@@ -292,7 +292,7 @@ describe('Property Modal Component', () => {
     expect(addMock).toHaveBeenCalledTimes(1);
   });
 
-  test('Add a Property with a newly created structured type', async () => {
+  test('Add a Property with a newly created structured type', () => {
     let entityType = propertyTableEntities.find( entity => entity.entityName === 'Customer' );
     let entityDefninitionsArray = definitionsParser(entityType?.model.definitions);
     let addMock = jest.fn();
@@ -314,14 +314,14 @@ describe('Property Modal Component', () => {
       </ModelingContext.Provider>
     );
 
-    await userEvent.type(getByPlaceholderText('Enter the property name'), 'alternate-address');
+    userEvent.type(getByPlaceholderText('Enter the property name'), 'alternate-address');
 
     userEvent.click(getByPlaceholderText('Select the property type'));
     userEvent.click(getByText('Structured'));
     userEvent.click(getByText('New Property Type'));
 
     expect(screen.getByText('Add New Structured Property Type')).toBeInTheDocument();
-    await userEvent.type(screen.getByLabelText('structured-input-name'), 'Product');
+    userEvent.type(screen.getByLabelText('structured-input-name'), 'Product');
 
     fireEvent.submit(screen.getByLabelText('structured-input-name'));
 
@@ -339,7 +339,7 @@ describe('Property Modal Component', () => {
     expect(addMock).toHaveBeenCalledTimes(1);
   });
 
-  test('Add an identifier to a new Property', async () => {
+  test('Add an identifier to a new Property', () => {
     let entityType = propertyTableEntities.find( entity => entity.entityName === 'Order' );
     let entityDefninitionsArray = definitionsParser(entityType?.model.definitions);
     let addMock = jest.fn();
@@ -360,7 +360,7 @@ describe('Property Modal Component', () => {
         />
       </ModelingContext.Provider>
     );
-    await userEvent.type(getByPlaceholderText('Enter the property name'), 'newId');
+    userEvent.type(getByPlaceholderText('Enter the property name'), 'newId');
 
     userEvent.click(getByPlaceholderText('Select the property type'));
     userEvent.click(getByText('string'));
@@ -573,7 +573,7 @@ describe('Property Modal Component', () => {
     expect(getByText('Edit Property')).toBeInTheDocument();
 
     userEvent.clear(getByPlaceholderText('Enter the property name'));
-    await userEvent.type(getByPlaceholderText('Enter the property name'), 'alt_shipping');
+    userEvent.type(getByPlaceholderText('Enter the property name'), 'alt_shipping');
 
     const multipleRadio = screen.getByLabelText('multiple-yes')
     expect(multipleRadio['value']).toBe('yes');
@@ -589,7 +589,7 @@ describe('Property Modal Component', () => {
     expect(editMock).toHaveBeenCalledTimes(1);
   });
 
-  test('can edit a basic property from a structured type', async () => {
+  test('can edit a basic property from a structured type', () => {
     mockEntityReferences.mockResolvedValueOnce({ status: 200, data: referencePayloadEmpty });
 
     let entityType = propertyTableEntities.find( entity => entity.entityName === 'Customer' );
@@ -646,7 +646,7 @@ describe('Property Modal Component', () => {
     expect(getByText('Structured Type:')).toBeInTheDocument();
 
     userEvent.clear(getByPlaceholderText('Enter the property name'));
-    await userEvent.type(getByPlaceholderText('Enter the property name'), 'county');
+    userEvent.type(getByPlaceholderText('Enter the property name'), 'county');
 
     const piiRadio = screen.getByLabelText('pii-yes')
     expect(piiRadio['value']).toBe('yes');
@@ -709,7 +709,7 @@ describe('Property Modal Component', () => {
 
     userEvent.click(getByTestId(`delete-${editPropertyOptions.name}`));
     expect(mockEntityReferences).toBeCalledWith(entityType?.entityName);
-    expect(mockEntityReferences).toBeCalledTimes(1);
+    expect(mockEntityReferences).toBeCalledTimes(2);
 
     await wait(() =>
       expect(screen.getByLabelText('delete-property-text')).toBeInTheDocument(),
@@ -770,7 +770,7 @@ describe('Property Modal Component', () => {
 
     userEvent.click(getByTestId(`delete-${editPropertyOptions.name}`));
     expect(mockEntityReferences).toBeCalledWith(entityType?.entityName);
-    expect(mockEntityReferences).toBeCalledTimes(1);
+    expect(mockEntityReferences).toBeCalledTimes(2);
 
     await wait(() =>
       expect(screen.getByLabelText('delete-property-step-text')).toBeInTheDocument(),
@@ -824,7 +824,7 @@ describe('Property Modal Component', () => {
 
     userEvent.click(getByTestId(`delete-${editPropertyOptions.name}`));
     expect(mockEntityReferences).toBeCalledWith(entityType?.entityName);
-    expect(mockEntityReferences).toBeCalledTimes(1);
+    expect(mockEntityReferences).toBeCalledTimes(2);
 
     await wait(() =>
       expect(screen.getByLabelText('delete-property-text')).toBeInTheDocument(),

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.tsx
@@ -601,7 +601,12 @@ const PropertyModal: React.FC<Props> = (props) => {
 
   const modalFooter = <div className={props.editPropertyOptions.isEdit ? styles.editFooter : styles.addFooter}>
     { props.editPropertyOptions.isEdit &&
-      <MLButton type="link" onClick={() => toggleConfirmModal(true)} >
+      <MLButton type="link" onClick={async () => {
+        if (confirmType === ConfirmationType.Identifer) {
+          await getEntityReferences();
+        }
+        toggleConfirmModal(true);
+      }}>
         <FontAwesomeIcon data-testid={'delete-' + props.editPropertyOptions.name} className={styles.trashIcon} icon={faTrashAlt} />
       </MLButton>
     }

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.test.tsx
@@ -147,7 +147,7 @@ describe('Entity Modeling Property Table Component', () => {
     expect(getAllByText('string')).toHaveLength(13);
   });
 
-  test('can add sortable and facetable Property to the table', async () => {
+  test('can add sortable and facetable Property to the table', () => {
       let entityName = propertyTableEntities[2].entityName;
       let definitions = propertyTableEntities[2].model.definitions;
       const { getByTestId, getByLabelText } =  render(
@@ -169,7 +169,7 @@ describe('Entity Modeling Property Table Component', () => {
 
       userEvent.click(getByLabelText('Customer-add-property'));
       userEvent.clear(screen.getByLabelText('input-name'));
-      await userEvent.type(screen.getByLabelText('input-name'), 'altName');
+      userEvent.type(screen.getByLabelText('input-name'), 'altName');
 
       userEvent.click(screen.getByPlaceholderText('Select the property type'));
       userEvent.click(screen.getByText('dateTime'));
@@ -186,7 +186,7 @@ describe('Entity Modeling Property Table Component', () => {
       expect(getByTestId('altName-span')).toBeInTheDocument();
   });
 
-  test('can add a Property to the table and then edit it', async () => {
+  test('can add a Property to the table and then edit it', () => {
     let entityName = propertyTableEntities[0].entityName;
     let definitions = propertyTableEntities[0].model.definitions;
     const { getByText, getByTestId, getByLabelText, debug } =  render(
@@ -200,7 +200,7 @@ describe('Entity Modeling Property Table Component', () => {
 
     userEvent.click(screen.getByLabelText('Concept-add-property'));
 
-    await userEvent.type(screen.getByLabelText('input-name'), 'conceptDate');
+    userEvent.type(screen.getByLabelText('input-name'), 'conceptDate');
     userEvent.click(screen.getByPlaceholderText('Select the property type'));
     userEvent.click(screen.getByText('dateTime'));
 
@@ -211,13 +211,13 @@ describe('Entity Modeling Property Table Component', () => {
     userEvent.click(screen.getByTestId('conceptDate-span'));
 
     userEvent.clear(screen.getByLabelText('input-name'));
-    await userEvent.type(screen.getByLabelText('input-name'), 'conception');
+    userEvent.type(screen.getByLabelText('input-name'), 'conception');
 
     fireEvent.submit(screen.getByLabelText('input-name'));
     expect(getByTestId('conception-span')).toBeInTheDocument();
   });
 
-  test('can add a new structured type property to the table and then edit it', async () => {
+  test('can add a new structured type property to the table and then edit it', () => {
     let entityName = propertyTableEntities[0].entityName;
     let definitions = propertyTableEntities[0].model.definitions;
     const { getByText, getByTestId } =  render(
@@ -231,13 +231,13 @@ describe('Entity Modeling Property Table Component', () => {
 
     userEvent.click(screen.getByLabelText('Concept-add-property'));
 
-    await userEvent.type(screen.getByLabelText('input-name'), 'newStructure');
+    userEvent.type(screen.getByLabelText('input-name'), 'newStructure');
     userEvent.click(screen.getByPlaceholderText('Select the property type'));
     userEvent.click(screen.getByText('Structured'));
     userEvent.click(screen.getByText('New Property Type'));
 
     expect(screen.getByText('Add New Structured Property Type')).toBeInTheDocument();
-    await userEvent.type(screen.getByLabelText('structured-input-name'), 'Product');
+    userEvent.type(screen.getByLabelText('structured-input-name'), 'Product');
     fireEvent.submit(screen.getByLabelText('structured-input-name'));
 
     fireEvent.submit(screen.getByLabelText('input-name'));
@@ -246,7 +246,7 @@ describe('Entity Modeling Property Table Component', () => {
 
     userEvent.click(screen.getByTestId('newStructure-span'));
     userEvent.clear(screen.getByLabelText('input-name'));
-    await userEvent.type(screen.getByLabelText('input-name'), 'basicName');
+    userEvent.type(screen.getByLabelText('input-name'), 'basicName');
     userEvent.click(screen.getByLabelText('type-dropdown'));
     userEvent.click(screen.getByText('More date types'));
     userEvent.click(screen.getByText('dayTimeDuration'));
@@ -255,7 +255,7 @@ describe('Entity Modeling Property Table Component', () => {
     expect(getByTestId('conception-span')).toBeInTheDocument();
   });
 
-  test('can edit a property and change the type from basic to relationship', async () => {
+  test('can edit a property and change the type from basic to relationship', () => {
     let entityName = propertyTableEntities[2].entityName;
     let definitions = propertyTableEntities[2].model.definitions;
     const { getByText, getByTestId, queryByTestId, getAllByTestId } =  render(
@@ -276,7 +276,7 @@ describe('Entity Modeling Property Table Component', () => {
     userEvent.click(getByTestId('nicknames-span'));
     userEvent.clear(screen.getByLabelText('input-name'));
 
-    await userEvent.type(screen.getByLabelText('input-name'), 'altName');
+    userEvent.type(screen.getByLabelText('input-name'), 'altName');
 
     const multipleRadio = screen.getByLabelText('multiple-yes');
     fireEvent.change(multipleRadio, { target: { value: "yes" } });
@@ -299,7 +299,7 @@ describe('Entity Modeling Property Table Component', () => {
     userEvent.click(screen.getByTestId('altName-span'));
 
     userEvent.clear(screen.getByLabelText('input-name'));
-    await userEvent.type(screen.getByLabelText('input-name'), 'orderRelationship');
+    userEvent.type(screen.getByLabelText('input-name'), 'orderRelationship');
     userEvent.click(screen.getByLabelText('type-dropdown'));
     userEvent.click(screen.getByText('Relationship'));
     userEvent.click(screen.getAllByText('Order')[0]);
@@ -309,7 +309,7 @@ describe('Entity Modeling Property Table Component', () => {
     userEvent.click(screen.getByTestId('orderRelationship-span'));
 
     userEvent.clear(screen.getByLabelText('input-name'));
-    await userEvent.type(screen.getByLabelText('input-name'), 'basicID');
+    userEvent.type(screen.getByLabelText('input-name'), 'basicID');
     userEvent.click(screen.getByLabelText('type-dropdown'));
     userEvent.click(screen.getAllByText('integer')[0]);
     fireEvent.submit(screen.getByLabelText('input-name'));

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
@@ -247,28 +247,32 @@ const PropertyTable: React.FC<Props> = (props) => {
       render: text => {
         let textParse = text && text.split(',');
         let structuredTypeName = Array.isArray(textParse) ? textParse[textParse.length-1] : text
-        return ( text &&
+
+        const addIcon = props.canWriteEntityModel ? (
           <MLTooltip title={ModelingTooltips.addStructuredProperty}>
             <FontAwesomeIcon
               data-testid={'add-struct-'+ structuredTypeName}
-              className={!props.canWriteEntityModel && props.canReadEntityModel ? styles.addIconReadOnly : styles.addIcon}
+              className={styles.addIcon}
               icon={faPlusSquare}
-              onClick={(event) => {
-                if (!props.canWriteEntityModel && props.canReadEntityModel) {
-                  return event.preventDefault()
-                } else {
-                  setStructuredTypeOptions({
-                    isStructured: true,
-                    name: text,
-                    propertyName: ''
-                  });
-                  setEditPropertyOptions({ ...editPropertyOptions, isEdit: false })
-                  toggleShowPropertyModal(true);
-                }
+              onClick={() => {
+                setStructuredTypeOptions({
+                  isStructured: true,
+                  name: text,
+                  propertyName: ''
+                });
+                setEditPropertyOptions({ ...editPropertyOptions, isEdit: false })
+                toggleShowPropertyModal(true);           
               }}
             />
           </MLTooltip>
-        )
+        ) : (
+          <FontAwesomeIcon 
+            data-testid={'add-struct-'+ structuredTypeName} className={styles.addIconReadOnly}
+            icon={faPlusSquare}
+          />
+        );
+
+        return text && addIcon
       }
     }
   ];

--- a/marklogic-data-hub-central/ui/src/components/modeling/structured-type-modal/structured-type-modal.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/structured-type-modal/structured-type-modal.test.tsx
@@ -20,7 +20,7 @@ describe('Structured Type Modal Component', () => {
     expect(queryByText('Add New Structured Property Type')).toBeNull();
   });
 
-  test('can create structured property with valid name', async () => {
+  test('can create structured property with valid name', () => {
     const toggleModal = jest.fn();
     const updateStructuredTypesAndHideModal = jest.fn();
 
@@ -33,14 +33,14 @@ describe('Structured Type Modal Component', () => {
       />);
 
     expect(getByText('Add New Structured Property Type')).toBeInTheDocument();
-    await userEvent.type(getByPlaceholderText('Enter name'), 'Product');
+    userEvent.type(getByPlaceholderText('Enter name'), 'Product');
 
     userEvent.click(getByText('Add'));
     expect(updateStructuredTypesAndHideModal).toHaveBeenCalledTimes(1)
     expect(toggleModal).toHaveBeenCalledTimes(1)
   });
 
-  test('can do error handling for duplicate name and name regex validation ', async () => {
+  test('can do error handling for duplicate name and name regex validation ', () => {
     const toggleModal = jest.fn();
     const updateStructuredTypesAndHideModal = jest.fn();
 
@@ -53,12 +53,12 @@ describe('Structured Type Modal Component', () => {
       />);
 
     expect(getByText('Add New Structured Property Type')).toBeInTheDocument();
-    await userEvent.type(getByLabelText('structured-input-name'), 'Address');
+    userEvent.type(getByLabelText('structured-input-name'), 'Address');
     userEvent.click(getByText('Add'));
     expect(getByText('A structured type already exists with a name of Address')).toBeInTheDocument();
     userEvent.clear(getByLabelText('structured-input-name'));
 
-    await userEvent.type(getByLabelText('structured-input-name'), '123-Name');
+    userEvent.type(getByLabelText('structured-input-name'), '123-Name');
     userEvent.click(getByText('Add'));
     expect(getByText(ModelingTooltips.nameRegex)).toBeInTheDocument();
 

--- a/marklogic-data-hub-central/ui/src/components/navigation-prompt/navigation-prompt.tsx
+++ b/marklogic-data-hub-central/ui/src/components/navigation-prompt/navigation-prompt.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useRef, useContext } from 'react';
+import { ModelingContext } from '../../util/modeling-context';
+
+const NavigationPrompt: React.FC = () => {
+  const hasUnsavedChanges = useRef(false);
+  const { modelingOptions } = useContext(ModelingContext);
+
+  useEffect(() => {
+    window.addEventListener("beforeunload", onUnload);
+
+    return () => window.removeEventListener("beforeunload", onUnload);
+  }, []);
+
+  useEffect(() => {
+    hasUnsavedChanges.current = modelingOptions.isModified;
+  }, [modelingOptions.isModified]);
+
+  const onUnload = (e) => {
+    e.preventDefault();
+    if (hasUnsavedChanges.current) {
+      return e.returnValue = 'message'
+    }
+  }
+
+  return null
+}
+
+export default NavigationPrompt;

--- a/marklogic-data-hub-central/ui/src/pages/Modeling.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Modeling.test.tsx
@@ -55,12 +55,10 @@ describe("Modeling Page", () => {
     expect(getByText(/Add Entity Type/i)).toBeInTheDocument();
 
     userEvent.click(getByText('Save All'));
-    expect(screen.getByText(/Confirmation/i)).toBeInTheDocument();
     userEvent.click(screen.getByLabelText(`confirm-${ConfirmationType.SaveAll}-yes`));
     expect(mockUpdateEntityModels).toHaveBeenCalledTimes(1)
 
     userEvent.click(getByText('Revert All'));
-    expect(screen.getByText(/Confirmation/i)).toBeInTheDocument();
     userEvent.click(screen.getByLabelText(`confirm-${ConfirmationType.RevertAll}-yes`));
     expect(mockPrimaryEntityType).toHaveBeenCalledTimes(1);
   });
@@ -68,7 +66,7 @@ describe("Modeling Page", () => {
   test("Modeling: with mock data, no Alert component renders and operator role can not click add", async () => {
     mockPrimaryEntityType.mockResolvedValueOnce({ status: 200, data: getEntityTypes });
   
-    const { getByText, getByLabelText, queryByText, debug } = render(
+    const { getByText, getByLabelText, queryByLabelText, debug } = render(
       <AuthoritiesContext.Provider value={mockOpRolesService}>
         <ModelingContext.Provider value={notModified}>
           <Router>
@@ -85,7 +83,7 @@ describe("Modeling Page", () => {
 
     expect(getByLabelText("add-entity")).toBeDisabled();
     expect(getByLabelText("save-all")).toBeDisabled();
-    expect(queryByText('You have edited some of the entity types and/or properties.')).toBeNull();
+    expect(queryByLabelText('entity-modified-alert')).toBeNull();
   });
 });
 

--- a/marklogic-data-hub-central/ui/src/types/modeling-types.ts
+++ b/marklogic-data-hub-central/ui/src/types/modeling-types.ts
@@ -65,7 +65,8 @@ export enum ConfirmationType {
   SaveEntity = 'saveEntity',
   SaveAll = 'saveAllEntity',
   RevertEntity = 'revertEntity',
-  RevertAll = 'revertAllEntity'
+  RevertAll = 'revertAllEntity',
+  NavigationWarn = 'navigationWarn'
 }
 
 export enum PropertyType {


### PR DESCRIPTION
### Description
updated @testing-library/user-event to v12 for type method no longer being async 
https://github.com/testing-library/user-event/releases/tag/v12.0.0
added @testing-library/dom -> new dependency for user-event

added model reader e2e test

Persist model between tiles + navigation warn when logout: https://drive.google.com/file/d/15jSoV-fe7JgRWs4xeaYaJEBHTmNDrzQY/view

Navigate away with edits: https://drive.google.com/file/d/1eI-cDhw0GlTXd0YDSGvjnVzWsTWjmaOu/view

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

