### PR TITLE
DHFPROD-5562: UI Spike: Cross-platform scrollbar UX

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/header/header.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/header/header.test.tsx
@@ -29,7 +29,7 @@ describe('Header component', () => {
 
   test('should render correctly when a user is logged in', async () => {
 
-    const { getByText, getByLabelText } = render(
+    const { getByText, getByLabelText, rerender } = render(
       <Router>
         <UserContext.Provider value={userAuthenticated}>
           <Header environment = {{...data.environment, dataHubVersion: '5.3-SNAPSHOT'}}/>
@@ -41,14 +41,15 @@ describe('Header component', () => {
     expect(getByText(data.environment.serviceName)).toBeInTheDocument();
     // expect(getByLabelText('icon: search')).toBeInTheDocument();
     expect(getByLabelText('icon: question-circle')).toBeInTheDocument();
-    //test version specific link is correct when environment hub version data is set to '5.3-SNAPSHOT'
-    expect(document.querySelector('#help-link')).toHaveAttribute('href', 'https://docs.marklogic.com/datahub/5.3');
-    // expect(getByLabelText('icon: setting')).toBeInTheDocument();
     expect(getByLabelText('icon: user')).toBeInTheDocument();
-  });
+    // expect(getByLabelText('icon: setting')).toBeInTheDocument();
 
-  test('Verify proper version link given specific release dataHub release version', async () => {
-    const {} = render(
+
+    //verify correct version specific link when environment hub version data is set to '5.3-SNAPSHOT'
+    expect(document.querySelector('#help-link')).toHaveAttribute('href', 'https://docs.marklogic.com/datahub/5.3');
+
+    //verify correct version specific link given specific dataHub release version
+    rerender(
       <Router>
         <UserContext.Provider value={userAuthenticated}>
           <Header environment = {{...data.environment, dataHubVersion: '5.2.1'}}/>
@@ -57,10 +58,8 @@ describe('Header component', () => {
     )
     expect(document.querySelector('#help-link')).toHaveAttribute('href', 'https://docs.marklogic.com/datahub/5.2');
 
-  });
-
-  test('Verify proper version link given scenario with multi-digit dataHub versions', async () => {
-    const {} = render(
+    //verify correct version specific link given multi-digit dataHub versions
+    rerender(
       <Router>
         <UserContext.Provider value={userAuthenticated}>
           <Header environment = {{...data.environment, dataHubVersion: '5.64.123456'}}/>

--- a/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.module.scss
@@ -1,7 +1,7 @@
 .container {
     display: flex;
     flex-direction: column;
-    min-height: 100%;
+    min-height: 99%;
   }
 
   .zeroContent {

--- a/marklogic-data-hub-central/ui/src/pages/Overview.module.scss
+++ b/marklogic-data-hub-central/ui/src/pages/Overview.module.scss
@@ -25,7 +25,7 @@
     }
     .cardsContainer {
         min-width: 700px;
-        overflow: scroll;
+        overflow: auto;
         .cards {
             display: grid;
             grid-template-columns: 20% 20% 20% 25%;

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.scss
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.scss
@@ -39,7 +39,7 @@ div.mosaic-container div.mosaic-window-toolbar {
 }
 
 div.mosaic-container div.mosaic-window-body {
-    overflow: scroll;
+    overflow: auto;
 }
 
 div.mosaic-container-load div.mosaic-tile {


### PR DESCRIPTION
### Description

- Short css fixes to Overview, Tilesview, and zero-state explorer pages so that scrollbar is no longer visible when no scrolling is needed.
- No test for this scenario as could not find a way in RTL to verify the visibility of the scrollbar (elaboration in comments)
- Cleaning up tests from previous PR: https://github.com/marklogic/marklogic-data-hub/pull/4327.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

