### PR TITLE
DHFPROD-5678: Moving deployment of amps from RunMarkLogicUnitTestsTest to Installer and fixing 9.0-11 tests

### DIFF
--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/EntitySearchManagerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/EntitySearchManagerTest.java
@@ -45,7 +45,12 @@ public class EntitySearchManagerTest extends AbstractHubCentralTest {
     @AfterEach
     public void resetData() {
         EntitySearchManager.QUERY_OPTIONS = ACTUAL_QUERY_OPTIONS;
-        runAsDataHubDeveloper();
+        if (isVersionCompatibleWith520Roles()) {
+            runAsDataHubDeveloper();
+        } else {
+            logger.warn("ML version is not compatible with 5.2.0 roles, so will run as flow-developer instead of data-hub-developer");
+            runAsUser("flow-developer", "password");
+        }
         applyDatabasePropertiesForTests(getHubConfig());
     }
 
@@ -173,6 +178,12 @@ public class EntitySearchManagerTest extends AbstractHubCentralTest {
     public void testSearchResultsWithSorting() {
         runAsDataHubDeveloper();
         installProjectInFolder("customer-entity-with-indexes", true);
+
+        if (!isVersionCompatibleWith520Roles()) {
+            logger.warn("ML version is not compatible with 5.2.0 roles, so will deploy indexes as flow-developer instead of data-hub-developer");
+            runAsUser("flow-developer", "password");
+        }
+
         new EntityManagerImpl(getHubConfig()).saveDbIndexes();
         new DhsDeployer().deployAsDeveloper(getHubConfig());
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub_unit_test/RunMarkLogicUnitTestsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub_unit_test/RunMarkLogicUnitTestsTest.java
@@ -65,15 +65,8 @@ public class RunMarkLogicUnitTestsTest extends HubTestBase {
     @Override
     protected void init() {
         if (!initialized) {
-            super.init();
-            try {
-                adminHubConfig.getAppConfig().getConfigDirs().add(new ConfigDir(new ClassPathResource("test-config").getFile()));
-                new SimpleAppDeployer(new DeployRolesCommand(), new DeployAmpsCommand(), new CreateGranularPrivilegesCommand(adminHubConfig))
-                    .deploy(adminHubConfig.getAppConfig());
-                initialized = true;
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+          super.init();
+          initialized = true;
         }
     }
 


### PR DESCRIPTION
### Description

- Moving the deployment of data-hub-test-internal role and amps to Installer class so that tests can be run from http://localhost:8011/test/default.xqy without running the RunMarkLogicUnitTestsTest once. (Currently, the role and amp is deployed by RunMarkLogicUnitTestsTest)

- Adding version compatibility check for deploying indexes in EntitySearchManagerTest to work with 9.0-11 version

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

