### PR TITLE
DHFPROD-5412: Can't clear/unselect selected facets on sidebar

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.json.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.json.tsx
@@ -312,7 +312,7 @@ describe('json scenario for table on browse documents page', () => {
     browsePage.getTotalDocuments().should('be.equal', 2);
   });
 
-  xit('apply multiple facets, select and discard new facet, verify original facets checked', () => {
+  it('apply multiple facets, select and discard new facet, verify original facets checked', () => {
     browsePage.selectEntity('Customer');
     browsePage.getShowMoreLink().first().click();
     browsePage.getFacetItemCheckbox('name', 'Jacqueline Knowles').click();
@@ -328,6 +328,34 @@ describe('json scenario for table on browse documents page', () => {
     browsePage.getFacetItemCheckbox('name', 'Jacqueline Knowles').should('be.checked');
     browsePage.getFacetItemCheckbox('name', 'Lola Dunn').should('be.checked');
     browsePage.getFacetItemCheckbox('email', 'jacquelineknowles@nutralab.com').should('not.be.checked');
+  });
+
+  it('apply multiple facets, deselect them, apply changes, apply multiple, clear them, verify no facets checked' , () => {
+    browsePage.selectEntity('Customer');
+    browsePage.getShowMoreLink().first().click();
+    browsePage.getFacetItemCheckbox('name', 'Adams Cole').click();
+    browsePage.getFacetItemCheckbox('email', 'adamscole@nutralab.com').click();
+    browsePage.getGreySelectedFacets('Adams Cole').should('exist');
+    browsePage.getGreySelectedFacets('adamscole@nutralab.com').should('exist');
+    browsePage.getFacetApplyButton().click();
+    browsePage.getFacetItemCheckbox('name', 'Adams Cole').should('be.checked');
+    browsePage.getFacetItemCheckbox('email', 'adamscole@nutralab.com').should('be.checked');
+    browsePage.getFacetItemCheckbox('name', 'Adams Cole').click();
+    browsePage.getFacetItemCheckbox('email', 'adamscole@nutralab.com').click();
+    browsePage.getFacetApplyButton().click();
+    browsePage.getFacetItemCheckbox('name', 'Adams Cole').should('not.be.checked');
+    browsePage.getFacetItemCheckbox('email', 'adamscole@nutralab.com').should('not.be.checked');
+    browsePage.getGreySelectedFacets('Adams Cole').should('not.exist');
+    browsePage.getGreySelectedFacets('adamscole@nutralab.com').should('not.exist');
+    browsePage.getFacetItemCheckbox('name', 'Adams Cole').click();
+    browsePage.getFacetItemCheckbox('email', 'adamscole@nutralab.com').click();
+    browsePage.getFacetApplyButton().click();
+    browsePage.clearFacetSelection('name');
+    browsePage.clearFacetSelection('email');
+    browsePage.getFacetItemCheckbox('name', 'Adams Cole').should('not.be.checked');
+    browsePage.getFacetItemCheckbox('email', 'adamscole@nutralab.com').should('not.be.checked');
+    browsePage.getGreySelectedFacets('Adams Cole').should('not.exist');
+    browsePage.getGreySelectedFacets('adamscole@nutralab.com').should('not.exist');
   });
 });
 

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/browse.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/browse.tsx
@@ -115,6 +115,15 @@ class BrowsePage {
     return cy.get('[data-cy="clear-' + facet + '"]');
   }
 
+  getClearFacetSelection(facet: string) {
+    return cy.get(`[data-cy="${facet}-clear"]`);
+  }
+
+  clearFacetSelection(facet: string) {
+    cy.get(`[data-cy="${facet}-clear"]`).click();
+    this.waitForSpinnerToDisappear();
+  }
+
   clearFacetSearchSelection(facet: string) {
     cy.get('[data-cy="clear-' + facet + '"]').click();
     this.waitForSpinnerToDisappear();
@@ -186,7 +195,7 @@ class BrowsePage {
   }
 
   getHubPropertiesExpanded() {
-    return cy.get("#hub-properties > div > i").click();
+    return cy.get("#hub-properties > div").eq(1).invoke('show').click();
   }
 
   getExpandableSnippetView() {
@@ -217,7 +226,7 @@ class BrowsePage {
   getSideBarCollapseIcon() {
     return cy.get('#sidebar-collapse-icon');
   }
-  
+
   //table
   getColumnTitle(index: number) {
     return cy.get(`.ant-table-thead th:nth-child(${index}) .ant-table-column-title`).invoke('text');

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/entities/Order.entity.json
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/entities/Order.entity.json
@@ -28,7 +28,8 @@
           }
         },
         "shippedDate": {
-          "datatype": "dateTime"
+          "datatype": "dateTime",
+          "facetable": true
         }
       }
     },

--- a/marklogic-data-hub-central/ui/src/components/facet/facet.tsx
+++ b/marklogic-data-hub-central/ui/src/components/facet/facet.tsx
@@ -21,6 +21,12 @@ interface Props {
   propertyPath: any;
   updateSelectedFacets: (constraint: string, vals: string[], datatype: string, isNested: boolean) => void;
   addFacetValues: (constraint: string, vals: string[], datatype: string, facetCategory: string) => void;
+  toggleClearRequest: (request: boolean) => void;
+  toggleUncheckLastFacet: (request: boolean) => void;
+  discardChangesRequest: boolean;
+  setDiscardChangesRequest: (request: boolean) => void;
+  clearRequest: boolean;
+  uncheckLastFacet: boolean;
 };
 
 const Facet: React.FC<Props> = (props) => {
@@ -73,10 +79,11 @@ const Facet: React.FC<Props> = (props) => {
 
     useEffect(() => {
         if (Object.entries(greyedOptions.selectedFacets).length !== 0 && greyedOptions.selectedFacets.hasOwnProperty(props.constraint)) {
-            setCheckedOptions(greyedOptions)
+          setCheckedOptions(greyedOptions)
         } else if (Object.entries(greyedOptions.selectedFacets).length === 0 && Object.entries(searchOptions.selectedFacets).length !== 0) {
-            setCheckedOptions(searchOptions);
-        } else if ((Object.entries(searchOptions.selectedFacets).length === 0 || (!searchOptions.selectedFacets.hasOwnProperty(props.constraint)))) {
+          (props.clearRequest || props.uncheckLastFacet) ? setCheckedOptions(greyedOptions) : setCheckedOptions(searchOptions)
+        }
+        else if ((Object.entries(searchOptions.selectedFacets).length === 0 || (!searchOptions.selectedFacets.hasOwnProperty(props.constraint)))) {
             setChecked([]);
         }
     }, [greyedOptions]);
@@ -104,6 +111,9 @@ const Facet: React.FC<Props> = (props) => {
     // Deselection
     else if (index !== -1) {
       let newChecked = [...checked];
+      if (checked.length === 1) {
+        props.toggleUncheckLastFacet(true);
+      }
       newChecked.splice(index, 1);
       setChecked(newChecked);
       props.updateSelectedFacets(props.constraint, newChecked, props.facetType, isNested);
@@ -111,8 +121,9 @@ const Facet: React.FC<Props> = (props) => {
   }
 
   const handleClear = () => {
-    setChecked([]);
-    props.updateSelectedFacets(props.constraint, [], props.facetType, false);
+      setChecked([]);
+      props.toggleClearRequest(true);
+      props.updateSelectedFacets(props.constraint, [], props.facetType, false);
   }
 
 

--- a/marklogic-data-hub-central/ui/src/components/queries/queries.tsx
+++ b/marklogic-data-hub-central/ui/src/components/queries/queries.tsx
@@ -504,13 +504,15 @@ const Query = (props) => {
                 </MLTooltip>
             </div>
             <div className={styles.selectedFacets}>
-                <SelectedFacets
+              <SelectedFacets
                     selectedFacets={props.selectedFacets}
                     greyFacets={props.greyFacets}
                     applyClicked={applyClicked}
                     showApply={showApply}
                     toggleApply={(clicked) => toggleApply(clicked)}
                     toggleApplyClicked={(clicked) => toggleApplyClicked(clicked)}
+                    setDiscardChangesRequest={props.setDiscardChangesRequest}
+                    discardChangesRequest={props.discardChangesRequest}
                 />
             </div>
             <QueryModal

--- a/marklogic-data-hub-central/ui/src/components/queries/saving/save-query-modal/save-query-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/queries/saving/save-query-modal/save-query-modal.tsx
@@ -58,7 +58,6 @@ const SaveQueryModal: React.FC<Props> = (props) => {
             case 1:
                 facets = { ...facets, ...greyedOptions.selectedFacets };
                 setAllSearchFacets(facets);
-                clearAllGreyFacets();
                 props.toggleApplyClicked(true);
                 props.toggleApply(false);
                 break;

--- a/marklogic-data-hub-central/ui/src/components/sidebar/sidebar.tsx
+++ b/marklogic-data-hub-central/ui/src/components/sidebar/sidebar.tsx
@@ -25,6 +25,8 @@ interface Props {
   entityDefArray: any[];
   facetRender: (facets: any) => void;
   checkFacetRender: (facets:any) =>void;
+  discardChangesRequest: boolean;
+  setDiscardChangesRequest: (request: boolean) => void;
 };
 
 const Sidebar: React.FC<Props> = (props) => {
@@ -43,10 +45,17 @@ const Sidebar: React.FC<Props> = (props) => {
   let decimals = ['decimal', 'double', 'float'];
   const dateRangeOptions = ['Today', 'This Week', 'This Month', 'Custom'];
   const [activeKey, setActiveKey] = useState<any[]>([]);
+  const [clearRequest, toggleClearRequest] = useState<boolean>(false);
+  const [uncheckRequest, toggleUncheckLastFacet] = useState<boolean>(false);
 
   useEffect(() => {
     if (props.facets) {
       props.selectedEntities.length === 1 ? setActiveKey(['entityProperties']) : setActiveKey(['hubProperties','entityProperties']);
+      for (let i in hubFacets) {
+        if (searchOptions.selectedFacets.hasOwnProperty(hubFacets[i].facetName) || greyedOptions.selectedFacets.hasOwnProperty(hubFacets[i].facetName)) {
+          setActiveKey(['hubProperties', 'entityProperties']);
+        }
+      }
       const parsedFacets = facetParser(props.facets);
       const filteredHubFacets = hubPropertiesConfig.map(hubFacet => {
         let hubFacetValues = parsedFacets.find(facet => facet.facetName === hubFacet.facetName);
@@ -148,10 +157,21 @@ const Sidebar: React.FC<Props> = (props) => {
           }
       } else {
           if (Object.entries(searchOptions.selectedFacets).length === 0) {
-              //setAllSearchFacets({});
               setAllSelectedFacets({});
-          } else{
+          } else if ((Object.entries(greyedOptions.selectedFacets).length === 0 || (clearRequest || uncheckRequest)) || props.discardChangesRequest) {
+            if (props.discardChangesRequest) {
+              setAllGreyedOptions(searchOptions.selectedFacets);
+              props.setDiscardChangesRequest(false);
+            }
+            if (uncheckRequest && Object.entries(greyedOptions.selectedFacets).length === 0){
+              setAllSelectedFacets({});
+              toggleUncheckLastFacet(false);
+            } else if (clearRequest && Object.entries(greyedOptions.selectedFacets).length === 0){
+              setAllSelectedFacets({});
+              toggleClearRequest(false);
+            } else {
               setAllSelectedFacets(searchOptions.selectedFacets);
+            }
           }
           props.checkFacetRender([]);
       }
@@ -183,7 +203,6 @@ const Sidebar: React.FC<Props> = (props) => {
       default:
         break;
     }
-
     if (vals.length > 0) {
       facets = {
         ...facets,
@@ -400,6 +419,12 @@ const Sidebar: React.FC<Props> = (props) => {
                       propertyPath={facet.propertyPath}
                       updateSelectedFacets={updateSelectedFacets}
                       addFacetValues={addFacetValues}
+                      toggleClearRequest={toggleClearRequest}
+                      toggleUncheckLastFacet={toggleUncheckLastFacet}
+                      discardChangesRequest={props.discardChangesRequest}
+                      setDiscardChangesRequest={props.setDiscardChangesRequest}
+                      clearRequest={clearRequest}
+                      uncheckLastFacet={uncheckRequest}
                     />
                   )
                 }
@@ -534,6 +559,12 @@ const Sidebar: React.FC<Props> = (props) => {
                 referenceType={facet.referenceType}
                 entityTypeId={facet.entityTypeId}
                 propertyPath={facet.propertyPath}
+                toggleClearRequest={toggleClearRequest}
+                toggleUncheckLastFacet={toggleUncheckLastFacet}
+                discardChangesRequest={props.discardChangesRequest}
+                setDiscardChangesRequest={props.setDiscardChangesRequest}
+                clearRequest={clearRequest}
+                uncheckLastFacet={uncheckRequest}
               />
             )
           })}

--- a/marklogic-data-hub-central/ui/src/pages/Browse.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Browse.tsx
@@ -62,6 +62,7 @@ const Browse: React.FC<Props> = ({ location }) => {
   const [entityPropertyDefinitions, setEntityPropertyDefinitions] = useState<any[]>([]);
   const [selectedPropertyDefinitions, setSelectedPropertyDefinitions] = useState<any[]>([]);
   const [isColumnSelectorTouched, setColumnSelectorTouched] = useState(false);
+  const [discardChangesRequest, setDiscardChangesRequest] = useState<boolean>(false);
 
   const getEntityModel = async () => {
     try {
@@ -212,7 +213,7 @@ const Browse: React.FC<Props> = ({ location }) => {
   if (searchOptions.zeroState) {
     return (
       <>
-        <Query queries={queries} setQueries={setQueries} isSavedQueryUser={isSavedQueryUser} columns={columns} setIsLoading={setIsLoading} entities={entities} selectedFacets={[]} greyFacets={[]} entityDefArray={entityDefArray} />
+        <Query queries={queries} setQueries={setQueries} isSavedQueryUser={isSavedQueryUser} columns={columns} setIsLoading={setIsLoading} entities={entities} selectedFacets={[]} greyFacets={[]} entityDefArray={entityDefArray} setDiscardChangesRequest={setDiscardChangesRequest} discardChangesRequest={discardChangesRequest}/>
         <ZeroStateExplorer entities={entities} setEntity={setEntity} queries={queries} columns={columns} setIsLoading={setIsLoading} tableView={tableView} toggleTableView={toggleTableView} />
       </>
     );
@@ -232,6 +233,8 @@ const Browse: React.FC<Props> = ({ location }) => {
             entityDefArray={entityDefArray}
             facetRender={updateSelectedFacets}
             checkFacetRender={updateCheckedFacets}
+            discardChangesRequest={discardChangesRequest}
+            setDiscardChangesRequest={setDiscardChangesRequest}
           />
         </Sider>
         <Content className={styles.content}>
@@ -289,6 +292,8 @@ const Browse: React.FC<Props> = ({ location }) => {
                   greyFacets={greyFacets}
                   isColumnSelectorTouched={isColumnSelectorTouched}
                   entityDefArray={entityDefArray}
+                  setDiscardChangesRequest={setDiscardChangesRequest}
+                  discardChangesRequest={discardChangesRequest}
                 />
               </div>
               <div className={styles.fixedView} >

--- a/marklogic-data-hub-central/ui/src/util/search-context.tsx
+++ b/marklogic-data-hub-central/ui/src/util/search-context.tsx
@@ -372,14 +372,18 @@ const SearchProvider: React.FC<{ children: any }> = ({ children }) => {
 
   const clearGreyFacet = (constraint: string, val: string) => {
     let facets = greyedOptions.selectedFacets;
+    let selectedFacetsLength = Object.keys(searchOptions.selectedFacets).length
     let valueKey = '';
     if (facets[constraint].dataType === 'xs:string' || facets[constraint].dataType === 'string') {
       valueKey = 'stringValues';
     }
-    if (facets[constraint][valueKey].length > 1) {
+    if (facets[constraint][valueKey].length > 1 || (facets[constraint][valueKey].length > 0 && selectedFacetsLength)) {
       facets[constraint][valueKey] = facets[constraint][valueKey].filter(option => option !== val);
     } else {
       delete facets[constraint]
+    }
+    if (facets[constraint]) {
+      if (facets[constraint][valueKey].length === 0 && selectedFacetsLength) delete facets[constraint]
     }
     setGreyedOptions({ ...greyedOptions, selectedFacets: facets })
   }

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/entities/entity-search-lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/entities/entity-search-lib.sjs
@@ -58,6 +58,10 @@ function addPropertiesToSearchResponse(entityName, searchResponse, propertiesToD
     searchResponse.results.forEach(result => {
       addEntitySpecificProperties(result, entityInfo, selectedPropertyMetadata)
     });
+
+    // Remove entityName from Collection facetValues
+    removeEntityNameFromCollection(searchResponse, entityName);
+
   } else {
     //'All Entities' option is selected
     searchResponse.results.forEach(result => {
@@ -428,6 +432,18 @@ function addPrimaryKeyToResult(result, entityInstance, entityDef) {
     result.primaryKey = {
       "propertyPath": "uri",
       "propertyValue": result.uri
+    }
+  }
+}
+
+function removeEntityNameFromCollection(searchResponse, entityName) {
+  if (searchResponse.hasOwnProperty('facets')) {
+    if (searchResponse.facets.hasOwnProperty("Collection")) {
+      let updatedFacetValues = []
+      searchResponse.facets.Collection.facetValues.map(facet => {
+        if (facet.name !== entityName) updatedFacetValues.push(facet);
+      })
+      searchResponse.facets.Collection.facetValues = updatedFacetValues
     }
   }
 }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/addPropertiesToSearchResponse.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/addPropertiesToSearchResponse.sjs
@@ -681,7 +681,7 @@ function verifyEntityInstanceResultsForAllEntities() {
     test.assertEqual(null, response.results[1].entityInstance.status),
     // instanceWithAdditionalProperty
     test.assertEqual(4, Object.keys(response.results[2].entityInstance).length, "4 props are populated. which are available in the xpath /*:envelope/*:instance" +
-        "Additional property birthDate is returned. There are only 4 properties in the instance"),
+      "Additional property birthDate is returned. There are only 4 properties in the instance"),
     // instanceWithNonExistentModel
     test.assertEqual(0, Object.keys(response.results[3].entityInstance).length),
     // instanceWithNamespace
@@ -700,6 +700,60 @@ function verifyEntityInstanceResultsForAllEntities() {
   ];
 }
 
+function verifyEntityNameNotInCollectionFacet() {
+  const response = {
+    "snippet-format": "snippet",
+    "total": 1,
+    "results": [
+      {
+        "index": 1,
+        "uri": "/content/jane.json",
+      }
+    ],
+    "facets": {
+      "Collection": {
+        "type": "collection",
+        "facetValues": [
+          {
+            "name": "Customer",
+            "count": 10,
+            "value": "Customer"
+          },
+          {
+            "name": "mapCustomersJSON",
+            "count": 5,
+            "value": "mapCustomersJSON"
+          },
+          {
+            "name": "mapCustomersXML",
+            "count": 5,
+            "value": "mapCustomersXML"
+          }
+        ]
+      }
+    }
+  };
+  const expectedFacetValues = [
+    {
+      "name": "mapCustomersJSON",
+      "count": 5,
+      "value": "mapCustomersJSON"
+    },
+    {
+      "name": "mapCustomersXML",
+      "count": 5,
+      "value": "mapCustomersXML"
+    }
+  ];
+  entitySearchLib.addPropertiesToSearchResponse(entityName, response);
+  let facetValues = response.facets.Collection.facetValues
+  return ([
+    test.assertEqual(2, facetValues.length),
+    test.assertEqual(expectedFacetValues, facetValues),
+  ]);
+}
+
+
 []
   .concat(verifySimpleSelectedPropertiesResults())
   .concat(verifyStructuredFirstLevelSelectedPropertiesResults())
@@ -711,4 +765,5 @@ function verifyEntityInstanceResultsForAllEntities() {
   .concat(verifyPropertiesForAllEntitiesOption())
   .concat(verifyIdentifierWithoutDefinedPrimaryKey())
   .concat(verifyEntityInstanceResults())
-  .concat(verifyEntityInstanceResultsForAllEntities());
+  .concat(verifyEntityInstanceResultsForAllEntities())
+  .concat(verifyEntityNameNotInCollectionFacet());


### PR DESCRIPTION
### Description
- includes a fix for DHFPROD-5408: Discard all changes icon in explorer screen not works consistently
- hub properties now persist after selecting a hub property
- removed entity name from showing in Collection facet under hub properties

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests

