### PR TITLE
DHFPROD-5527:Changes to sort should be consideration for actions on Saved Query

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.json.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.json.tsx
@@ -274,8 +274,9 @@ describe('json scenario for table on browse documents page', () => {
   it('verify source view of the document', () => {
     browsePage.selectEntity('Customer');
     browsePage.search('Adams Cole');
-    browsePage.getFacetItemCheckbox('name', 'loadCustomersJSON').click();
-    browsePage.getGreySelectedFacets('loadCustomersJSON').should('exist');
+    browsePage.getHubPropertiesExpanded();
+    browsePage.getFacetItemCheckbox('collection', 'mapCustomersJSON').click();
+    browsePage.getGreySelectedFacets('mapCustomersJSON').should('exist');
     browsePage.getFacetApplyButton().click();
     browsePage.getTotalDocuments().should('be.equal', 2);
     browsePage.getTableViewSourceIcon().click();
@@ -288,7 +289,7 @@ describe('json scenario for table on browse documents page', () => {
     //Verify navigating back from detail view should persist search options
     detailPage.clickBackButton();
     browsePage.getSelectedEntity().should('contain', 'Customer');
-    browsePage.getClearFacetSearchSelection('loadCustomersJSON').should('exist');
+    browsePage.getClearFacetSearchSelection('mapCustomersJSON').should('exist');
     browsePage.getSearchText().should('have.value', 'Adams Cole');
     browsePage.getTableView().should('have.css', 'background-color', 'rgb(68, 73, 156)');
   });
@@ -311,22 +312,22 @@ describe('json scenario for table on browse documents page', () => {
     browsePage.getTotalDocuments().should('be.equal', 2);
   });
 
-  it('apply multiple facets, select and discard new facet, verify original facets checked', () => {
+  xit('apply multiple facets, select and discard new facet, verify original facets checked', () => {
     browsePage.selectEntity('Customer');
     browsePage.getShowMoreLink().first().click();
-    browsePage.getFacetItemCheckbox('name', 'loadCustomersJSON').click();
-    browsePage.getFacetItemCheckbox('name', 'loadCustomersXML').click();
-    browsePage.getGreySelectedFacets('loadCustomersJSON').should('exist');
-    browsePage.getGreySelectedFacets('loadCustomersXML').should('exist');
+    browsePage.getFacetItemCheckbox('name', 'Jacqueline Knowles').click();
+    browsePage.getFacetItemCheckbox('name', 'Lola Dunn').click();
+    browsePage.getGreySelectedFacets('Jacqueline Knowles').should('exist');
+    browsePage.getGreySelectedFacets('Lola Dunn').should('exist');
     browsePage.getFacetApplyButton().click();
-    browsePage.getFacetItemCheckbox('name', 'loadCustomersJSON').should('be.checked');
-    browsePage.getFacetItemCheckbox('name', 'loadCustomersXML').should('be.checked');
-    browsePage.getFacetItemCheckbox('name', 'Adams Cole').click();
-    browsePage.getGreySelectedFacets('Adams Cole').should('exist');
+    browsePage.getFacetItemCheckbox('name', 'Jacqueline Knowles').should('be.checked');
+    browsePage.getFacetItemCheckbox('name', 'Lola Dunn').should('be.checked');
+    browsePage.getFacetItemCheckbox('email', 'jacquelineknowles@nutralab.com').click();
+    browsePage.getGreySelectedFacets('jacquelineknowles@nutralab.com').should('exist');
     browsePage.getClearGreyFacets().click();
-    browsePage.getFacetItemCheckbox('name', 'loadCustomersJSON').should('be.checked');
-    browsePage.getFacetItemCheckbox('name', 'loadCustomersXML').should('be.checked');
-    browsePage.getFacetItemCheckbox('name', 'Adams Cole').should('not.be.checked');
+    browsePage.getFacetItemCheckbox('name', 'Jacqueline Knowles').should('be.checked');
+    browsePage.getFacetItemCheckbox('name', 'Lola Dunn').should('be.checked');
+    browsePage.getFacetItemCheckbox('email', 'jacquelineknowles@nutralab.com').should('not.be.checked');
   });
 });
 
@@ -336,7 +337,7 @@ describe('Verify numeric facet can be applied', () => {
     beforeEach(() => {
         cy.visit('/');
         cy.contains(Application.title);
-        cy.loginAsTestUserWithRoles("pii-reader").withRequest();
+        cy.loginAsTestUserWithRoles("pii-reader","hub-central-developer").withRequest();
         cy.waitUntil(() => toolbar.getExploreToolbarIcon()).click();
         cy.waitUntil(() => browsePage.getExploreButton()).click();
         browsePage.waitForSpinnerToDisappear();
@@ -346,6 +347,7 @@ describe('Verify numeric facet can be applied', () => {
     it('Apply numeric facet values multiple times, clears the previous values and applies the new one', () => {
         browsePage.selectEntity('Customer');
         browsePage.getSelectedEntity().should('contain', 'Customer');
+        browsePage.waitForSpinnerToDisappear();
         browsePage.changeNumericSlider('2273');
         browsePage.getGreyRangeFacet(2273).should('exist');
         browsePage.getFacetApplyButton().click();

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.queries.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.queries.tsx
@@ -25,6 +25,8 @@ describe('save/manage queries scenarios, developer role', () => {
         browsePage.getSelectedFacets().should('exist');
         browsePage.getGreySelectedFacets('Adams Cole').should('exist');
         browsePage.getFacetApplyButton().click();
+        browsePage.clickColumnTitle(2);
+        browsePage.waitForSpinnerToDisappear();
         browsePage.getSaveModalIcon().click();
         browsePage.waitForSpinnerToDisappear();
         browsePage.getSaveQueryName().should('be.visible');
@@ -50,12 +52,16 @@ describe('save/manage queries scenarios, developer role', () => {
         browsePage.getSaveQueryDescription().type('new-query-2 description');
         browsePage.getSaveQueryButton().click();
         browsePage.getSelectedQuery().should('contain', 'new-query-2');
-        browsePage.getFacetItemCheckbox('name', 'loadCustomersJSON').click();
-        browsePage.getGreySelectedFacets('loadCustomersJSON').should('exist');
+        browsePage.getHubPropertiesExpanded();
+        browsePage.getFacetItemCheckbox('collection', 'mapCustomersJSON').click();
+        browsePage.getGreySelectedFacets('mapCustomersJSON').should('exist');
         browsePage.getSaveModalIcon().click();
         browsePage.getRadioOptionSelected();
         browsePage.getEditSaveChangesButton().click();
         browsePage.getSelectedQueryDescription().should('contain', 'new-query-2 description');
+        browsePage.waitForSpinnerToDisappear();
+        browsePage.getTableCell(1, 2).should('contain','102');
+        browsePage.getTableCell(2, 2).should('contain','103');
     });
 
     it('save/saveAs/edit more queries with duplicate query name from browse and manage queries view', () => {
@@ -168,9 +174,9 @@ describe('save/manage queries scenarios, developer role', () => {
     it('Edit saved query and verify discard changes functionality', () => {
         browsePage.selectEntity('Person');
         browsePage.getSelectedEntity().should('contain', 'Person');
-        browsePage.getFacetItemCheckbox('fname', 'Alexandra').click();
+        browsePage.getFacetItemCheckbox('lname', 'Bates').click();
         browsePage.getSelectedFacets().should('exist');
-        browsePage.getGreySelectedFacets('Alexandra').should('exist');
+        browsePage.getGreySelectedFacets('Bates').should('exist');
         browsePage.getFacetApplyButton().click();
         browsePage.getSaveModalIcon().click();
         browsePage.waitForSpinnerToDisappear();
@@ -179,16 +185,17 @@ describe('save/manage queries scenarios, developer role', () => {
         browsePage.getSaveQueryButton().click();
         browsePage.waitForSpinnerToDisappear();
         browsePage.getSelectedQuery().should('contain', 'person-query');
-        browsePage.getFacetItemCheckbox('lname', 'Wilson').click();
-        browsePage.getGreySelectedFacets('Wilson').should('exist');
+        browsePage.search('Bates');
+        browsePage.clickColumnTitle(4);
         browsePage.getDiscardChangesIcon().click();
         browsePage.getDiscardYesButton().click();
-        browsePage.getAppliedFacets('Alexandra').should('exist');
-        browsePage.getFacetItemCheckbox('lname', 'Wilson').click();
-        browsePage.getGreySelectedFacets('Wilson').should('exist');
+        browsePage.getAppliedFacets('Bates').should('exist');
+        browsePage.search('Bates');
+        browsePage.clickColumnTitle(4);
         browsePage.getDiscardChangesIcon().click();
         browsePage.getDiscardNoButton().click();
-        browsePage.getGreySelectedFacets('Wilson').should('exist');
+        browsePage.getSearchText().should('have.value', 'Bates');
+        browsePage.getSortIndicatorAsc().should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
     });
 
 
@@ -196,10 +203,10 @@ describe('save/manage queries scenarios, developer role', () => {
         // creating query 1 with customer entity
         browsePage.selectEntity('Customer');
         browsePage.getSelectedEntity().should('contain', 'Customer');
-        browsePage.getShowMoreLink().first().click();
-        browsePage.getFacetItemCheckbox('email', 'carmellahardin@nutralab.com').click();
-        browsePage.getFacetItemCheckbox('name', 'Carmella Hardin').click();
+        browsePage.getHubPropertiesExpanded();
+        browsePage.getFacetItemCheckbox('collection', 'mapCustomersJSON').click();
         browsePage.getFacetApplyButton().click();
+        browsePage.search('Adams Cole');
         browsePage.getSaveModalIcon().click();
         browsePage.waitForSpinnerToDisappear();
         browsePage.getSaveQueryName().type('query-1');
@@ -213,28 +220,33 @@ describe('save/manage queries scenarios, developer role', () => {
         browsePage.getSaveQueryName().type("query-2");
         browsePage.getSaveQueryButton().click();
         // Making changes to query-2 and switching to query-1
-        browsePage.getClearFacetSearchSelection('Carmella Hardin').click();
+        browsePage.clickColumnTitle(2);
         browsePage.selectQuery("query-1");
         browsePage.getQueryConfirmationCancelClick().click();
+        browsePage.getSortIndicatorAsc().should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
         browsePage.selectQuery("query-1");
         browsePage.getQueryConfirmationNoClick().click();
         browsePage.getSelectedQuery().should('contain', 'query-1');
-        browsePage.getClearFacetSearchSelection('Carmella Hardin').click();
+        browsePage.getClearFacetSearchSelection('mapCustomersJSON').click();
+        browsePage.clickColumnTitle(2);
         browsePage.selectQuery("query-2");
         browsePage.getQueryConfirmationYesClick().click();
         browsePage.getEditSaveChangesButton().click();
         browsePage.getSelectedQuery().should('contain', 'query-2');
+        browsePage.getAppliedFacets('mapCustomersJSON').should('exist');
         browsePage.selectQuery("query-1");
-        browsePage.getClearAllButton().should('exist');
+        browsePage.getSortIndicatorAsc().should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
     });
 
     it('Switching between entities when making changes to saved query', () => {
         browsePage.selectQuery("new-query");
         browsePage.getClearFacetSearchSelection('Adams Cole').click();
+        browsePage.clickColumnTitle(3);
         browsePage.selectEntity('Person');
         browsePage.getEntityConfirmationCancelClick().click();
         browsePage.getSelectedQuery().should('contain', 'new-query');
         browsePage.getSelectedEntity().should('contain', 'Customer');
+        browsePage.getSortIndicatorAsc().should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
         browsePage.selectEntity('Person');
         browsePage.getEntityConfirmationNoClick().click();
         browsePage.getSelectedEntity().should('contain', 'Person');
@@ -242,6 +254,7 @@ describe('save/manage queries scenarios, developer role', () => {
         browsePage.getSelectedQuery().should('contain', 'select a query');
         browsePage.selectQuery('new-query');
         browsePage.getFacetItemCheckbox('email', 'adamscole@nutralab.com').click();
+        browsePage.clickColumnTitle(2);
         browsePage.selectEntity('Person');
         browsePage.getEntityConfirmationYesClick().click();
         browsePage.getEditSaveChangesButton().click();
@@ -249,6 +262,9 @@ describe('save/manage queries scenarios, developer role', () => {
         browsePage.selectEntity('Customer');
         browsePage.selectQuery('new-query');
         browsePage.getAppliedFacets('Adams Cole').should('exist');
+        browsePage.getSortIndicatorDesc().should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
+        browsePage.getTableCell(1,2).should('contain', '103');
+        browsePage.getTableCell(2,2).should('contain', '102');
     });
 
     it('Switching between entities when there are saved queries', () => {
@@ -298,6 +314,7 @@ describe('save/manage queries scenarios, developer role', () => {
         browsePage.getFacetItemCheckbox('name', 'Adams Cole').click();
         browsePage.getSelectedFacets().should('exist');
         browsePage.getFacetApplyButton().click();
+        browsePage.clickColumnTitle(2);
         browsePage.waitForSpinnerToDisappear();
         browsePage.getResetQueryButton().click();
         //selecting yes will save the new query and navigates to zero state
@@ -314,6 +331,9 @@ describe('save/manage queries scenarios, developer role', () => {
         browsePage.selectEntity('Customer');
         browsePage.selectQuery('reset-query');
         browsePage.getAppliedFacets('Adams Cole').should('exist');
+        browsePage.getSortIndicatorAsc().should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
+        browsePage.getTableCell(1,2).should('contain', '102');
+        browsePage.getTableCell(2,2).should('contain', '103');
     });
 
     it('Show Reset query button, clicking reset confirmation when making changes to saved query', () => {
@@ -338,16 +358,18 @@ describe('save/manage queries scenarios, developer role', () => {
         //selecting yes will update the query and navigates to zero state
         browsePage.selectEntity('Customer');
         browsePage.selectQuery('reset-query');
-        browsePage.getFacetItemCheckbox('email', 'adamscole@nutralab.com').click();
+        browsePage.clickColumnTitle(2);
         browsePage.getResetQueryButton().click();
         browsePage.getResetConfirmationYesClick();
-        browsePage.getRadioOptionSelected();
         browsePage.getEditSaveChangesButton().click();
         browsePage.getExploreButton().should('be.visible');
         browsePage.getExploreButton().click();
         browsePage.selectEntity('Customer');
         browsePage.selectQuery('reset-query');
-        browsePage.getAppliedFacets('adamscole@nutralab.com').should('exist');
+        browsePage.getAppliedFacets('Adams Cole').should('exist');
+        browsePage.getSortIndicatorDesc().should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
+        browsePage.getTableCell(1,2).should('contain', '103');
+        browsePage.getTableCell(2,2).should('contain', '102');
     });
 
     it('Show Reset query button, clicking reset icon navigates to zero state', () => {
@@ -444,5 +466,5 @@ describe('manage queries modal scenarios on zero sate page, developer role', () 
         queryComponent.getManageQueryModal().should('not.be.visible');
     });
 
-    
+
 });

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/browse.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/browse.tsx
@@ -223,6 +223,18 @@ class BrowsePage {
     return cy.get(`.ant-table-thead th:nth-child(${index}) .ant-table-column-title`).invoke('text');
   }
 
+  clickColumnTitle(index: number) {
+    return cy.get(`.ant-table-thead th:nth-child(${index}) .ant-table-column-title`).click();
+  }
+
+  getSortIndicatorAsc(){
+    return cy.get(`.ant-table-column-sorter-up.on`);
+  }
+
+  getSortIndicatorDesc(){
+    return cy.get(`.ant-table-column-sorter-down.on`);
+  }
+
   getTableRows() {
     return cy.get('.ant-table-row');
   }

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/entities/Customer.entity.json
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/entities/Customer.entity.json
@@ -15,12 +15,14 @@
       "primaryKey": "customerId",
       "properties": {
         "customerId": {
-          "datatype": "integer"
+          "datatype": "integer",
+          "sortable": true
         },
         "name": {
           "datatype": "string",
           "collation": "http://marklogic.com/collation/codepoint",
-          "facetable": true
+          "facetable": true,
+          "sortable": true
         },
         "email": {
           "datatype": "string",
@@ -29,7 +31,8 @@
         },
         "pin": {
           "datatype": "integer",
-          "facetable": true
+          "facetable": true,
+          "sortable": true
         },
         "nicknames": {
           "datatype": "array",

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/entities/Person.entity.json
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/entities/Person.entity.json
@@ -21,12 +21,14 @@
         "fname": {
           "datatype": "string",
           "collation": "http://marklogic.com/collation/codepoint",
-          "facetable": true
+          "facetable": true,
+          "sortable": true
         },
         "lname": {
           "datatype": "string",
           "collation": "http://marklogic.com/collation/codepoint",
-          "facetable": true
+          "facetable": true,
+          "sortable": true
         },
         "desc": {
           "datatype": "string",

--- a/marklogic-data-hub-central/ui/src/components/queries/queries.tsx
+++ b/marklogic-data-hub-central/ui/src/components/queries/queries.tsx
@@ -127,6 +127,7 @@ const Query = (props) => {
         if (currentQuery && currentQuery.hasOwnProperty('savedQuery') && currentQuery.savedQuery.hasOwnProperty('query')) {
             if ((JSON.stringify(currentQuery.savedQuery.query.selectedFacets) !== JSON.stringify(searchOptions.selectedFacets)) ||
                 (currentQuery.savedQuery.query.searchText !== searchOptions.query) ||
+                (JSON.stringify(currentQuery.savedQuery.sortOrder) !== JSON.stringify(searchOptions.sortOrder)) ||
                 (JSON.stringify(currentQuery.savedQuery.propertiesToDisplay) !== JSON.stringify(searchOptions.selectedTableProperties)) ||
                 (props.greyFacets.length > 0)) {
                 return true;
@@ -191,7 +192,6 @@ const Query = (props) => {
     const onResetCancel = () => {
         toggleResetQueryNewConfirmation(false);
         toggleResetQueryEditedConfirmation(false);
-
     }
 
     const onResetOk = () => {
@@ -228,7 +228,8 @@ const Query = (props) => {
         const resetQueryEditedConfirmation = props.isSavedQueryUser && props.queries.length > 0
                                             && searchOptions.selectedQuery !== 'select a query' && isSaveQueryChanged()
         const resetQueryNewConfirmation = props.isSavedQueryUser && props.queries.length > 0 &&
-                                          (props.selectedFacets.length > 0 || searchOptions.query.length > 0)
+                                          (props.selectedFacets.length > 0 || searchOptions.query.length > 0
+                                          || searchOptions.sortOrder.length > 0)
                                           && searchOptions.selectedQuery === 'select a query'
         if (resetQueryNewConfirmation) {
             toggleResetQueryNewConfirmation(true)
@@ -278,7 +279,7 @@ const Query = (props) => {
         <div>
             <div>
                 {props.isSavedQueryUser && (props.selectedFacets.length > 0 || searchOptions.query
-                    || props.isColumnSelectorTouched) &&
+                    || props.isColumnSelectorTouched || searchOptions.sortOrder.length > 0) &&
                 showSaveNewIcon && searchOptions.entityTypeIds.length > 0 && searchOptions.selectedQuery === 'select a query' &&
                     <div style={{ marginTop: '-22px' }}>
                         <MLTooltip title={'Save the current query'}>

--- a/marklogic-data-hub-central/ui/src/components/queries/saving/edit-save-query/save-changes-modal.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/queries/saving/edit-save-query/save-changes-modal.test.tsx
@@ -34,6 +34,7 @@ describe("<SaveChangesModal/>", () => {
             toggleEntityQueryUpdate={jest.fn()}
             entityQueryUpdate={false}
             isSaveQueryChanged={jest.fn()}
+            resetYesClicked={false}
         />)
         queryField = getByPlaceholderText("Enter query name");
         expect(queryField).toHaveAttribute('value', 'Order query');
@@ -64,6 +65,7 @@ describe("<SaveChangesModal/>", () => {
             toggleEntityQueryUpdate={jest.fn()}
             entityQueryUpdate={false}
             isSaveQueryChanged={jest.fn()}
+            resetYesClicked={false}
         />)
         queryField = getByPlaceholderText("Enter query name");
         fireEvent.change(queryField, { target: {value: ''} });
@@ -84,8 +86,8 @@ describe("<SaveChangesModal/>", () => {
                         "searchText": "",
                          "selectedFacets": {},
                     },
-                    "propertiesToDisplay": [
-                    ]
+                    "propertiesToDisplay": [],
+                    "sortOrder": []
                 }
         }
 
@@ -117,6 +119,7 @@ describe("<SaveChangesModal/>", () => {
             toggleEntityQueryUpdate={jest.fn()}
             entityQueryUpdate={false}
             isSaveQueryChanged={jest.fn()}
+            resetYesClicked={false}
         />)
         queryField = getByPlaceholderText("Enter query name");
         fireEvent.change(queryField, { target: {value: 'Edit new query'} });
@@ -133,8 +136,8 @@ describe("<SaveChangesModal/>", () => {
                     "searchText": "",
                     "selectedFacets": {},
                 },
-                "propertiesToDisplay": [
-                ]
+                "propertiesToDisplay": [],
+                "sortOrder": [],
             }
         }
 

--- a/marklogic-data-hub-central/ui/src/components/queries/saving/edit-save-query/save-changes-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/queries/saving/edit-save-query/save-changes-modal.tsx
@@ -100,6 +100,7 @@ const SaveChangesModal: React.FC<Props> = (props) => {
                 currentQuery.savedQuery.query.entityTypeIds = searchOptions.entityTypeIds;
             }
             currentQuery.savedQuery.propertiesToDisplay = searchOptions.selectedTableProperties;
+            currentQuery.savedQuery.sortOrder = searchOptions.sortOrder;
 
             const response = await axios.put(`/api/entitySearch/savedQueries`, currentQuery);
             if (response.data) {

--- a/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.test.tsx
@@ -157,12 +157,16 @@ describe("Results Table view component", () => {
 
         const customerIdColumnSort = getByTestId('resultsTableColumn-customerId'); // For name column sorting
         const nameColumnSort = getByTestId('resultsTableColumn-name'); // For value column sorting
+        const nickNamesColumnSort = getByTestId('resultsTableColumn-nicknames'); // For nicknames column sorting
 
-        //Sorted document uris based on name and customerId columns to be used later
+        //Sorted document uris based on name,customerId and nicknames columns to be used later
         const urisDefault = ['/Customer/Cust1.json', '/Customer/Cust2.json', '/Customer/Cust3.json', '/Customer/Cust4.json','/Customer/Cust5.json'];
         const urisBasedOnDescendingCustomerId = ['/Customer/Cust5.json', '/Customer/Cust2.json', '/Customer/Cust3.json', '/Customer/Cust4.json','/Customer/Cust5.json'];
         const urisBasedOnAscendingName = ['/Customer/Cust2.json', '/Customer/Cust3.json', '/Customer/Cust1.json', '/Customer/Cust5.json','/Customer/Cust4.json'];
         const urisBasedOnDescendingName = ['/Customer/Cust4.json', '/Customer/Cust5.json', '/Customer/Cust1.json', '/Customer/Cust3.json','/Customer/Cust2.json'];
+        const urisBasedOnAscendingNickNames = ['/Customer/Cust2.json', '/Customer/Cust3.json', '/Customer/Cust1.json', '/Customer/Cust5.json','/Customer/Cust4.json'];
+        const urisBasedOnDescendingNickNames = ['/Customer/Cust4.json', '/Customer/Cust5.json', '/Customer/Cust1.json', '/Customer/Cust2.json','/Customer/Cust3.json'];
+
 
         /* Validate sorting on name column in results*/
         //Check the sort order of Name column rows before enforcing sort order
@@ -189,6 +193,17 @@ describe("Results Table view component", () => {
         fireEvent.click(customerIdColumnSort);
         resultsTable = document.querySelectorAll('.ant-table-row ant-table-row-level-0');
         validateExplorerResultsTableRow(resultsTable, urisBasedOnDescendingCustomerId);
+
+        /* Validate sorting on nicknames column in results*/
+        //Click on the nicknames column to sort the rows by Ascending order
+        fireEvent.click(nickNamesColumnSort);
+        resultsTable = document.querySelectorAll('.ant-table-row ant-table-row-level-0');
+        validateExplorerResultsTableRow(resultsTable, urisBasedOnAscendingNickNames);
+
+        //Click on the nicknames column to sort the rows by Descending order
+        fireEvent.click(nickNamesColumnSort);
+        resultsTable = document.querySelectorAll('.ant-table-row ant-table-row-level-0');
+        validateExplorerResultsTableRow(resultsTable, urisBasedOnDescendingNickNames);
 
     });
 })

--- a/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.tsx
+++ b/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.tsx
@@ -169,17 +169,24 @@ const ResultsTabularView = (props) => {
         return columns;
     }
 
+    const handleChange = (sorter) => {
+        if(searchOptions.sortOrder.length && searchOptions.sortOrder[0].sortDirection == 'descending')
+            setSortOrder(searchOptions.sortOrder[0].propertyName,null)
+    }
+
     const setSortOptions = (item) => (
         item.sortable ?
-            {
-                sorter: (a: any, b: any, sortOrder) => {
-                    if (!sortingOrder) {
-                        setSortOrder(item.propertyLabel, item.datatype, sortOrder)
-                        sortingOrder = true;
-                    }
-                    return getTableSortValue(a, b, item);
-                }
-            } : "")
+        {
+        sorter: (a: any, b: any, sortOrder) => {
+            if(!sortingOrder) {
+                setSortOrder(item.propertyLabel,sortOrder)
+                sortingOrder = true;
+            }
+            return getTableSortValue(a,b,item);
+        },
+         sortOrder : (searchOptions.sortOrder.length && (searchOptions.sortOrder[0].propertyName === item.propertyLabel)
+             && searchOptions.sortOrder[0].hasOwnProperty('sortDirection') ) ? (searchOptions.sortOrder[0].sortDirection === 'ascending') ?'ascend':'descend' : null,
+    } : "")
 
     const updatedTableHeader = () => {
         let header = tableHeaderRender(selectedTableColumns);
@@ -195,12 +202,11 @@ const ResultsTabularView = (props) => {
     const tableHeaders = props.selectedEntities?.length === 0 ? DEFAULT_ALL_ENTITIES_HEADER : updatedTableHeader();
 
     const getTableSortValue = (a, b, item) => {
-        let sortValue = item.datatype !== 'string' ? getValueToCompare(a, item.propertyPath)?.length - getValueToCompare(b, item.propertyPath)?.length : getValueToCompare(a, item.propertyPath)?.localeCompare(getValueToCompare(b, item.propertyPath));
+        let sortValue = (item.datatype !== 'string' || item.multiple) ? getValueToCompare(a, item.propertyPath)?.length - getValueToCompare(b, item.propertyPath)?.length : getValueToCompare(a, item.propertyPath)?.localeCompare(getValueToCompare(b, item.propertyPath));
         return sortValue;
     }
 
     const getValueToCompare = (prop, propertyPath) => {
-
         if (!prop[propertyPath]) {
             return "";
         } else if (Array.isArray(prop[propertyPath]) && (JSON.stringify(prop[propertyPath]) === JSON.stringify([]))) {
@@ -407,6 +413,7 @@ const ResultsTabularView = (props) => {
                     rowKey='uri'
                     dataSource={dataSource}
                     columns={tableHeaders}
+                    onChange={handleChange}
                     expandedRowRender={tableHeaders.length > 0 ? expandedRowRender : null}
                     pagination={false}
                     defaultShowEmbeddedTableBodies={true}

--- a/marklogic-data-hub-central/ui/src/util/search-context.tsx
+++ b/marklogic-data-hub-central/ui/src/util/search-context.tsx
@@ -72,7 +72,7 @@ interface ISearchContextInterface {
   setSelectedTableProperties: (propertiesToDisplay: string[]) => void;
   setView: (viewId: JSX.Element| null, zeroState?:boolean) => void;
   setPageWithEntity: (option: [], pageNumber: number, start: number, facets: any, searchString: string) => void;
-  setSortOrder: (propertyName: string, datatype, sortOrder) => void;
+  setSortOrder: (propertyName: string, sortOrder: any) => void;
 }
 
 export const SearchContext = React.createContext<ISearchContextInterface>({
@@ -196,6 +196,7 @@ const SearchProvider: React.FC<{ children: any }> = ({ children }) => {
       pageLength: searchOptions.pageSize,
       selectedQuery: 'select a query',
       selectedTableProperties: [],
+      sortOrder: []
     });
     setGreyedOptions({
       ...greyedOptions,
@@ -203,7 +204,8 @@ const SearchProvider: React.FC<{ children: any }> = ({ children }) => {
       pageNumber: 1,
       selectedFacets: {},
       entityTypeIds: entityOptions,
-      pageLength: greyedOptions.pageSize
+      pageLength: greyedOptions.pageSize,
+      sortOrder: []
     });
   }
 
@@ -476,28 +478,25 @@ const SearchProvider: React.FC<{ children: any }> = ({ children }) => {
         });
     }
 
-  const setSortOrder = (propertyName: string, datatype, sortOrder: string) => {
+  const setSortOrder = (propertyName: string, sortOrder: any) => {
     let sortingOrder: any = [];
     switch (sortOrder) {
       case 'ascend':
         sortingOrder = [{
           propertyName: propertyName,
-          sortDirection: "ascending"
+          sortDirection: 'ascending'
         }];
         break;
       case 'descend':
         sortingOrder = [{
           propertyName: propertyName,
-          sortDirection: "descending"
+          sortDirection: 'descending'
         }];
         break;
       default:
-        sortingOrder = [{
-          propertyName: propertyName
-        }];
+        sortingOrder = [];
         break;
     }
-
     setSearchOptions({
       ...searchOptions,
       sortOrder: sortingOrder

--- a/marklogic-data-hub-central/ui/src/util/user-context.tsx
+++ b/marklogic-data-hub-central/ui/src/util/user-context.tsx
@@ -171,7 +171,7 @@ const UserProvider: React.FC<{ children: any }> = ({children}) => {
       case 405:
       case 408:
       case 414: {
-        console.log('HTTP ERROR', error.resonse);
+        console.log('HTTP ERROR', error.response);
         let title = error.response.status + ' ' + error.response.statusText;
         let message = DEFAULT_MESSAGE;
 


### PR DESCRIPTION
### Description

- Also Includes https://project.marklogic.com/jira/browse/DHFPROD-5689

- Added an additional role for numeric slider e2e tests to pass

- Previously loadCustomersJSON name facet was shown on the sidebar under name entity properties but it seems to be a bug and loadCustomersJSON has been removed from the facets as part of https://project.marklogic.com/jira/browse/DHFPROD-5018, unfortunately most e2e tests are written based on loadCustomersJSON facet, Addressed all those issues in this PR

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

