### PR TITLE
DHFPROD-5638: Download and clear-user-data roles are now limited

### DIFF
--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-custom-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-custom-writer.json
@@ -1,4 +1,14 @@
 {
   "role-name": "data-hub-custom-writer",
-  "description": "Permits writing a custom step"
+  "description": "Permits writing a custom step",
+  "role": [
+    "data-hub-custom-reader"
+  ],
+  "privilege": [
+    {
+      "privilege-name": "data-hub-write-custom",
+      "action": "http://marklogic.com/data-hub/privileges/write-custom",
+      "kind": "execute"
+    }
+  ]
 }

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-developer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-developer.json
@@ -6,15 +6,15 @@
     "manage-user",
     "ps-user",
     "tde-admin",
-    "data-hub-module-writer",
-    "data-hub-flow-writer",
-    "data-hub-mapping-writer",
-    "data-hub-step-definition-writer",
+    "data-hub-custom-writer",
     "data-hub-entity-model-writer",
-    "data-hub-match-merge-writer",
+    "data-hub-flow-writer",
     "data-hub-ingestion-writer",
-    "data-hub-saved-query-user",
-    "data-hub-custom-writer"
+    "data-hub-mapping-writer",
+    "data-hub-match-merge-writer",
+    "data-hub-module-writer",
+    "data-hub-step-definition-writer",
+    "data-hub-saved-query-user"
   ],
   "privilege": [
     {
@@ -30,11 +30,6 @@
     {
       "privilege-name": "data-hub-download-project-files",
       "action": "http://marklogic.com/data-hub/privileges/download-project-files",
-      "kind": "execute"
-    },
-    {
-      "privilege-name": "data-hub-write-custom",
-      "action": "http://marklogic.com/data-hub/privileges/write-custom",
       "kind": "execute"
     },
     {

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-ingestion-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-ingestion-writer.json
@@ -3,6 +3,7 @@
   "description": "Permits writing an ingestion step",
   "role": [
     "data-hub-step-definition-reader",
+    "data-hub-ingestion-reader",
     "data-hub-common-writer"
   ],
   "privilege": [

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-mapping-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-mapping-writer.json
@@ -3,6 +3,7 @@
   "description": "Permits updating mapping documents",
   "role": [
     "data-hub-common-writer",
+    "data-hub-mapping-reader",
     "data-hub-step-definition-reader"
   ],
   "privilege": [

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-match-merge-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-match-merge-writer.json
@@ -1,4 +1,8 @@
 {
   "role-name": "data-hub-match-merge-writer",
-  "description": "Permits writing a matching or merging configuration"
+  "description": "Permits writing a matching or merging configuration",
+  "role": [
+    "data-hub-common-writer",
+    "data-hub-match-merge-reader"
+  ]
 }

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-clear-user-data.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-clear-user-data.json
@@ -1,14 +1,17 @@
 {
   "role-name": "hub-central-clear-user-data",
-  "description": "This temporarily inherits data-hub-developer so it has the necessary privileges to use Data Hub and to insert artifacts. Will rework this once the new 5.3.0 roles are available.",
+  "description": "Permits clearing user data via Hub Central",
   "role": [
+    "data-hub-custom-writer",
+    "data-hub-entity-model-writer",
+    "data-hub-flow-writer",
+    "data-hub-ingestion-writer",
+    "data-hub-mapping-writer",
+    "data-hub-match-merge-writer",
+    "data-hub-operator",
+    "data-hub-step-definition-writer",
     "hub-central-user",
-    "data-hub-developer",
-    "data-hub-entity-model-reader",
-    "data-hub-flow-reader",
-    "data-hub-ingestion-reader",
-    "data-hub-mapping-reader",
-    "data-hub-match-merge-reader",
-    "data-hub-step-definition-reader"
+    "manage-user",
+    "tde-admin"
   ]
 }

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-downloader.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-downloader.json
@@ -1,9 +1,8 @@
 {
   "role-name": "hub-central-downloader",
-  "description": "This temporarily inherits data-hub-operator so it has the necessary privileges to use Data Hub. Will rework this once the new 5.3.0 roles are available.",
+  "description": "Permits downloading user configuration files in Hub Central",
   "role": [
     "hub-central-user",
-    "data-hub-operator",
     "data-hub-entity-model-reader",
     "data-hub-flow-reader",
     "data-hub-ingestion-reader",


### PR DESCRIPTION
The download role didn't need data-hub-operator, and the tests for it still ran fine.

The clear-user-data role just needed to swap out data-hub-developer for the individual writer roles. It already had the granular privileges needed for clearing databases. 

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

