### PR TITLE
DHFPROD-5626: Fix for facet-values APIs

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/entitySearch/getMatchingPropertyValues.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/entitySearch/getMatchingPropertyValues.sjs
@@ -70,8 +70,8 @@ if(referenceType === 'element') {
 } else if(referenceType === 'collection') {
   query = cts.collectionReference();
 } else {
-  let rangeIndexPath = lib.getPropertyRangePath(entityTypeId, propertyPath);
-  query = cts.pathReference(rangeIndexPath);
+  const result = lib.buildPathReferenceParts(entityTypeId, propertyPath);
+  query = cts.pathReference(result.pathExpression, null, result.namespaces);
 }
 
 var facetValues = cts.valueMatch(query, pattern + "*",

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/entitySearch/getMinAndMaxPropertyValues.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/entitySearch/getMinAndMaxPropertyValues.sjs
@@ -55,8 +55,8 @@ if(!referenceType || referenceType === "") {
 if(referenceType === 'element') {
   query = cts.elementReference(propertyPath);
 } else {
-  let rangeIndexPath = lib.getPropertyRangePath(entityTypeId, propertyPath);
-  query = cts.pathReference(rangeIndexPath);
+  const result = lib.buildPathReferenceParts(entityTypeId, propertyPath);
+  query = cts.pathReference(result.pathExpression, null, result.namespaces);
 }
 
 rangeValues.min = cts.min(query);

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -438,16 +438,7 @@ public class HubTestBase extends AbstractHubTest implements InitializingBean {
         if (isSslRun() || isCertAuth()) {
             certInit();
         }
-        adminHubConfig.setMlUsername(user);
-        adminHubConfig.setMlPassword(password);
-
-        // Turning off CMA for resources that have bugs in ML 9.0-7/8
-        adminHubConfig.getAppConfig().getCmaConfig().setCombineRequests(false);
-        adminHubConfig.getAppConfig().getCmaConfig().setDeployDatabases(false);
-        adminHubConfig.getAppConfig().getCmaConfig().setDeployRoles(false);
-        adminHubConfig.getAppConfig().getCmaConfig().setDeployUsers(false);
-
-        return adminHubConfig;
+        return runAsFlowDeveloper();
     }
 
     protected HubConfigImpl runAsFlowOperator() {
@@ -471,7 +462,7 @@ public class HubTestBase extends AbstractHubTest implements InitializingBean {
             return super.runAsDataHubDeveloper();
         }
         logger.warn("ML version is not compatible with 5.2.0 roles, so will run as flow-developer instead of data-hub-developer");
-        return getDataHubAdminConfig();
+        return runAsFlowDeveloper();
     }
 
     @Override
@@ -519,6 +510,13 @@ public class HubTestBase extends AbstractHubTest implements InitializingBean {
         }
         // Re-initializes the Manage API connection
         manageClient.setManageConfig(manageConfig);
+
+        // Turning off CMA for resources that have bugs in ML 9.0-7/8
+        adminHubConfig.getAppConfig().getCmaConfig().setCombineRequests(false);
+        adminHubConfig.getAppConfig().getCmaConfig().setDeployDatabases(false);
+        adminHubConfig.getAppConfig().getCmaConfig().setDeployRoles(false);
+        adminHubConfig.getAppConfig().getCmaConfig().setDeployUsers(false);
+
         return adminHubConfig;
     }
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/entity/GenerateProtectedPathsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/entity/GenerateProtectedPathsTest.java
@@ -2,10 +2,8 @@ package com.marklogic.hub.entity;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.marklogic.appdeployer.AppConfig;
 import com.marklogic.appdeployer.command.CommandContext;
 import com.marklogic.appdeployer.command.security.DeployProtectedPathsCommand;
-import com.marklogic.appdeployer.command.security.DeployQueryRolesetsCommand;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
@@ -13,6 +11,7 @@ import com.marklogic.client.io.StringHandle;
 import com.marklogic.hub.AbstractHubCoreTest;
 import com.marklogic.hub.HubClient;
 import com.marklogic.hub.HubConfig;
+import com.marklogic.hub.dhs.installer.deploy.DeployHubQueryRolesetsCommand;
 import com.marklogic.hub.impl.EntityManagerImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -108,16 +107,9 @@ public class GenerateProtectedPathsTest extends AbstractHubCoreTest {
     }
 
     private void deployProtectedPathsAndQueryRolesets() {
-        AppConfig appConfig = getHubConfig().getAppConfig();
         CommandContext context = newCommandContext();
-        boolean originalCmaSetting = appConfig.getCmaConfig().isCombineRequests();
-        try {
-            appConfig.getCmaConfig().setCombineRequests(false);
-            new DeployQueryRolesetsCommand().execute(context);
-            new DeployProtectedPathsCommand().execute(context);
-        } finally {
-            appConfig.getCmaConfig().setCombineRequests(originalCmaSetting);
-        }
+        new DeployHubQueryRolesetsCommand().execute(context);
+        new DeployProtectedPathsCommand().execute(context);
     }
 
     private void insertJsonEntity() {

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-es/test-data/entities/EntitiesSearchEntity.entity.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-es/test-data/entities/EntitiesSearchEntity.entity.json
@@ -63,6 +63,19 @@
         }
       }
     },
+    "NamespacedEntity": {
+      "rangeIndex": [
+        "namespacedProperty"
+      ],
+      "namespace": "org:example",
+      "namespacePrefix": "oex",
+      "properties": {
+        "namespacedProperty": {
+          "datatype": "string",
+          "collation": "http://marklogic.com/collation/codepoint"
+        }
+      }
+    },
     "NumStringEntity": {
       "required": [],
       "pii": [],


### PR DESCRIPTION
### Description

The es namespace and entity def namespace are now included when calling cts.pathReference.

I am not convinced these are fully working yet - the cts.pathReference call may need the second argument populated to specify the correct datatype and collation. Going to do some more testing, but wanted to get this merged ASAP as it's breaking HC. 

Also fixing GenerateProtectedPathsTest on 9.0-11 - need to use DeployHubQueryRolesetsCommand, which ignores the bug in the Manage API that throws an error when updating a query roleset. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

