### PR TITLE
DHFPROD-5066: Change app title from 'React App' to 'MarkLogic Data Hu…

### DIFF
--- a/marklogic-data-hub-central/ui/public/index.html
+++ b/marklogic-data-hub-central/ui/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>MarkLogic Data Hub Central</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
…b Central'

### Description

- Short adjustment so browser tab no longer says 'React App' when loading, but says 'MarkLogic Data Hub Central' 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- N/A Added Tests
  

- ##### Reviewer:

- N/A Reviewed Tests

