### PR TITLE
DHFPROD-5684: Sort state names are now entity type-specific

### DIFF
--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/EntitySearchManager.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/EntitySearchManager.java
@@ -368,11 +368,20 @@ public class EntitySearchManager {
     protected void buildSearchTextWithSortOperator(SearchQuery searchQuery) {
         StringBuilder searchTextBuilder = new StringBuilder(searchQuery.getQuery().getSearchText());
         Optional<List<SearchQuery.SortOrder>> sortOrders = searchQuery.getSortOrder();
+
+        DocSearchQueryInfo docQuery = searchQuery.getQuery();
+        // When sorting on a property, it is assumed there's one and only one entity type selected. If no type is
+        // provided somehow, then a sort state name will be built, but it's not going to match anything and thus won't sort
+        final String entityName =
+            docQuery != null && docQuery.getEntityTypeIds() != null && !docQuery.getEntityTypeIds().isEmpty() ?
+            docQuery.getEntityTypeIds().get(0) : "";
+
         sortOrders.ifPresent(sortOrderList -> sortOrderList.forEach(sortOrder -> {
             String sortOperator = "sort";
-            String sortState = sortOrder.getPropertyName().concat(StringUtils.capitalize(sortOrder.getSortDirection()));
-            searchTextBuilder.append(" ").append(sortOperator).append(":").append(sortState);
+            String stateName = entityName + "_" + sortOrder.getPropertyName().concat(StringUtils.capitalize(sortOrder.getSortDirection()));
+            searchTextBuilder.append(" ").append(sortOperator).append(":").append(stateName);
         }));
+
         searchQuery.getQuery().setSearchText(searchTextBuilder.toString().trim());
     }
 

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/EntitySearchManagerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/EntitySearchManagerTest.java
@@ -148,22 +148,22 @@ public class EntitySearchManagerTest extends AbstractHubCentralTest {
         query.setSortOrder(sortOrderList);
 
         entitySearchManager.buildSearchTextWithSortOperator(query);
-        assertTrue("sort:customerIdAscending".equals(query.getQuery().getSearchText()));
+        assertEquals("sort:Customer_customerIdAscending", query.getQuery().getSearchText());
 
         query.getQuery().setSearchText("");
         sortOrderList.get(0).setSortDirection("descending");
         entitySearchManager.buildSearchTextWithSortOperator(query);
-        assertTrue("sort:customerIdDescending".equals(query.getQuery().getSearchText()));
+        assertEquals("sort:Customer_customerIdDescending", query.getQuery().getSearchText());
 
         query.getQuery().setSearchText("Jane");
         sortOrderList.get(0).setSortDirection("descending");
         entitySearchManager.buildSearchTextWithSortOperator(query);
-        assertTrue("Jane sort:customerIdDescending".equals(query.getQuery().getSearchText()));
+        assertEquals("Jane sort:Customer_customerIdDescending", query.getQuery().getSearchText());
 
         query.getQuery().setSearchText("Jane");
         sortOrderList.get(0).setSortDirection("someOtherValue");
         entitySearchManager.buildSearchTextWithSortOperator(query);
-        assertTrue("Jane sort:customerIdDescending".equals(query.getQuery().getSearchText()));
+        assertEquals("Jane sort:Customer_customerIdDescending", query.getQuery().getSearchText());
 
         query.getQuery().setSearchText("Jane");
         sortOrderList.get(0).setSortDirection("descending");
@@ -172,7 +172,14 @@ public class EntitySearchManagerTest extends AbstractHubCentralTest {
         sortOrder.setSortDirection("ascending");
         sortOrderList.add(sortOrder);
         entitySearchManager.buildSearchTextWithSortOperator(query);
-        assertTrue("Jane sort:customerIdDescending sort:customerIdAscending".equals(query.getQuery().getSearchText()));
+        assertEquals("Jane sort:Customer_customerIdDescending sort:Customer_customerIdAscending", query.getQuery().getSearchText());
+
+        info.setEntityTypeIds(null);
+        query.getQuery().setSearchText("Jane");
+        entitySearchManager.buildSearchTextWithSortOperator(query);
+        assertEquals("Jane sort:_customerIdDescending sort:_customerIdAscending", query.getQuery().getSearchText(),
+            "If there's somehow no entity type specified, then an error shouldn't be thrown; we should just have sort " +
+                "state names that don't correspond to actual states, which will result in no error but no sorting either");
     }
 
     /**

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-entities.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-entities.xqy
@@ -205,7 +205,11 @@ declare %private function hent:fix-options-for-explorer(
           $n/@*,
           let $path-expression := fix-path-expression(fn:string($n/search:range/search:path-index))
           let $search-range-node := $n/search:range
-          let $is-sortable-only := map:get($sortable-properties, $path-expression) = fn:true()
+          let $is-sortable-only :=
+            let $sort-info := map:get($sortable-properties, $path-expression)
+            return
+              if (fn:exists($sort-info)) then map:get($sort-info, "is-sortable-only") = fn:true()
+              else fn:false()
           return
             if (fn:empty($search-range-node) or fn:not($is-sortable-only)) then
               hent:fix-options-for-explorer($n/node(), $sortable-properties, $entity-namespace-map)
@@ -251,13 +255,13 @@ declare %private function hent:build-sort-operator(
 {
   let $states :=
     for $path-expression in map:keys($sortable-properties)
-    let $constraint-name :=
-      let $token := fn:tokenize($path-expression, "/")[last()]
-      return fn:tokenize($token, ":")[last()]
+    let $state-name-prefix :=
+      let $sort-info := map:get($sortable-properties, $path-expression)
+      return fn:concat(map:get($sort-info, "entity-title"), "_", map:get($sort-info, "property-name"))
 
     for $direction in ("ascending", "descending")
     return
-      <search:state name="{fn:concat($constraint-name, xdmp:initcap($direction))}">
+      <search:state name="{fn:concat($state-name-prefix, xdmp:initcap($direction))}">
         <search:sort-order direction="{$direction}">
           {
             element search:path-index {
@@ -655,8 +659,12 @@ declare %private function hent:add-indexes-for-entity-properties($entities as js
                     fn:concat("/(es:envelope|envelope)/(es:instance|instance)/", $entity-title, "/", $entity-type-property)
                 (: If something is only sortable, we need a path range index for it, but we need to ensure that a facet
                 is not configured for it :)
-                let $is-only-sortable := $is-sortable and fn:not($is-facetable)
-                return map:put($sortable-properties, $path-expression, $is-only-sortable)
+                let $sort-info := map:new((
+                  map:entry("is-sortable-only", $is-sortable and fn:not($is-facetable)),
+                  map:entry("entity-title", $entity-title),
+                  map:entry("property-name", $entity-type-property)
+                ))
+                return map:put($sortable-properties, $path-expression, $sort-info)
               else ()
 
             where $is-facetable or $is-sortable

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/generateSearchOptions.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/generateSearchOptions.sjs
@@ -166,7 +166,7 @@ function entityDefWithNamespace() {
 
   const expOptions = hent.dumpSearchOptions(input, true);
 
-  const pathNamespaces = expOptions.xpath("/*:operator/*:state[@name = 'ratingAscending']/*:sort-order/*:path-index/namespace::*").toArray();
+  const pathNamespaces = expOptions.xpath("/*:operator/*:state[@name = 'Book_ratingAscending']/*:sort-order/*:path-index/namespace::*").toArray();
   const bookNamespaceIndex = pathNamespaces.findIndex(val => val == "org:example");
   const authorNamespaceIndex = pathNamespaces.findIndex(val => val == "urn:author");
 
@@ -182,14 +182,14 @@ function entityDefWithNamespace() {
     test.assertEqual("false", xs.string(fn.head(expOptions.xpath("/*:constraint[contains(@name, 'rating')]/*:range/@facet"))),
       "A range constraint should exist for rating, but since it's only sortable and not facetable, facet should be 'false'"),
 
-    test.assertEqual("descending", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'ratingDescending']/*:sort-order/@direction")))),
-    test.assertEqual("/es:envelope/es:instance/oex:Book/oex:rating", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'ratingDescending']/*:sort-order/*:path-index")))),
-    test.assertEqual("ascending", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'ratingAscending']/*:sort-order/@direction")))),
-    test.assertEqual("/es:envelope/es:instance/oex:Book/oex:rating", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'ratingAscending']/*:sort-order/*:path-index")))),
+    test.assertEqual("descending", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'Book_ratingDescending']/*:sort-order/@direction")))),
+    test.assertEqual("/es:envelope/es:instance/oex:Book/oex:rating", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'Book_ratingDescending']/*:sort-order/*:path-index")))),
+    test.assertEqual("ascending", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'Book_ratingAscending']/*:sort-order/@direction")))),
+    test.assertEqual("/es:envelope/es:instance/oex:Book/oex:rating", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'Book_ratingAscending']/*:sort-order/*:path-index")))),
 
-    test.assertNotExists(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'titleAscending']"),
+    test.assertNotExists(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'Book_titleAscending']"),
       "title is not sortable, so there should not be a sort operator"),
-    test.assertNotExists(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'titleDescending']"))
+    test.assertNotExists(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'Book_titleDescending']"))
   ];
 }
 
@@ -214,21 +214,61 @@ function verifySortOperatorsForSortableProperties() {
   const expOptions = hent.dumpSearchOptions(input, true);
   return [
     test.assertEqual("sort", xs.string(fn.head(expOptions.xpath("/*:operator/@name")))),
-    test.assertExists(expOptions.xpath("/*:operator/*:state[@name = 'titleDescending']")),
-    test.assertEqual("descending", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'titleDescending']/*:sort-order/@direction")))),
-    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/title", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'titleDescending']/*:sort-order/*:path-index")))),
-    test.assertExists(expOptions.xpath("/*:operator/*:state[@name = 'titleAscending']")),
-    test.assertEqual("ascending", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'titleAscending']/*:sort-order/@direction")))),
-    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/title", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'titleAscending']/*:sort-order/*:path-index")))),
-    test.assertExists(expOptions.xpath("/*:operator/*:state[@name = 'authorsDescending']")),
-    test.assertEqual("descending", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'authorsDescending']/*:sort-order/@direction")))),
-    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/authors", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'authorsDescending']/*:sort-order/*:path-index")))),
-    test.assertExists(expOptions.xpath("/*:operator/*:state[@name = 'authorsAscending']")),
-    test.assertEqual("ascending", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'authorsAscending']/*:sort-order/@direction")))),
-    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/authors", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'authorsAscending']/*:sort-order/*:path-index")))),
+    test.assertExists(expOptions.xpath("/*:operator/*:state[@name = 'Book_titleDescending']")),
+    test.assertEqual("descending", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'Book_titleDescending']/*:sort-order/@direction")))),
+    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/title", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'Book_titleDescending']/*:sort-order/*:path-index")))),
+    test.assertExists(expOptions.xpath("/*:operator/*:state[@name = 'Book_titleAscending']")),
+    test.assertEqual("ascending", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'Book_titleAscending']/*:sort-order/@direction")))),
+    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/title", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'Book_titleAscending']/*:sort-order/*:path-index")))),
+    test.assertExists(expOptions.xpath("/*:operator/*:state[@name = 'Book_authorsDescending']")),
+    test.assertEqual("descending", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'Book_authorsDescending']/*:sort-order/@direction")))),
+    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/authors", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'Book_authorsDescending']/*:sort-order/*:path-index")))),
+    test.assertExists(expOptions.xpath("/*:operator/*:state[@name = 'Book_authorsAscending']")),
+    test.assertEqual("ascending", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'Book_authorsAscending']/*:sort-order/@direction")))),
+    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/authors", xs.string(fn.head(expOptions.xpath("/*:operator[@name = 'sort']/*:state[@name = 'Book_authorsAscending']/*:sort-order/*:path-index")))),
     test.assertNotExists(expOptions.xpath("/*:operator[@name = 'bookId']")),
     test.assertNotExists(expOptions.xpath("/*:operator[@name = 'completedDate']"))
   ];
+}
+
+function twoEntitiesHaveSameSortablePropertyName() {
+  const input = [
+    {
+      "info": {
+        "title": "Book"
+      },
+      "definitions": {
+        "Book": {
+          "properties": {
+            "title": {"datatype": "string", "sortable": true, "collation": "http://marklogic.com/collation/"}
+          }
+        }
+      }
+    },
+    {
+      "info": {
+        "title": "Author"
+      },
+      "definitions": {
+        "Author": {
+          "properties": {
+            "title": {"datatype": "string", "sortable": true, "collation": "http://marklogic.com/collation/"}
+          }
+        }
+      }
+    }
+  ];
+
+  const options = hent.dumpSearchOptions(input, true);
+  return [
+    test.assertExists(options.xpath("/*:operator/*:state[@name = 'Book_titleAscending']"),
+      "To ensure that state names are unique, the state name should begin with the entity name, an " +
+      "underscore, and then the property name. An underscore seems safe to use because it's more likely " +
+      "that a user would have a hyphen in an entity name as opposed to an underscore."),
+    test.assertExists(options.xpath("/*:operator/*:state[@name = 'Book_titleDescending']")),
+    test.assertExists(options.xpath("/*:operator/*:state[@name = 'Author_titleAscending']")),
+    test.assertExists(options.xpath("/*:operator/*:state[@name = 'Author_titleDescending']"))
+  ]
 }
 
 []
@@ -236,4 +276,5 @@ function verifySortOperatorsForSortableProperties() {
   .concat(generateOptionsWithElementRangeIndex())
   .concat(generateExplorerOptionsWithElementRangeIndex())
   .concat(generateExplorerWithFacetableAndSortableProperties())
+  .concat(twoEntitiesHaveSameSortablePropertyName())
   .concat(verifySortOperatorsForSortableProperties());


### PR DESCRIPTION
### Description

This avoids search API errors due to duplicate state names. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

