### PR TITLE
DHFPROD-5381: Upon refreshing the explorer page, the query name and description not persist

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.json.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.json.tsx
@@ -279,6 +279,17 @@ describe('json scenario for table on browse documents page', () => {
     browsePage.getGreySelectedFacets('mapCustomersJSON').should('exist');
     browsePage.getFacetApplyButton().click();
     browsePage.getTotalDocuments().should('be.equal', 2);
+
+    //Refresh the browser page at Browse table view.
+    cy.reload();
+
+    //Verify if the facet, search text and view persists.
+    browsePage.getSelectedEntity().should('contain', 'Customer');
+    browsePage.getClearFacetSearchSelection('mapCustomersJSON').should('exist');
+    browsePage.getSearchText().should('have.value', 'Adams Cole');
+    browsePage.getTableView().should('have.css', 'background-color', 'rgb(68, 73, 156)');
+
+    //Navigating to detail view
     browsePage.getTableViewSourceIcon().click();
     detailPage.getSourceView().click();
     detailPage.getDocumentJSON().should('exist');
@@ -286,8 +297,19 @@ describe('json scenario for table on browse documents page', () => {
     detailPage.getDocumentTimestamp().should('exist');
     detailPage.getDocumentSource().should('contain', 'loadCustomersJSON');
     detailPage.getDocumentFileType().should('contain', 'json');
+
+    //Refresh the browser page at Detail view.
+    cy.reload();
+
+    //Verify if the detail view is intact after page refresh
+    detailPage.getDocumentEntity().should('contain', 'Customer');
+    detailPage.getDocumentTimestamp().should('exist');
+    detailPage.getDocumentSource().should('contain', 'loadCustomersJSON');
+    detailPage.getDocumentFileType().should('contain', 'json');
+
+    cy.waitUntil(() => detailPage.clickBackButton()); //Click on Back button to navigate back to the browse table view.
+
     //Verify navigating back from detail view should persist search options
-    detailPage.clickBackButton();
     browsePage.getSelectedEntity().should('contain', 'Customer');
     browsePage.getClearFacetSearchSelection('mapCustomersJSON').should('exist');
     browsePage.getSearchText().should('have.value', 'Adams Cole');

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.queries.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.queries.tsx
@@ -62,6 +62,16 @@ describe('save/manage queries scenarios, developer role', () => {
         browsePage.waitForSpinnerToDisappear();
         browsePage.getTableCell(1, 2).should('contain','102');
         browsePage.getTableCell(2, 2).should('contain','103');
+
+        //Refresh the browser page.
+        cy.reload();
+
+        //Verify if the facets and other query related properties are intact after refreshing the browser page.
+        browsePage.waitForSpinnerToDisappear();
+        browsePage.getSelectedQuery().should('contain', 'new-query-2');
+        browsePage.getSelectedQueryDescription().should('contain', 'new-query-2 description');
+        browsePage.getTableCell(1, 2).should('contain','102');
+        browsePage.getTableCell(2, 2).should('contain','103');
     });
 
     it('save/saveAs/edit more queries with duplicate query name from browse and manage queries view', () => {

--- a/marklogic-data-hub-central/ui/src/components/queries/queries.tsx
+++ b/marklogic-data-hub-central/ui/src/components/queries/queries.tsx
@@ -16,12 +16,14 @@ import SaveChangesModal from "./saving/edit-save-query/save-changes-modal";
 import DiscardChangesModal from "./saving/discard-changes/discard-changes-modal";
 import { QueryOptions } from '../../types/query-types';
 import { MLButton, MLTooltip } from '@marklogic/design-system';
+import { getUserPreferences } from '../../services/user-preferences';
 
 
 
 const Query = (props) => {
 
     const {
+        user,
         handleError
     } = useContext(UserContext);
     const {
@@ -151,6 +153,10 @@ const Query = (props) => {
     }, [searchOptions.entityTypeIds]);
 
     useEffect(() => {
+        initializeUserPreferences();
+    },[])
+
+    useEffect(() => {
             if(!entityCancelClicked && searchOptions.nextEntityType !== searchOptions.entityTypeIds[0]) {
                 // TO CHECK IF THERE HAS BEEN A CANCEL CLICKED WHILE CHANGING ENTITY
                 if (isSaveQueryChanged() && !searchOptions.zeroState) {
@@ -162,6 +168,20 @@ const Query = (props) => {
                 toggleEntityCancelClicked(false); // RESETTING THE STATE TO FALSE
             }
     }, [searchOptions.nextEntityType]);
+
+    const initializeUserPreferences = async () => {
+
+        let defaultPreferences = getUserPreferences(user.name);
+        if (defaultPreferences !== null) {
+            let parsedPreferences = JSON.parse(defaultPreferences);
+            if (parsedPreferences.selectedQuery !== 'select a query' && JSON.stringify(parsedPreferences) !== JSON.stringify([])) {
+                let queryObject = parsedPreferences.queries.find(obj => parsedPreferences.selectedQuery === obj.savedQuery?.name);
+                if (queryObject?.savedQuery && queryObject.savedQuery.hasOwnProperty('description') && queryObject.savedQuery.description) {
+                     setCurrentQueryDescription(queryObject?.savedQuery.description);
+                }
+            }
+        }
+    }
 
     // Switching between entity confirmation modal buttons
     const onCancel = () => {

--- a/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.tsx
+++ b/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.tsx
@@ -231,7 +231,8 @@ const ResultsTabularView = (props) => {
                         start: searchOptions.start,
                         searchFacets: searchOptions.selectedFacets,
                         query: searchOptions.query,
-                        tableView: props.tableView
+                        tableView: props.tableView,
+                        sortOrder: searchOptions.sortOrder
                     }
                 }} id={'instance'}
                     data-cy='instance'>
@@ -246,7 +247,8 @@ const ResultsTabularView = (props) => {
                         start: searchOptions.start,
                         searchFacets: searchOptions.selectedFacets,
                         query: searchOptions.query,
-                        tableView: props.tableView
+                        tableView: props.tableView,
+                        sortOrder: searchOptions.sortOrder
                     }
                 }} id={'source'}
                     data-cy='source'>

--- a/marklogic-data-hub-central/ui/src/components/search-result/search-result.tsx
+++ b/marklogic-data-hub-central/ui/src/components/search-result/search-result.tsx
@@ -126,7 +126,8 @@ const SearchResult: React.FC<Props> = (props) => {
                             start : searchOptions.start,
                             searchFacets : searchOptions.selectedFacets,
                             query: searchOptions.query,
-                            tableView: props.tableView
+                            tableView: props.tableView,
+                            sortOrder: searchOptions.sortOrder
                         }}} id={'instance'} data-cy='instance' >
                         <MLTooltip title={'Show the processed data'}><FontAwesomeIcon  icon={faExternalLinkAlt} size="sm" data-testid='instance-icon'/></MLTooltip>
                     </Link>

--- a/marklogic-data-hub-central/ui/src/components/tiles/toolbar.tsx
+++ b/marklogic-data-hub-central/ui/src/components/tiles/toolbar.tsx
@@ -43,7 +43,11 @@ const Toolbar: React.FC<Props> = (props) => {
                 if (tiles[id]['iconType'] === 'custom') {
                     return (
                         props.enabled && props.enabled.includes(id) ?
-                            <Link to={'/tiles/' + id} aria-label={'tool-' + id + '-link'} key={i}>
+                            <Link to={
+                                {pathname: `/tiles/${id}`,
+                                state: {
+                                    tileIconClicked : true
+                                }}} aria-label={'tool-' + id + '-link'} key={i}>
                                 <MLTooltip title={getTooltip(id)} placement="leftTop" key={i}>
                                     <div
                                         className={tiles[id]['icon']}

--- a/marklogic-data-hub-central/ui/src/util/search-context.tsx
+++ b/marklogic-data-hub-central/ui/src/util/search-context.tsx
@@ -71,8 +71,9 @@ interface ISearchContextInterface {
   setManageQueryModal: (visibility: boolean) => void;
   setSelectedTableProperties: (propertiesToDisplay: string[]) => void;
   setView: (viewId: JSX.Element| null, zeroState?:boolean) => void;
-  setPageWithEntity: (option: [], pageNumber: number, start: number, facets: any, searchString: string) => void;
+  setPageWithEntity: (option: [], pageNumber: number, start: number, facets: any, searchString: string, sortOrder: []) => void;
   setSortOrder: (propertyName: string, sortOrder: any) => void;
+  setPageQueryOptions: (query: any) => void;
 }
 
 export const SearchContext = React.createContext<ISearchContextInterface>({
@@ -106,7 +107,8 @@ export const SearchContext = React.createContext<ISearchContextInterface>({
   setSelectedTableProperties: () => { },
   setView: () => { },
   setPageWithEntity: () => { },
-  setSortOrder: () => { }
+  setSortOrder: () => { },
+  setPageQueryOptions: () => { }
 });
 
 const SearchProvider: React.FC<{ children: any }> = ({ children }) => {
@@ -466,7 +468,7 @@ const SearchProvider: React.FC<{ children: any }> = ({ children }) => {
         });
     }
 
-    const setPageWithEntity = (option: [], pageNumber: number, start : number, facets: any, searchString: string  ) => {
+    const setPageWithEntity = (option: [], pageNumber: number, start : number, facets: any, searchString: string, sortOrder: []  ) => {
       setSearchOptions({
             ...searchOptions,
            entityTypeIds: option,
@@ -474,6 +476,7 @@ const SearchProvider: React.FC<{ children: any }> = ({ children }) => {
            query: searchString,
            start: start,
            pageNumber : pageNumber,
+           sortOrder: sortOrder,
            zeroState: false
         });
     }
@@ -503,6 +506,23 @@ const SearchProvider: React.FC<{ children: any }> = ({ children }) => {
     });
   }
 
+  const setPageQueryOptions = (query: any) => {
+    setSearchOptions({
+      ...searchOptions,
+      start: query.start || 1,
+      selectedFacets: query.selectedFacets,
+      query: query.searchText,
+      entityTypeIds: query.entityTypeIds,
+      nextEntityType: query.entityTypeIds[0],
+      pageNumber: query.pageNumber || 1,
+      pageLength: searchOptions.pageSize,
+      selectedQuery: query.selectedQuery,
+      selectedTableProperties: query.propertiesToDisplay,
+      zeroState: query.zeroState,
+      manageQueryModal: query.manageQueryModal,
+      sortOrder: query.sortOrder
+    });
+  }
     useEffect(() => {
     if (user.authenticated) {
       setSearchFromUserPref(user.name);
@@ -541,7 +561,8 @@ const SearchProvider: React.FC<{ children: any }> = ({ children }) => {
       setSelectedTableProperties,
       setView,
       setPageWithEntity,
-      setSortOrder
+      setSortOrder,
+      setPageQueryOptions
     }}>
       {children}
     </SearchContext.Provider>


### PR DESCRIPTION
### Description
This PR resolves the bug DHFPROD-5381 and also adds user preferences in explorer.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

