### PR TITLE
DHFPROD-5359: Incorrect XPATH is generated when Mapping XML documents

### DIFF
--- a/marklogic-data-hub-central/ui/src/assets/mock-data/common.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/common.data.ts
@@ -157,7 +157,7 @@ const xmlSourceData = [
       ]
       },
       { rowKey: 7, key: 'proteinCat', val: 'commercial' },
-      { rowKey: 8, key: 'proteinDog', val: 'retriever, , golden, labrador', array: true}
+      { rowKey: 8, key: 'nutFree:proteinDog', val: 'retriever, , golden, labrador', array: true}
     ]
   }
 ];

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
@@ -370,9 +370,10 @@ const MappingCard: React.FC<Props> = (props) => {
                     if (val[0].constructor.name === "String") {
                             let stringValues = val.join(', ')
                             sourceTableKeyIndex = sourceTableKeyIndex + 1;
+                            let finalKey = !/^@/.test(key) ? getNamespace(key, val, parentNamespace) : key;
                             let propty = {
                                 rowKey: sourceTableKeyIndex,
-                                key: key,
+                                key: finalKey,
                                 val: stringValues,
                                 array: true
                             };
@@ -405,7 +406,6 @@ const MappingCard: React.FC<Props> = (props) => {
                             key: finalKey,
                             val: String(val)
                         };
-
                         nestedDoc.push(propty);
                     }
                 }
@@ -420,7 +420,6 @@ const MappingCard: React.FC<Props> = (props) => {
                         key: finalKey,
                         val: ""
                     };
-
                     nestedDoc.push(propty);
                 }
             }

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
@@ -644,7 +644,7 @@ describe('RTL Source-to-entity map tests', () => {
 
     test('CollapseAll/Expand All feature in XML Source data table', () => {
 
-        const { getByTestId, getByText, queryByText } = render(<SourceToEntityMap {...data.mapProps}
+        const { getByTestId, getByText, getAllByText, queryByText } = render(<SourceToEntityMap {...data.mapProps}
             mappingVisible={true}
             sourceData={data.xmlSourceData}
         />);
@@ -652,7 +652,8 @@ describe('RTL Source-to-entity map tests', () => {
         //Check if the expected elements are present in the DOM before hittting the Expand/Collapse button
         expect(queryByText('FirstNamePreferred')).not.toBeInTheDocument();
         expect(queryByText('LastName')).not.toBeInTheDocument();
-        let nutFree = getByText(/nutFree/);
+        let nutFree = getAllByText(/nutFree/);
+        expect(nutFree.length).toEqual(2);
         expect(getByText('@proteinType')).toBeInTheDocument();
         expect(getByText('proteinId')).toBeInTheDocument();
 
@@ -799,9 +800,9 @@ describe('Enzyme Source-to-entity map tests', () => {
         expect(getByText('123EAC')).toBeInTheDocument();
         expect(getByText('@proteinType')).toBeInTheDocument();
         expect(getByText('home')).toBeInTheDocument();
-        expect(getByText(/nutFree:/)).toBeInTheDocument();
+        expect(getAllByText(/nutFree:/)).toHaveLength(2);
         expect(getByText('FirstNamePreferred')).toBeInTheDocument();
-        expect(getByTestId('proteinDog-srcValue')).toHaveTextContent('retriever (2 more)');
+        expect(getByTestId('nutFree:proteinDog-srcValue')).toHaveTextContent('retriever (2 more)');
         fireEvent.mouseOver(getByText('(2 more)'));
         await waitForElement(() => getByText('retriever, , golden, labrador'));
     });
@@ -993,10 +994,10 @@ describe('RTL Source Selector/Source Search tests', () => {
         expect(getByTestId('sampleProtein-optionIcon')).toHaveAttribute('src', 'icon_array.png')
 
         //Verify Array icon is present when item has no children but value was an Array of simple values.
-        expect(getByTestId('proteinDog-optionIcon')).toHaveAttribute('src', 'icon_array.png')
+        expect(getByTestId('nutFree:proteinDog-optionIcon')).toHaveAttribute('src', 'icon_array.png')
 
         //Verify option in source dropdown only appears once when value is an Array of simple values.
-        let proteinDog = (getAllByTestId('proteinDog-option'));
+        let proteinDog = (getAllByTestId('nutFree:proteinDog-option'));
         expect(proteinDog.length).toEqual(1);
 
         //Verify option representing object in source dropdown only appears once when value is an array of Objects.
@@ -1016,6 +1017,16 @@ describe('RTL Source Selector/Source Search tests', () => {
         let mapExp = getByTestId("itemTypes-mapexpression");
         //Right Xpath is populated
         expect(mapExp).toHaveTextContent("sampleProtein/nutFree:name/LastName");
+
+        //Right Xpath population for namespaced option representing array of values
+        sourceSelector = getByTestId("items-listIcon");
+        fireEvent.click(sourceSelector);
+        await(waitForElement(() =>  getAllByRole("option"),{"timeout":200}))
+        let proteinDogOption = (getAllByTestId('nutFree:proteinDog-option'));
+        expect(proteinDogOption.length).toEqual(2);
+        fireEvent.click(proteinDogOption[1]);
+        mapExp = getByTestId("items-mapexpression");
+        expect(mapExp).toHaveTextContent("sampleProtein/nutFree:proteinDog");
 
     });
 

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
@@ -10,7 +10,6 @@ import { getMappingValidationResp } from "../../../../util/manageArtifacts-servi
 import DropDownWithSearch from "../../../common/dropdown-with-search/dropdownWithSearch";
 import SplitPane from 'react-split-pane';
 import Highlighter from 'react-highlight-words';
-import ColumnGroup from "antd/lib/table/ColumnGroup";
 import { MLButton, MLTooltip, MLCheckbox } from '@marklogic/design-system';
 
 


### PR DESCRIPTION
### Description
- Fix to XML source data format when there is a Namespace and the property is an array of values, causing invalid XPATH.
   (should be 'custOrderInfo: nicknames' instead of 'nicknames')

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

