### PR TITLE
DHFPROD-5638: Updates to e2e project, setup scripts and custom command for loginAsD…

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/fixtures/users/developer.json
+++ b/marklogic-data-hub-central/ui/e2e/cypress/fixtures/users/developer.json
@@ -1,8 +1,10 @@
 {
     "user-name": "hc-developer",
-    "description": "A hub central developer user",
+    "description": "A user with hub-central-developer, data-hub-developer and data-hub-security-admin to run hubDeploy and hubDeployAsDeveloper tasks",
     "password": "password",
     "role": [
-      "hub-central-developer"
+      "hub-central-developer",
+      "data-hub-developer",
+      "data-hub-security-admin"
     ]
 }

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/commands.js
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/commands.js
@@ -83,7 +83,8 @@ Cypress.Commands.add('withRequest', { prevSubject: 'optional'}, (subject) => {
 })
 
 Cypress.Commands.add('loginAsDeveloper', () => {
-  return cy.fixture('users/developer')
+  setTestUserRoles(["hub-central-developer"])
+  return cy.fixture('users/hub-user')
 })
 
 Cypress.Commands.add("loginAsOperator", () => {

--- a/marklogic-data-hub-central/ui/e2e/setup.sh
+++ b/marklogic-data-hub-central/ui/e2e/setup.sh
@@ -18,15 +18,11 @@ if $DHS
 then
         env=dhs
         perl -i -pe"s/mlHost=/mlHost=$mlHost/g" gradle-dhs.properties
-        ./gradlew hubSaveIndexes -PenvironmentName=$env --info --stacktrace
-        ./gradlew hubGeneratePII -PenvironmentName=$env --info --stacktrace
         ./gradlew hubDeployAsDeveloper -PenvironmentName=$env --info --stacktrace
 else
         cp ../cypress/fixtures/users/* src/main/ml-config/security/users/
 
         ./gradlew mlDeploy -PmlUsername=admin -PmlPassword=admin --info --stacktrace
-        ./gradlew hubSaveIndexes --info --stacktrace
-        ./gradlew hubGeneratePII --info --stacktrace
         ./gradlew hubDeployAsDeveloper --info --stacktrace
 fi
 


### PR DESCRIPTION
…eveloper

updated developer.json to include dh-developer and dh-sec-admin so hubDeployAsDeveloper, hubDeploy and hubDeployAsSecurityAdmin deploy tasks can be run in the future.
updated commands.js so loginAsDeveloper now sets test user with hc-developer role.
updated setup.sh script, since hubDeployAsDeveloper now runs hubSaveIndexes and hubGeneratePii
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

