### PR TITLE
DHFPROD-5312: Make a (tile height + footer) fit into 100% of the page…

### DIFF
--- a/marklogic-data-hub-central/ui/src/App.scss
+++ b/marklogic-data-hub-central/ui/src/App.scss
@@ -17,7 +17,7 @@ body {
   position: relative;
   margin-right: 70px;
   overflow-y: auto;
-  height: 100vh;
+  height: 90vh;
   max-height: 92vh;
 }
 
@@ -44,7 +44,7 @@ main {
 .ant-layout-footer {
   display: flex;
   justify-content: center;
-  padding: 30px 0;
+  padding: 50px 0 0 0;
   margin: 0;
   background-color: transparent;
 }

--- a/marklogic-data-hub-central/ui/src/App.tsx
+++ b/marklogic-data-hub-central/ui/src/App.tsx
@@ -121,8 +121,8 @@ const App: React.FC<Props> = ({history, location}) => {
               </PrivateRoute>
               <Route component={NoMatchRedirect}/>
             </Switch>
-              <Footer pageTheme={pageTheme}/>
             </div>
+            <Footer pageTheme={pageTheme}/>
           </main>
         </ModelingProvider>
       </SearchProvider>

--- a/marklogic-data-hub-central/ui/src/pages/Overview.module.scss
+++ b/marklogic-data-hub-central/ui/src/pages/Overview.module.scss
@@ -6,7 +6,7 @@
 }
 
 .overviewContainer {
-    line-height: 1.7;
+    line-height: 1.4;
     color: #333;
     background: #fff;
     margin: 20px 70px 20px 40px;


### PR DESCRIPTION
… to avoid activating page scrollbar

### Description
- Adjusted footer to default fit into same view as tile without scrolling
- CSS adjustments to remove "second" scrollbar appearing outside tiles
- No tests needed for css refactoring.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- N/A Added Tests
  

- ##### Reviewer:

- N/A Reviewed Tests

