### PR TITLE
DHFPROD-5391: Improper position of spinner in explorer tile results view

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/facet/facet.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/facet/facet.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-
 import Facet from './facet';
 import { facetValues } from '../../assets/mock-data/entity-table';
 
@@ -72,4 +71,30 @@ describe("Facet component", () => {
     expect(getByText(/CustomerType/i)).toBeInTheDocument();
     expect(getByText(/999/i)).toBeInTheDocument();
   });
+
+  it("Collapse/Expand carets render properly for facet properties" , () => {
+    const { getByTestId } = render(
+        <Facet
+          name="sales_region"
+          constraint="sales_region"
+          facetValues={facetValues}
+          key=""
+          tooltip=""
+          facetType="xs:string"
+          facetCategory="entity"
+          updateSelectedFacets={jest.fn()}
+          addFacetValues={jest.fn()}
+          referenceType="element"
+          entityTypeId=""
+          propertyPath="sales_region"
+        />
+    )
+
+    expect(getByTestId('sales_region-toggle')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid=sales_region-toggle] i svg')).toBeInTheDocument();
+    expect(document.querySelector('[data-testid=sales_region-toggle] i svg')).not.toHaveStyle('transform: rotate(180deg);');
+    fireEvent.click(getByTestId('sales_region-toggle')); 
+    expect(document.querySelector('[data-testid=sales_region-toggle] i svg')).toHaveStyle('transform: rotate(180deg);');
+  });
+
 });

--- a/marklogic-data-hub-central/ui/src/components/facet/facet.tsx
+++ b/marklogic-data-hub-central/ui/src/components/facet/facet.tsx
@@ -184,8 +184,8 @@ const Facet: React.FC<Props> = (props) => {
             data-cy={stringConverter(props.name) + "-clear"}
           >Clear
           </div>
-          <div className={styles.toggle} onClick={() => toggleShow(!show)}>
-            <Icon style={{fontSize: '12px'}} type='down' rotate={show ? 180 : undefined}/>
+          <div className={styles.toggle} onClick={() => toggleShow(!show)} data-testid={stringConverter(props.name) + "-toggle"}>
+            <Icon style={{fontSize: '12px'}} type='down' rotate={show ? 0 : 180} />
           </div>
         </div>
       </div>

--- a/marklogic-data-hub-central/ui/src/components/sidebar/sidebar.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/sidebar/sidebar.test.tsx
@@ -1,50 +1,48 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 import Sidebar from './sidebar';
 import { entityFromJSON, entityParser } from '../../util/data-conversion';
 import modelResponse from '../../assets/mock-data/model-response';
 import searchPayloadFacets from '../../assets/mock-data/search-payload-facets';
+import { render, fireEvent } from '@testing-library/react';
+
 
 describe("Sidebar component", () => {
-    let wrapper;
-    const parsedModelData = entityFromJSON(modelResponse);
-    const entityDefArray = entityParser(parsedModelData);
+  const parsedModelData = entityFromJSON(modelResponse);
+  const entityDefArray = entityParser(parsedModelData);
 
-    describe('All Entities Dropdown Option', () => {
-      beforeEach(() => {
-        wrapper = shallow(
-          <Sidebar
-            entityDefArray={entityDefArray}
-            facets={searchPayloadFacets}
-            selectedEntities={[]}
-            facetRender = {jest.fn()}
-            checkFacetRender = {jest.fn()}
-          />
-        )
-      });
+  it("Collapse/Expand carets render properly for hub properties", () => {
+    const { getByTestId } = render(
+      <Sidebar
+        entityDefArray={entityDefArray}
+        facets={searchPayloadFacets}
+        selectedEntities={[]}
+        facetRender={jest.fn()}
+        checkFacetRender={jest.fn()}
+      />
+    )
+    expect(document.querySelector('#hub-properties [data-icon=down]')).toBeInTheDocument();
+    expect(document.querySelector('#hub-properties [data-icon=down]')).not.toHaveStyle('transform: rotate(180deg);');
+    fireEvent.click(getByTestId('toggle'));
+    expect(document.querySelector('#hub-properties [data-icon=down]')).toHaveStyle('transform: rotate(180deg);');
+  });
 
-      it('should render only Hub Properties Panel', () => {
-        expect(wrapper.exists('#hub-properties')).toBe(true);
-        expect(wrapper.exists('#entity-properties')).toBe(false);
-      });
-    });
-
-    describe('An Entity is selected', () => {
-      beforeEach(() => {
-        wrapper = shallow(
-          <Sidebar
-            entityDefArray={entityDefArray}
-            facets={searchPayloadFacets}
-            selectedEntities={['Customer']}
-            facetRender = {jest.fn()}
-            checkFacetRender = {jest.fn()}
-          />
-        )
-      });
-
-      it('should render both Entity and Hub Properties panel', () => {
-        expect(wrapper.exists('#hub-properties')).toBe(true);
-        expect(wrapper.exists('#entity-properties')).toBe(true);
-      });
-    });
+  it("Collapse/Expand carets render properly for entity and hub properties", () => {
+    const { getAllByTestId } = render(
+      <Sidebar
+        entityDefArray={entityDefArray}
+        facets={searchPayloadFacets}
+        selectedEntities={['Customer']}
+        facetRender={jest.fn()}
+        checkFacetRender={jest.fn()}
+      />
+    )
+    expect(document.querySelector('#entity-properties [data-icon=down]')).toBeInTheDocument();
+    expect(document.querySelector('#entity-properties [data-icon=down]')).not.toHaveStyle('transform: rotate(180deg);');
+    fireEvent.click(getAllByTestId('toggle')[0]);
+    expect(document.querySelector('#entity-properties [data-icon=down]')).toHaveStyle('transform: rotate(180deg);');
+    expect(document.querySelector('#hub-properties [data-icon=down]')).toBeInTheDocument();
+    expect(document.querySelector('#hub-properties [data-icon=down]')).toHaveStyle('transform: rotate(180deg);');
+    fireEvent.click(getAllByTestId('toggle')[1]);
+    expect(document.querySelector('#hub-properties [data-icon=down]')).not.toHaveStyle('transform: rotate(180deg);');
+  });
 })

--- a/marklogic-data-hub-central/ui/src/components/sidebar/sidebar.tsx
+++ b/marklogic-data-hub-central/ui/src/components/sidebar/sidebar.tsx
@@ -424,7 +424,7 @@ const Sidebar: React.FC<Props> = (props) => {
       <Collapse
         className={styles.sideBarFacets}
         activeKey={activeKey}
-        expandIcon={panelProps => <Icon type="up" rotate={panelProps.isActive ? 0 : 180} />}
+        expandIcon={panelProps => <Icon type="down" rotate={panelProps.isActive ? 0 : 180} data-testid='toggle' />}
         expandIconPosition="right"
         bordered={false}
         onChange={setActive}

--- a/marklogic-data-hub-central/ui/src/pages/Browse.module.scss
+++ b/marklogic-data-hub-central/ui/src/pages/Browse.module.scss
@@ -49,12 +49,9 @@
 }
 
 .overlay {
-  position: absolute;
-  margin-left: auto;
-  margin-right: auto;
-  left: 0;
-  right: 0;
-  z-index: 999;
+  display: flex;
+  justify-content: center; 
+  margin-top: 100px; 
 }
 
 .ant-table-content {

--- a/marklogic-data-hub-central/ui/src/pages/Browse.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Browse.tsx
@@ -325,7 +325,6 @@ const Browse: React.FC<Props> = ({ location }) => {
                   />
                 </div>
                 <div className={styles.spinViews}>
-                  {isLoading && <MLSpin data-testid="spinner" className={styles.overlay} />}
                   <div className={styles.switchViews}>
                     <div className={!tableView ? styles.toggled : styles.toggleView}
                       data-cy="facet-view" id={'snippetView'}
@@ -351,6 +350,8 @@ const Browse: React.FC<Props> = ({ location }) => {
                   entityDefArray={entityDefArray}
                 />
               </div>
+              {isLoading ? <MLSpin data-testid="spinner" className={styles.overlay} /> :
+              <div>
               <div className={styles.fixedView} >
                 {tableView ?
                   <div>
@@ -384,6 +385,7 @@ const Browse: React.FC<Props> = ({ location }) => {
                   maxRowsPerPage={searchOptions.maxRowsPerPage}
                 />
               </div>
+              </div>}
             </>
           }
         </Content>


### PR DESCRIPTION
### Description
Includes DHFPROD-5383: Collapse/Expand carets in Explorer are backwards
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

