### PR TITLE
DHFPROD-5368: Tile UI displays vertical and horizontal scrolls when n…

### DIFF
--- a/marklogic-data-hub-central/ui/src/App.scss
+++ b/marklogic-data-hub-central/ui/src/App.scss
@@ -119,6 +119,14 @@ tr.ant-table-row:hover > td {
   content: "\22C1";
 }
 
+.ant-table-body {
+  overflow: auto !important;
+}
+
+.ant-table-header {
+  background: #FAFAFA
+}
+
 .react-resizable {
   position: relative;
   background-clip: padding-box;

--- a/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.module.scss
@@ -1,7 +1,7 @@
 .container {
     display: flex;
     flex-direction: column;
-    min-height: 99%;
+    min-height: 99.5%;
   }
 
   .zeroContent {


### PR DESCRIPTION
…ot needed

### Description
- CSS fix for Mapping Tile cross-platform scrollbar consistency
- On Windows, horizontal and vertical scrollbars now only show when necessary inside Mapping table.
- Before: https://drive.google.com/file/d/1iZOrsVkIkFX9xGaozUO8pSAg0Q1xC7l4/view
- After: https://drive.google.com/file/d/1DxpXo3RdvR7GWkB8VBR1d57wrY91drD7/view
- No tests needed for CSS changes

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- N/A Added Tests
  

- ##### Reviewer:

- N/A Reviewed Tests

