### PR TITLE
DHFPROD-5753: Custom roles can now inherit pii-reader

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesCommand.java
@@ -77,7 +77,8 @@ public class CreateGranularPrivilegesCommand extends LoggingObject implements Co
         "data-hub-odbc-user",
         "data-hub-saved-query-user",
         "data-hub-step-definition-reader",
-        "data-hub-step-definition-writer"
+        "data-hub-step-definition-writer",
+        "pii-reader"
     );
 
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubSecurityAdminTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubSecurityAdminTest.java
@@ -97,11 +97,11 @@ public class DataHubSecurityAdminTest extends AbstractSecurityTest {
         Role customRole = new Role(userWithRoleBeingTestedApi, roleName);
         customRole.setRole(CreateGranularPrivilegesCommand.ROLES_THAT_CAN_BE_INHERITED);
 
-        assertEquals(41, customRole.getRole().size(), "As of DHFPROD-5551 in 5.3.0, 41 roles are expected to be " +
+        assertEquals(42, customRole.getRole().size(), "As of DHFPROD-5753 in 5.3.0, 42 roles are expected to be " +
             "inheritable in custom roles created by a user with the data-hub-security-admin role. When new roles must " +
             "be inheritable, they should be added to the list in CreateGranularPrivilegesCommand, and this count " +
             "should be updated to match the new total.");
-        
+
         try {
             customRole.save();
             Role actualRole = getRole(roleName);


### PR DESCRIPTION

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

