### PR TITLE
DHFPROD-5636: User without hub-central-saved-query-user can use Explorer and SavedQueries dropdown is not displayed on Zero state page

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.queries.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.queries.tsx
@@ -483,3 +483,44 @@ describe('manage queries modal scenarios on zero sate page, developer role', () 
 
 
 });
+
+describe('User without hub-central-saved-query-user role should not see saved queries drop down on zero sate page', () => {
+    beforeEach(() => {
+        cy.visit('/');
+        cy.contains(Application.title);
+        cy.loginAsTestUserWithRoles("hub-central-user").withRequest();
+        cy.waitUntil(() => toolbar.getExploreToolbarIcon()).click();
+    });
+
+    afterEach(() => {
+        cy.resetTestUser();
+    });
+
+    after(() => {
+        cy.loginAsDeveloper().withRequest();
+    });
+
+    it('verifies saved queries drop down does not exist', () => {
+        browsePage.getSaveQueriesDropdown().should('not.be.visible');
+    });
+
+    it('verifies user without hub-central-saved-query-user role can explore data', () => {
+        browsePage.getSaveQueriesDropdown().should('not.be.visible');
+        cy.waitUntil(() => browsePage.getExploreButton()).click();
+        browsePage.selectEntity('Customer');
+        browsePage.getSelectedEntity().should('contain', 'Customer');
+    });
+
+    it('verifies user without hub-central-saved-query-user can not save query', () => {
+        browsePage.getSaveQueriesDropdown().should('not.be.visible');
+        cy.waitUntil(() => browsePage.getExploreButton()).click();
+        browsePage.selectEntity('Customer');
+        browsePage.getSelectedEntity().should('contain', 'Customer');
+        browsePage.getFacetItemCheckbox('name', 'Adams Cole').click();
+        browsePage.getSelectedFacets().should('exist');
+        browsePage.getGreySelectedFacets('Adams Cole').should('exist');
+        browsePage.getFacetApplyButton().click();
+        browsePage.waitForSpinnerToDisappear();
+        browsePage.getSaveModalIcon().should('not.be.visible');
+    });
+});

--- a/marklogic-data-hub-central/ui/src/components/queries/queries.tsx
+++ b/marklogic-data-hub-central/ui/src/components/queries/queries.tsx
@@ -84,10 +84,11 @@ const Query = (props) => {
 
     const getSaveQueries = async () => {
         try {
-            const response = await fetchQueries();
-
-            if (response.data) {
-               props.setQueries(response.data);
+            if(props.isSavedQueryUser) {
+                const response = await fetchQueries();
+                if (response.data) {
+                    props.setQueries(response.data);
+                }
             }
         } catch (error) {
             handleError(error)
@@ -97,27 +98,29 @@ const Query = (props) => {
     const getSaveQueryWithId = async (key) => {
        try {
            const response = await fetchQueryById(key);
-           if (response.data) {
-            let options: QueryOptions = {
-                searchText: response.data.savedQuery.query.searchText,
-                entityTypeIds: response.data.savedQuery.query.entityTypeIds,
-                selectedFacets: response.data.savedQuery.query.selectedFacets,
-                selectedQuery: response.data.savedQuery.name,
-                propertiesToDisplay: response.data.savedQuery.propertiesToDisplay,
-                zeroState: searchOptions.zeroState,
-                manageQueryModal: searchOptions.manageQueryModal,
-                sortOrder: response.data.savedQuery.sortOrder
-            }
-            applySaveQuery(options);
-            setCurrentQuery(response.data);
-               if(props.greyFacets.length > 0){
-                   clearAllGreyFacets();
-               }
-               toggleApply(false);
-               if(response.data.savedQuery.hasOwnProperty('description') && response.data.savedQuery.description){
-                   setCurrentQueryDescription(response.data.savedQuery.description);
-               } else{
-                   setCurrentQueryDescription('');
+           if(props.isSavedQueryUser) {
+               if (response.data) {
+                   let options: QueryOptions = {
+                       searchText: response.data.savedQuery.query.searchText,
+                       entityTypeIds: response.data.savedQuery.query.entityTypeIds,
+                       selectedFacets: response.data.savedQuery.query.selectedFacets,
+                       selectedQuery: response.data.savedQuery.name,
+                       propertiesToDisplay: response.data.savedQuery.propertiesToDisplay,
+                       zeroState: searchOptions.zeroState,
+                       manageQueryModal: searchOptions.manageQueryModal,
+                       sortOrder: response.data.savedQuery.sortOrder
+                   }
+                   applySaveQuery(options);
+                   setCurrentQuery(response.data);
+                   if(props.greyFacets.length > 0){
+                       clearAllGreyFacets();
+                   }
+                   toggleApply(false);
+                   if(response.data.savedQuery.hasOwnProperty('description') && response.data.savedQuery.description){
+                       setCurrentQueryDescription(response.data.savedQuery.description);
+                   } else{
+                       setCurrentQueryDescription('');
+                   }
                }
            }
        } catch (error) {

--- a/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.test.tsx
@@ -9,7 +9,7 @@ describe('zero state explorer component', () => {
     let columns = ["OrderID", "OrderDate", "StringField1", "StringField2", "StringField3", "NumberField1"];
 
     test('Verify Zero State components renders', () => {
-        const { getByTestId, getByText } = render(<ZeroStateExplorer entities={entities} setEntity={jest.fn()} queries={queries} hasStructured={false} columns={columns} setIsLoading={jest.fn()} tableView={true} toggleTableView={jest.fn()} />);
+        const { getByTestId, getByText } = render(<ZeroStateExplorer entities={entities} setEntity={jest.fn()} isSavedQueryUser={true} queries={queries} hasStructured={false} columns={columns} setIsLoading={jest.fn()} tableView={true} toggleTableView={jest.fn()} />);
         expect(getByText('All Entities')).toBeInTheDocument();
         expect(getByText('Search through loaded data and curated data')).toBeInTheDocument();
         expect(getByText('What do you want to explore?')).toBeInTheDocument();
@@ -19,8 +19,19 @@ describe('zero state explorer component', () => {
         expect(getByTestId('query-select')).toBeInTheDocument();
     });
 
+    test('Verify Zero State components renders when user does not have save query role', () => {
+        const { getByTestId, getByText, debug, queryByTestId, queryByText } = render(<ZeroStateExplorer entities={entities} setEntity={jest.fn()} isSavedQueryUser={false} queries={queries} hasStructured={false} columns={columns} setIsLoading={jest.fn()} tableView={true} toggleTableView={jest.fn()} />);
+        expect(getByText('All Entities')).toBeInTheDocument();
+        expect(getByText('Search through loaded data and curated data')).toBeInTheDocument();
+        expect(getByText('What do you want to explore?')).toBeInTheDocument();
+        expect(getByTestId('search-bar')).toBeInTheDocument();
+        expect(getByTestId('entity-select')).toBeInTheDocument();
+        expect(queryByText('- or -')).not.toBeInTheDocument();
+        expect(queryByTestId('query-select')).not.toBeInTheDocument();
+    });
+
     test('Verify setQuery gets called', () => {
-        const { getByTestId } = render(<ZeroStateExplorer entities={entities} setEntity={jest.fn()} queries={queries} hasStructured={false} columns={columns} setIsLoading={jest.fn()} tableView={true} toggleTableView={jest.fn()}/>);
+        const { getByTestId } = render(<ZeroStateExplorer entities={entities} setEntity={jest.fn()} isSavedQueryUser={true} queries={queries} hasStructured={false} columns={columns} setIsLoading={jest.fn()} tableView={true} toggleTableView={jest.fn()}/>);
         const searchInput = getByTestId('search-bar');
         searchInput.onchange = jest.fn();
         fireEvent.change(searchInput, { target: { value: 'Person' },});
@@ -29,7 +40,7 @@ describe('zero state explorer component', () => {
     });
 
     test('Verify onClickExplore gets called', () => {
-        const { getByText } = render(<ZeroStateExplorer entities={entities} setEntity={jest.fn()} queries={queries} hasStructured={false} columns={columns} setIsLoading={jest.fn()} tableView={true} toggleTableView={jest.fn()}/>);
+        const { getByText } = render(<ZeroStateExplorer entities={entities} setEntity={jest.fn()} isSavedQueryUser={true} queries={queries} hasStructured={false} columns={columns} setIsLoading={jest.fn()} tableView={true} toggleTableView={jest.fn()}/>);
         const exploreButton = getByText('Explore');
         exploreButton.onclick = jest.fn();
         fireEvent.click(exploreButton);

--- a/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.tsx
+++ b/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.tsx
@@ -150,12 +150,12 @@ const ZeroStateExplorer = (props) => {
             </div>
           </Col>
         </Row>
-        <Row gutter={[0, 28]}>
+        {props.isSavedQueryUser && <Row gutter={[0, 28]}>
           <Col span={24}>
             <p className={styles.p}>- or -</p>
           </Col>
-        </Row>
-        <Row >
+        </Row>}
+        {props.isSavedQueryUser && <Row >
           <Col span={24}>
             <div className={styles.box}>
               <Card className={styles.smallCard} bordered={false}>
@@ -178,7 +178,7 @@ const ZeroStateExplorer = (props) => {
               </Card>
             </div>
           </Col>
-        </Row>
+        </Row>}
       </div>
       <div className={styles.footer}>
       </div>

--- a/marklogic-data-hub-central/ui/src/pages/Browse.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Browse.tsx
@@ -273,7 +273,7 @@ const Browse: React.FC<Props> = ({ location }) => {
     return (
       <>
         <Query queries={queries} setQueries={setQueries} isSavedQueryUser={isSavedQueryUser} columns={columns} setIsLoading={setIsLoading} entities={entities} selectedFacets={[]} greyFacets={[]} entityDefArray={entityDefArray} />
-        <ZeroStateExplorer entities={entities} setEntity={setEntity} queries={queries} columns={columns} setIsLoading={setIsLoading} tableView={tableView} toggleTableView={toggleTableView} />
+        <ZeroStateExplorer entities={entities} setEntity={setEntity} isSavedQueryUser={isSavedQueryUser} queries={queries} columns={columns} setIsLoading={setIsLoading} tableView={tableView} toggleTableView={toggleTableView} />
       </>
     );
   } else {


### PR DESCRIPTION
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

