### PR TITLE
DHFPROD-5746: Migrating flows should be repeatable

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/hubcentral/migration/FlowMigrator.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/hubcentral/migration/FlowMigrator.java
@@ -149,6 +149,10 @@ public class FlowMigrator extends LoggingObject {
             ObjectNode newSteps = nodeFactory.objectNode();
             for (Map.Entry<String, Step> entry : steps.entrySet()) {
                 Step step = entry.getValue();
+                if (step.getStepId() != null) {
+                    newSteps.set(entry.getKey(), nodeFactory.objectNode().put("stepId", step.getStepId()));
+                    continue;
+                }
                 String stepId;
                 Path targetDir;
                 if (StepDefinitionType.INGESTION.equals(step.getStepDefinitionType())) {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/Step.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/Step.java
@@ -17,6 +17,7 @@
 package com.marklogic.hub.step.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -28,6 +29,7 @@ import java.util.Map;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Step {
+    private String stepId;
     private String name;
     private String description;
     private Map<String, Object> options;
@@ -38,6 +40,14 @@ public class Step {
     private String stepDefinitionName;
     private StepDefinition.StepDefinitionType stepDefinitionType;
     private JsonNode fileLocations;
+
+    public String getStepId() {
+        return stepId;
+    }
+
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
+    }
 
     public String getName() {
         return name;
@@ -123,6 +133,7 @@ public class Step {
         Step step = new Step();
 
         JSONObject jsonObject = new JSONObject(json);
+        step.setStepId(jsonObject.getString("stepId"));
         step.setStepDefinitionName(jsonObject.getString("stepDefinitionName"));
         step.setStepDefinitionType(StepDefinition.StepDefinitionType.getStepDefinitionType(jsonObject.getString("stepDefinitionType")));
         String stepName = jsonObject.getString("name");

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/hubcentral/migration/FlowMigratorTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/hubcentral/migration/FlowMigratorTest.java
@@ -71,6 +71,24 @@ class FlowMigratorTest extends AbstractHubCoreTest {
         verifyLegacyMappingsWereDeletedFromMarkLogic();
     }
 
+    @Test
+    void migrateFlowsTwice() {
+        HubConfig hubConfig = getHubConfig();
+        MappingManager mappingManager = new MappingManagerImpl(hubConfig);
+        FlowManager flowManager = new FlowManagerImpl(hubConfig, mappingManager);
+        flowManager.getLocalFlows().forEach(flow ->flowMap.put(flow.getName(), flow));
+        mappingManager.getMappings().forEach(mapping -> mappingMap.put(mapping.getName(), mapping));
+
+        FlowMigrator flowMigrator = new FlowMigrator(hubConfig);
+
+        flowMigrator.migrateFlows();
+        // migrateFlows() should be a no-op the 2nd time
+        flowMigrator.migrateFlows();
+
+        verifyLegacyMappingsStillExistInMarkLogic();
+        verifyFlowsWereMigrated();
+    }
+
     private void verifyFlowsWereMigrated() {
         HubProject hubProject = getHubConfig().getHubProject();
 

--- a/marklogic-data-hub/src/test/resources/test-projects/all-steps-referenced/flows/CurateCustomerJSON.flow.json
+++ b/marklogic-data-hub/src/test/resources/test-projects/all-steps-referenced/flows/CurateCustomerJSON.flow.json
@@ -5,7 +5,6 @@
       "name": "loadCustomersJSON",
       "stepDefinitionName": "default-ingestion",
       "stepDefinitionType": "ingestion",
-      "stepId": "loadCustomersJSON-ingestion",
       "description": "",
       "sourceFormat": "json",
       "targetFormat": "json",


### PR DESCRIPTION
### Description

In 5.3, FlowManagerImpl.getLocalFlow() does not know how to read referenced flows into Step objects. When you attempted to run migration twice, FlowMigrator would crash because of the mostly-empty Step object. (Specifically, trying to use the null result of step.getName().)

This PR is my attempt to make the smallest changes that will allow FlowMigrator.migrateFlows() to run twice.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

