### PR TITLE
DHFPROD-5448: Tooltip missing of Target Format in edit loading step

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/load/new-load-dialog/new-load-dialog.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/new-load-dialog/new-load-dialog.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent, waitForElement } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import NewLoadDialog from './new-load-dialog';
 import {BrowserRouter} from "react-router-dom";
+import {NewLoadTooltips} from '../../../config/tooltips.config';
 import axiosMock from 'axios'
 
 jest.mock('axios');
@@ -36,9 +37,21 @@ describe('New/edit load data configuration', () => {
     expect(queryAllByText("Target URI Preview:").length ).toEqual(0);
     expect(queryAllByPlaceholderText('Enter URI Prefix')[0]).toBeInTheDocument();
     let tooltip  = getAllByLabelText('icon: question-circle');
-    //should be the last field in the form
-    fireEvent.mouseOver(tooltip[tooltip.length-1]);
-    await waitForElement(() => getByText("The prefix you want for the URIs of the loaded records. Example: If your prefix is /rawData/ and you load a file called customer1.json, the URI of the loaded record becomes /rawData/customer1.json."))
+    //Tooltip for name
+    fireEvent.mouseOver(tooltip[0]);
+    await waitForElement(() => getByText(NewLoadTooltips.name));
+    //Tooltip for Description
+    fireEvent.mouseOver(tooltip[1]);
+    await waitForElement(() => getByText(NewLoadTooltips.description));
+    //Tooltip for Source Format
+    fireEvent.mouseOver(tooltip[2]);
+    await waitForElement(() => getByText(NewLoadTooltips.sourceFormat));
+    //Tooltip for Target Format
+    fireEvent.mouseOver(tooltip[3]);
+    await waitForElement(() => getByText(NewLoadTooltips.targetFormat));
+    //Tooltip for Target URI Prefix
+    fireEvent.mouseOver(tooltip[4]);
+    await waitForElement(() => getByText(NewLoadTooltips.outputURIPrefix))
     expect(getByText("Target Format:")).toHaveTextContent('Target Format: *');
     expect(getByText("Target URI Prefix:")).toHaveTextContent('Target URI Prefix:');
   });

--- a/marklogic-data-hub-central/ui/src/config/tooltips.config.js
+++ b/marklogic-data-hub-central/ui/src/config/tooltips.config.js
@@ -29,6 +29,7 @@ const NewLoadTooltips = {
     'description': 'The description of this data load configuration.',
     'files' : 'Click *Upload* to select the source files. The total size of the files must be 100MB or less.',
     'sourceFormat': 'The format of the source files to load.',
+    'targetFormat': 'The format of the processed record.',
     'fieldSeparator': 'The delimiter in source files. Required if *Source Format* is *Delimited Text*.',
     'outputURIPrefix': 'The prefix you want for the URIs of the loaded records. Example: If your prefix is /rawData/ and you load a file called customer1.json, the URI of the loaded record becomes /rawData/customer1.json.'
 }


### PR DESCRIPTION
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

