### PR TITLE
DHFPROD-5445: Updating default maskClosable property for edit query modal

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/queries/saving/edit-save-query/edit-query-details.tsx
+++ b/marklogic-data-hub-central/ui/src/components/queries/saving/edit-save-query/edit-query-details.tsx
@@ -91,8 +91,9 @@ const EditQueryDetails: React.FC<Props> = (props) => {
             title={'Edit Query Details'}
             closable={true}
             onCancel={() => onCancel()}
-            maskClosable={true}
+            maskClosable={false}
             footer={null}
+            destroyOnClose={true}
         >
             <Form
                 name="basic"


### PR DESCRIPTION
#### Description 
This PR is just about making the mask of edit query modal as closable so that the design is consistent with all other modals in Hub Central. No test is required for this as all other necessary e2e tests for modals are already available.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

