### PR TITLE
DHFPROD-5627:Add 'namespaces' to mapping step when xml docs are opened

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
@@ -223,6 +223,10 @@ const MappingCard: React.FC<Props> = (props) => {
                 let sDta = generateNestedDataSource(docRoot,nestedDoc);
                 setSourceData([]);
                 setSourceData([...sDta]);
+                if(typeof(srcDocResp.data) === 'string'){
+                    let mData = await props.getMappingArtifactByMapName(props.entityModel.entityTypeId,props.data[index].name);
+                    updateMappingWithNamespaces(mData);
+                }
             }
             setIsLoading(false);
         } catch(error)  {
@@ -241,13 +245,7 @@ const MappingCard: React.FC<Props> = (props) => {
     const updateMappingWithNamespaces = async (mapDataLocal) => {
         let {lastUpdated, ...dataPayload} = mapDataLocal;
         dataPayload['namespaces'] = nmspaces;
-        await props.updateMappingArtifact(dataPayload);
-
-        let mapArt = await props.getMappingArtifactByMapName(dataPayload.targetEntityType,dataPayload.name);
-
-        if(mapArt) {
-            await setMapData({...mapArt});
-        }
+        setMapData({...dataPayload});
     }
 
     //Generate namespaces for source properties


### PR DESCRIPTION
### Description
Add 'namespaces' to mapping step when xml docs are opened. No additional tests needed as we don't immediately save the updated mapping but wait for users to edit the mapping before saving it
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [n/a ] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

