### PR TITLE
DHFPROD-5766: Removed dh-job-internal from hc-step-runner

### DIFF
--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/FlowControllerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/FlowControllerTest.java
@@ -14,8 +14,7 @@ import javax.ws.rs.core.MediaType;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -270,6 +269,15 @@ public class FlowControllerTest extends AbstractMvcTest {
         rawDoc = getFinalDoc("/customers/file2.json");
         assertEquals("John", rawDoc.get("envelope").get("instance").get("name").asText(),
             "Verifying that 2 docs were ingested into the final database");
+
+        mockMvc.perform(multipart(PATH + "/{flowName}/steps/{stepNumber}", "ingestToFinal", "2")
+            .session(mockHttpSession))
+            .andExpect(status().isOk());
+
+        JsonNode mappedDoc = getStagingDoc("/customers/file1.json");
+        assertNotNull(mappedDoc);
+        mappedDoc = getStagingDoc("/customers/file2.json");
+        assertNotNull(mappedDoc);
     }
 
     private FlowController.FlowsWithStepDetails parseFlowsWithStepDetails(MvcResult result) throws Exception {

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-step-runner.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-step-runner.json
@@ -6,7 +6,6 @@
     "data-hub-common-writer",
     "data-hub-flow-reader",
     "data-hub-ingestion-reader",
-    "data-hub-job-internal",
     "data-hub-job-reader",
     "data-hub-mapping-reader",
     "data-hub-match-merge-reader",


### PR DESCRIPTION
### Description

Beefed up an existing test as hc-step-runner. No role should inherit the internal role, as it's granted via amps when it's needed. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

