### PR TITLE
DHFPROD-5775:Use step name to filter documents instead of step definition name in QS

### DIFF
--- a/web/src/main/ui/app/components/jobs-new/ui/job-details-ui.component.html
+++ b/web/src/main/ui/app/components/jobs-new/ui/job-details-ui.component.html
@@ -130,7 +130,7 @@
         <ng-container matColumnDef="committed">
           <mat-header-cell id="step-committed-sort-btn" *matHeaderCellDef mat-sort-header>Committed</mat-header-cell>
           <mat-cell class="step-committed" *matCellDef="let step">
-            <a *ngIf="step.successfulEvents !== 0" [routerLink]="['/browse']" [queryParams]="{ createdByJob:job.id, createdByStep:step.stepDefinitionName, d:step.targetDatabase }">
+            <a *ngIf="step.successfulEvents !== 0" [routerLink]="['/browse']" [queryParams]="{ createdByJob:job.id, createdByStep:step.name, d:step.targetDatabase }">
               {{step.successfulEvents | number}}
             </a>
             <span *ngIf="step.successfulEvents === 0">


### PR DESCRIPTION
### Description
Use step name to filter documents instead of step definition name in QS. No tests required.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [ n/a] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

