### PR TITLE
DHFPROD-5312: Make a (tile height + footer) fit into 100% of the page to avoid activating page scrollbar

### DIFF
--- a/marklogic-data-hub-central/ui/src/App.scss
+++ b/marklogic-data-hub-central/ui/src/App.scss
@@ -17,7 +17,7 @@ body {
   position: relative;
   margin-right: 70px;
   overflow-y: auto;
-  height: 100vh;
+  height: 90vh;
   max-height: 92vh;
 }
 
@@ -44,7 +44,7 @@ main {
 .ant-layout-footer {
   display: flex;
   justify-content: center;
-  padding: 30px 0;
+  padding: 50px 0 0 0;
   margin: 0;
   background-color: transparent;
 }

--- a/marklogic-data-hub-central/ui/src/App.scss
+++ b/marklogic-data-hub-central/ui/src/App.scss
@@ -19,6 +19,8 @@ body {
   overflow-y: auto;
   height: 90vh;
   max-height: 92vh;
+  margin-bottom: 70px;
+  flex: 1;
 }
 
 .ant-layout-header {
@@ -34,7 +36,9 @@ body {
   margin: 0;
 }
 main {
-  flex: 1;
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
 }
 #background {
   display: flex;
@@ -44,9 +48,10 @@ main {
 .ant-layout-footer {
   display: flex;
   justify-content: center;
-  padding: 50px 0 0 0;
+  padding: 20px 0 0 0;
   margin: 0;
   background-color: transparent;
+  height: 60px;
 }
 
 /* Handle any excess scroll space below background image */

--- a/marklogic-data-hub-central/ui/src/App.tsx
+++ b/marklogic-data-hub-central/ui/src/App.tsx
@@ -121,8 +121,8 @@ const App: React.FC<Props> = ({history, location}) => {
               </PrivateRoute>
               <Route component={NoMatchRedirect}/>
             </Switch>
-              <Footer pageTheme={pageTheme}/>
             </div>
+            <Footer pageTheme={pageTheme}/>
           </main>
         </ModelingProvider>
       </SearchProvider>

--- a/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.module.scss
@@ -1,7 +1,7 @@
 .container {
     display: flex;
     flex-direction: column;
-    min-height: 99.5%;
+    min-height: 99.2%;
   }
 
   .zeroContent {

--- a/marklogic-data-hub-central/ui/src/pages/Overview.module.scss
+++ b/marklogic-data-hub-central/ui/src/pages/Overview.module.scss
@@ -9,7 +9,7 @@
     line-height: 1.4;
     color: #333;
     background: #fff;
-    margin: 20px 70px 20px 40px;
+    margin: 20px 70px 0px 40px;
     .title {
         font-size: 28px;
     }

--- a/marklogic-data-hub-central/ui/src/pages/Overview.module.scss
+++ b/marklogic-data-hub-central/ui/src/pages/Overview.module.scss
@@ -6,7 +6,7 @@
 }
 
 .overviewContainer {
-    line-height: 1.7;
+    line-height: 1.4;
     color: #333;
     background: #fff;
     margin: 20px 70px 20px 40px;

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.module.scss
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.module.scss
@@ -1,5 +1,5 @@
 .tilesViewContainer {
-    height: 95%;
+    height: 100%;
     width: 100%;
     margin: 0;
     padding: 10px 10px 0 10px;


### PR DESCRIPTION
### Description
- Solves issue of double scrollbars appearing in tile view.
- Footer fits in the same view as tile to remove need for outer page scrollbar.
- Footer stays pinned at the bottom and in view even when window shrinks.
- No tests needed for css refactoring.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- N/A Added Tests
  

- ##### Reviewer:

- N/A Reviewed Tests

