### PR TITLE
DHFPROD-5778: Open panel after Add Step in Run

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
+++ b/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
@@ -85,6 +85,9 @@ const Flows: React.FC<Props> = (props) => {
                 getFlowWithJobInfo(props.newStepToFlowOptions.flowsDefaultKey);
             }
         }
+        if (activeKeys === undefined) {
+            setActiveKeys([]);
+        }
     }, [props.flows])
 
     useEffect(() => {
@@ -172,6 +175,12 @@ const Flows: React.FC<Props> = (props) => {
 
     const onAddStepOk = (stepName, flowName, stepType) => {
         props.addStepToFlow(stepName, flowName, stepType);
+        // Open flow panel if not open
+        const flowIndex = props.flows.findIndex(f => f.name === flowName);
+        if (!activeKeys.includes(flowIndex)) {
+            let newActiveKeys = [...activeKeys, flowIndex];
+            setActiveKeys(newActiveKeys);
+        }
         setAddStepDialogVisible(false);
     }
 

--- a/marklogic-data-hub-central/ui/src/pages/Run.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Run.test.tsx
@@ -333,8 +333,6 @@ describe('Verify step running', () => {
 
 });
 
-
-
 describe('Verify step display', () => {
 
     afterEach(() => {
@@ -690,6 +688,34 @@ describe('Verify Add Step function', () => {
         let addStep = getByText('Add Step');
         fireEvent.click(addStep);
         expect(queryByText(data.steps.data['ingestionSteps'][0].name)).not.toBeInTheDocument();
+
+    })
+
+    test('Verify a flow panel that is closed when a step is added to it is then opened', async () => {
+        mocks.runAddStepAPI(axiosMock);
+        const { getByText, getByLabelText, queryByText } = await render(<MemoryRouter>
+            <AuthoritiesContext.Provider value={ mockDevRolesService }><Run/></AuthoritiesContext.Provider>
+        </MemoryRouter>);
+
+        // Panel is closed
+        expect(queryByText(data.flows.data[0].steps[1].stepName)).not.toBeInTheDocument();
+
+        // Click to open Add Step menu and click a step
+        let addStep = getByText('Add Step');
+        fireEvent.click(addStep);
+        let step = getByText(data.steps.data['ingestionSteps'][0].name);
+        fireEvent.click(step);
+
+        // Click to confirm the add in the dialog
+        expect(getByText(`Are you sure you want to add step "${data.steps.data['ingestionSteps'][0].name}" to flow "${data.flows.data[0].name}"?`)).toBeInTheDocument();
+        let confirm = getByLabelText('Yes');
+        fireEvent.click(confirm);
+        await wait(() => {
+            expect(axiosMock.post).toHaveBeenNthCalledWith(1, `/api/flows/${data.flows.data[0].name}/steps`, {"stepDefinitionType": "ingestion", "stepName": data.steps.data['ingestionSteps'][0].name});
+        })
+
+        // Panel is open
+        expect(getByText(data.flows.data[0].steps[1].stepName)).toBeInTheDocument();
 
     })
 


### PR DESCRIPTION
If the panel for a flow is closed and a step is added to the flow (via the Add Step dropdown), then open the panel.

@jbelonoj has approved. Screencast: https://drive.google.com/file/d/15-g_pGeZOfaJPaAcpi0vgDEVBgeItcuh/view

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

