### PR TITLE
DHFPROD-5671: Explorer table does not show empty string sent by backend in the UI

### DIFF
--- a/marklogic-data-hub-central/ui/src/assets/mock-data/entity-search.js
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/entity-search.js
@@ -130,7 +130,9 @@ export const entitySearch = {
           "propertyPath": "nicknames",
           "propertyValue": [
             "Carm",
-            "din"
+            "din",
+            "",
+            null
           ]
         },
         {

--- a/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.test.tsx
@@ -38,6 +38,8 @@ describe("Results Table view component", () => {
         expect(getByText('Ellerslie2')).toBeInTheDocument();
         expect(getByTestId('101-detailOnSeparatePage')).toBeInTheDocument();
         expect(getByTestId('101-sourceOnSeparatePage')).toBeInTheDocument();
+        expect(getByText('""')).toBeInTheDocument();
+        expect(getByText('null')).toBeInTheDocument();
 
         //Check if the tooltip on 'Detail on separate page' icon works fine.
         fireEvent.mouseOver(getByTestId('101-detailOnSeparatePage'))

--- a/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.tsx
+++ b/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.tsx
@@ -123,13 +123,14 @@ const ResultsTabularView = (props) => {
                         if (Array.isArray(value)) {
                             let values = new Array();
                             value.forEach(item => {
-                                if (item) {
-                                    let title = item.toString();
-                                    if (title && title.length > 0) {
+                                let val = item === null ? 'null' : item === "" ? '""' : item;
+                                if (val !== undefined) {
+                                    let title = val.toString();
+                                    if (title) {
                                         values.push(
                                             <MLTooltip
                                                 title={title}>
-                                                <div style={{ textOverflow: 'ellipsis', overflow: 'hidden' }}>{item}</div>
+                                                <div style={{ textOverflow: 'ellipsis', overflow: 'hidden' }}>{title}</div>
                                             </MLTooltip>
                                         )
                                     }


### PR DESCRIPTION
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

