### PR TITLE
DHFPROD-5793: Find entity type references in referenced steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,7 +175,7 @@ def runCypressE2e(){
             rm -rf $M2_LOCAL_REPO || true
             mkdir -p $M2_LOCAL_REPO
             cd $WORKSPACE/data-hub;
-            ./gradlew marklogic-data-hub:publishToMavenLocal -Dmaven.repo.local=$M2_LOCAL_REPO
+            ./gradlew publishToMavenLocal -Dmaven.repo.local=$M2_LOCAL_REPO -PnodeDistributionBaseUrl=http://node-mirror.eng.marklogic.com:8080/
             '''
         )
         sh(script:'''
@@ -187,6 +187,8 @@ def runCypressE2e(){
           cd $WORKSPACE/data-hub;
           rm -rf $GRADLE_USER_HOME/caches;
           cd marklogic-data-hub-central/ui/e2e;
+          repo="maven {url '"$M2_LOCAL_REPO"'}"
+          sed -i "/repositories {/a$repo" hc-qa-project/build.gradle
           chmod +x setup.sh;
           ./setup.sh dhs=false mlHost=localhost;
           '''

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/ModelController.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/ModelController.java
@@ -259,7 +259,7 @@ public class ModelController extends BaseController {
     }
 
     public static class ModelReferencesInfo {
-        public List<String> stepAndMappingNames;
+        public List<String> stepNames;
         public List<String> entityNames;
     }
 

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/DeleteModelTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/DeleteModelTest.java
@@ -42,10 +42,10 @@ public class DeleteModelTest extends AbstractModelTest {
     private void getModelReferences() {
         JsonNode jsonNode = controller.getModelReferences("Entity2").getBody();
         assertNotNull(jsonNode);
-        assertEquals(2, jsonNode.get("stepAndMappingNames").size());
+        assertEquals(2, jsonNode.get("stepNames").size());
         assertEquals(1, jsonNode.get("entityNames").size());
         Stream.of("testMap2", "matching-step")
-                .forEach(s -> assertTrue(jsonNode.get("stepAndMappingNames").toString().contains(s)));
+                .forEach(s -> assertTrue(jsonNode.get("stepNames").toString().contains(s)));
         assertTrue(jsonNode.get("entityNames").toString().contains("Entity1"));
     }
 
@@ -65,7 +65,7 @@ public class DeleteModelTest extends AbstractModelTest {
     }
 
     private void removeReferencesToEntity() {
-        removeDocuments("/flows/testFlow.flow.json", "/steps/mapping/testMap2.step.json");
+        removeDocuments("/steps/matching/matching-step.step.json", "/steps/mapping/testMap2.step.json");
     }
 
     private void verifyReferencesToEntity2DontExistInEntity1() {
@@ -96,7 +96,7 @@ public class DeleteModelTest extends AbstractModelTest {
 
     private void deleteEntity1Model() {
         runAsDataHubDeveloper();
-        removeDocuments("/steps/mapping/testMap1.step.json");
+        removeDocuments("/steps/mapping/testMap1.step.json", "/steps/merging/merging-step.step.json");
         runAsTestUserWithRoles("hub-central-entity-model-writer");
 
         assertDoesNotThrow(() -> controller.deleteModel("Entity1"), "Should be ok since we deleted the references" +

--- a/marklogic-data-hub-central/src/test/resources/test-projects/delete-model-project/flows/testFlow.flow.json
+++ b/marklogic-data-hub-central/src/test/resources/test-projects/delete-model-project/flows/testFlow.flow.json
@@ -8,20 +8,10 @@
       "stepId": "testMap2-mapping"
     },
     "3": {
-      "name": "matching-step",
-      "stepDefinitionName": "default-matching",
-      "stepDefinitionType": "matching",
-      "options": {
-        "targetEntity": "Entity2"
-      }
+      "stepId": "matching-step-matching"
     },
     "4": {
-      "name": "merging-step",
-      "stepDefinitionName": "default-merging",
-      "stepDefinitionType": "merging",
-      "options": {
-        "targetEntity": "Entity1"
-      }
+      "stepId": "merging-step-merging"
     }
   }
 }

--- a/marklogic-data-hub-central/src/test/resources/test-projects/delete-model-project/steps/matching/matching-step.step.json
+++ b/marklogic-data-hub-central/src/test/resources/test-projects/delete-model-project/steps/matching/matching-step.step.json
@@ -1,0 +1,6 @@
+{
+  "name": "matching-step",
+  "stepDefinitionName": "default-matching",
+  "stepDefinitionType": "matching",
+  "targetEntity": "Entity2"
+}

--- a/marklogic-data-hub-central/src/test/resources/test-projects/delete-model-project/steps/merging/merrging-step.step.json
+++ b/marklogic-data-hub-central/src/test/resources/test-projects/delete-model-project/steps/merging/merrging-step.step.json
@@ -1,0 +1,6 @@
+{
+  "name": "merging-step",
+  "stepDefinitionName": "default-merging",
+  "stepDefinitionType": "merging",
+  "targetEntity": "Entity1"
+}

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writer.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writer.spec.tsx
@@ -125,8 +125,6 @@ describe('Entity Modeling: Writer Role', () => {
     propertyTable.editProperty('fname');
     cy.waitUntil(() => propertyModal.getToggleStepsButton().should('exist')).click();
     cy.contains('mapPersonJSON').should('be.visible');
-    cy.contains('match-person').should('be.visible');
-    cy.contains('merge-person').should('be.visible');
     cy.contains('master-person').should('be.visible');
     cy.contains('Hide Steps...').should('be.visible');
 
@@ -137,8 +135,6 @@ describe('Entity Modeling: Writer Role', () => {
     cy.contains('Show Steps...').should('be.visible');
 
     cy.contains('mapPersonJSON').should('not.be.visible');
-    cy.contains('match-person').should('not.be.visible');
-    cy.contains('merge-person').should('not.be.visible');
     cy.contains('master-person').should('not.be.visible');
     cy.contains('Hide Steps...').should('not.be.visible');
     propertyModal.getCancelButton().click();

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/build.gradle
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
     repositories {
-        maven {url 'http://distro.marklogic.com/nexus/repository/maven-snapshots/'}
         mavenLocal()
         maven { url "https://plugins.gradle.org/m2/" }
         jcenter()

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/modeling.js
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/modeling.js
@@ -854,21 +854,21 @@ export const entityDefinitionsArray = [
 ]
 
 export const referencePayloadEmpty = {
-  "stepAndMappingNames": [],
+  "stepNames": [],
   "entityNames": []
 }
 
 export const referencePayloadSteps = {
-  "stepAndMappingNames": ['Order-Load', 'Order-Map'],
+  "stepNames": ['Order-Load', 'Order-Map'],
   "entityNames": []
 }
 
 export const referencePayloadRelationships = {
-  "stepAndMappingNames": [],
+  "stepNames": [],
   "entityNames": ['Protein']
 }
 
 export const referencePayloadStepRelationships = {
-  "stepAndMappingNames": ['Order-Load', 'Order-Map'],
+  "stepNames": ['Order-Load', 'Order-Map'],
   "entityNames": ['Protein']
 }

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.tsx
@@ -88,9 +88,9 @@ const EntityTypeTable: React.FC<Props> = (props) => {
           setArrayValues(modelingOptions.modifiedEntitiesArray.map(entity => entity.entityName));
         }
 
-        if (response['data']['stepAndMappingNames'].length > 0) {
+        if (response['data']['stepNames'].length > 0) {
           newConfirmType = ConfirmationType.DeleteEntityStepWarn;
-          setArrayValues(response['data']['stepAndMappingNames']);
+          setArrayValues(response['data']['stepNames']);
         } else if (response['data']['entityNames'].length > 0) {
           if (isAnyEntityModified) {
             newConfirmType = ConfirmationType.DeleteEntityRelationshipOutstandingEditWarn;

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.tsx
@@ -219,13 +219,13 @@ const PropertyModal: React.FC<Props> = (props) => {
         let newConfirmType = ConfirmationType.DeletePropertyWarn;
         let boldText = [name]
 
-        if (response['data']['stepAndMappingNames'].length > 0) {
+        if (response['data']['stepNames'].length > 0) {
           newConfirmType = ConfirmationType.DeletePropertyStepWarn;
           boldText.push(props.entityName);
         }
         setConfirmBoldTextArray(boldText);
         setConfirmType(newConfirmType);
-        setStepValuesArray(response['data']['stepAndMappingNames']);
+        setStepValuesArray(response['data']['stepNames']);
       }
     } catch (error) {
       handleError(error)

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
@@ -586,14 +586,14 @@ const PropertyTable: React.FC<Props> = (props) => {
         let newConfirmType = ConfirmationType.DeletePropertyWarn;
         let boldText: string[] = [record.propertyName]
 
-        if (response['data']['stepAndMappingNames'].length > 0) {
+        if (response['data']['stepNames'].length > 0) {
           newConfirmType = ConfirmationType.DeletePropertyStepWarn;
           boldText.push(text);
         }
 
         setDeletePropertyOptions({ definitionName: definitionName, propertyName: record.propertyName });
         setConfirmBoldTextArray(boldText);
-        setStepValuesArray(response['data']['stepAndMappingNames']);
+        setStepValuesArray(response['data']['stepNames']);
         setConfirmType(newConfirmType);
         toggleConfirmModal(true);
       }

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-entity-model-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-entity-model-writer.json
@@ -5,6 +5,8 @@
     "hub-central-entity-model-reader",
     "data-hub-entity-model-writer",
     "data-hub-mapping-reader",
+    "data-hub-match-merge-reader",
+    "data-hub-custom-reader",
     "data-hub-flow-reader",
     "tde-admin"
   ],

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/deleteModel.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/deleteModel.sjs
@@ -33,9 +33,9 @@ if (!entityModel) {
 const entityTypeId = entityLib.getEntityTypeId(entityModel, entityName);
 const entityModelUri = entityLib.getModelUri(entityName);
 
-const stepAndMappingNames = entityLib.findModelReferencesInSteps(entityName, entityTypeId);
-if (stepAndMappingNames.length) {
-  ds.throwServerError(`Cannot delete the entity type '${entityName}' because it is referenced by the following step and/or mapping names: ${stepAndMappingNames}`);
+const stepNames = entityLib.findModelReferencesInSteps(entityName, entityTypeId);
+if (stepNames.length) {
+  ds.throwServerError(`Cannot delete the entity type '${entityName}' because it is referenced by the following step names: ${stepNames}`);
 }
 
 entityLib.deleteModel(entityName);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/getModelReferences.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/getModelReferences.sjs
@@ -34,8 +34,8 @@ if (!entityModel) {
 const entityTypeId = entityLib.getEntityTypeId(entityModel, entityName);
 const entityModelUri = entityLib.getModelUri(entityName);
 
-const stepAndMappingNames = entityLib.findModelReferencesInSteps(entityName, entityTypeId);
+const stepNames = entityLib.findModelReferencesInSteps(entityName, entityTypeId);
 const entityNames = entityLib.findModelReferencesInOtherModels(entityModelUri, entityTypeId);
-const result = {stepAndMappingNames, entityNames};
+const result = {stepNames, entityNames};
 
 result;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/entity-lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/entity-lib.sjs
@@ -218,31 +218,12 @@ function deleteModel(entityName) {
  * @returns {[]}
  */
 function findModelReferencesInSteps(entityName, entityTypeId) {
-  let steps = [];
-
-  const mappingQuery = cts.andQuery([
-    cts.collectionQuery('http://marklogic.com/data-hub/mappings'),
-    cts.jsonPropertyValueQuery("targetEntityType", [entityName, entityTypeId])
+  const stepQuery = cts.andQuery([
+    cts.collectionQuery('http://marklogic.com/data-hub/steps'),
+    cts.jsonPropertyValueQuery(["targetEntityType", "targetEntity"], [entityName, entityTypeId])
   ]);
-  steps = cts.search(mappingQuery).toArray().map(mapping => mapping.toObject().name);
 
-
-  const flowQuery = cts.andQuery([
-    cts.collectionQuery('http://marklogic.com/data-hub/flow'),
-    cts.notQuery(cts.collectionQuery(consts.HUB_ARTIFACT_COLLECTION)),
-    cts.jsonPropertyValueQuery("targetEntity", entityName)
-  ]);
-  cts.search(flowQuery).toArray()
-    .map(flow => flow.toObject())
-    .filter(flow => flow.steps)
-    .forEach(flow => {
-      const flowSteps = flow.steps;
-      Object.keys(flowSteps)
-        .filter(stepNumber => flowSteps[stepNumber].options && flowSteps[stepNumber].options.targetEntity === entityName)
-        .forEach(stepNumber => steps.push(flowSteps[stepNumber].name));
-    });
-
-  return steps;
+  return cts.search(stepQuery).toArray().map(step => step.toObject().name);
 }
 
 /**


### PR DESCRIPTION
### Description
* Assigned `data-hub-match-merge-reader` and `data-hub-custom-reader` roles to `hub-central-entity-model-writer` role so that we can check for entity type references in matching/merging/mastering/custom steps.
* Changed JSON model key from `stepAndMappingNames` to `stepNames`.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

