### PR TITLE
DHFPROD-5682:5788: Retrieve and apply keystore from cloud services

### DIFF
--- a/marklogic-data-hub-central/build.gradle
+++ b/marklogic-data-hub-central/build.gradle
@@ -68,6 +68,15 @@ dependencies {
         exclude group: "com.squareup.okhttp3", module: "okhttp"
         exclude group: "com.squareup.okhttp3", module: "logging-interceptor"
     }
+
+    // Excluding okhttp3 dependency as it bumps down the dependency from 4.4.0 to 3.x
+    implementation ('com.microsoft.azure:azure-keyvault-secrets-spring-boot-starter:2.2.4') {
+        exclude group: "com.squareup.okhttp3", module: "okhttp"
+    }
+    implementation 'com.azure:azure-storage-blob:12.8.0'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.11.847'
+    implementation 'com.amazonaws:aws-java-sdk-ssm:1.11.847'
+
     runtime "com.squareup.okhttp3:okhttp:4.4.0"
     runtime "com.squareup.okhttp3:logging-interceptor:4.4.0"
 

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/cloud/aws/AWSConfiguration.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/cloud/aws/AWSConfiguration.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2012-2020 MarkLogic Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.marklogic.hub.central.cloud.aws;
+
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
+import com.marklogic.hub.central.web.SslUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import java.io.InputStream;
+
+@Configuration
+@Profile("aws")
+public class AWSConfiguration {
+
+    private static final Logger logger = LoggerFactory.getLogger(AWSConfiguration.class);
+
+    @Value("${aws.s3.bucketName}")
+    private String bucketName;
+
+    @Value("${aws.s3.keyName}")
+    private String keyName;
+
+    private String keyStorePassword;
+
+    @Bean
+    public ServerProperties serverProperties() {
+        return SslUtil.buildServerProperties(retrieveKeyStorePassword());
+    }
+
+    @Bean
+    public WebServerFactoryCustomizer<TomcatServletWebServerFactory> tomcatSslStoreCustomizer() {
+        return SslUtil.configureSslStoreProvider(retrieveKeyStorePassword(), retrieveKeyStoreFile());
+    }
+
+    private String retrieveKeyStorePassword() {
+        if (keyStorePassword != null) {
+            return keyStorePassword;
+        }
+
+        logger.info("Retrieving keystore password");
+        GetParameterRequest parameterRequest = new GetParameterRequest()
+                .withName("key-store-password")
+                .withWithDecryption(true);
+
+        keyStorePassword = AWSSimpleSystemsManagementClientBuilder
+                .defaultClient()
+                .getParameter(parameterRequest)
+                .getParameter()
+                .getValue();
+        logger.info("Retrieved keystore password");
+
+        return keyStorePassword;
+    }
+
+    private InputStream retrieveKeyStoreFile() {
+        logger.info("Retrieving keystore file");
+        InputStream keyStoreStream = AmazonS3ClientBuilder
+                .defaultClient()
+                .getObject(bucketName, keyName)
+                .getObjectContent();
+        logger.info("Retrieved keystore file");
+
+        return keyStoreStream;
+    }
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/cloud/azure/AzureConfiguration.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/cloud/azure/AzureConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2012-2020 MarkLogic Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.marklogic.hub.central.cloud.azure;
+
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.storage.blob.BlobClientBuilder;
+import com.marklogic.hub.central.web.SslUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import java.io.InputStream;
+
+@Configuration
+@Profile("azure")
+public class AzureConfiguration {
+
+    private static final Logger logger = LoggerFactory.getLogger(AzureConfiguration.class);
+
+    @Value("${key-store-password}")
+    private String keyStorePassword;
+
+    @Value("${azure.storage.endpoint}")
+    private String endpoint;
+
+    @Value("${azure.storage.containerName}")
+    private String containerName;
+
+    @Value("${azure.storage.blobName}")
+    private String blobName;
+
+    @Bean
+    public ServerProperties serverProperties() {
+        return SslUtil.buildServerProperties(keyStorePassword);
+    }
+
+    @Bean
+    public WebServerFactoryCustomizer<TomcatServletWebServerFactory> tomcatSslStoreCustomizer() {
+        return SslUtil.configureSslStoreProvider(keyStorePassword, retrieveKeyStoreFile());
+    }
+
+    private InputStream retrieveKeyStoreFile() {
+        logger.info("Retrieving keystore file");
+        InputStream keyStoreStream = new BlobClientBuilder()
+                .endpoint(endpoint)
+                .containerName(containerName)
+                .blobName(blobName)
+                .credential(new DefaultAzureCredentialBuilder().build())
+                .buildClient()
+                .openInputStream();
+        logger.info("Retrieved keystore file");
+
+        return keyStoreStream;
+    }
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/web/SslUtil.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/web/SslUtil.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2012-2020 MarkLogic Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.marklogic.hub.central.web;
+
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.Ssl;
+import org.springframework.boot.web.server.SslStoreProvider;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+
+import java.io.InputStream;
+import java.security.KeyStore;
+
+public class SslUtil {
+
+    public static String KEY_STORE_TYPE = "PKCS12";
+
+    public static ServerProperties buildServerProperties(String keyStorePassword) {
+        final ServerProperties serverProperties = new ServerProperties();
+        final Ssl ssl = new Ssl();
+        System.setProperty("server.ssl.key-store-password", keyStorePassword);
+        ssl.setKeyPassword(keyStorePassword);
+        serverProperties.setSsl(ssl);
+        return serverProperties;
+    }
+
+    public static WebServerFactoryCustomizer<TomcatServletWebServerFactory> configureSslStoreProvider(String keyStorePassword, InputStream keyStoreFile) {
+        KeyStore keyStore;
+
+        try (InputStream is = keyStoreFile) {
+            keyStore = KeyStore.getInstance(KEY_STORE_TYPE);
+            keyStore.load(is, keyStorePassword.toCharArray());
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Cannot load keystore file; cause: " + e.getMessage(), e);
+        }
+
+        return tomcat -> tomcat.setSslStoreProvider(new SslStoreProvider() {
+            @Override
+            public KeyStore getKeyStore() {
+                return keyStore;
+            }
+
+            @Override
+            public KeyStore getTrustStore() {
+                return null;
+            }
+        });
+    }
+}


### PR DESCRIPTION
### Description
Introduced two new spring profiles specific to Azure and AWS which when activated will try to fetch the certificate artifacts from Azure/AWS services using the configured properties.

Following properties are needed for configuration:

AWS properties
```
spring.profiles.active=aws
aws.s3.bucketName=
aws.s3.keyName=
```

Azure properties
```
spring.profiles.active=azure
azure.keyvault.uri=
azure.storage.endpoint=
azure.storage.containerName=
azure.storage.blobName=
```

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [N/A] Added Tests
  

- ##### Reviewer:

- [N/A] Reviewed Tests

