### PR TITLE
DHFPROD-5840: Avoiding null pointer while upgrading project

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
@@ -633,9 +633,11 @@ public class HubProjectImpl implements HubProject {
     protected void updateStepDefinitionTypeForInlineMappingSteps() {
         try {
             flowManager.getLocalFlows().forEach(flow -> {
-                flow.getSteps().values().forEach((step) -> {
-                    if ((step.getStepDefinitionType().equals(StepDefinition.StepDefinitionType.MAPPING)) &&
-                        step.getStepDefinitionName().equalsIgnoreCase("default-mapping")) {
+                flow.getSteps().values().forEach(step -> {
+                    if (
+                        StepDefinition.StepDefinitionType.MAPPING.equals(step.getStepDefinitionType()) &&
+                            "default-mapping".equalsIgnoreCase(step.getStepDefinitionName()))
+                    {
                         step.setStepDefinitionName("entity-services-mapping");
                     }
                 });


### PR DESCRIPTION
### Description

Without changing the code quite a bit, it's not possible to write a test for this condition because the null pointer exception (which occurs when stepDefinitionType is not set, which is true for converted steps) is caught and logged. And it's the logged error message that's confusing for users. So this just modifies the "if" condition so that the values being tested are on the right hand side of "equals" instead of the left hand side, thus avoiding the chance of a confusing NPE. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

