### PR TITLE
DHFPROD-5794: Speeding up saving models

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/ModelsService.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/ModelsService.java
@@ -54,6 +54,7 @@ public interface ModelsService {
             private BaseProxy.DBFunctionRequest req_getPrimaryEntityTypes;
             private BaseProxy.DBFunctionRequest req_deleteModel;
             private BaseProxy.DBFunctionRequest req_createModel;
+            private BaseProxy.DBFunctionRequest req_saveModels;
             private BaseProxy.DBFunctionRequest req_getModelReferences;
             private BaseProxy.DBFunctionRequest req_updateModelEntityTypes;
             private BaseProxy.DBFunctionRequest req_getLatestJobData;
@@ -76,6 +77,8 @@ public interface ModelsService {
                     "deleteModel.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC);
                 this.req_createModel = this.baseProxy.request(
                     "createModel.sjs", BaseProxy.ParameterValuesKind.SINGLE_NODE);
+                this.req_saveModels = this.baseProxy.request(
+                    "saveModels.sjs", BaseProxy.ParameterValuesKind.SINGLE_NODE);
                 this.req_getModelReferences = this.baseProxy.request(
                     "getModelReferences.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC);
                 this.req_updateModelEntityTypes = this.baseProxy.request(
@@ -181,6 +184,19 @@ public interface ModelsService {
             }
 
             @Override
+            public void saveModels(com.fasterxml.jackson.databind.JsonNode models) {
+                saveModels(
+                    this.req_saveModels.on(this.dbClient), models
+                    );
+            }
+            private void saveModels(BaseProxy.DBFunctionRequest request, com.fasterxml.jackson.databind.JsonNode models) {
+              request
+                      .withParams(
+                          BaseProxy.documentParam("models", false, BaseProxy.JsonDocumentType.fromJsonNode(models))
+                          ).responseNone();
+            }
+
+            @Override
             public com.fasterxml.jackson.databind.JsonNode getModelReferences(String entityName) {
                 return getModelReferences(
                     this.req_getModelReferences.on(this.dbClient), entityName
@@ -283,6 +299,14 @@ public interface ModelsService {
    * @return	as output
    */
     com.fasterxml.jackson.databind.JsonNode createModel(com.fasterxml.jackson.databind.JsonNode input);
+
+  /**
+   * Save an array of entity models
+   *
+   * @param models	The array of entity models
+   * 
+   */
+    void saveModels(com.fasterxml.jackson.databind.JsonNode models);
 
   /**
    * Returns a json containing the names of the models and steps that reference the given entity model.

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/createModel.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/createModel.sjs
@@ -15,6 +15,8 @@
 */
 'use strict';
 
+declareUpdate();
+
 xdmp.securityAssert("http://marklogic.com/data-hub/privileges/write-entity-model", "execute");
 
 const ds = require("/data-hub/5/data-services/ds-utils.sjs");

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/saveModel.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/saveModel.sjs
@@ -15,6 +15,8 @@
 */
 'use strict';
 
+declareUpdate();
+
 xdmp.securityAssert("http://marklogic.com/data-hub/privileges/write-entity-model", "execute");
 
 const ds = require("/data-hub/5/data-services/ds-utils.sjs");

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/saveModels.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/saveModels.api
@@ -1,0 +1,12 @@
+{
+    "functionName": "saveModels",
+    "desc": "Save an array of entity models to only the database associated with the app server that receives this request",
+    "params": [
+        {
+            "name": "models",
+            "datatype": "jsonDocument",
+            "$javaClass": "com.fasterxml.jackson.databind.JsonNode",
+            "desc": "The array of entity models"
+        }
+    ]
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/saveModels.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/saveModels.sjs
@@ -1,0 +1,39 @@
+/**
+ Copyright (c) 2020 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+declareUpdate();
+
+xdmp.securityAssert("http://marklogic.com/data-hub/privileges/write-entity-model", "execute");
+
+const ds = require("/data-hub/5/data-services/ds-utils.sjs");
+const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
+
+var models = fn.head(xdmp.fromJSON(models));
+
+/*
+This endpoint only writes to one database, as testing has shown that using xdmp.invoke in conjunction with
+pre and post commit triggers results in significantly worse performance - e.g. 20 models will take several seconds to load,
+as opposed to hundreds of milliseconds when saved directly via xdmp.documentInsert.
+ */
+const databases = [xdmp.databaseName(xdmp.database())];
+models.forEach(model => {
+  const name = model.info.title;
+  if (name == null) {
+    ds.throwBadRequest("The model must have an info object with a title property");
+  }
+  entityLib.writeModelToDatabases(name, model, databases);
+});

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelEntityTypes.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelEntityTypes.sjs
@@ -15,6 +15,8 @@
 */
 'use strict';
 
+declareUpdate();
+
 xdmp.securityAssert("http://marklogic.com/data-hub/privileges/write-entity-model", "execute");
 
 const ds = require("/data-hub/5/data-services/ds-utils.sjs");

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelInfo.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelInfo.sjs
@@ -15,6 +15,8 @@
 */
 'use strict';
 
+declareUpdate();
+
 xdmp.securityAssert("http://marklogic.com/data-hub/privileges/write-entity-model", "execute");
 
 const ds = require("/data-hub/5/data-services/ds-utils.sjs");

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsPerformanceTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsPerformanceTest.java
@@ -1,0 +1,143 @@
+package com.marklogic.hub.deploy.commands;
+
+import com.marklogic.hub.AbstractHubCoreTest;
+import com.marklogic.hub.step.StepDefinition;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.FileCopyUtils;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is intended as a quick performance test of loading a significant number of artifacts of a certain type. Each
+ * test is meant to finish under a second or so, which indicates that performance is acceptable for the number of
+ * artifacts being loaded in each test. The tests are not doing assertions on the amount of time, as those
+ * assertions are likely to be very brittle. Instead, the time to load artifacts is logged for manual inspection.
+ */
+public class LoadUserArtifactsPerformanceTest extends AbstractHubCoreTest {
+
+    /**
+     * The root cause that led to this test being created was that when an entity model is saved, the use of
+     * xdmp.invoke to write a document to a different database plus the existence of a pre and post triggers on that
+     * document led to some significant performance delays. So this test is used as a quick sanity check that a
+     * reasonably large number of entity models can be written in a second or so.
+     *
+     * @throws Exception
+     */
+    @Test
+    void entities() throws Exception {
+        String template = "{\n" +
+            "  \"info\": {\n" +
+            "    \"title\": \"changeme\",\n" +
+            "    \"version\": \"0.0.1\",\n" +
+            "    \"baseUri\": \"http://marklogic.com/\"\n" +
+            "  },\n" +
+            "  \"definitions\": {\n" +
+            "    \"changeme\": {\n" +
+            "      \"properties\": {\n" +
+            "        \"OrderID\": {\n" +
+            "          \"datatype\": \"string\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
+        final int entityCount = 10;
+        for (int i = 1; i <= entityCount; i++) {
+            String model = template.replaceAll("changeme", "Entity" + i);
+            File file = getHubProject().getHubEntitiesDir().resolve("Entity" + i + ".entity.json").toFile();
+            FileCopyUtils.copy(model.getBytes(), file);
+        }
+
+        loadUserArtifacts();
+
+        final String collection = "http://marklogic.com/entity-services/models";
+        assertEquals(entityCount, getStagingDocCount(collection));
+        assertEquals(entityCount, getFinalDocCount(collection));
+    }
+
+    /**
+     * This test is included as a quick verification that writing artifacts to both staging and final works just fine
+     * when there's not a pre-commit trigger involved.
+     *
+     * @throws Exception
+     */
+    @Test
+    void stepsWithoutPreCommitTriggers() throws Exception {
+        String template = "{\n" +
+            "  \"name\": \"changeme\",\n" +
+            "  \"collections\": [\n" +
+            "    \"ingestion-step\"\n" +
+            "  ],\n" +
+            "  \"permissions\": \"data-hub-common,read,data-hub-common,update\",\n" +
+            "  \"stepDefinitionName\": \"default-ingestion\",\n" +
+            "  \"stepDefinitionType\": \"INGESTION\",\n" +
+            "  \"targetDatabase\": \"data-hub-STAGING\",\n" +
+            "  \"targetFormat\": \"json\",\n" +
+            "  \"inputFilePath\": \"input/json/customers\",\n" +
+            "  \"outputURIReplacement\": \".*input,'/cusIngTest/'\",\n" +
+            "  \"sourceFormat\": \"json\",\n" +
+            "  \"sourceQuery\": \"cts.collectionQuery([])\",\n" +
+            "  \"outputFormat\": \"json\"\n" +
+            "}\n";
+
+        final int stepCount = 20;
+        for (int i = 1; i <= stepCount; i++) {
+            String step = template.replaceAll("changeme", "ingest" + i);
+            getHubProject().getStepsPath(StepDefinition.StepDefinitionType.INGESTION).toFile().mkdirs();
+            File file = getHubProject().getStepsPath(StepDefinition.StepDefinitionType.INGESTION).resolve("ingest" + i + ".step.json").toFile();
+            FileCopyUtils.copy(step.getBytes(), file);
+        }
+
+        loadUserArtifacts();
+
+        final String collection = "http://marklogic.com/data-hub/steps/ingestion";
+        assertEquals(stepCount, getStagingDocCount(collection));
+        assertEquals(stepCount, getFinalDocCount(collection));
+    }
+
+    /**
+     * Mapping steps have pre-commit triggers, but not post-commit triggers. Interestingly, 20 mappings still load
+     * in around a second or so and thus don't have the same performance issues as entity models. So it may be the
+     * combination of pre and post commit triggers on entity models that cause problems.
+     *
+     * @throws Exception
+     */
+    @Test
+    void mappingStepsWhichHavePreCommitTriggers() throws Exception {
+        installOnlyReferenceModelEntities();
+
+        String template = "{\n" +
+            "  \"lang\": \"zxx\",\n" +
+            "  \"name\": \"changeme\",\n" +
+            "  \"version\": 1,\n" +
+            "  \"targetEntityType\": \"Order\",\n" +
+            "  \"sourceContext\": \"/\",\n" +
+            "  \"selectedSource\": \"collection\",\n" +
+            "  \"properties\": {\n" +
+            "  }\n" +
+            "}";
+
+        final int stepCount = 20;
+        for (int i = 1; i <= stepCount; i++) {
+            String step = template.replaceAll("changeme", "mapping" + i);
+            getHubProject().getStepsPath(StepDefinition.StepDefinitionType.MAPPING).toFile().mkdirs();
+            File file = getHubProject().getStepsPath(StepDefinition.StepDefinitionType.MAPPING).resolve("mapping" + i + ".step.json").toFile();
+            FileCopyUtils.copy(step.getBytes(), file);
+        }
+
+        loadUserArtifacts();
+
+        final String collection = "http://marklogic.com/data-hub/steps/mapping";
+        assertEquals(stepCount, getStagingDocCount(collection));
+        assertEquals(stepCount, getFinalDocCount(collection));
+    }
+
+    private void loadUserArtifacts() {
+        long start = System.currentTimeMillis();
+        new LoadUserArtifactsCommand(getHubConfig()).execute(newCommandContext());
+        logger.info("Time to load: " + (System.currentTimeMillis() - start));
+    }
+}


### PR DESCRIPTION
### Description

Added saveModels.sjs endpoint that saves models to one database only to avoid the combo of xdmp.invoke plus pre/post triggers, which causes performance delays. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

