### PR TITLE
DHFPROD-5862: Speeding up deployment of granular privileges

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesTest.java
@@ -51,28 +51,28 @@ public class CreateGranularPrivilegesTest extends AbstractHubCoreTest {
 
         Privilege p = resourceMapper.readResource(mgr.getAsJson("admin-database-clear-data-hub-STAGING", "kind", "execute"), Privilege.class);
         assertEquals("http://marklogic.com/xdmp/privileges/admin/database/clear/" + stagingDbId, p.getAction());
-        assertEquals("data-hub-admin", p.getRole().get(0));
-        assertEquals("hub-central-clear-user-data", p.getRole().get(1));
+        assertTrue(p.getRole().contains("data-hub-admin"));
+        assertTrue(p.getRole().contains("hub-central-clear-user-data"));
 
         p = resourceMapper.readResource(mgr.getAsJson("admin-database-clear-data-hub-FINAL", "kind", "execute"), Privilege.class);
         assertEquals("http://marklogic.com/xdmp/privileges/admin/database/clear/" + finalDbId, p.getAction());
-        assertEquals("data-hub-admin", p.getRole().get(0));
-        assertEquals("hub-central-clear-user-data", p.getRole().get(1));
+        assertTrue(p.getRole().contains("data-hub-admin"));
+        assertTrue(p.getRole().contains("hub-central-clear-user-data"));
 
         p = resourceMapper.readResource(mgr.getAsJson("admin-database-clear-data-hub-JOBS", "kind", "execute"), Privilege.class);
         assertEquals("http://marklogic.com/xdmp/privileges/admin/database/clear/" + jobsDbId, p.getAction());
-        assertEquals("data-hub-admin", p.getRole().get(0));
-        assertEquals("hub-central-clear-user-data", p.getRole().get(1));
+        assertTrue(p.getRole().contains("data-hub-admin"));
+        assertTrue(p.getRole().contains("hub-central-clear-user-data"));
 
         p = resourceMapper.readResource(mgr.getAsJson("admin-database-index-data-hub-STAGING", "kind", "execute"), Privilege.class);
         assertEquals("http://marklogic.com/xdmp/privileges/admin/database/index/" + stagingDbId, p.getAction());
-        assertEquals("data-hub-developer", p.getRole().get(0));
-        assertEquals("hub-central-entity-model-writer", p.getRole().get(1));
+        assertTrue(p.getRole().contains("data-hub-developer"));
+        assertTrue(p.getRole().contains("hub-central-entity-model-writer"));
 
         p = resourceMapper.readResource(mgr.getAsJson("admin-database-index-data-hub-FINAL", "kind", "execute"), Privilege.class);
         assertEquals("http://marklogic.com/xdmp/privileges/admin/database/index/" + finalDbId, p.getAction());
-        assertEquals("data-hub-developer", p.getRole().get(0));
-        assertEquals("hub-central-entity-model-writer", p.getRole().get(1));
+        assertTrue(p.getRole().contains("data-hub-developer"));
+        assertTrue(p.getRole().contains("hub-central-entity-model-writer"));
 
         p = resourceMapper.readResource(mgr.getAsJson("admin-database-index-data-hub-JOBS", "kind", "execute"), Privilege.class);
         assertEquals("http://marklogic.com/xdmp/privileges/admin/database/index/" + jobsDbId, p.getAction());


### PR DESCRIPTION
### Description

Using CMA instead of RMA, and updating roles w/privileges instead of updating privileges w/ roles. Had to update the assertions in the test because the order in which the roles appear in a privilege isn't guaranteed. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

