### PR TITLE
DHFPROD-5239: Creating a new ingestion step may result in it being in…

### DIFF
--- a/marklogic-data-hub-central/ui/src/assets/mock-data/common.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/common.data.ts
@@ -57,6 +57,15 @@ const loadData = {
       outputURIReplacement: "",
       inputFilePath: "/xml-test/data-sets/testLoad",
       lastUpdated: "2020-04-15T14:22:54.057519-07:00"
+    },
+    {
+      name: "testLoad123",
+      description: "description for CSV load",
+      sourceFormat: "csv",
+      targetFormat: "csv",
+      outputURIReplacement: "",
+      inputFilePath: "/csv-test/data-sets/testLoad",
+      lastUpdated: "2016-08-27T03:10:30.073426-05:00"
     }
   ],
   deleteLoadArtifact: jest.fn(),

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.test.tsx
@@ -8,6 +8,7 @@ import loadData from "../../assets/mock-data/ingestion.data";
 import { AdvancedSettingsMessages } from '../../config/messages.config';
 import {MemoryRouter} from "react-router-dom";
 import { AuthoritiesService, AuthoritiesContext } from '../../util/authorities';
+import { validateTableRow } from '../../util/test-utils';
 
 jest.mock('axios');
 
@@ -46,9 +47,8 @@ describe('Load data component', () => {
   })
 
   test('Verify Load list view renders correctly with data', () => {
-    const { getByText, getAllByLabelText } = render(<MemoryRouter><LoadList {...data.loadData} /></MemoryRouter>)
+    const { getByText, getAllByLabelText, getByTestId } = render(<MemoryRouter><LoadList {...data.loadData} /></MemoryRouter>)
     const dataRow = within(getByText('testLoadXML').closest('tr'));
-
     expect(dataRow.getByText(data.loadData.data[1].name)).toBeInTheDocument();
     expect(dataRow.getByText(data.loadData.data[1].description)).toBeInTheDocument();
     expect(dataRow.getByText(data.loadData.data[1].sourceFormat)).toBeInTheDocument();
@@ -57,7 +57,56 @@ describe('Load data component', () => {
     expect(dataRow.getByTestId(`${data.loadData.data[1].name}-settings`)).toBeInTheDocument();
     expect(dataRow.getByTestId(`${data.loadData.data[1].name}-delete`)).toBeInTheDocument();
 
-    expect(getAllByLabelText('icon: setting').length).toBe(2);
+    expect(getAllByLabelText('icon: setting').length).toBe(3);
+
+    //verify load list table enforces last updated sort order by default
+    let loadTable: any = document.querySelectorAll('.ant-table-row ant-table-row-level-0');
+    validateTableRow(loadTable, ['testLoadXML', 'testLoadXMLtoJSON','testLoad']);
+
+    //verify load list table enforces sorting by ascending date updated as well
+    let loadTableSort = getByTestId('loadTableDate');
+    fireEvent.click(loadTableSort);
+    validateTableRow(loadTable, ['testLoad', 'testLoad123', 'testLoadXML']);
+
+    //verify load list table enforces sorting by name alphabetically in ascending order
+    loadTableSort = getByTestId('loadTableName');
+    fireEvent.click(loadTableSort);
+    validateTableRow(loadTable, ['testLoad', 'testLoad123', 'testLoadXML']);
+
+    //verify load list table enforces sorting by name alphabetically in descending order
+    loadTableSort = getByTestId('loadTableName');
+    fireEvent.click(loadTableSort);
+    validateTableRow(loadTable, ['testLoadXML', 'testLoad123', 'testLoad']);
+
+    //verify load list table enforces sorting by source format alphabetically in ascending order
+    loadTableSort = getByTestId('loadTableSourceFormat');
+    fireEvent.click(loadTableSort);
+    validateTableRow(loadTable, ['testLoad123', 'testLoad', 'testLoadXML']);
+
+    //verify load list table enforces sorting by source format alphabetically in descending order
+    loadTableSort = getByTestId('loadTableSourceFormat');
+    fireEvent.click(loadTableSort);
+    validateTableRow(loadTable, ['testLoadXML', 'testLoad', 'testLoad123']);
+
+    //verify load list table enforces sorting by target format alphabetically in ascending order
+    loadTableSort = getByTestId('loadTableTargetFormat');
+    fireEvent.click(loadTableSort);
+    validateTableRow(loadTable, ['testLoad123', 'testLoad', 'testLoadXML']);
+
+    //verify load list table enforces sorting by target format alphabetically in descending order
+    loadTableSort = getByTestId('loadTableTargetFormat');
+    fireEvent.click(loadTableSort);
+    validateTableRow(loadTable, ['testLoadXML', 'testLoad', 'testLoad123']);
+
+    //verify load list table enforces sorting by Description alphabetically in ascending order
+    loadTableSort = getByTestId('loadTableDescription');
+    fireEvent.click(loadTableSort);
+    validateTableRow(loadTable, ['testLoad123', 'testLoad', 'testLoadXML']);
+
+    //verify load list table enforces sorting by Description alphabetically in descending order
+    loadTableSort = getByTestId('loadTableDescription');
+    fireEvent.click(loadTableSort);
+    validateTableRow(loadTable, ['testLoadXML', 'testLoad', 'testLoad123']);
   })
 
   test('Verify Load settings from list view renders correctly', async () => {

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.tsx
@@ -8,6 +8,7 @@ import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
 import {faTrashAlt} from '@fortawesome/free-regular-svg-icons';
 import NewLoadDialog from './new-load-dialog/new-load-dialog';
 import { MLButton } from '@marklogic/design-system';
+import  moment  from 'moment';
 import { convertDateFromISO } from '../../util/conversionFunctions';
 import AdvancedSettingsDialog from "../advanced-settings/advanced-settings-dialog";
 import {AdvLoadTooltips} from "../../config/tooltips.config";
@@ -170,24 +171,24 @@ const LoadList: React.FC<Props> = (props) => {
         <span style={{ fontSize: '16px' }}>Are you sure you want to delete this?</span>
     </Modal>;
 
-    const columns = [
+    const columns: any = [
         {
-          title: 'Name',
+          title: <span data-testid="loadTableName">Name</span>,
           dataIndex: 'name',
           key: 'name',
           render: (text: any,record: any) => (
               <span><span onClick={() => OpenEditStepDialog(record)} className={styles.editLoadConfig}>{text}</span> </span>
           ),
-          sorter: (a:any, b:any) => a.name.length - b.name.length,
+          sorter: (a:any, b:any) => a.name.localeCompare(b.name),
         },
         {
-          title: 'Description',
+          title: <span data-testid="loadTableDescription">Description</span>,
           dataIndex: 'description',
           key: 'description',
-          sorter: (a:any, b:any) => a.description.length - b.description.length,
+          sorter: (a:any, b:any) => a.description?.localeCompare(b.description)
         },
         {
-            title: 'Source Format',
+            title: <span data-testid="loadTableSourceFormat">Source Format</span>,
             dataIndex: 'sourceFormat',
             key: 'sourceFormat',
             render: (text, row) => (
@@ -196,22 +197,24 @@ const LoadList: React.FC<Props> = (props) => {
                     {row.sourceFormat === 'csv' ? <div className={styles.sourceFormatFS}>Field Separator: ( {row.separator} )</div> : ''}
                 </div>
             ),
-            sorter: (a:any, b:any) => a.sourceFormat.length - b.sourceFormat.length,
+            sorter: (a:any, b:any) => a.sourceFormat.localeCompare(b.sourceFormat),
         },
         {
-            title: 'Target Format',
+            title: <span data-testid="loadTableTargetFormat">Target Format</span>,
             dataIndex: 'targetFormat',
             key: 'targetFormat',
-            sorter: (a:any, b:any) => a.targetFormat.length - b.targetFormat.length,
+            sorter: (a:any, b:any) => a.targetFormat.localeCompare(b.targetFormate),
         },
         {
-            title: 'Last Updated',
+            title: <span data-testid="loadTableDate">Last Updated</span>,
             dataIndex: 'lastUpdated',
             key: 'lastUpdated',
             render: (text) => (
                 <div>{convertDateFromISO(text)}</div>
             ),
-            sorter: (a:any, b:any) => a.lastUpdated.length - b.lastUpdated.length,
+            sorter: (a:any, b:any) => moment(a.lastUpdated).unix() - moment(b.lastUpdated).unix(),
+            sortDirections: ["descend", "ascend"],
+            defaultSortOrder: "descend"
         },
         {
             title: 'Action',

--- a/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.test.tsx
@@ -4,7 +4,7 @@ import {entitySearch, entityPropertyDefinitions, selectedPropertyDefinitions, en
 import ResultsTabularView from "./results-tabular-view";
 import userEvent from "@testing-library/user-event";
 import { BrowserRouter as Router } from 'react-router-dom';
-import { validateExplorerResultsTableRow } from '../../util/test-utils';
+import { validateTableRow } from '../../util/test-utils';
 
 describe("Results Table view component", () => {
     test('Results table with data renders', async () => {
@@ -173,39 +173,39 @@ describe("Results Table view component", () => {
         /* Validate sorting on name column in results*/
         //Check the sort order of Name column rows before enforcing sort order
         let resultsTable: any = document.querySelectorAll('.ant-table-row ant-table-row-level-0');
-        validateExplorerResultsTableRow(resultsTable, urisDefault);
+        validateTableRow(resultsTable, urisDefault);
 
         //Click on the Name column to sort the rows by Ascending order
         fireEvent.click(nameColumnSort);
         resultsTable = document.querySelectorAll('.ant-table-row ant-table-row-level-0');
-        validateExplorerResultsTableRow(resultsTable, urisBasedOnAscendingName);
+        validateTableRow(resultsTable, urisBasedOnAscendingName);
 
         //Click on the Name column to sort the rows by Descending order
         fireEvent.click(nameColumnSort);
         resultsTable = document.querySelectorAll('.ant-table-row ant-table-row-level-0');
-        validateExplorerResultsTableRow(resultsTable, urisBasedOnDescendingName);
+        validateTableRow(resultsTable, urisBasedOnDescendingName);
 
         /* Validate sorting on customerId column in results*/
         //Click on the CustomerId column to sort the rows by Ascending order
         fireEvent.click(customerIdColumnSort);
         resultsTable = document.querySelectorAll('.ant-table-row ant-table-row-level-0');
-        validateExplorerResultsTableRow(resultsTable, urisDefault);
+        validateTableRow(resultsTable, urisDefault);
 
         //Click on the CustomerId column to sort the rows by Descending order
         fireEvent.click(customerIdColumnSort);
         resultsTable = document.querySelectorAll('.ant-table-row ant-table-row-level-0');
-        validateExplorerResultsTableRow(resultsTable, urisBasedOnDescendingCustomerId);
+        validateTableRow(resultsTable, urisBasedOnDescendingCustomerId);
 
         /* Validate sorting on nicknames column in results*/
         //Click on the nicknames column to sort the rows by Ascending order
         fireEvent.click(nickNamesColumnSort);
         resultsTable = document.querySelectorAll('.ant-table-row ant-table-row-level-0');
-        validateExplorerResultsTableRow(resultsTable, urisBasedOnAscendingNickNames);
+        validateTableRow(resultsTable, urisBasedOnAscendingNickNames);
 
         //Click on the nicknames column to sort the rows by Descending order
         fireEvent.click(nickNamesColumnSort);
         resultsTable = document.querySelectorAll('.ant-table-row ant-table-row-level-0');
-        validateExplorerResultsTableRow(resultsTable, urisBasedOnDescendingNickNames);
+        validateTableRow(resultsTable, urisBasedOnDescendingNickNames);
 
     });
 })

--- a/marklogic-data-hub-central/ui/src/util/test-utils.tsx
+++ b/marklogic-data-hub-central/ui/src/util/test-utils.tsx
@@ -34,7 +34,7 @@ const onClosestTableBody:any = command => command.closest('tbody');
 const onClosestTable:any = command => command.closest('table');
 const onClosestDiv:any = command => command.closest('div');
 
-const validateExplorerResultsTableRow = (dataTable, uris) => {
+const validateTableRow = (dataTable, uris) => {
     let rowKey = 0;
     
     dataTable.forEach(item => {
@@ -50,5 +50,5 @@ export {
     onClosestTableBody,
     onClosestTable,
     onClosestDiv,
-    validateExplorerResultsTableRow
+    validateTableRow
 }


### PR DESCRIPTION
… second page of table results

### Description
- Fixed all column sorters in Load List Table view as none were working properly, see my comment in https://project.marklogic.com/jira/browse/DHFPROD-5239 for more details.
- Load List Table now default sorts by Last Updated so newly created steps are seen at the top and do not disappear in later pages.
- Added tests that were missing for all sorting options in Load List component

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

