### PR TITLE
DHFPROD-5338: Handle internal bookmarks when unauthorized

### DIFF
--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/auth/WebSecurityConfiguration.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/auth/WebSecurityConfiguration.java
@@ -26,7 +26,11 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 
+import javax.servlet.DispatcherType;
+import javax.servlet.RequestDispatcher;
 import javax.servlet.http.HttpServletResponse;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
 
 /**
  * Configures Spring Security for the central web application.
@@ -55,7 +59,13 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
             .addFilterAfter(new AuthenticationFilter(hubCentral, hubClientProvider), LogoutFilter.class)
             .csrf().disable()
             // Need to setStatus, sendError causes issues. see https://stackoverflow.com/a/34911131
-            .exceptionHandling().authenticationEntryPoint(((request, response, authException) -> response.setStatus(HttpServletResponse.SC_UNAUTHORIZED)))
+            .exceptionHandling().authenticationEntryPoint(((request, response, authException) -> {
+                if (request.getRequestURI().startsWith("/api/")) {
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                } else {
+                    response.sendRedirect("/?from=" + URLEncoder.encode(request.getRequestURI(), "UTF-8"));
+                }
+            }))
             .and()
             // Define requests that are always permitted, regardless of whether the user is authenticated or not
             .authorizeRequests()

--- a/marklogic-data-hub-central/ui/src/App.tsx
+++ b/marklogic-data-hub-central/ui/src/App.tsx
@@ -41,6 +41,16 @@ const App: React.FC<Props> = ({history, location}) => {
     )}/>
   );
 
+  const getPageRoute = (loc) => {
+    if (loc.search && loc.search.startsWith("?from=")) {
+      return decodeURIComponent(loc.search.substring(6));
+    } else if (location.pathname !== '/' && location.pathname !== '/noresponse') {
+      return location.pathname
+    } else {
+      return user.pageRoute;
+    }
+  }
+
   useEffect(() => {
     if (user.authenticated){
       if (location.pathname === '/') {
@@ -53,9 +63,8 @@ const App: React.FC<Props> = ({history, location}) => {
     } else {
       if (user.error.type !== '') {
         history.push('/error');
-      } else if (location.pathname !== '/' && location.pathname !== '/noresponse') {
-        user.pageRoute = location.pathname;
       }
+      user.pageRoute = getPageRoute(location);
     }
   }, [user]);
 


### PR DESCRIPTION
NOTE: This update addresses the behavior when running on port 8080. (A port 3000 dev setup already worked.)

When a user is unauthorized and executes an internal browser bookmark or enters an internal URL in the browser bar:

1. Redirect user to login page.
2. Include route as URL param to enable redirection.
3. Redirect to that URL after login.

If the initial route is bad (e.g., /notavalidroute), the user sees a 404 page after login (as would be expected when redirecting to a bad route). 

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [ ] JIRA_ID included in all the commit messages
- [ ] PR title is in the format JIRA_ID:Title
- [ ] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [ ] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests

