### PR TITLE
DHFPROD-5338: Bookmark redirect

### DIFF
--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/auth/WebSecurityConfiguration.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/auth/WebSecurityConfiguration.java
@@ -26,7 +26,11 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 
+import javax.servlet.DispatcherType;
+import javax.servlet.RequestDispatcher;
 import javax.servlet.http.HttpServletResponse;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
 
 /**
  * Configures Spring Security for the central web application.
@@ -55,7 +59,13 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
             .addFilterAfter(new AuthenticationFilter(hubCentral, hubClientProvider), LogoutFilter.class)
             .csrf().disable()
             // Need to setStatus, sendError causes issues. see https://stackoverflow.com/a/34911131
-            .exceptionHandling().authenticationEntryPoint(((request, response, authException) -> response.setStatus(HttpServletResponse.SC_UNAUTHORIZED)))
+            .exceptionHandling().authenticationEntryPoint(((request, response, authException) -> {
+                if (request.getRequestURI().startsWith("/api/") || request.getRequestURI().startsWith("/websocket/")) {
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                } else {
+                    response.sendRedirect("/?from=" + URLEncoder.encode(request.getRequestURI(), "UTF-8"));
+                }
+            }))
             .and()
             // Define requests that are always permitted, regardless of whether the user is authenticated or not
             .authorizeRequests()

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/login/authorization.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/login/authorization.spec.tsx
@@ -8,6 +8,7 @@ import loadPage from "../../support/pages/load";
 import modelPage from "../../support/pages/model";
 import runPage from "../../support/pages/run";
 import curatePage from "../../support/pages/curate";
+import browsePage from "../../support/pages/browse";
 
 describe('login', () => {
 
@@ -76,7 +77,7 @@ describe('login', () => {
 
   it('should only enable Model and Explorer tile for hub-central-entity-model-reader', () => {
       cy.loginAsTestUserWithRoles('hub-central-entity-model-reader', 'hub-central-saved-query-user').withUI()
-          .url().should('include', '/tile');
+          .url().should('include', '/tiles');
       //All tiles but Explore and Model, should show a tooltip that says contact your administrator
       ['Load', 'Curate', 'Run'].forEach((tile) => {
           toolbar.getToolBarIcon(tile).should('have.attr', {style: 'cursor: not-allowed'})
@@ -90,8 +91,8 @@ describe('login', () => {
   it('should only enable Load and Explorer tile for hub-central-load-reader', () => {
       let stepName = 'loadCustomersJSON';
       let flowName= 'personJSON'
-      cy.loginAsTestUserWithRoles('hub-central-load-reader').withRequest()
-          .url().should('include', '/tile');
+      cy.loginAsTestUserWithRoles('hub-central-load-reader').withUI()
+          .url().should('include', '/tiles');
       //All tiles but Explore and Model, should show a tooltip that says contact your administrator
       ['Model', 'Curate', 'Run'].forEach((tile) => {
           toolbar.getToolBarIcon(tile).should('have.attr', {style: 'cursor: not-allowed'})
@@ -129,8 +130,8 @@ describe('login', () => {
   it('should only enable Curate and Explorer tile for hub-central-mapping-reader', () => {
       let entityTypeId = 'Customer'
       let mapStepName = 'mapCustomersXML'
-      cy.loginAsTestUserWithRoles('hub-central-mapping-reader').withRequest()
-          .url().should('include', '/tile');
+      cy.loginAsTestUserWithRoles('hub-central-mapping-reader').withUI()
+          .url().should('include', '/tiles');
       //All tiles but Explore and Model, should show a tooltip that says contact your administrator
       ['Load', 'Model', 'Run'].forEach((tile) => {
           toolbar.getToolBarIcon(tile).should('have.attr', {style: 'cursor: not-allowed'})
@@ -154,8 +155,8 @@ describe('login', () => {
   it('should only enable Run and Explorer tile for hub-central-step-runner', () => {
       const flowName = 'personJSON';
       const stepName = 'loadPersonJSON';
-      cy.loginAsTestUserWithRoles('hub-central-step-runner').withRequest()
-          .url().should('include', '/tile');
+      cy.loginAsTestUserWithRoles('hub-central-step-runner').withUI()
+          .url().should('include', '/tiles');
       //All tiles but Run and Explore, should show a tooltip that says contact your administrator
       ['Load', 'Model', 'Curate'].forEach((tile) => {
           toolbar.getToolBarIcon(tile).should('have.attr', {style: 'cursor: not-allowed'})
@@ -172,8 +173,8 @@ describe('login', () => {
   it('should only enable Run and Explorer tile for hub-central-flow-writer', () => {
       const flowName = 'personJSON';
       const stepName = 'loadPersonJSON';
-      cy.loginAsTestUserWithRoles('hub-central-flow-writer').withRequest()
-          .url().should('include', '/tile');
+      cy.loginAsTestUserWithRoles('hub-central-flow-writer').withUI()
+          .url().should('include', '/tiles');
       //All tiles but Run and Explore, should show a tooltip that says contact your administrator
       ['Load', 'Model', 'Curate'].forEach((tile) => {
           toolbar.getToolBarIcon(tile).should('have.attr', {style: 'cursor: not-allowed'})
@@ -195,6 +196,31 @@ describe('login', () => {
       projectInfo.getAboutProject().click();
       projectInfo.waitForInfoPageToLoad();
       projectInfo.getDownloadButton().click();
+  });
+
+  it('should redirect to /tiles/explore when uri is undefined for /detail view bookmark', () => {
+      let host = Cypress.config().baseUrl
+      cy.visit(`${host}/?from=%2Ftiles%2Fexplore%2Fdetail`)
+      loginPage.getUsername().type('hc-test-user');
+      loginPage.getPassword().type('password');
+      loginPage.getLoginButton().click();
+      cy.location('pathname').should('include', '/tiles/explore');
+      tiles.getExploreTile().should('exist');
+      browsePage.getSelectedEntity().should('contain', 'All Entities');
+  });
+
+  it('should redirect a bookmark to login screen when not authenticated', () => {
+      let host = Cypress.config().baseUrl
+      //URL from bookmark
+      cy.visit(`${host}/?from=%2Ftiles%2Fcurate`)
+      //Redirected to login
+      loginPage.getUsername().type('hc-developer');
+      loginPage.getPassword().type('password');
+      loginPage.getLoginButton().click();
+      cy.location('pathname').should('include', '/tiles/curate');
+      cy.waitUntil(() => cy.contains('Customer'));
+      cy.contains('Person');
+      cy.contains('No Entity Type');
   });
 
 });

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/login.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/login.tsx
@@ -1,27 +1,15 @@
 class LoginPage {
 
-    getPrivacyLink() {
-        return cy.get('[data-cy=privacy]');
-    }
-
-    getTermsLink() {
-        return cy.get('[data-cy=terms]');
-    }
-
-    getforgotPasswordLink() {
-        return cy.get('[data-cy=forgot]');    
-    }
-
     getUsername() {
-        return cy.get('#username'); 
+        return cy.get('#username');
     }
 
     getPassword() {
-        return cy.get('#password');  
+        return cy.get('#password');
     }
 
     getLoginButton() {
-        return cy.get('#submit'); 
+        return cy.get('#submit');
     }
 }
 

--- a/marklogic-data-hub-central/ui/src/App.test.tsx
+++ b/marklogic-data-hub-central/ui/src/App.test.tsx
@@ -29,8 +29,6 @@ describe('App component', () => {
   test('Verify header title links return to overview', async () => {
       mocks.loadAPI(axiosMock);
       const firstTool = Object.keys(tiles)[0];
-      // App defaults to pathname "/" which renders Login page. So setting the path to /tiles when App is rendered
-      history.push('/tiles');
       const { getByLabelText, queryByText } = render(<Router history={history}>
           <AuthoritiesContext.Provider value={mockDevRolesService}>
             <UserContext.Provider value={userAuthenticated}><App/></UserContext.Provider>

--- a/marklogic-data-hub-central/ui/src/App.tsx
+++ b/marklogic-data-hub-central/ui/src/App.tsx
@@ -41,6 +41,16 @@ const App: React.FC<Props> = ({history, location}) => {
     )}/>
   );
 
+  const getPageRoute = (loc) => {
+    if (loc.search && loc.search.startsWith("?from=")) {
+      return decodeURIComponent(loc.search.substring(6));
+    } else if (loc.pathname !== '/' && loc.pathname !== '/noresponse') {
+      return loc.pathname
+    } else {
+      return user.pageRoute;
+    }
+  }
+
   useEffect(() => {
     if (user.authenticated){
       if (location.pathname === '/') {
@@ -53,9 +63,8 @@ const App: React.FC<Props> = ({history, location}) => {
     } else {
       if (user.error.type !== '') {
         history.push('/error');
-      } else if (location.pathname !== '/' && location.pathname !== '/noresponse') {
-        user.pageRoute = location.pathname;
       }
+      user.pageRoute = getPageRoute(location);
     }
   }, [user]);
 

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/user-context-mock.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/user-context-mock.ts
@@ -34,7 +34,7 @@ export const userAuthenticated: IUserContextInterface = Object.assign(defaultUse
     error : {
       type: ''
     },
-    pageRoute: '/',
+    pageRoute: '/tiles',
     maxSessionTime: 300
   }
 })

--- a/marklogic-data-hub-central/ui/src/pages/Detail.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Detail.tsx
@@ -50,6 +50,11 @@ const Detail: React.FC<Props> = ({ history, location }) => {
     setIsLoading(true);
 
     const fetchData = async () => {
+      // When Detail URI is undefined, redirect to Explore
+      if (!uri) {
+        history.push('/tiles/explore');
+        return;
+      }
       try {
         const result = await axios(`/api/entitySearch?docUri=${uri}`);
         if (!result.data) {

--- a/marklogic-data-hub-central/ui/src/pages/noMatchRedirect.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/noMatchRedirect.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {fireEvent, render} from "@testing-library/react";
+import { createMemoryHistory } from 'history'
+const history = createMemoryHistory()
+import NoMatchRedirect from './noMatchRedirect';
+import {Router} from "react-router";
+import {AuthoritiesContext} from "../util/authorities";
+import { userAuthenticated } from '../assets/mock-data/user-context-mock';
+import authorities from "../assets/authorities.testutils";
+import {UserContext} from "../util/user-context";
+
+const testAsDeveloper = authorities.DeveloperRolesService;
+
+describe('noMatchRedirect component test', () => {
+
+    test('Verify error page redirects correctly when "Back Home" is clicked', async () => {
+
+        const { getByText, getByLabelText, rerender } = render(<Router history={history}><NoMatchRedirect /></Router>);
+
+        expect(getByText('404')).toBeInTheDocument();
+        expect(getByText('Sorry, the page you visited does not exist.')).toBeInTheDocument();
+
+        //Should redirect to / when not authenticated
+        fireEvent.click(getByLabelText('back home'));
+        expect(history.location.pathname.endsWith('/')).toBeTruthy();
+
+        //Should redirect to /tiles when authenticated
+        rerender(<Router history={history}>
+            <AuthoritiesContext.Provider value={testAsDeveloper}>
+                <UserContext.Provider value={userAuthenticated}><NoMatchRedirect /></UserContext.Provider>
+            </AuthoritiesContext.Provider>
+        </Router>);
+        fireEvent.click(getByLabelText('back home'));
+        expect(history.location.pathname.endsWith('/tiles')).toBeTruthy();
+    });
+
+});

--- a/marklogic-data-hub-central/ui/src/pages/noMatchRedirect.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/noMatchRedirect.tsx
@@ -14,14 +14,14 @@ const NoMatchRedirect = ({history}) => {
   }, []);
 
   const backToHomePage = () => {
-    return user.authenticated ? history.push('/home') : history.push('/');
+    return user.authenticated ? history.push('/tiles') : history.push('/');
   }
   return (
       <Result
           status={404}
           title="404"
           subTitle="Sorry, the page you visited does not exist."
-          extra={<MLButton type="primary" onClick={backToHomePage}>Back Home</MLButton>}
+          extra={<MLButton type="primary" aria-label="back home" onClick={backToHomePage}>Back Home</MLButton>}
       />
   )
 }


### PR DESCRIPTION
NOTE: This update addresses the behavior when running on port 8080. (A port 3000 dev setup already worked.)

When a user is unauthorized and executes an internal browser bookmark or enters an internal URL in the browser bar:

Redirect user to login page.
Include route as URL param to enable redirection.
Redirect to that URL after login.
If the initial route is bad (e.g., /notavalidroute), the user sees a 404 page after login (as would be expected when redirecting to a bad route).

@bsrikan I need to discuss relevant tests for this since this is reliant on server redirection (i.e., not React UI behavior). 

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

