### PR TITLE
DHFPROD-5849: Expanding rows remain consistent even after changing page in explorer tile for snippet view.

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/search-result/search-result-rtl.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/search-result/search-result-rtl.test.tsx
@@ -5,10 +5,30 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { entityFromJSON, entityParser } from '../../util/data-conversion';
 import modelResponse from '../../assets/mock-data/model-response';
 import searchPayloadResults from '../../assets/mock-data/search-payload-results';
+import { SearchContext } from "../../util/search-context";
+
 
 describe("Search Result view component", () => {
     const parsedModelData = entityFromJSON(modelResponse);
     const entityDefArray = entityParser(parsedModelData);
+
+    const defaultSearchOptions = {
+        query: '',
+        entityTypeIds: [],
+        nextEntityType: '',
+        start: 1,
+        pageNumber: 1,
+        pageLength: 20,
+        pageSize: 20,
+        selectedFacets: {},
+        maxRowsPerPage: 100,
+        selectedQuery: 'select a query',
+        zeroState: false,
+        manageQueryModal: false,
+        selectedTableProperties: [],
+        view: null,
+        sortOrder: []
+    }
 
     test('Source and instance tooltips render', async () => {
         const { getByText, getByTestId } = render(
@@ -24,10 +44,41 @@ describe("Search Result view component", () => {
         expect(getByTestId('instance-icon')).toBeInTheDocument();
 
         fireEvent.mouseOver(getByTestId('source-icon'));
-        await(waitForElement(() => (getByText('Show the complete JSON'))));
+        await (waitForElement(() => (getByText('Show the complete JSON'))));
 
         fireEvent.mouseOver(getByTestId('instance-icon'));
-        await(waitForElement(() => (getByText('Show the processed data'))));
+        await (waitForElement(() => (getByText('Show the processed data'))));
+    });
 
+    test('Verify expandable icon closes if page number changes', async () => {
+        const { container, rerender, getByTestId } = render(
+                <SearchContext.Provider value={{searchOptions: defaultSearchOptions}}>
+                    <Router>
+                        <SearchResult
+                            entityDefArray={entityDefArray}
+                            item={searchPayloadResults[0]}
+                            tableView={false}
+                        />
+                    </Router>
+                </SearchContext.Provider>
+        );
+        expect(getByTestId('expandable-icon')).toBeInTheDocument();
+        expect(container.querySelector('[data-testid=expandable-icon] > svg')).not.toHaveStyle('transform: rotate(90deg);')
+        fireEvent.click(getByTestId('expandable-icon'));
+        expect(container.querySelector('[data-testid=expandable-icon] > svg')).toHaveStyle('transform: rotate(90deg);')
+
+        rerender(
+            <SearchContext.Provider value={{searchOptions: { ...defaultSearchOptions, pageNumber: 2 }}}>
+                <Router>
+                    <SearchResult
+                        entityDefArray={entityDefArray}
+                        item={searchPayloadResults[0]}
+                        tableView={false}
+                    />
+                </Router>
+            </SearchContext.Provider>
+            )
+
+        expect(container.querySelector('[data-testid=expandable-icon] > svg')).not.toHaveStyle('transform: rotate(90deg);')
     });
 })

--- a/marklogic-data-hub-central/ui/src/components/search-result/search-result.tsx
+++ b/marklogic-data-hub-central/ui/src/components/search-result/search-result.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect} from 'react';
 import { Link, withRouter, RouteComponentProps } from 'react-router-dom';
 import styles from './search-result.module.scss';
 import ReactHtmlParser from 'react-html-parser';
@@ -31,6 +31,10 @@ const SearchResult: React.FC<Props> = (props) => {
     let createdOnVal: string = '';
     let sourcesVal: string = '';
     let fileTypeVal: string = props.item.format;
+
+    useEffect(() => {
+        toggleShow(false);
+    }, [searchOptions.pageNumber, searchOptions.entityTypeIds])
 
     if (Object.keys(props.item.primaryKey).length) {
         primaryKeyValue = props.item.primaryKey.propertyValue;
@@ -84,7 +88,7 @@ const SearchResult: React.FC<Props> = (props) => {
     return (
         <div style={{ width: '100%' }}>
             <div className={styles.title} onClick={() => showTableEntityProperties()}>
-                <Icon className={styles.expandableIcon} data-cy='expandable-icon' type='right' rotate={show ? 90 : undefined} />
+                <Icon className={styles.expandableIcon} data-cy='expandable-icon' data-testid="expandable-icon" type='right' rotate={show ? 90 : undefined} />
                 <div className={styles.redirectIcons}>
                     <Link to={{pathname: "/tiles/explore/detail",state: {selectedValue:'instance',
                             entity : searchOptions.entityTypeIds ,


### PR DESCRIPTION

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

