### PR TITLE
DHFPROD-5888: Handling null values in user preferences for saved queries

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.json.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.json.tsx
@@ -100,6 +100,7 @@ describe('json scenario for snippet on browse documents page', () => {
     browsePage.getFacetItemCheckbox('collection', 'mapPersonJSON').should('be.checked')
     browsePage.selectEntity('Customer');
     browsePage.getEntityConfirmationNoClick().click();
+    cy.waitForModalToDisappear();
     browsePage.waitForSpinnerToDisappear();
     browsePage.getSelectedEntity().should('contain', 'Customer');
     browsePage.getFacetItemCheckbox('collection', 'mapCustomerXML').should('not.be.visible')

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.queries.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.queries.tsx
@@ -216,7 +216,7 @@ describe('save/manage queries scenarios, developer role', () => {
         browsePage.getSelectedEntity().should('contain', 'Customer');
         browsePage.waitForSpinnerToDisappear()
         browsePage.getHubPropertiesExpanded();
-        browsePage.getFacetItemCheckbox('collection', 'mapCustomersJSON').click();
+        cy.waitUntil(() => browsePage.getFacetItemCheckbox('collection', 'mapCustomersJSON')).click();
         browsePage.getFacetApplyButton().click();
         browsePage.search('Adams Cole');
         browsePage.getSaveModalIcon().click();

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.xml.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.xml.tsx
@@ -140,7 +140,7 @@ describe('xml scenario for table on browse documents page', () => {
     browsePage.selectEntity('Customer');
     browsePage.getSelectedEntity().should('contain', 'Customer');
     browsePage.getHubPropertiesExpanded();
-    browsePage.getFacetItemCheckbox('collection', 'mapCustomersXML').click();
+    cy.waitUntil(() => browsePage.getFacetItemCheckbox('collection', 'mapCustomersXML')).click();
     browsePage.getGreySelectedFacets('mapCustomersXML').should('exist');
     browsePage.getFacetApplyButton().click();
     browsePage.getTotalDocuments().should('be.gte', 5)

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/browse.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/browse.tsx
@@ -21,7 +21,7 @@ class BrowsePage {
   selectEntity(entity: string) {
     this.waitForSpinnerToDisappear();
     cy.get('#entity-select').click();
-    cy.get(`[data-cy="entity-option-${entity}"]`).click();
+    cy.get(`[data-cy="entity-option-${entity}"]`).click({force:true});
     cy.waitForAsyncRequest();
     this.waitForSpinnerToDisappear();
   }
@@ -208,7 +208,7 @@ class BrowsePage {
   }
 
   getHubPropertiesExpanded() {
-    cy.waitUntil(() => cy.get("#hub-properties > div > i")).click();
+    cy.get("#hub-properties > div > i").click();
   }
 
   getExpandableSnippetView() {

--- a/marklogic-data-hub-central/ui/src/components/queries/queries.tsx
+++ b/marklogic-data-hub-central/ui/src/components/queries/queries.tsx
@@ -148,7 +148,7 @@ const Query: React.FC<Props> = (props) => {
                 (currentQuery.savedQuery.query.searchText !== searchOptions.query) ||
                 (JSON.stringify(currentQuery.savedQuery.sortOrder) !== JSON.stringify(searchOptions.sortOrder)) ||
                 (JSON.stringify(currentQuery.savedQuery.propertiesToDisplay) !== JSON.stringify(searchOptions.selectedTableProperties)) ||
-                (props.greyFacets.length > 0) || props.isColumnSelectorTouched) && 
+                (props.greyFacets.length > 0) || props.isColumnSelectorTouched) &&
                 searchOptions.selectedQuery !== 'select a query')   {
                 return true;
             }
@@ -206,9 +206,11 @@ const Query: React.FC<Props> = (props) => {
         if (defaultPreferences !== null) {
             let parsedPreferences = JSON.parse(defaultPreferences);
             if (parsedPreferences.selectedQuery !== 'select a query' && JSON.stringify(parsedPreferences) !== JSON.stringify([])) {
-                let queryObject = parsedPreferences.queries.find(obj => parsedPreferences.selectedQuery === obj.savedQuery?.name);
-                if (queryObject?.savedQuery && queryObject.savedQuery.hasOwnProperty('description') && queryObject.savedQuery.description) {
-                     setCurrentQueryDescription(queryObject?.savedQuery.description);
+                if (parsedPreferences.queries && Array.isArray(parsedPreferences.queries)) {
+                    let queryObject = parsedPreferences.queries.find(obj => parsedPreferences.selectedQuery === obj.savedQuery?.name);
+                    if (queryObject?.savedQuery && queryObject.savedQuery.hasOwnProperty('description') && queryObject.savedQuery.description) {
+                        setCurrentQueryDescription(queryObject?.savedQuery.description);
+                    }
                 }
             }
         }
@@ -222,6 +224,7 @@ const Query: React.FC<Props> = (props) => {
     }
 
     const onNoClick  = () => {
+        toggleEntityConfirmation(false);
         setCurrentQueryOnEntityChange();
     }
 
@@ -244,7 +247,6 @@ const Query: React.FC<Props> = (props) => {
         setCurrentQuery({});
         setCurrentQueryName('select a query');
         setCurrentQueryDescription('');
-        toggleEntityConfirmation(false);
     }
 
    // Reset confirmation modal buttons when making changes to saved query


### PR DESCRIPTION
### Description
This PR fixes the bug DHFPROD-5888. e2e tests are already present for saved queries.
Also updated few e2e tests to fix certain intermittent failures.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [N/A] Added Tests
  

- ##### Reviewer:

- [ N/A] Reviewed Tests

