### PR TITLE
DHFPROD-5811: Hopefully fixing how schemas dbs are cleared in tests

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/DeployUserAmpsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/DeployUserAmpsTest.java
@@ -36,7 +36,10 @@ public class DeployUserAmpsTest extends AbstractHubCoreTest {
     @BeforeEach
     void checkIfTestsCanBeRun(){
         Versions.MarkLogicVersion mlVersion = versions.getMLVersion();
-        assumeTrue(mlVersion.isNightly() || (mlVersion.getMajor() > 10) ||(mlVersion.getMajor() == 10 && mlVersion.getMinor() >= 440));
+        assumeTrue(
+            (mlVersion.isNightly() && mlVersion.getMajor() >= 10) ||
+            (mlVersion.getMajor() > 10) ||(mlVersion.getMajor() == 10 && mlVersion.getMinor() >= 440)
+        );
         if(operatorHubClient == null || adminHubClient == null){
             operatorHubClient = runAsDataHubOperator().newHubClient();
             adminHubClient = runAsAdmin().newHubClient();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/GetMLVersionTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/GetMLVersionTest.java
@@ -1,0 +1,25 @@
+package com.marklogic.hub.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GetMLVersionTest {
+
+    @Test
+    void nightly9() {
+        Versions.MarkLogicVersion version = new Versions().getMLVersion("9.0-20200909");
+        assertTrue(version.isNightly());
+        assertEquals("2020-09-09", version.getDateString());
+        assertEquals(9, version.getMajor());
+    }
+
+    @Test
+    void nightly10() {
+        Versions.MarkLogicVersion version = new Versions().getMLVersion("10.0-20200909");
+        assertTrue(version.isNightly());
+        assertEquals("2020-09-09", version.getDateString());
+        assertEquals(10, version.getMajor());
+    }
+}


### PR DESCRIPTION
### Description

The use of newAppServicesDatabaseClient is failing intermittently. Since we don't need to retain any documents, we can use the Manage API to clear the database. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

