### PR TITLE
DHFPROD-5788: Missed environment property for verify tasks

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/build.gradle
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/build.gradle
@@ -73,10 +73,10 @@ class DocCount extends HubTask {
 
 task verifyStagingCounts(type: DocCount) {
     client = hubConfig.newStagingClient()
-    script = "fn.count(fn.collection(['loadCustomersJSON', 'loadCustomersXML', 'order-input', 'loadPersonJSON']))"
+    script = "cts.estimate(cts.collectionQuery(['loadCustomersJSON', 'loadCustomersXML', 'order-input', 'loadPersonJSON']))"
 }
 
 task verifyFinalCounts(type: DocCount) {
     client = hubConfig.newFinalClient()
-    script = "fn.count(fn.collection(['mapCustomersJSON', 'mapCustomersXML', 'map-orders', 'mapPersonJSON']))"
+    script = "cts.estimate(cts.collectionQuery(['mapCustomersJSON', 'mapCustomersXML', 'map-orders', 'mapPersonJSON']))"
 }

--- a/marklogic-data-hub-central/ui/e2e/setup.sh
+++ b/marklogic-data-hub-central/ui/e2e/setup.sh
@@ -32,5 +32,5 @@ fi
 
 #Verify flow was run successfully based on record count in staging and final database.
 #The task would fail if there was a count mismatch
-./gradlew verifyStagingCounts -q
-./gradlew verifyFinalCounts -q
+./gradlew verifyStagingCounts -PenvironmentName=$env -q
+./gradlew verifyFinalCounts -PenvironmentName=$env -q


### PR DESCRIPTION
### Description
Using cts.estimate in place of fn.count
Included environment property to verify gradle task
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [NA] Added Tests
  

- ##### Reviewer:

- [NA] Reviewed Tests

