### PR TITLE
DHFPROD-5584: Remove 'return to default' sorting

### DIFF
--- a/examples/reference-entity-model/README.md
+++ b/examples/reference-entity-model/README.md
@@ -17,6 +17,16 @@ To verify that the application is installed, visit http://localhost:8011 in your
 the users defined in the gradle.properties file in this project. If the application was successfully installed, you'll
 see a "MarkLogic REST Server" page.
 
+## Deploying resources as a data-hub-developer user 
+
+A user with the data-hub-developer role is permitted to deploy the project to DHS. Update the mlUsername and mlPassword
+in gradle-dhs.properties file in this project.
+
+Then deploy the application (the "-i" is for info-level logging, which is helpful to see in case anything goes wrong):
+
+    ./gradlew -i -PenvironmentName=dhs hubDeployAsDeveloper
+ 
+
 ## Authenticating 
 
 This project defines several users in ./src/main/ml-config/security/users that can be used for development and testing. 

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/commands.js
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/commands.js
@@ -45,6 +45,9 @@ Cypress.Commands.add('withUI', { prevSubject: 'optional'}, (subject) => {
       loginPage.getLoginButton().click();
     })
     cy.wait(2000)
+    cy.window()
+        .its('stompClientConnected')
+        .should('exist');
   }
 })
 
@@ -77,6 +80,9 @@ Cypress.Commands.add('withRequest', { prevSubject: 'optional'}, (subject) => {
       cy.visit('/tiles')
       cy.location('pathname', { timeout: 10000 }).should('include', '/tiles');
       cy.wait(2000);
+      cy.window()
+          .its('stompClientConnected')
+          .should('exist');
     })
   }
 })

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.test.tsx
@@ -60,53 +60,73 @@ describe('Load data component', () => {
     expect(getAllByLabelText('icon: setting').length).toBe(3);
 
     //verify load list table enforces last updated sort order by default
-    let loadTable: any = document.querySelectorAll('.ant-table-row ant-table-row-level-0');
-    validateTableRow(loadTable, ['testLoadXML', 'testLoadXMLtoJSON','testLoad']);
-
+    let loadTable: any = document.querySelectorAll('.ant-table-row-level-0');
+    validateTableRow(loadTable, ['testLoadXML', 'testLoad123','testLoad']);
     //verify load list table enforces sorting by ascending date updated as well
     let loadTableSort = getByTestId('loadTableDate');
     fireEvent.click(loadTableSort);
+    loadTable = document.querySelectorAll('.ant-table-row-level-0');
     validateTableRow(loadTable, ['testLoad', 'testLoad123', 'testLoadXML']);
+    //verify third click does not return to default, but returns to descending order
+    fireEvent.click(loadTableSort);
+    loadTable = document.querySelectorAll('.ant-table-row-level-0');
+    validateTableRow(loadTable, ['testLoadXML', 'testLoad123','testLoad']);
 
     //verify load list table enforces sorting by name alphabetically in ascending order
     loadTableSort = getByTestId('loadTableName');
     fireEvent.click(loadTableSort);
+    loadTable = document.querySelectorAll('.ant-table-row-level-0');
     validateTableRow(loadTable, ['testLoad', 'testLoad123', 'testLoadXML']);
-
     //verify load list table enforces sorting by name alphabetically in descending order
-    loadTableSort = getByTestId('loadTableName');
     fireEvent.click(loadTableSort);
+    loadTable = document.querySelectorAll('.ant-table-row-level-0');
     validateTableRow(loadTable, ['testLoadXML', 'testLoad123', 'testLoad']);
+    //verify third click does not return to default, but returns to ascending order
+    fireEvent.click(loadTableSort);
+    loadTable = document.querySelectorAll('.ant-table-row-level-0');
+    validateTableRow(loadTable, ['testLoad', 'testLoad123', 'testLoadXML']);
 
     //verify load list table enforces sorting by source format alphabetically in ascending order
     loadTableSort = getByTestId('loadTableSourceFormat');
     fireEvent.click(loadTableSort);
+    loadTable = document.querySelectorAll('.ant-table-row-level-0');
     validateTableRow(loadTable, ['testLoad123', 'testLoad', 'testLoadXML']);
-
     //verify load list table enforces sorting by source format alphabetically in descending order
-    loadTableSort = getByTestId('loadTableSourceFormat');
     fireEvent.click(loadTableSort);
-    validateTableRow(loadTable, ['testLoadXML', 'testLoad', 'testLoad123']);
+    loadTable = document.querySelectorAll('.ant-table-row-level-0');
+    validateTableRow(loadTable, ['testLoad', 'testLoadXML', 'testLoad123']);
+    //verify third click does not return to default, but returns to ascending order
+    fireEvent.click(loadTableSort);
+    loadTable = document.querySelectorAll('.ant-table-row-level-0');
+    validateTableRow(loadTable, ['testLoad123', 'testLoad', 'testLoadXML']);
 
     //verify load list table enforces sorting by target format alphabetically in ascending order
     loadTableSort = getByTestId('loadTableTargetFormat');
     fireEvent.click(loadTableSort);
+    loadTable = document.querySelectorAll('.ant-table-row-level-0');
     validateTableRow(loadTable, ['testLoad123', 'testLoad', 'testLoadXML']);
-
     //verify load list table enforces sorting by target format alphabetically in descending order
-    loadTableSort = getByTestId('loadTableTargetFormat');
     fireEvent.click(loadTableSort);
+    loadTable = document.querySelectorAll('.ant-table-row-level-0');
     validateTableRow(loadTable, ['testLoadXML', 'testLoad', 'testLoad123']);
+    //verify third click does not return to default, but returns to ascending order
+    fireEvent.click(loadTableSort);
+    loadTable = document.querySelectorAll('.ant-table-row-level-0');
+    validateTableRow(loadTable, ['testLoad123', 'testLoad', 'testLoadXML']);
 
     //verify load list table enforces sorting by Description alphabetically in ascending order
     loadTableSort = getByTestId('loadTableDescription');
     fireEvent.click(loadTableSort);
+    loadTable = document.querySelectorAll('.ant-table-row-level-0');
     validateTableRow(loadTable, ['testLoad123', 'testLoad', 'testLoadXML']);
-
     //verify load list table enforces sorting by Description alphabetically in descending order
-    loadTableSort = getByTestId('loadTableDescription');
     fireEvent.click(loadTableSort);
+    loadTable = document.querySelectorAll('.ant-table-row-level-0');
     validateTableRow(loadTable, ['testLoadXML', 'testLoad', 'testLoad123']);
+    //verify third click does not return to default, but returns to ascending order
+    fireEvent.click(loadTableSort);
+    loadTable = document.querySelectorAll('.ant-table-row-level-0');
+    validateTableRow(loadTable, ['testLoad123', 'testLoad', 'testLoadXML']);
   })
 
   test('Verify Load settings from list view renders correctly', async () => {

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.tsx
@@ -179,12 +179,14 @@ const LoadList: React.FC<Props> = (props) => {
           render: (text: any,record: any) => (
               <span><span onClick={() => OpenEditStepDialog(record)} className={styles.editLoadConfig}>{text}</span> </span>
           ),
+          sortDirections: ["ascend", "descend", "ascend"],
           sorter: (a:any, b:any) => a.name.localeCompare(b.name),
         },
         {
           title: <span data-testid="loadTableDescription">Description</span>,
           dataIndex: 'description',
           key: 'description',
+          sortDirections: ["ascend", "descend", "ascend"],
           sorter: (a:any, b:any) => a.description?.localeCompare(b.description)
         },
         {
@@ -197,12 +199,14 @@ const LoadList: React.FC<Props> = (props) => {
                     {row.sourceFormat === 'csv' ? <div className={styles.sourceFormatFS}>Field Separator: ( {row.separator} )</div> : ''}
                 </div>
             ),
+            sortDirections: ["ascend", "descend", "ascend"],
             sorter: (a:any, b:any) => a.sourceFormat.localeCompare(b.sourceFormat),
         },
         {
             title: <span data-testid="loadTableTargetFormat">Target Format</span>,
             dataIndex: 'targetFormat',
             key: 'targetFormat',
+            sortDirections: ["ascend", "descend", "ascend"],
             sorter: (a:any, b:any) => a.targetFormat.localeCompare(b.targetFormate),
         },
         {
@@ -212,8 +216,8 @@ const LoadList: React.FC<Props> = (props) => {
             render: (text) => (
                 <div>{convertDateFromISO(text)}</div>
             ),
+            sortDirections: ["ascend", "descend", "ascend"],
             sorter: (a:any, b:any) => moment(a.lastUpdated).unix() - moment(b.lastUpdated).unix(),
-            sortDirections: ["descend", "ascend"],
             defaultSortOrder: "descend"
         },
         {

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { render, wait, screen, within } from '@testing-library/react';
+import { render, wait, screen, within, fireEvent } from '@testing-library/react';
 import userEvent from "@testing-library/user-event";
 import EntityTypeTable from './entity-type-table';
+import { validateTableRow } from '../../../util/test-utils';
 
 import { 
   entityReferences,
@@ -82,15 +83,51 @@ describe('EntityTypeModal Component', () => {
     expect(getByText(/2,384/i)).toBeInTheDocument();
     expect(getByTestId('Order-last-processed')).toBeInTheDocument();
 
-    // Verify sorting doesn't crash the component
-    userEvent.click(getByText('Name'));
-    userEvent.click(getByText('Last Processed'));
-    userEvent.click(getByText('Instances'));
-
     const anotherModelExpandIcon = getByTestId('mltable-expand-AnotherModel');
     userEvent.click(within(anotherModelExpandIcon).getByRole('img'));
 
     expect(getByLabelText('AnotherModel-add-property')).toBeDisabled();
+
+    //Verify sorting works as expected in entity table
+    let entityTable = document.querySelectorAll('.ant-table-row-level-0');
+
+    //Initial sort should be in descending 'Last Processed' order
+    validateTableRow(entityTable, ['AnotherModel,Testing','Protein,','Product,','Provider,','TestEntityForMapping,The TestEntityForMapping entity root.','Order,','Customer,']);
+    //verify sort by ascending 'Last Processed' order is next and works
+    fireEvent.click(getByTestId('lastProcessed'));
+    entityTable = document.querySelectorAll('.ant-table-row-level-0');
+    validateTableRow(entityTable, ['Customer,','Order,','AnotherModel,Testing','Protein,','Product,','Provider,', 'TestEntityForMapping,The TestEntityForMapping entity root.']);
+    //verify third click does not return to default, but returns to descending order
+    fireEvent.click(getByTestId('lastProcessed'));
+    entityTable = document.querySelectorAll('.ant-table-row-level-0');
+    validateTableRow(entityTable, ['AnotherModel,Testing','Protein,','Product,','Provider,','TestEntityForMapping,The TestEntityForMapping entity root.','Order,','Customer,']);
+
+    //verify sort by name alphabetically works in ascending order
+    fireEvent.click(getByTestId('entityName'));
+    entityTable = document.querySelectorAll('.ant-table-row-level-0');
+    validateTableRow(entityTable, ['AnotherModel,Testing', 'Customer,', 'Order,', 'Product,', 'Protein,','Provider,','TestEntityForMapping,The TestEntityForMapping entity root.']);
+    //verify sort by name alphabetically works in descending order
+    fireEvent.click(getByTestId('entityName'));
+    entityTable = document.querySelectorAll('.ant-table-row-level-0');
+    validateTableRow(entityTable, ['TestEntityForMapping,The TestEntityForMapping entity root.','Provider,','Protein,','Product,','Order,','Customer,','AnotherModel,Testing']);    
+    //verify third click does not return to default, but returns to ascending order
+    fireEvent.click(getByTestId('entityName'));
+    entityTable = document.querySelectorAll('.ant-table-row-level-0');
+    validateTableRow(entityTable, ['AnotherModel,Testing', 'Customer,', 'Order,', 'Product,', 'Protein,','Provider,','TestEntityForMapping,The TestEntityForMapping entity root.']);
+
+    //verify sort by instances works in ascending order
+    fireEvent.click(getByTestId('Instances'));
+    entityTable = document.querySelectorAll('.ant-table-row-level-0');
+    validateTableRow(entityTable, ['AnotherModel,Testing', 'Protein,', 'Product,','Provider,', 'TestEntityForMapping,The TestEntityForMapping entity root.', 'Customer,', 'Order,']);
+    //verify sort by instances works in descending order
+    fireEvent.click(getByTestId('Instances'));
+    entityTable = document.querySelectorAll('.ant-table-row-level-0');
+    validateTableRow(entityTable, ['Order,','Customer,','AnotherModel,Testing','Protein,','Product,','Provider,', 'TestEntityForMapping,The TestEntityForMapping entity root.', 'Order,','Customer,']);    
+    //verify third click does not return to default, but returns to ascending order
+    fireEvent.click(getByTestId('Instances'));
+    entityTable = document.querySelectorAll('.ant-table-row-level-0');
+    validateTableRow(entityTable, ['AnotherModel,Testing', 'Protein,', 'Product,','Provider,', 'TestEntityForMapping,The TestEntityForMapping entity root.', 'Customer,', 'Order,']);
+    
   });
 
   test('Table renders with mock data, with writer role, with auto expanded entity, and can click edit', () => {

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.tsx
@@ -214,7 +214,7 @@ const EntityTypeTable: React.FC<Props> = (props) => {
 
   const columns = [
     {
-      title: 'Name',
+      title: <span data-testid="entityName">Name</span>,
       dataIndex: 'entityName',
       className: styles.tableText,
       width: 400,
@@ -237,12 +237,13 @@ const EntityTypeTable: React.FC<Props> = (props) => {
           </>
         )
       },
+      sortDirections: ["ascend", "descend", "ascend"],
       sorter: (a, b) => {
         return a['entityName'].split(',')[0].localeCompare(b['entityName'].split(',')[0])
       }
     },
     {
-      title: 'Instances',
+      title: <span data-testid="Instances">Instances</span>,
       dataIndex: 'instances',
       className: styles.rightHeader,
       width: 100,
@@ -269,6 +270,7 @@ const EntityTypeTable: React.FC<Props> = (props) => {
          </> 
         )
       },
+      sortDirections: ["ascend", "descend", "ascend"],
       sorter: (a, b) => {
         let splitA = a['instances'].split(',');
         let aCount = parseInt(splitA[1]);
@@ -279,7 +281,7 @@ const EntityTypeTable: React.FC<Props> = (props) => {
       }
     },
     {
-      title: 'Last Processed',
+      title: <span data-testid="lastProcessed">Last Processed</span>,
       dataIndex: 'lastProcessed',
       className: styles.tableText,
       width: 100,
@@ -305,6 +307,8 @@ const EntityTypeTable: React.FC<Props> = (props) => {
           )
         }
       },
+      sortDirections: ["ascend", "descend", "ascend"],
+      defaultSortOrder: "descend",
       sorter: (a, b) => {
         let splitA = a['lastProcessed'].split(',');
         let splitB = b['lastProcessed'].split(',');

--- a/marklogic-data-hub-central/ui/src/components/queries/managing/manage-query-modal/manage-query.tsx
+++ b/marklogic-data-hub-central/ui/src/components/queries/managing/manage-query-modal/manage-query.tsx
@@ -31,7 +31,6 @@ const QueryModal = (props) => {
     const [tableData, setTableData] = useState<Object[]>();
     const [query, setQuery] = useState({});
     const [hasStructured, setStructured] = useState<boolean>(false);
-
     const data = new Array();
 
     const getQueries = async () => {
@@ -143,19 +142,23 @@ const QueryModal = (props) => {
         setExportModalVisibility(true);
     };
 
-    const columns = [
+    const columns : any = [
         {
             title: 'Name',
             dataIndex: 'name',
             key: 'name',
             sorter: (a, b) => a.name.localeCompare(b.name),
             width: 200,
+            sortDirections: ["ascend", "descend", "ascend"],
+            defaultSortOrder: "ascend",
             render: text => <a data-id={text} data-testid={text} className={styles.name} onClick={onApply}>{text}</a>,
         },
         {
             title: 'Description',
             dataIndex: 'description',
             key: 'description',
+            sorter: (a, b) => a.name.localeCompare(b.name),
+            sortDirections: ["ascend", "descend", "ascend"],
             width: 200,
             render: text => <div className={styles.cell}>{text}</div>,
         },
@@ -163,6 +166,7 @@ const QueryModal = (props) => {
             title: 'Edited',
             dataIndex: 'edited',
             key: 'edited',
+            sortDirections: ["ascend", "descend", "ascend"],
             sorter: (a, b) => a.edited.localeCompare(b.edited),
             width: 200,
             render: text => <div className={styles.cell}>{text}</div>,

--- a/marklogic-data-hub-central/ui/src/util/user-context.tsx
+++ b/marklogic-data-hub-central/ui/src/util/user-context.tsx
@@ -168,6 +168,7 @@ const UserProvider: React.FC<{ children: any }> = ({children}) => {
     switch (error.response.status) {
       case 401: {
         localStorage.setItem('dataHubUser', '');
+        localStorage.setItem('loginResp', '');
         setUser({ ...user, name: '', authenticated: false });
         break;
       }


### PR DESCRIPTION
### Description

- Remove 'return to default' sorting (happens on third click on table sort options) for tables across HC (except mapping modal)
- Updated existing tests and added new sorting tests for Entity table 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

