### PR TITLE
DHFPROD-5927: Removing unused Gradle application plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,6 @@ allprojects {
 subprojects {
     apply plugin: 'java'
     apply plugin: 'jacoco'
-    apply plugin: 'application'
     sourceCompatibility = "9"
     targetCompatibility = "9"
 
@@ -34,12 +33,6 @@ subprojects {
             xml.enabled true
         }
     }
-    task applicationCodeCoverageReport(type:JacocoReport) {
-        executionData run
-        sourceSets sourceSets.main
-    }
-
-
 }
 
 //Task to update versions in files they are hardcoded. If version is hardcoded in any other files in the future,it has to be added to the list

--- a/marklogic-data-hub-central/build.gradle
+++ b/marklogic-data-hub-central/build.gradle
@@ -24,8 +24,6 @@ apply plugin: "com.github.node-gradle.node"
 apply plugin: "jsonschema2pojo"
 apply from: 'build-rpm.gradle'
 
-mainClassName = "com.marklogic.hub.central.Application"
-
 sourceCompatibility = "9"
 targetCompatibility = "9"
 

--- a/marklogic-data-hub-glue-connector/build.gradle
+++ b/marklogic-data-hub-glue-connector/build.gradle
@@ -10,8 +10,6 @@ repositories {
 sourceCompatibility = "9"
 targetCompatibility = "9"
 
-mainClassName = "com.marklogic.hub.ApplicationConfig"
-
 dependencies {
     // Contrary to the marklogic-data-hub-central project, when this project is brought over, the okhttp3 dependencies
     // remain at version 4.4.0. So no need to exclude them and then depend on them explicitly.

--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -16,7 +16,6 @@ plugins {
 // seeing them when running a Gradle task (like publishToMavenLocal) is just useless noise
 javadoc.options.addStringOption('Xdoclint:none', '-quiet')
 
-mainClassName='com.marklogic.hub.ApplicationConfig'
 repositories {
     jcenter()
     maven { url 'http://repo.spring.io/milestone' }

--- a/ml-data-hub-plugin/build.gradle
+++ b/ml-data-hub-plugin/build.gradle
@@ -35,7 +35,6 @@ plugins {
     id "io.spring.dependency-management" version "1.0.7.RELEASE"
 }
 
-mainClassName = "com.marklogic.hub.ApplicationConfig"
 apply plugin: "com.gradle.plugin-publish"
 
 sourceCompatibility = "9"
@@ -74,11 +73,6 @@ dependencies {
         exclude module: "logback-classic"
     }
 }
-
-springBoot {
-    mainClassName = 'com.marklogic.hub.ApplicationConfig'
-}
-
 
 test {
     testLogging {

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -38,7 +38,7 @@ war {
   }
 
 }
-mainClassName = "com.marklogic.hub.web.WebApplication"
+
 bootWar {
   baseName "marklogic-datahub"
 }


### PR DESCRIPTION
### Description

Now we don't need mainClassName specified on each subproject. We weren't using the application plugin for anything except by the unused jacoco task in ./build.gradle which has been removed. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

