### PR TITLE
DHFPROD-4854: Removed spring-boot dependency from core project

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -5,10 +5,7 @@ plugins {
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.7.2'
     id 'com.marklogic.ml-gradle' version '4.0.4'
-    //id 'com.moowork.node' version '1.1.1'
     id "com.github.node-gradle.node" version "2.2.4"
-    id 'org.springframework.boot' version '2.1.15.RELEASE'
-    id "io.spring.dependency-management" version "1.0.7.RELEASE"
     id 'com.marklogic.ml-development-tools' version '5.2.0'
 }
 
@@ -55,9 +52,7 @@ dependencies {
         exclude group: 'com.marklogic', module: 'marklogic-client-api'
     }
 
-    compile group: 'org.springframework.boot', name: 'spring-boot', version: '2.1.15.RELEASE'
-    compile group: 'org.springframework.integration', name: 'spring-integration-http', version: '5.1.11.RELEASE'
-    compile group: 'org.springframework.boot', name: 'spring-boot-autoconfigure', version: '2.1.15.RELEASE'
+    compile group: 'org.springframework', name: 'spring-context', version: '5.2.8.RELEASE'
 
     compile 'com.marklogic:mlcp-util:0.9.0'
     compile ('com.marklogic:marklogic-data-movement-components:2.0.0') {
@@ -113,11 +108,21 @@ configurations.all {
     exclude group: "log4j", module: "log4j"
 }
 
-// The Spring Boot bootJar task produces an executable jar with all dependencies that runs the DHF installer
-// This jar is only meant to be used by the DHS team for installing DHF into DHS
-bootJar {
+task installerJar(type: Jar) {
+    description = "Build an executable jar for installing DHF into DHS"
+    manifest {
+        attributes "Main-Class": "com.marklogic.hub.dhs.installer.Main"
+    }
     archiveClassifier = "installer"
-    mainClassName = "com.marklogic.hub.dhs.installer.Main"
+    from(configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }) {
+        exclude "META-INF/*.SF"
+        exclude "META-INF/*.DSA"
+        exclude "META-INF/*.RSA"
+    }
+    from("src/installer") {
+        include "logback.xml"
+    }
+    with jar
 }
 
 task clientJar(type: Jar) {
@@ -131,7 +136,9 @@ task clientJar(type: Jar) {
         exclude "META-INF/*.DSA"
         exclude "META-INF/*.RSA"
     }
-    exclude "spring-boot*.jar"
+    from("src/installer") {
+        include "logback.xml"
+    }
     with jar
 }
 build.dependsOn clientJar
@@ -186,11 +193,6 @@ task copyUIAssets(type: Copy) {
 processResources {
     filesMatching("**/version.properties") {
         expand(project: project)
-    }
-
-    // Includes installer-specific files into the jar produced by bootJar
-    from ("src/installer") {
-        into "."
     }
 }
 
@@ -255,10 +257,6 @@ jar{
     enabled = true
 }
 
-bootRun {
-    enabled = false
-}
-
 javadoc {
    options.overview = 'src/main/resources/overview.html'
 }
@@ -304,7 +302,7 @@ publishing {
             from components.java
             artifact sourcesJar
             artifact javadocJar
-            artifact bootJar
+            artifact installerJar
             artifact clientJar
 
             pom.withXml {

--- a/marklogic-data-hub/src/installer/logback.xml
+++ b/marklogic-data-hub/src/installer/logback.xml
@@ -1,5 +1,10 @@
 <configuration>
 
+  <!--
+  This file is included in executable jars to define what should be logged.
+  It is not included in src/main/resources so that it is not included automatically in the library jar.
+  -->
+
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/ApplicationConfig.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/ApplicationConfig.java
@@ -2,9 +2,6 @@ package com.marklogic.hub;
 
 import com.marklogic.hub.impl.HubConfigImpl;
 import com.marklogic.hub.impl.HubProjectImpl;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -16,7 +13,6 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ComponentScan(basePackages = {"com.marklogic.hub.impl", "com.marklogic.hub.legacy.impl", "com.marklogic.hub.deploy.commands",
     "com.marklogic.hub.job.impl", "com.marklogic.hub.flow.impl", "com.marklogic.hub.step", "com.marklogic.hub.util"})
-@EnableAutoConfiguration
 public class ApplicationConfig {
 
     /**
@@ -30,10 +26,6 @@ public class ApplicationConfig {
         return new HubConfigImpl(new HubProjectImpl());
     }
 
-    public static void main(String[] args) {
-        LoggerFactory.getLogger(ApplicationConfig.class).info("Starting Data Hub Application Context");
-        SpringApplication.run(ApplicationConfig.class);
-    }
 
 }
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dhs/installer/Main.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dhs/installer/Main.java
@@ -6,9 +6,8 @@ import com.marklogic.hub.ApplicationConfig;
 import com.marklogic.hub.dhs.installer.command.CanInstallDhsCommand;
 import com.marklogic.hub.dhs.installer.command.InstallIntoDhsCommand;
 import com.marklogic.hub.dhs.installer.command.VerifyDhfInDhsCommand;
-import org.springframework.boot.Banner;
-import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 /**
  * Intended for installing and upgrading DHF via a command-line interface. It is expected to be run as the main class
@@ -35,10 +34,7 @@ public class Main {
         } else {
             InstallerCommand command = (InstallerCommand) commander.getCommands().get(parsedCommand).getObjects().get(0);
 
-            SpringApplication app = new SpringApplication(ApplicationConfig.class);
-            app.setBannerMode(Banner.Mode.OFF);
-
-            ConfigurableApplicationContext context = app.run();
+            ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(ApplicationConfig.class);
             try {
                 command.run(context, options);
             } finally {

--- a/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/TestAppInstaller.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/bootstrap/TestAppInstaller.java
@@ -25,10 +25,9 @@ import com.marklogic.mgmt.mapper.DefaultResourceMapper;
 import com.marklogic.mgmt.resource.security.PrivilegeManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.WebApplicationType;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
@@ -40,10 +39,8 @@ public class TestAppInstaller {
 
     private final static Logger logger = LoggerFactory.getLogger(TestAppInstaller.class);
 
-    public static void main(String[] args) throws Exception {
-        SpringApplication app = new SpringApplication(HubCoreTestConfig.class);
-        app.setWebApplicationType(WebApplicationType.NONE);
-        ConfigurableApplicationContext ctx = app.run();
+    public static void main(String[] args) {
+        ConfigurableApplicationContext ctx = new AnnotationConfigApplicationContext(HubCoreTestConfig.class);
         try {
             HubConfigObjectFactory factory = ctx.getBean(HubConfigInterceptor.class).getHubConfigObjectFactory();
             String[] hosts = factory.getHosts();
@@ -124,8 +121,7 @@ public class TestAppInstaller {
             modulesClient.newServerEval().xquery("cts:uri-match('/custom-modules/**') ! xdmp:document-add-collections(., 'hub-core-module')").evalAs(String.class);
         } catch (Exception ex) {
             throw new RuntimeException(ex);
-        }
-        finally {
+        } finally {
             appConfig.setAppServicesPort(originalAppServicesPort);
             appConfig.setModulesLoaderBatchSize(originalBatchSize);
             appConfig.setModulePaths(originalModulePaths);

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/hubcentral/conversion/EntityModelConverterTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/hubcentral/conversion/EntityModelConverterTest.java
@@ -80,10 +80,6 @@ public class EntityModelConverterTest extends AbstractHubCoreTest {
         currentFileName = "MissingIndexedProperty.entity.json";
         JsonNode missingIndexedPropertyEntity = readJsonObject(entitiesDir.resolve(currentFileName).toFile());
         assertTrue(hubCentralConverter.entityModelValidForConversion(currentFileName, (ObjectNode) missingIndexedPropertyEntity));
-
-        currentFileName = "EmptyFile.entity.json";
-        JsonNode emptyFileEntity = readJsonObject(entitiesDir.resolve(currentFileName).toFile());
-        assertFalse(hubCentralConverter.entityModelValidForConversion(currentFileName, (ObjectNode) emptyFileEntity));
     }
 
     @Test
@@ -127,10 +123,6 @@ public class EntityModelConverterTest extends AbstractHubCoreTest {
         currentFileName = "MissingIndexedProperty.entity.json";
         JsonNode missingIndexedPropertyEntity = readJsonObject(entitiesDir.resolve(currentFileName).toFile());
         assertTrue(hubCentralConverter.entityModelRequiresConversion(currentFileName, (ObjectNode) missingIndexedPropertyEntity));
-
-        currentFileName = "EmptyFile.entity.json";
-        JsonNode emptyFileEntity = readJsonObject(entitiesDir.resolve(currentFileName).toFile());
-        assertFalse(hubCentralConverter.entityModelRequiresConversion(currentFileName, (ObjectNode) emptyFileEntity));
     }
 
     @Test

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -47,10 +47,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 
-@EnableAutoConfiguration
 class DataHubPlugin implements Plugin<Project> {
 
     private DataHubImpl dataHub


### PR DESCRIPTION
### Description

The irony here is this mostly involves removing code!

For the core project, we only need spring-context, and we now obtain a ConfigurableApplicationContext where needed by just instantiating an AnnotationConfigurableApplicationContext with the appropriate Configuration class. 

Replaced the spring-boot bootJar task with a custom jar task that is almost identical to the existing one for clientJar - just has a different main class. 

Renamed logback-spring.xml to logback.xml, and this no longer is included in the DHF library jar, since processResources no longer copies it in. It's only included in the executable jars that need it.

Removed EnableAutoConfiguration from DataHubPlugin, which wasn't even doing anything. The Spring container is created manually in that class. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests

