### PR TITLE
DHFPROD-5597: Show search link when facets > 20

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.json.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.json.tsx
@@ -464,9 +464,6 @@ describe('json scenario for table on browse documents page', () => {
       browsePage.getFacetApplyButton().click();
       browsePage.getFacetItemCheckbox('name', 'Mcgee Burch').should('be.checked');
       browsePage.getFacetItemCheckbox('name', 'Powers Bauer').should('be.checked');
-      browsePage.clickPopoverSearch('name');
-      browsePage.setInputField('name', 'Mc');
-      browsePage.getPopOverCheckbox('Mcgee Burch').should('be.checked');
       browsePage.getFacetItemCheckbox('email','mcgeeburch@nutralab.com').click();
       browsePage.getFacetItemCheckbox('name', 'Mcgee Burch').click();
       browsePage.waitForSpinnerToDisappear();
@@ -477,23 +474,6 @@ describe('json scenario for table on browse documents page', () => {
       browsePage.getFacetItemCheckbox('name', 'Powers Bauer').should('not.be.checked');
       browsePage.getFacetItemCheckbox('email','mcgeeburch@nutralab.com').should('not.be.checked');
   })
-
-  it('Verify facets checked from popover search can be unchecked on clicking discard all changes', () => {
-     browsePage.selectEntity('Person');
-     browsePage.getFacetItemCheckbox('fname', 'Alexandra').click();
-     browsePage.getGreySelectedFacets('Alexandra').should('exist');
-     browsePage.waitForSpinnerToDisappear();
-     browsePage.clickPopoverSearch('fname');
-     browsePage.setInputField('fname', 'Al');
-     browsePage.getPopOverCheckbox('Alexandra').click();
-     browsePage.getGreySelectedFacets('Alexandra').should('be.visible');
-     browsePage.getFacetSearchSelectionCount('fname').should('contain', '1');
-     browsePage.getClearGreyFacets().click();
-     browsePage.getFacetItemCheckbox('fname', 'Alexandra').should('not.be.checked');
-     browsePage.clickPopoverSearch('fname');
-     browsePage.getPopOverCheckbox('Alexandra').should('not.be.checked');
-  })
-
 });
 
 

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/facet.js
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/facet.js
@@ -1,3 +1,79 @@
 export const numericRange = { "data": { "min": 11, "max": 110 } };
 
 export const stringSearchResponse = ["Adams Cole"];
+
+export const facetProps = {
+    name: "sales_region",
+    constraint: "sales_region",
+    key: "",
+    tooltip: "",
+    facetType: "xs:string",
+    facetCategory: "entity",
+    updateSelectedFacets: jest.fn(),
+    addFacetValues: jest.fn(),
+    referenceType: "element",
+    entityTypeId: "",
+    propertyPath: "sales_region",
+    facetValues: [
+    {
+      "name": "Customer",
+      "count": 50,
+      "value": "Customer"
+    },
+    {
+      "name": "ProductGroupLicense",
+      "count": 1200,
+      "value": "ProductGroupLicense"
+    },
+    {
+      "name": "OrderDetail",
+      "count": 15000,
+      "value": "OrderDetail"
+    },
+    {
+      "name": "ItemType",
+      "count": 300,
+      "value": "ItemType"
+    },
+    {
+      "name": "ProductDetail",
+      "count": 4095,
+      "value": "ProductDetail"
+    },
+    {
+      "name": "OrderType",
+      "count": 1034,
+      "value": "OrderType"
+    },
+    {
+      "name": "Order",
+      "count": 2334,
+      "value": "Order"
+    },
+    {
+      "name": "ProductGroup",
+      "count": 2346,
+      "value": "ProductGroup"
+    },
+    {
+      "name": "Protein",
+      "count": 607,
+      "value": "Protein"
+    },
+    {
+      "name": "Provider",
+      "count": 12584,
+      "value": "Provider"
+    },
+    {
+      "name": "TestEntityForMapping",
+      "count": 100,
+      "value": "TestEntityForMapping"
+    },
+    {
+      "name": "CustomerType",
+      "count": 999,
+      "value": "CustomerType"
+    }
+  ]
+}

--- a/marklogic-data-hub-central/ui/src/components/facet/facet.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/facet/facet.test.tsx
@@ -1,26 +1,12 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import Facet from './facet';
-import { facetValues } from '../../assets/mock-data/entity-table';
+import { facetProps } from '../../assets/mock-data/facet';
 
 describe("Facet component", () => {
   it("Facet component renders with data properly" , () => {
-    const { getByTestId, getByText } = render(
-        <Facet
-          name="sales_region"
-          constraint="sales_region"
-          facetValues={facetValues}
-          key=""
-          tooltip=""
-          facetType="xs:string"
-          facetCategory="entity"
-          updateSelectedFacets={jest.fn()}
-          addFacetValues={jest.fn()}
-          referenceType="element"
-          entityTypeId=""
-          propertyPath="sales_region"
-        />
-    )
+    const { getByTestId, getByText, queryByLabelText } = render(<Facet {...facetProps} />)
+
     expect(getByText(/sales_region/i)).toBeInTheDocument();
 
     expect(getByText(/Customer/i)).toBeInTheDocument();
@@ -36,25 +22,12 @@ describe("Facet component", () => {
     expect(getByText(/607/i)).toBeInTheDocument();
     expect(getByText(/CustomerType/i)).toBeInTheDocument();
     expect(getByText(/999/i)).toBeInTheDocument();
+    // Search link not shown for facets < 20
+    expect(queryByLabelText('popover-search-label')).not.toBeInTheDocument();
   });
 
   it("Facet component renders with nested data properly" , () => {
-    const { getByTestId, getByText } = render(
-        <Facet
-          name="Sales.sales_region"
-          constraint="Sales.sales_region"
-          facetValues={facetValues}
-          key=""
-          tooltip=""
-          facetType="xs:string"
-          facetCategory="entity"
-          updateSelectedFacets={jest.fn()}
-          addFacetValues={jest.fn()}
-          referenceType="element"
-          entityTypeId=""
-          propertyPath="sales_region"
-        />
-    )
+    const { getByTestId, getByText } = render(<Facet {...facetProps} name="Sales.sales_region" constraint="Sales.sales_region" />)
     expect(getByText(/Sales.sales_region/i)).toBeInTheDocument();
 
     expect(getByText(/Customer/i)).toBeInTheDocument();
@@ -73,28 +46,30 @@ describe("Facet component", () => {
   });
 
   it("Collapse/Expand carets render properly for facet properties" , () => {
-    const { getByTestId } = render(
-        <Facet
-          name="sales_region"
-          constraint="sales_region"
-          facetValues={facetValues}
-          key=""
-          tooltip=""
-          facetType="xs:string"
-          facetCategory="entity"
-          updateSelectedFacets={jest.fn()}
-          addFacetValues={jest.fn()}
-          referenceType="element"
-          entityTypeId=""
-          propertyPath="sales_region"
-        />
-    )
+    const { getByTestId } = render(<Facet {...facetProps} />)
 
     expect(getByTestId('sales_region-toggle')).toBeInTheDocument();
     expect(document.querySelector('[data-testid=sales_region-toggle] i svg')).toBeInTheDocument();
     expect(document.querySelector('[data-testid=sales_region-toggle] i svg')).not.toHaveStyle('transform: rotate(180deg);');
     fireEvent.click(getByTestId('sales_region-toggle'));
     expect(document.querySelector('[data-testid=sales_region-toggle] i svg')).toHaveStyle('transform: rotate(180deg);');
+  });
+
+  it("Search link shown only when facet number greater than limit" , () => {
+    const LIMIT =  20,
+          facetValsNew: any = [];
+    for (let i = 0; i < LIMIT; i++) {
+      facetValsNew.push({"name": "fName", "count": 1, "value": "fVal"});
+    }
+    const { getByLabelText, queryByLabelText, rerender } = render(<Facet {...facetProps} />)
+
+    // Search link NOT shown for facets < LIMIT
+    expect(queryByLabelText('popover-search-label')).not.toBeInTheDocument();
+
+    rerender(<Facet {...facetProps} facetValues={facetValsNew}/>)
+    
+    // Search link shown for facets >= LIMIT
+    expect(getByLabelText('popover-search-label')).toBeInTheDocument();
   });
 
 });

--- a/marklogic-data-hub-central/ui/src/components/facet/facet.tsx
+++ b/marklogic-data-hub-central/ui/src/components/facet/facet.tsx
@@ -25,7 +25,8 @@ interface Props {
 
 const Facet: React.FC<Props> = (props) => {
   const SHOW_MINIMUM = 3;
-  const { searchOptions, greyedOptions } = useContext(SearchContext);
+  const SEARCH_MINIMUM = 20;
+  const {searchOptions, greyedOptions} = useContext(SearchContext);
   const [showFacets, setShowFacets] = useState(SHOW_MINIMUM);
   const [show, toggleShow] = useState(true);
   const [more, toggleMore] = useState(false);
@@ -182,9 +183,9 @@ const Facet: React.FC<Props> = (props) => {
           data-cy="show-more"
           data-testid={`show-more-${stringConverter(props.name)}`}
         >{(more) ? '<< less' : 'more >>'}</div>
-        {(props.facetType === 'xs:string' || 'collection') &&
-          <div className={styles.searchValues}>
-            <PopOverSearch
+        {(props.facetType === 'xs:string' || 'collection') && (checkedFacets.length >= SEARCH_MINIMUM) && 
+        <div className={styles.searchValues}>
+          <PopOverSearch
               referenceType={props.referenceType}
               entityTypeId={props.entityTypeId}
               propertyPath={props.propertyPath}

--- a/marklogic-data-hub-central/ui/src/components/pop-over-search/pop-over-search.tsx
+++ b/marklogic-data-hub-central/ui/src/components/pop-over-search/pop-over-search.tsx
@@ -110,7 +110,7 @@ const PopOverSearch: React.FC<Props> = (props) => {
       trigger="click"
       onVisibleChange={handleChange}
       visible={popOverVisibility}>
-      <div className={styles.search} data-testid={(props.facetName)+"-search-input"}>Search</div>
+      <div className={styles.search} data-testid={(props.facetName)+"-search-input"} aria-label={'popover-search-label'}>Search</div>
     </Popover>
   )
 }


### PR DESCRIPTION
### Description

Popover search link only shown for a facet when number of facet items is great than a limit (20).

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

