### PR TITLE
DHFPROD-5945: Schema for a DH envelope

### DIFF
--- a/specs/models/DataHubEnvelope.schema.json
+++ b/specs/models/DataHubEnvelope.schema.json
@@ -1,0 +1,137 @@
+{
+  "title": "DataHubEnvelope",
+  "description": "Defines the envelope structure with DHF-specific additions to headers",
+  "type": "object",
+  "properties": {
+    "headers": {
+      "description": "Container for what can typically be considered metadata that pertains to the instance data in the envelope",
+      "type": "object",
+      "properties": {
+        "createdBy": {
+          "description": "MarkLogic user that created this document",
+          "type": "string"
+        },
+        "createdOn": {
+          "description": "dateTime at which this document was created",
+          "type": "string"
+        },
+        "createdUsingFile": {
+          "description": "Will be set when running an ingestion step via DHF and ingesting CSV files",
+          "type": "string"
+        },
+        "datahub": {
+          "description": "Intended to store all DHF-specific headers in the future",
+          "type": "object",
+          "properties": {
+            "validationErrors": {
+              "description": "Populated by a mapping step that has entity validation enabled",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "data": {
+                  "type": "object"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "formattedMessages": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "id": {
+          "description": "Appears to be set as part of mastering",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "merges": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "document-uri": {
+                "type": "string"
+              },
+              "last-merge": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "merge-options": {
+          "type": "object",
+          "properties": {
+            "lang": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        "sources": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "dateTime": {
+                "description": "Specific to mastering",
+                "type": "string"
+              },
+              "import-id": {
+                "description": "Specific to mastering",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of a source that provides instance data in this envelope",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "triples": {
+      "description": "Optional array of triples",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "triple": {
+            "type": "object",
+            "properties": {
+              "subject": {
+                "type": "string"
+              },
+              "predicate": {
+                "type": "string"
+              },
+              "object": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "instance": {
+      "description": "Instance data can be anything a user chooses",
+      "type": "object"
+    },
+    "attachments": {
+      "type": "array",
+      "items": {
+        "description": "Each attachment can contain any data a user chooses",
+        "type": "object"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description

This is being added to the develop branch so that it can be used by the Spark connector team without having to switch to the 5.4-develop branch. It has no impact on anything in 5.3, other than if the Gradle task generateSchemaPojos is run. And I verified that it runs successfully. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

