### PR TITLE
DHFPROD-5971: Link Overview containers to tile views

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/tiles/toolbar.tsx
+++ b/marklogic-data-hub-central/ui/src/components/tiles/toolbar.tsx
@@ -1,6 +1,5 @@
 import React, { CSSProperties } from 'react';
 import { Link } from 'react-router-dom';
-import { Tooltip } from 'antd';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import styles from './toolbar.module.scss';

--- a/marklogic-data-hub-central/ui/src/pages/Overview.module.scss
+++ b/marklogic-data-hub-central/ui/src/pages/Overview.module.scss
@@ -43,12 +43,63 @@
                 padding-right: 10px;
                 font-size: 24px;
             }
+
+            // Enabled cards: hover border, cursor pointer, default backaground
+            .cardLoad.enabled:hover,
+            .cardModel.enabled:hover,
+            .cardCurate.enabled:hover,
+            .cardExplore.enabled:hover,
+            .cardRun.enabled:hover {
+                border: 1px solid #394494;
+                cursor: pointer;
+            }
+
+            // Disabled cards: no hover border, default cursor, light-gray background
+            .cardLoad.disabled:hover,
+            .cardModel.disabled:hover,
+            .cardCurate.disabled:hover,
+            .cardExplore.disabled:hover,
+            .cardRun.disabled:hover {
+                cursor: default;
+            }
+            .cardLoad.disabled,
+            .cardModel.disabled,
+            .cardCurate.disabled {
+                .head {
+                    background-color: #FAFBFC;
+                }
+            }
+            .cardExplore.disabled,
+            .cardRun.disabled {
+                background-color: #FAFBFC;
+            }
+
+            // Disabled cards have permissions text
+            .permissions, .permissionsCurate, .permissionsRun, .permissionsExplore {
+                position: relative;
+                padding: 24px 0 0 10px;
+                text-align: right;
+                font-size: 9pt;
+                bottom: 5px;
+                right: 5px;
+            }
+            .permissionsCurate {
+                padding: 42px 0 0 10px;
+            }
+            .permissionsRun {
+                padding: 98px 0 0 10px;
+            }
+            .permissionsExplore {
+                padding: 110px 0 0 10px;
+            }
+
             .cardLoad {
                 position: relative;
                 border-radius: 4px;
                 border: 1px solid #a8819c;
                 background-color: #eee6eb;
                 .head {
+                    border-radius: 4px 4px 0 0;
                     min-height: 21vh;
                     border-bottom: 1px solid #a8819c;
                     background-image: url("../assets/load_visual_big.png");
@@ -72,6 +123,7 @@
                 border: 1px solid #7f9cc5;
                 background-color: #e6ebf4;
                 .head {
+                    border-radius: 4px 4px 0 0;
                     min-height: 21vh;
                     border-bottom: 1px solid #7f9cc5;
                     background-image: url("../assets/model_visual_big.png");
@@ -95,6 +147,7 @@
                 border: 1px solid #dcbd8a;
                 background-color: #f8f2e8;
                 .head {
+                    border-radius: 4px 4px 0 0;
                     min-height: 21vh;
                     border-bottom: 1px solid #dcbd8a;
                     background-image: url("../assets/curate_visual_map.png");
@@ -119,7 +172,9 @@
                 background-repeat:no-repeat;
                 background-position: 50% 25%;
                 position: relative;
+                border-radius: 4px;
                 .head {
+                    border-radius: 0 0 4px 4px;
                     min-height: 22vh;
                     width: 100%;
                     border-top: 1px solid #90aeb2;
@@ -149,6 +204,7 @@
                 background-position: 85% 45%;
                 background-size: 55%;
                 .head {
+                    border-radius: 4px 0 0 4px;
                     width: 30%;
                     border-right: 1px solid #8288bb;
                     min-height: 23vh;
@@ -162,6 +218,7 @@
                     }
                 }
             }
+
         }
     }
 }

--- a/marklogic-data-hub-central/ui/src/pages/Overview.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Overview.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import {render } from "@testing-library/react";
+import { Router } from 'react-router'
+import { createMemoryHistory } from 'history'
+import {render, fireEvent } from "@testing-library/react";
 import Overview from './Overview';
 
 describe('Overview component', () => {
 
-    test('Verify static display', async () => {
+    it('Verify content display', async () => {
 
         const { getByText, getByLabelText } = render(<Overview/>);
 
@@ -21,6 +23,38 @@ describe('Overview component', () => {
         expect(getByLabelText('run-icon')).toBeInTheDocument();
         expect(getByText('Explore')).toBeInTheDocument();
         expect(getByLabelText('explore-icon')).toBeInTheDocument();
+
+    });
+
+    it('Verify enabled cards are clickable', async () => {
+
+        const history = createMemoryHistory();
+        history.push('/tiles'); // initial state
+
+        let enabled = ['load', 'model', 'curate', 'run', 'explore']
+        const {getByLabelText} = render(<Router history={history}><Overview enabled={enabled}/></Router>);
+
+        enabled.forEach((card, i) => {
+            expect(getByLabelText(card + "-card")).toHaveClass(`enabled`);
+            fireEvent.click(getByLabelText(card + "-card"));
+            expect(history.location.pathname).toEqual(`/tiles/${card}`);
+        })
+
+    });
+
+    it('Verify disabled cards are not clickable', async () => {
+
+        const history = createMemoryHistory();
+        history.push('/tiles'); // initial state
+
+        let disabled = ['load', 'model', 'curate', 'run', 'explore']
+        const {getByLabelText} = render(<Router history={history}><Overview enabled={[]}/></Router>);
+
+        disabled.forEach((card, i) => {
+            expect(getByLabelText(card + "-card")).toHaveClass(`disabled`);
+            fireEvent.click(getByLabelText(card + "-card"));
+            expect(history.location.pathname).toEqual(`/tiles`); // no change
+        })
 
     });
 

--- a/marklogic-data-hub-central/ui/src/pages/Overview.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Overview.tsx
@@ -1,11 +1,42 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import styles from './Overview.module.scss';
+import { useHistory } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faLongArrowAltRight, faCube, faCubes, faObjectUngroup, faProjectDiagram } from "@fortawesome/free-solid-svg-icons";
 
+interface Props {
+    enabled: any;
+}
 
-const Overview = (props) => {
+const Overview: React.FC<Props> = (props) => {
+
+    const history: any = useHistory();
+
+    const goToTile = (id) => {
+        if (props.enabled && props.enabled.includes(id)) {
+            history.push({
+                pathname: `/tiles/${id}`,
+                state: {
+                    tileIconClicked : true
+                }
+            })
+        }
+    }
+
+    const getClassNames = (id) => {
+        const nameMap = {
+            'load': 'cardLoad',
+            'model': 'cardModel',
+            'curate': 'cardCurate',
+            'explore': 'cardExplore',
+            'run': 'cardRun'
+        }
+        if (props.enabled && props.enabled.includes(id)) {
+            return `${styles[nameMap[id]]} ${styles.enabled}`;
+        } else {
+            return `${styles[nameMap[id]]} ${styles.disabled}`
+        }
+    }
 
     return (
         <div className={styles.overviewContainer} aria-label="overview">
@@ -17,49 +48,65 @@ const Overview = (props) => {
             </div>
             <div className={styles.cardsContainer}>
                 <div className={styles.cards}>
-                    <div className={styles.cardLoad}>
+                    <div className={getClassNames('load')} onClick={() => {goToTile('load')}} aria-label={'load-card'}>
                         <div className={styles.head}></div>
                         <div className={styles.subtitle}>
                             <i aria-label="load-icon"><FontAwesomeIcon icon={faLongArrowAltRight} /></i>Load
                         </div>
-                        <div className={styles.body}>Ingest raw data from multiple file types.</div>
+                        <div className={styles.body}>Ingest raw data from multiple file types.
+                            { props.enabled && !props.enabled.includes('load') &&
+                            <div className={styles.permissions}><span>*</span>additional permissions required</div> }
+                        </div>
                     </div>
                     
-                    <div className={styles.cardModel}>
+                    <div className={getClassNames('model')} onClick={() => {goToTile('model')}} aria-label={'model-card'}>
                         <div className={styles.head}></div>
                         <span className={styles.icon}></span> 
                         <div className={styles.subtitle}>
                             <i aria-label="model-icon"><FontAwesomeIcon icon={faCube} /></i>Model
                         </div>
-                        <div className={styles.body}>Define entity types to describe curated data.</div>
+                        <div className={styles.body}>Define entity types to describe curated data.
+                            { props.enabled && !props.enabled.includes('model') &&
+                            <div className={styles.permissions}><span>*</span>additional permissions required</div> }
+                        </div>
                     </div>
                     
-                    <div className={styles.cardCurate}>
+                    <div className={getClassNames('curate')} onClick={() => {goToTile('curate')}} aria-label={'curate-card'}>
                         <div className={styles.head}></div>
                         <span className={styles.icon}></span> 
                         <div className={styles.subtitle}>
                             <i aria-label="curate-icon"><FontAwesomeIcon icon={faObjectUngroup} /></i>Curate
                         </div>
-                        <div className={styles.body}>Create a 360º view.</div>
+                        <div className={styles.body}>Create a 360º view.
+                            { props.enabled && !props.enabled.includes('curate') &&
+                            <div className={styles.permissionsCurate}><span>*</span>additional permissions required</div> }
+                        </div>
                     </div>
-                    
-                    <div className={styles.cardExplore}>
+
+                    <div className={getClassNames('explore')} onClick={() => {goToTile('explore')}} aria-label={'explore-card'}>
                         <div className={styles.head}>
                             <span className={styles.icon} aria-label="explore-icon"></span> 
                             <div className={styles.subtitle}>Explore</div>
-                            <div className={styles.body}>Search through curated data.</div>
+                            <div className={styles.body}>Search through curated data.
+                                { props.enabled && !props.enabled.includes('explore') &&
+                                <div className={styles.permissionsExplore}><span>*</span>additional permissions required</div> }
+                            </div>
                         </div>
                     </div>
                     
-                    <div className={styles.cardRun}>
+                    <div className={getClassNames('run')} onClick={() => {goToTile('run')}} aria-label={'run-card'}>
                         <div className={styles.head}>
                             <span className={styles.icon}></span> 
                             <div className={styles.subtitle}>
                                 <i aria-label="run-icon"><FontAwesomeIcon icon={faCubes} /></i>Run
                             </div>
-                            <div className={styles.body}>Arrange steps into data flows to test loading and curation.</div>
+                            <div className={styles.body}>Arrange steps into data flows to test loading and curation.
+                                { props.enabled && !props.enabled.includes('run') &&
+                                <div className={styles.permissionsRun}><span>*</span>additional permissions required</div> }
+                            </div>
                         </div>
                     </div>
+                    
                 </div>
             </div>
         </div>

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.tsx
@@ -118,7 +118,7 @@ const TilesView = (props) => {
                     />
                     ) : null }
                 </div> ) :
-                <Overview/>
+                <Overview enabled={enabled}/>
             }
 
         </>


### PR DESCRIPTION
This makes the containers on the Overview landing page clickable links (for users with the right permissions).

Also adds permissions content to containers when the containers are disabled and fixes minor corner radius issues.

To manually test, you can view disabled cards (all except Explore) as hub-user or enabled cards as hub-developer.

Note that this doesn't update the main icons or colors of the cards, that will come in a future story. We're keeping the current Overview page style, see the screenshots here: 

https://project.marklogic.com/jira/browse/DHFPROD-5971?focusedCommentId=184459&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-184459

@jbelonoj has reviewed and approved.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

