### PR TITLE
DHFPROD-6001:Run tile e2e test failure fix

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/run/runFlow.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/run/runFlow.spec.tsx
@@ -43,6 +43,8 @@ describe('Run Tile tests', () => {
         browsePage.getFacetItemCheckbox('collection', 'sm-Person-merged').click();
         browsePage.getGreySelectedFacets('sm-Person-merged').should('exist');
         browsePage.getFacetApplyButton().click();
+        //comment below line if there is alternate solution for DHFPROD-5878
+        browsePage.getMosaicContainer().scrollTo('top');
         browsePage.getTotalDocuments().should('be', 2);
         browsePage.getSourceViewIcon().first().click();
         cy.waitForAsyncRequest();


### PR DESCRIPTION
### Description
Added a e2e test fix for Run tile to check for scroll when facets are applied. Previously there was a scroll on the content which is not causing the failure to happen but as UX requested I removed the extra scroll as a part of https://github.com/marklogic/marklogic-data-hub/pull/4570. Currently the ticket is assigned to @wooldridge to look for alternate solution. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

