### PR TITLE
DHFPROD-5868:Set 'outputURIPrefix' to empty string if it's not set

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
@@ -406,8 +406,16 @@ public class WriteStepRunner implements StepRunner {
             this.withStopOnFailure(Boolean.parseBoolean(stepConfig.get("stopOnFailure").toString()));
         }
 
-        if(outputURIPrefix != null && StringUtils.isNotEmpty(outputURIReplacement)){
-            throw new RuntimeException("'outputURIPrefix' and 'outputURIReplacement' cannot be set simultaneously");
+        if(StringUtils.isNotEmpty(outputURIReplacement)){
+            if(outputURIPrefix != null){
+                throw new RuntimeException("'outputURIPrefix' and 'outputURIReplacement' cannot be set simultaneously");
+            }
+        }
+        else{
+            //set 'outputURIPrefix' to "" if it's not set and 'outputURIReplacement' is also not set
+            if(outputURIPrefix == null){
+                outputURIPrefix = "";
+            }
         }
 
         if (inputFilePath == null || inputFileType == null) {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/step/impl/WriteStepRunnerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/step/impl/WriteStepRunnerTest.java
@@ -87,7 +87,7 @@ public class WriteStepRunnerTest extends AbstractHubCoreTest {
     }
 
     @Test
-    public void testLoadStepRunnerParameters() {
+    public void testOutputUriPrefix() {
         WriteStepRunner wsr = new WriteStepRunner(getHubConfig().newHubClient(), getHubConfig().getHubProject());
         Flow flow = flowManager.getFullFlow("testCsvLoadData");
         Map<String, Step> steps = flow.getSteps();
@@ -99,7 +99,25 @@ public class WriteStepRunnerTest extends AbstractHubCoreTest {
         Assertions.assertEquals("csv", wsr.inputFileType, "Input file type should be 'csv'");
         Assertions.assertEquals("json", wsr.outputFormat, "Output format should be 'json'");
         Assertions.assertEquals(".*/input,''", wsr.outputURIReplacement, "output URI replacement format should be '.*/input,'''");
+        //if 'outputURIReplacement' is set and 'outputURIPrefix' is not set, it will remain null
+        Assertions.assertEquals(null, wsr.outputURIPrefix, "output URI prefix format should be null");
         Assertions.assertEquals(",", wsr.separator, "separator should be ','");
+
+        Map<String, Object> stepConfig = new HashMap<>();
+        Map<String, Object> fileLocations = new HashMap<>();
+        fileLocations.put("outputURIReplacement", null);
+        fileLocations.put("outputURIPrefix", null);
+        stepConfig.put("fileLocations", fileLocations);
+
+        wsr.withStepDefinition(stepDef).withFlow(flow).withStep("1").withBatchSize(1).withStepConfig(stepConfig)
+            .withJobId(UUID.randomUUID().toString());
+        wsr.loadStepRunnerParameters();
+
+        Assertions.assertEquals(null, wsr.outputURIReplacement, "output URI replacement should be null");
+        //if 'outputURIReplacement' and 'outputURIPrefix' are not set, 'outputURIPrefix' will be set to ""
+        Assertions.assertEquals("", wsr.outputURIPrefix, "output URI prefix will be set to empty string as" +
+            "outputURIReplacement is null");
+
     }
 
     @Test


### PR DESCRIPTION
### Description
Set 'outputURIPrefix' to empty string if it's not set
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

