### PR TITLE
DHFPROD-5878:Stop table scrolling in Explorer

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.json.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.json.tsx
@@ -124,8 +124,6 @@ describe('json scenario for snippet on browse documents page', () => {
     browsePage.getFacetApplyButton().should('exist');
     browsePage.getClearGreyFacets().should('exist');
     browsePage.getFacetApplyButton().click();
-    browsePage.waitForSpinnerToDisappear();
-    browsePage.getMosaicContainer().scrollTo('top');
     browsePage.getTotalDocuments().should('be.equal', 14);
     browsePage.getClearAllButton().should('exist');
     browsePage.getFacetSearchSelectionCount('collection').should('contain', '1');

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.queries.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.queries.tsx
@@ -308,7 +308,6 @@ describe('save/manage queries scenarios, developer role', () => {
         // Clicking on reset after selected facets are applied, saves new query and navigates to zero state
         browsePage.selectEntity('Customer');
         browsePage.getSelectedEntity().should('contain', 'Customer');
-        browsePage.getMosaicContainer().scrollTo('top');
         browsePage.getSaveQueriesDropdown().should('be.visible');
         browsePage.getSelectedQuery().should('contain', 'select a query');
         browsePage.getFacetItemCheckbox('name', 'Adams Cole').click();
@@ -355,7 +354,6 @@ describe('save/manage queries scenarios, developer role', () => {
         // Select saved query, make changes, click on reset opens a confirmation
         browsePage.selectEntity('Customer');
         browsePage.getSelectedEntity().should('contain', 'Customer');
-        browsePage.getMosaicContainer().scrollTo('top');
         browsePage.getSaveQueriesDropdown().should('be.visible');
         browsePage.getSelectedQuery().should('contain', 'select a query');
         browsePage.getSaveQueriesDropdown().should('be.visible');
@@ -416,10 +414,9 @@ describe('save/manage queries scenarios, developer role', () => {
         // browsePage.getResetQueryButton().click();
         browsePage.getExploreButton().should('be.visible');
         browsePage.getExploreButton().click();
-        //verify no confirmation modal after reset.
+        //verify no confirmation modal after reset. 
         browsePage.selectEntity('Customer');
         browsePage.getSelectedEntity().should('contain', 'Customer');
-        browsePage.getMosaicContainer().scrollTo('top');
         browsePage.getSaveQueriesDropdown().should('be.visible');
         browsePage.selectQuery('reset-query');
         browsePage.getResetQueryButton().click();
@@ -429,7 +426,6 @@ describe('save/manage queries scenarios, developer role', () => {
     it('verify export array/structured data warning', () => {
         browsePage.selectEntity('Order');
         browsePage.getSelectedEntity().should('contain', 'Order');
-        browsePage.getMosaicContainer().scrollTo('top');
         browsePage.getDataExportIcon().click();
         browsePage.getStructuredDataWarning().should('be.visible');
     });
@@ -502,7 +498,6 @@ describe('manage queries modal scenarios, developer role', () => {
         queryComponent.getManageQueryModal().should('not.be.visible');
         browsePage.getSelectedQuery().should('contain', 'select a query');
         browsePage.getSelectedQueryDescription().should('contain', '');
-        browsePage.getMosaicContainer().scrollTo('top');
         browsePage.getResetQueryButton().should('be.visible');
     });
 });

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.table.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.table.tsx
@@ -43,7 +43,6 @@ describe('column selector test scenarios', () => {
   it('has columns selector popover, draggable titles and checkable titles', () => {
     browsePage.selectEntity('Customer');
     browsePage.getSelectedEntity().should('contain', 'Customer');
-    browsePage.getMosaicContainer().scrollTo('top');
     browsePage.getColumnSelectorIcon().should('be.visible')
     browsePage.getColumnSelectorIcon().click()
     browsePage.getColumnSelector().should('be.visible')

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.xml.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explorer/scenarios.xml.tsx
@@ -57,8 +57,6 @@ describe('xml scenario for snippet view on browse documents page', () => {
     browsePage.getFacetApplyButton().should('exist');
     browsePage.getClearGreyFacets().should('exist');
     browsePage.getFacetApplyButton().click();
-    browsePage.waitForSpinnerToDisappear();
-    browsePage.getMosaicContainer().scrollTo('top');
     browsePage.getTotalDocuments().should('be.equal', 5);
     browsePage.getClearAllButton().should('exist');
     browsePage.getFacetSearchSelectionCount('collection').should('contain', '1');

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/browse.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/browse.tsx
@@ -33,10 +33,6 @@ class BrowsePage {
     });
   }
 
-  getMosaicContainer(){
-    return cy.get('.mosaic-window > .mosaic-window-body');
-  }
-
   clickPaginationItem(index: number) {
     return cy.get(`#top-search-pagination-bar .ant-pagination-item-${index}`).click();
   }

--- a/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.module.scss
@@ -4,9 +4,9 @@
   height: 10px;
 }
 .tabular {
-  margin-top: 20px;
-  overflow-x: auto;
-  height: 74vh;
+    margin-top: 20px;
+    overflow-x: auto;
+    height: 46vh;
 }
 
 .columnSelector {
@@ -27,5 +27,5 @@
 
 .redirectIcons a {
   padding: 8px;
-  color: #44499c;
+  color: #44499C;
 }

--- a/marklogic-data-hub-central/ui/src/components/sidebar/sidebar.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/sidebar/sidebar.module.scss
@@ -1,7 +1,6 @@
 .sideBarContainer {
   overflow-y: auto;
-  max-height: 110vh;
-  height: 110vh;
+  max-height: 100vh;
   background-color: #F1F2F5;
 }
 

--- a/marklogic-data-hub-central/ui/src/pages/Browse.module.scss
+++ b/marklogic-data-hub-central/ui/src/pages/Browse.module.scss
@@ -6,6 +6,7 @@
   background: #fff;
   padding: 20px 24px 34px 36px;
   width: 100%;
+  max-height: 100vh;
 }
 
 .sideBarFacets {
@@ -32,8 +33,7 @@
 .snippetViewResult {
   border-top: 1px solid #d0d1d5;
   border-bottom: 1px solid #d0d1d5;
-  max-height: 80vh;
-  height: 80vh;
+  max-height: 55vh;
   overflow: auto;
 }
 
@@ -62,7 +62,7 @@
 }
 
 .ant-table-content {
-  //height: 400px;
+  height: 400px;
 }
 
 .collapseIcon {

--- a/marklogic-data-hub-central/ui/src/pages/Browse.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Browse.tsx
@@ -283,6 +283,7 @@ const Browse: React.FC<Props> = ({ location }) => {
       tableView = 'table';
     }
     setUserPreferences(tableView);
+
     if (resultsRef && resultsRef.current) {
       resultsRef.current['style']['boxShadow'] = 'none'
     }
@@ -313,7 +314,7 @@ const Browse: React.FC<Props> = ({ location }) => {
             checkFacetRender={updateCheckedFacets}
           />
         </Sider>
-        <Content className={styles.content} style={{overflowX: 'unset'}}>
+        <Content className={styles.content}>
 
           <div className={styles.collapseIcon} id='sidebar-collapse-icon'>
             {collapse ?


### PR DESCRIPTION
This reverts commit cc6c322ce87e879adac2d433054ed55e98ef1bb7, please refer DHFPROD-5878 ticket for reasons to revert this commit.
Reverting this commit also fixes some explorer e2e tests(https://project.marklogic.com/jira/browse/DHFPROD-6004) failing on DHS

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

