### PR TITLE
DHFPROD-4381: Move slider to curate match

### DIFF
--- a/marklogic-data-hub-central/ui/package.json
+++ b/marklogic-data-hub-central/ui/package.json
@@ -9,6 +9,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/react-fontawesome": "^0.1.9",
     "@marklogic/design-system": "^1.0.5",
+    "@marklogic/react-compound-slider": "^3.0.0",
     "@types/enzyme": "^3.10.3",
     "@types/jest": "24.0.23",
     "@types/node": "12.12.11",

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/matching-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/matching-card.tsx
@@ -8,6 +8,8 @@ import {convertDateFromISO, getInitialChars, extractCollectionFromSrcQuery} from
 import CreateEditMatchingDialog from './create-edit-matching-dialog/create-edit-matching-dialog';
 import { MLTooltip } from '@marklogic/design-system';
 
+import MultiSlider from './multi-slider/multi-slider';
+
 
 interface Props {
     data: any;
@@ -58,16 +60,46 @@ const MatchingCard: React.FC<Props> = (props) => {
     const handleCardDelete = (name) => {
         setDialogVisible(true);
         setLoadArtifactName(name);
-      }
+    }
 
-      const onOk = (name) => {
+    const onOk = (name) => {
         props.deleteMatchingArtifact(name)
         setDialogVisible(false);
-      }
+    }
 
-      const onCancel = () => {
+    const onCancel = () => {
         setDialogVisible(false);
-      }
+    }
+
+    // TODO get match options from backend
+    const matchOptions = [
+        {
+            props: [{
+                prop: 'First',
+                type: 'Exact'
+            }],
+            value: 0
+        },
+        {
+            props: [{
+                prop: 'DOB',
+                type: 'Exact'
+            }],
+            value: 0
+        },
+        {
+            props: [{
+                prop: 'Foo',
+                type: 'Bar'
+            }],
+            value: 0
+        },
+    ];
+
+    const handleSlider = (values) => {
+        // TODO put match options to backend
+        console.log('handleSlider', values);
+    }
 
     const deleteConfirmation = <Modal
         visible={dialogVisible}
@@ -114,6 +146,9 @@ const MatchingCard: React.FC<Props> = (props) => {
                         <p className={styles.lastUpdatedStyle}>Last Updated: {convertDateFromISO(elem.lastUpdated)}</p>
                     </Card></Col>
                 )) : <span></span> }</Row>
+
+                <MultiSlider options={matchOptions} handleSlider={handleSlider} />
+
                 <CreateEditMatchingDialog
                 newMatching={newMatching}
                 title={title}

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/multi-slider/multi-slider.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/multi-slider/multi-slider.scss
@@ -1,0 +1,74 @@
+.multiSlider {
+
+  height: 120px;
+  margin-top: 80px;
+  width: 100%;
+
+  .slider {
+    position: relative;
+    width: 100%;
+    height: 80px;
+  }
+
+  .sliderRail {
+    position: absolute;
+    width: 100%;
+    height: 4px;
+    margin-top: 35px;
+    border-radius: 2px;
+    background-color: #b5b8cd;
+  }
+
+  .handle {
+    position: absolute;
+    margin-left: -15px;
+    margin-top: 25px;
+    z-index: 2;
+    width: 25px;
+    height: 25px;
+    border: solid 3px #8b94c6;
+    text-align: center;
+    cursor: pointer;
+    border-radius: 50%;
+    background-color: #fff;
+  }
+
+  .tooltipContainer {
+
+    position: absolute;
+    margin-left: -11px;
+    margin-top: -5px;
+
+    .tooltip {
+      position: relative;
+      display: block;
+      width: 200px;
+      bottom: 10px;
+      right: 92px;
+  
+      .tooltipText {
+        margin-top: 2px;
+        width: 200px;
+        background-color: #444;
+        color: #f0f0f0;
+        opacity: 0.8;
+        text-align: center;
+        border-radius: 6px;
+        padding: 5px 0;
+        position: relative;
+        z-index: 1;
+      }
+  
+      .tooltipText::after {
+        content: "";
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        margin-left: -5px;
+        border-width: 5px;
+        border-style: solid;
+        border-color: #444 transparent transparent transparent;
+      }
+    }
+  }
+}

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/multi-slider/multi-slider.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/multi-slider/multi-slider.tsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import { Slider, Handles } from '@marklogic/react-compound-slider'
+import './multi-slider.scss';
+
+export function Handle({
+  handle: { id, value, percent },
+  options: options,
+  getHandleProps
+}) { return (
+    <>
+      <div className={'tooltipContainer'} style={{ left: `${percent}%` }}>
+        <div className="tooltip">
+          { options.map((opt, i) => (
+              <div className="tooltipText" key={i}> {opt.prop} - {opt.type} </div>
+          )) }
+        </div>
+      </div>
+      <div 
+        className={'handle'}
+        style={{
+          left: `${percent}%`,
+        }}
+        {...getHandleProps(id)}
+      >
+      </div>
+    </>
+  )
+}
+
+const MultiSlider = (props) => {
+
+    const options = props.options;
+
+    const onUpdate = values => {
+      // console.log('onUpdate values', values);
+    }
+
+    const onChange = values => {
+      let result = options.map((opt, i) => {
+        // TODO handle multiple tooltips
+        return {
+          props: opt['props'][0],
+          value: values[i]
+        }
+      })
+      props.handleSlider(result);
+    }
+
+    const onSlideStart = values => {
+      // console.log('onSlideStart values', values);
+    }
+
+    const onSlideEnd = values => {
+      // console.log('onSlideEnd values', values);
+    }
+
+    return (
+      <div className={'multiSlider'}>
+        <Slider
+            mode={1} 
+            className={'slider'}
+            domain={[0, 64]}
+            values={options.map(opt => opt.value)} // Array of starting values
+            step={1}
+            onUpdate={onUpdate}
+            onChange={onChange}
+            onSlideStart={onSlideStart}
+            onSlideEnd={onSlideEnd}
+        >
+          <div className={'sliderRail'}/>
+          <Handles>
+            {({ handles, getHandleProps }) => { 
+              return (
+                  <div className={'sliderHandles'}>
+                  { handles.map((handle, index) => {
+                    return (
+                      <Handle
+                        key={handle.id}
+                        handle={handle}
+                        options={options[index].props}
+                        getHandleProps={getHandleProps}
+                      />
+                    ) }
+                  ) }
+                  </div>
+              )
+            }}
+          </Handles>
+        </Slider>
+      </div>
+    )
+}
+
+export default MultiSlider;


### PR DESCRIPTION
- Create a multi-slider component that displays a slider rail with multiple labeled "handles"
- Display an initial example of the slider under the Match tab

Also use @marklogic/react-compound-slider, a modified version of the slider library that supports labeled, crossing handles.

This merge provides @Sanjeevani19 with a slider component to work with for her Mastering work:

https://project.marklogic.com/jira/browse/DHFPROD-5230

No tests necessary for this.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests (N/A)
  

- ##### Reviewer:

- [x] Reviewed Tests (N/A)

