### PR TITLE
DHFPROD-5944: Configure Document Ingestion via connector

### DIFF
--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/AbstractSparkConnectorTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/AbstractSparkConnectorTest.java
@@ -69,26 +69,26 @@ public abstract class AbstractSparkConnectorTest extends AbstractHubTest {
     @Override
     protected HubConfigImpl runAsUser(String username, String password) {
         hubProperties = new Properties();
-        String mlHost="localhost";
-        String hubDhs="false";
-        String hubSsl="false";
-        boolean isDhs=false;
+        String mlHost = "localhost";
+        String hubDhs = "false";
+        String hubSsl = "false";
+        boolean isDhs = false;
         //Can override if we want to run tests on DHS
-        if(System.getProperty("mlHost")!=null){
-            mlHost=System.getProperty("mlHost");
+        if (System.getProperty("mlHost") != null) {
+            mlHost = System.getProperty("mlHost");
         }
-        if(System.getProperty("isDhs")!=null) {
+        if (System.getProperty("isDhs") != null) {
             isDhs = Boolean.parseBoolean(System.getProperty("isDhs"));
         }
-        if(isDhs){
-            hubDhs="true";
-            hubSsl="true";
+        if (isDhs) {
+            hubDhs = "true";
+            hubSsl = "true";
         }
-        hubProperties.setProperty("mlHost",mlHost);
+        hubProperties.setProperty("mlHost", mlHost);
         hubProperties.setProperty("mlUsername", username);
         hubProperties.setProperty("mlPassword", password);
-        hubProperties.setProperty("hubDHS",hubDhs);
-        hubProperties.setProperty("hubSsl",hubSsl);
+        hubProperties.setProperty("hubDHS", hubDhs);
+        hubProperties.setProperty("hubSsl", hubSsl);
         this.hubConfig = HubConfigImpl.withProperties(hubProperties);
         return hubConfig;
     }
@@ -103,6 +103,23 @@ public abstract class AbstractSparkConnectorTest extends AbstractHubTest {
         Map<String, String> params = new HashMap<>();
         hubProperties.keySet().forEach(key -> params.put((String) key, hubProperties.getProperty((String) key)));
         return params;
+    }
+
+    /**
+     * @return a default set of fruit-specific options to simplify writing tests. Uses a batch size of 1 so that there's
+     * no need for tests to call commit by default.
+     */
+    protected Options newFruitOptions() {
+        return new Options(getHubPropertiesAsMap()).withBatchSize(1).withCollections("fruits");
+    }
+
+    /**
+     * @return all the URIs of docs in the 'fruits' collection, which assumes usage of newFruitOptions
+     */
+    protected String[] getFruitUris() {
+        return getHubClient().getStagingClient().newServerEval()
+            .javascript("cts.uris(null, null, cts.collectionQuery('fruits'))")
+            .evalAs(String.class).split("\n");
     }
 
     /**

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/Options.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/Options.java
@@ -17,6 +17,10 @@ public class Options {
     private Integer batchSize;
     private String uriPrefix;
     private String ingestApiPath;
+    private String collections;
+    private String permissions;
+    private String sourceName;
+    private String sourceType;
     private JsonNode ingestWorkUnit;
     private JsonNode ingestEndpointState;
     private Map<String, String> hubProperties;
@@ -39,6 +43,22 @@ public class Options {
         }
         if (uriPrefix != null) {
             params.put("uriprefix", uriPrefix);
+        }
+
+        if (collections != null) {
+            params.put("collections", collections);
+        }
+
+        if (permissions != null) {
+            params.put("permissions", permissions);
+        }
+
+        if (sourceName != null) {
+            params.put("sourceName", sourceName);
+        }
+
+        if (sourceType != null) {
+            params.put("sourceType", sourceType);
         }
 
         if (ingestApiPath != null || ingestWorkUnit != null || ingestEndpointState != null) {
@@ -74,6 +94,26 @@ public class Options {
         return this;
     }
 
+    public Options withCollections(String collections) {
+        this.collections = collections;
+        return this;
+    }
+
+    public Options withPermissions(String permissions) {
+        this.permissions = permissions;
+        return this;
+    }
+
+    public Options withSourceName(String sourceName) {
+        this.sourceName = sourceName;
+        return this;
+    }
+
+    public Options withSourceType(String sourceType) {
+        this.sourceType = sourceType;
+        return this;
+    }
+
     public Options withIngestWorkUnit(JsonNode ingestWorkUnit) {
         this.ingestWorkUnit = ingestWorkUnit;
         return this;
@@ -83,4 +123,6 @@ public class Options {
         this.ingestEndpointState = ingestEndpointState;
         return this;
     }
+
+
 }

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/WriteDataWithOptionsTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/WriteDataWithOptionsTest.java
@@ -1,0 +1,72 @@
+package com.marklogic.hub.spark.sql.sources.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.JacksonHandle;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.sources.v2.writer.DataWriter;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class WriteDataWithOptionsTest extends AbstractSparkConnectorTest {
+
+    @Test
+    void ingestDocsWithCollection() throws IOException {
+        String collections = "fruits,stuff";
+        DataWriter<InternalRow> dataWriter = buildDataWriter(newFruitOptions().withCollections(collections));
+        dataWriter.write(buildRow("pineapple", "green"));
+
+        DocumentMetadataHandle metadata = getFirstFruitMetadata();
+        assertEquals(2, metadata.getCollections().size());
+        assertTrue(metadata.getCollections().contains("fruits"));
+        assertTrue(metadata.getCollections().contains("stuff"));
+
+        // Verify default permissions
+        DocumentMetadataHandle.DocumentPermissions perms = getFirstFruitMetadata().getPermissions();
+        Set<DocumentMetadataHandle.Capability> capabilities = perms.get("data-hub-common");
+        assertTrue(capabilities.contains(DocumentMetadataHandle.Capability.READ));
+        assertTrue(capabilities.contains(DocumentMetadataHandle.Capability.UPDATE));
+    }
+
+    @Test
+    void ingestDocsWithSourceName() throws IOException {
+        String sourceName = "spark";
+        DataWriter<InternalRow> dataWriter = buildDataWriter(newFruitOptions().withSourceName(sourceName));
+        dataWriter.write(buildRow("pineapple", "green"));
+
+        JsonNode doc = getHubClient().getStagingClient().newJSONDocumentManager().read(getFruitUris()[0], new JacksonHandle()).get();
+        assertEquals(sourceName, doc.get("envelope").get("headers").get("sources").get(0).get("name").asText());
+    }
+
+    @Test
+    void ingestDocsWithSourceType() throws IOException {
+        String sourceType = "fruits";
+        DataWriter<InternalRow> dataWriter = buildDataWriter(newFruitOptions().withSourceType(sourceType));
+        dataWriter.write(buildRow("pineapple", "green"));
+
+        JsonNode doc = getHubClient().getStagingClient().newJSONDocumentManager().read(getFruitUris()[0], new JacksonHandle()).get();
+        assertEquals(sourceType, doc.get("envelope").get("headers").get("sources").get(0).get("datahubSourceType").asText());
+    }
+
+    @Test
+    void ingestDocsWithPermissions() throws IOException {
+        String permissions = "qconsole-user,read,manage-admin,update";
+        DataWriter<InternalRow> dataWriter = buildDataWriter(newFruitOptions().withPermissions(permissions));
+        dataWriter.write(buildRow("pineapple", "green"));
+
+        DocumentMetadataHandle.DocumentPermissions perms = getFirstFruitMetadata().getPermissions();
+        assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("qconsole-user").iterator().next());
+        assertEquals(DocumentMetadataHandle.Capability.UPDATE, perms.get("manage-admin").iterator().next());
+    }
+
+    private DocumentMetadataHandle getFirstFruitMetadata() {
+        String[] uris = getFruitUris();
+        assertTrue(uris.length > 0, "Expected at least one fruit URI, found zero");
+        return getHubClient().getStagingClient().newDocumentManager().readMetadata(uris[0], new DocumentMetadataHandle());
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/ingestion/BulkIngestTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/ingestion/BulkIngestTest.java
@@ -1,27 +1,45 @@
 package com.marklogic.hub.dataservices.ingestion;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.dataservices.InputEndpoint;
 import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.eval.EvalResultIterator;
+import com.marklogic.client.ext.util.DefaultDocumentPermissionsParser;
+import com.marklogic.client.ext.util.DocumentPermissionsParser;
+import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.hub.AbstractHubCoreTest;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BulkIngestTest extends AbstractHubCoreTest {
 
     DatabaseClient db;
+    Map<String, String> options;
+    String workUnit;
+
+    public static InputStream asInputStream(String value) {
+        return new ByteArrayInputStream(value.getBytes());
+    }
+
+    public void setOptions() {
+        this.options = new HashMap<String, String>();
+    }
 
     @BeforeEach
     public void setupTest() {
@@ -29,12 +47,58 @@ public class BulkIngestTest extends AbstractHubCoreTest {
     }
 
     @Test
-    public void testBulkIngest() {
+    public void testBulkIngestWithoutOptions() {
 
         String prefix = "/bulkIngesterTest";
-        String endpointState =  "{}";
-        String workUnit      = "{\"userDefinedValue\":" + 1 + ", \"uriprefix\":\""+prefix+"\"}";
+        workUnit = "{\"uriprefix\":\"" + prefix + "\"}";
 
+        Output output = runIngest(workUnit);
+        for (String i : output.uris) {
+            checkResults(i);
+        }
+    }
+
+    @Test
+    public void testBulkIngestWithAllOptions() {
+
+        workUnit = "";
+        setAllOptions();
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            workUnit = objectMapper.writeValueAsString(options);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        Output output = runIngest(workUnit);
+        for (String i : output.uris) {
+            checkResults(i);
+        }
+    }
+
+    @Test
+    public void testBulkIngestWithEmptyPermissions() {
+
+        workUnit = "";
+        setOptions();
+        options.put("uriprefix", "bulkIngestOptions");
+        options.put("permissions", "");
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            workUnit = objectMapper.writeValueAsString(options);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            runIngest(workUnit);
+        });
+
+
+    }
+
+    Output runIngest(String workUnit) {
+        String endpointState = "{}";
         runAsDataHubOperator();
         InputEndpoint loadEndpt = InputEndpoint.on(adminHubConfig.newStagingClient(null),
             adminHubConfig.newModulesDbClient().newTextDocumentManager().read("/data-hub/5/data-services/ingestion/bulkIngester.api", new StringHandle()));
@@ -43,7 +107,7 @@ public class BulkIngestTest extends AbstractHubCoreTest {
         loader.setEndpointState(new ByteArrayInputStream(endpointState.getBytes()));
         loader.setWorkUnit(new ByteArrayInputStream(workUnit.getBytes()));
 
-        Stream<InputStream> input         = Stream.of(
+        Stream<InputStream> input = Stream.of(
             asInputStream("{\"docNum\":1, \"docName\":\"doc1\"}"),
             asInputStream("{\"docNum\":2, \"docName\":\"doc2\"}"),
             asInputStream("{\"docNum\":3, \"docName\":\"doc3\"}")
@@ -54,37 +118,83 @@ public class BulkIngestTest extends AbstractHubCoreTest {
         String uriQuery = "cts.uriMatch('/bulkIngesterTest**')";
         EvalResultIterator uriQueryResult = db.newServerEval().javascript(uriQuery).eval();
 
-        class Output {
-            List<String> uris = new ArrayList();
-        }
         Output output = new Output();
         uriQueryResult.iterator().forEachRemaining(item -> {
             output.uris.add(item.getString());
         });
-        for(String i:output.uris)
-            checkResults(i);
+        return output;
     }
 
-    public static InputStream asInputStream(String value) {
-        return new ByteArrayInputStream(value.getBytes());
+    void setAllOptions() {
+        setOptions();
+        options.put("uriprefix", "bulkIngestOptions");
+        options.put("collections", "docs");
+        options.put("sourcename", "glue");
+        options.put("sourcetype", "xml");
+        options.put("permissions", "data-hub-common,read,data-hub-operator,update");
     }
 
     void checkResults(String uri) {
         JSONDocumentManager jd = db.newJSONDocumentManager();
         JsonNode doc = jd.read(uri, new JacksonHandle()).get();
-        assertNotNull("Could not find file ",uri);
-        assertNotNull("document "+uri+" is null ",doc);
+        assertNotNull("Could not find file ", uri);
+        assertNotNull("document " + uri + " is null ", doc);
+
         verifyDocumentContents(doc);
+        verifyDocumentOptions(uri);
     }
 
     void verifyDocumentContents(JsonNode doc) {
         String user = "test-data-hub-operator";
+
         if (!isVersionCompatibleWith520Roles()) {
             user = "flow-operator";
         }
+
+        if (options == null) {
+            setOptions();
+        }
+
         assertNotNull("Could not find createdOn DateTime", doc.get("envelope").get("headers").get("createdOn"));
         assertEquals(user, doc.get("envelope").get("headers").get("createdBy").asText());
         assertNotNull("Could not find Triples", doc.get("envelope").get("triples"));
         assertNotNull("Could not find instance", doc.get("envelope").get("instance"));
+
+        if (options.get("sourcename") != null) {
+            assertEquals(options.get("sourcename"), doc.get("envelope").get("headers").get("sources").get(0).get("name").asText());
+        } else {
+            assertNull(doc.get("envelope").get("headers").get("sources"));
+        }
+
+        if (options.get("sourcetype") != null) {
+            assertEquals(options.get("sourcetype"), doc.get("envelope").get("headers").get("sources").get(0).get("datahubSourceType").asText());
+        } else {
+            assertNull(doc.get("envelope").get("headers").get("sources"));
+        }
+    }
+
+    void verifyDocumentOptions(String uri) {
+        JSONDocumentManager jd = db.newJSONDocumentManager();
+        DocumentMetadataHandle docMetaData = jd.readMetadata(uri, new DocumentMetadataHandle());
+
+        DocumentPermissionsParser documentPermissionParser = new DefaultDocumentPermissionsParser();
+        DocumentMetadataHandle permissionMetadata = new DocumentMetadataHandle();
+
+        if (options.get("permissions") == null) {
+            options.put("permissions", "data-hub-common,read,data-hub-common,update");
+        }
+
+        documentPermissionParser.parsePermissions(options.get("permissions"), permissionMetadata.getPermissions());
+        assertEquals(permissionMetadata.getPermissions(), docMetaData.getPermissions());
+
+        if (options.get("collections") != null) {
+            assertEquals(options.get("collections"), docMetaData.getCollections().toArray()[0].toString());
+        } else {
+            assertTrue("Expected zero Collection", docMetaData.getCollections().isEmpty());
+        }
+    }
+
+    class Output {
+        List<String> uris = new ArrayList();
     }
 }


### PR DESCRIPTION
### Description
Configure Document Ingestion, sets the permissions, collections and sources of the document configured through options from Spark
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

