### PR TITLE
DHFPROD-6027: Add intro text to the top of each tile

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/login/authorization.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/login/authorization.spec.tsx
@@ -67,7 +67,7 @@ describe('login', () => {
       toolbar.getExploreToolbarIcon().trigger('mouseover');
       cy.contains('Explore');
       toolbar.getExploreToolbarIcon().click();
-      cy.findByText('Search through loaded data and curated data');
+      cy.findByText('Search, filter, review, and export your curated data.');
       tiles.getExploreTile().should('exist');
       projectInfo.getAboutProject().click();
       projectInfo.waitForInfoPageToLoad();

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/login/customRole.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/login/customRole.spec.tsx
@@ -42,7 +42,7 @@ describe('customRole', () => {
     cy.findByText(flowName).should('be.visible');
 
     toolbar.getExploreToolbarIcon().click();
-    cy.findByText('Search through loaded data and curated data');
+    cy.findByText('Search, filter, review, and export your curated data.');
 
   });
 

--- a/marklogic-data-hub-central/ui/src/components/load/load-card.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/load/load-card.module.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
-    padding-top: 20px;
+    padding-top: 10px;
 }
 .cardStyle{
     width: 300px;

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.module.scss
@@ -8,7 +8,7 @@
     display: flex;
     flex-direction: row-reverse;
     width: 100%;
-    padding-top: 20px;
+    padding-top: 10px;
 }
 
 .loadTable {

--- a/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.module.scss
@@ -8,12 +8,10 @@
     flex: 1;
   }
 
-  .italicized {
-    font-size: 18px;
+  .intro {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    font-style: italic;
     color: #333333;
-    margin: 10px 10px 30px 30px;
+    margin: 24px 10px 30px 20px;
   }
 
   @media all and (max-width: 800px) {

--- a/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent, waitForElement, cleanup } from '@testing-library/react';
 import ZeroStateExplorer from './zero-state-explorer';
+import tiles from '../../config/tiles.config'
 
 describe('zero state explorer component', () => {
 
@@ -10,8 +11,8 @@ describe('zero state explorer component', () => {
 
     test('Verify Zero State components renders', () => {
         const { getByTestId, getByText } = render(<ZeroStateExplorer entities={entities} setEntity={jest.fn()} isSavedQueryUser={true} queries={queries} hasStructured={false} columns={columns} setIsLoading={jest.fn()} tableView={true} toggleTableView={jest.fn()} />);
+        expect(getByText(tiles.explore.intro)).toBeInTheDocument(); // tile intro text
         expect(getByText('All Entities')).toBeInTheDocument();
-        expect(getByText('Search through loaded data and curated data')).toBeInTheDocument();
         expect(getByText('What do you want to explore?')).toBeInTheDocument();
         expect(getByText('- or -')).toBeInTheDocument();
         expect(getByTestId('search-bar')).toBeInTheDocument();
@@ -21,8 +22,8 @@ describe('zero state explorer component', () => {
 
     test('Verify Zero State components renders when user does not have save query role', () => {
         const { getByTestId, getByText, debug, queryByTestId, queryByText } = render(<ZeroStateExplorer entities={entities} setEntity={jest.fn()} isSavedQueryUser={false} queries={queries} hasStructured={false} columns={columns} setIsLoading={jest.fn()} tableView={true} toggleTableView={jest.fn()} />);
+        expect(getByText(tiles.explore.intro)).toBeInTheDocument(); // tile intro text
         expect(getByText('All Entities')).toBeInTheDocument();
-        expect(getByText('Search through loaded data and curated data')).toBeInTheDocument();
         expect(getByText('What do you want to explore?')).toBeInTheDocument();
         expect(getByTestId('search-bar')).toBeInTheDocument();
         expect(getByTestId('entity-select')).toBeInTheDocument();

--- a/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.tsx
+++ b/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.tsx
@@ -7,7 +7,7 @@ import { QueryOptions } from '../../types/query-types';
 import { MLButton, MLRadio } from '@marklogic/design-system';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faStream, faTable } from '@fortawesome/free-solid-svg-icons'
-
+import tiles from '../../config/tiles.config'
 
 const ZeroStateExplorer = (props) => {
 
@@ -90,7 +90,7 @@ const ZeroStateExplorer = (props) => {
       <div className={styles.zeroContent}>
         <Row>
           <Col span={18}>
-            <p className={styles.italicized}>Search through loaded data and curated data</p>
+            <p className={styles.intro}>{tiles.explore.intro}</p>
           </Col>
           <Col span={6} >
             <div className={styles.image}>

--- a/marklogic-data-hub-central/ui/src/config/tiles.config.ts
+++ b/marklogic-data-hub-central/ui/src/config/tiles.config.ts
@@ -12,6 +12,7 @@ interface TileItem {
     bgColor: string;
     border: string;
     controls: ControlType[];
+    intro: string;
 }
 
 const tiles: Record<TileId, TileItem>  = {
@@ -23,6 +24,7 @@ const tiles: Record<TileId, TileItem>  = {
         bgColor: '#F4F6F8',
         border: '#a8819c',
         controls: ['close'],
+        intro: 'Create and configure steps that ingest raw data from multiple sources.',
     },
     model: { 
         title: 'Model',
@@ -32,6 +34,7 @@ const tiles: Record<TileId, TileItem>  = {
         bgColor: '#F4F6F8',
         border: '#7f9cc5',
         controls: ['close'],
+        intro: 'Define the entity models that describe and standardize your data. You need these entity models to curate your data.',
     },
     curate: { 
         title: 'Curate',
@@ -41,6 +44,7 @@ const tiles: Record<TileId, TileItem>  = {
         bgColor: '#F4F6F8',
         border: '#dcbd8a',
         controls: ['close'],
+        intro: 'Create and configure steps that curate and refine your data. In the Mapping step, you associate a field in your raw data model with each property in your entity model. When you run a Mapping step, these associations are applied to your data.',
     },
     run: { 
         title: 'Run',
@@ -50,6 +54,7 @@ const tiles: Record<TileId, TileItem>  = {
         bgColor: '#F4F6F8',
         border: '#8288bb',
         controls: ['close'],
+        intro: 'Run your step. Add your step to a flow and run it.',
     },
     explore: { 
         title: 'Explore',
@@ -59,6 +64,7 @@ const tiles: Record<TileId, TileItem>  = {
         bgColor: '#F4F6F8',
         border: '#90aeb2',
         controls: ['menu', 'close'],
+        intro: 'Search, filter, review, and export your curated data.',
     },
 };
 

--- a/marklogic-data-hub-central/ui/src/pages/Curate.module.scss
+++ b/marklogic-data-hub-central/ui/src/pages/Curate.module.scss
@@ -5,4 +5,10 @@
     width: 100%;
     margin: 0;
     padding: 20px;
+    .intro {
+        width: 100%;
+        p {
+            padding: 10px 0 15px 0;
+        }
+    }
 }

--- a/marklogic-data-hub-central/ui/src/pages/Curate.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Curate.test.tsx
@@ -6,6 +6,7 @@ import axiosMock from 'axios';
 import mocks from '../api/__mocks__/mocks.data';
 import Curate from "./Curate";
 import {MemoryRouter} from "react-router-dom";
+import tiles from '../config/tiles.config'
 
 jest.mock('axios');
 
@@ -27,6 +28,8 @@ describe('Curate component', () => {
         const { getByText, getAllByText, queryByText, getByTestId, queryByTestId, debug } = await render(<MemoryRouter><AuthoritiesContext.Provider value={authorityService}><Curate/></AuthoritiesContext.Provider></MemoryRouter>);
 
         expect(await(waitForElement(() => getByText('Customer')))).toBeInTheDocument();
+
+        expect(getByText(tiles.curate.intro)).toBeInTheDocument(); // tile intro text
 
         // Check for steps to be populated
         expect(axiosMock.get).toBeCalledWith('/api/steps/mapping');

--- a/marklogic-data-hub-central/ui/src/pages/Curate.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Curate.tsx
@@ -5,6 +5,7 @@ import { AuthoritiesContext } from '../util/authorities';
 import { UserContext } from '../util/user-context';
 import axios from 'axios'
 import EntityTiles from '../components/entities/entity-tiles';
+import tiles from '../config/tiles.config'
 
 const Curate: React.FC = () => {
 
@@ -102,6 +103,9 @@ const Curate: React.FC = () => {
 
     return (
         <div className={styles.curateContainer}>
+          <div className={styles.intro}>
+            <p>{tiles.curate.intro}</p>
+          </div>
           <EntityTiles
             flows={flows}
             canReadMatchMerge={canReadMatchMerge}

--- a/marklogic-data-hub-central/ui/src/pages/Load.module.scss
+++ b/marklogic-data-hub-central/ui/src/pages/Load.module.scss
@@ -5,12 +5,19 @@
     width: 100%;
     margin: 0;
     padding: 20px;
+    .intro {
+        display: flex;
+        justify-content: space-between;
+        width: 100%;
+        p {
+            padding: 10px 0 15px 0;
+        }
+        .switchViewContainer {
+            display: flex;
+            flex-direction: row-reverse;
+            margin: 0;
+            padding: 0;
+        }
+    }
 }
 
-.switchViewContainer {
-    display: flex;
-    flex-direction: row-reverse;
-    width: 100%;
-    margin: 0;
-    padding: 0;
-}

--- a/marklogic-data-hub-central/ui/src/pages/Load.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Load.test.tsx
@@ -7,6 +7,7 @@ import mocks from '../api/__mocks__/mocks.data';
 import Load from "./Load";
 import LoadList from "../components/load/load-list";
 import {MemoryRouter} from "react-router-dom";
+import tiles from '../config/tiles.config'
 
 jest.mock('axios');
 jest.setTimeout(30000);
@@ -187,6 +188,8 @@ describe('Load component', () => {
         );
 
         expect(await(waitForElement(() => getByLabelText('switch-view-list')))).toBeInTheDocument();
+
+        expect(getByText(tiles.load.intro)).toBeInTheDocument(); // tile intro text
 
         // Check for steps to be populated in default view
         expect(axiosMock.get).toBeCalledWith('/api/steps/ingestion');

--- a/marklogic-data-hub-central/ui/src/pages/Load.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Load.tsx
@@ -7,6 +7,7 @@ import LoadCard from '../components/load/load-card';
 import { UserContext } from '../util/user-context';
 import axios from 'axios'
 import { AuthoritiesContext } from "../util/authorities";
+import tiles from '../config/tiles.config'
 
 export type ViewType =  'card' | 'list';
 
@@ -181,8 +182,11 @@ const Load: React.FC = () => {
     <div>
       {canReadWrite || canReadOnly ?
       <div className={styles.loadContainer}>
-        <div className={styles.switchViewContainer}>
-          <SwitchView handleSelection={handleViewSelection} defaultView={view}/>
+        <div className={styles.intro}>
+          <p>{tiles.load.intro}</p>
+          <div className={styles.switchViewContainer}>
+            <SwitchView handleSelection={handleViewSelection} defaultView={view}/>
+          </div>
         </div>
         {output}
       </div> : ''

--- a/marklogic-data-hub-central/ui/src/pages/Modeling.module.scss
+++ b/marklogic-data-hub-central/ui/src/pages/Modeling.module.scss
@@ -5,11 +5,17 @@
   width: 100%;
   margin: 0;
   padding: 20px;
+  .intro {
+    width: 100%;
+    p {
+        padding: 10px 0 15px 0;
+    }
+  }
 }
 
 .header {
   display: flex;
-  margin: 5px auto 0 auto;
+  margin: 0 auto 0 auto;
   width: 100%;
   justify-content: space-between;
 }

--- a/marklogic-data-hub-central/ui/src/pages/Modeling.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Modeling.test.tsx
@@ -12,6 +12,7 @@ import { getEntityTypes } from '../assets/mock-data/modeling';
 import { isModified, notModified } from '../assets/mock-data/modeling-context-mock';
 import { primaryEntityTypes, updateEntityModels } from '../api/modeling';
 import { ConfirmationType } from '../types/modeling-types';
+import tiles from '../config/tiles.config'
 
 jest.mock('../api/modeling');
 
@@ -42,6 +43,8 @@ describe("Modeling Page", () => {
     );
 
     await wait(() => expect(mockPrimaryEntityType).toHaveBeenCalledTimes(1));
+
+    expect(getByText(tiles.model.intro)).toBeInTheDocument(); // tile intro text
 
     expect(getByText('Entity Types')).toBeInTheDocument()
     expect(getByLabelText("add-entity")).toBeInTheDocument();

--- a/marklogic-data-hub-central/ui/src/pages/Modeling.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Modeling.tsx
@@ -14,6 +14,7 @@ import { ModelingContext } from '../util/modeling-context';
 import { ModelingTooltips } from '../config/tooltips.config';
 import { AuthoritiesContext } from '../util/authorities';
 import { ConfirmationType, EntityModified } from '../types/modeling-types';
+import tiles from '../config/tiles.config'
 
 const Modeling: React.FC = () => {
   const { handleError } = useContext(UserContext);
@@ -158,6 +159,9 @@ const Modeling: React.FC = () => {
   if (canReadEntityModel) {
     return (
       <div className={styles.modelContainer}>
+        <div className={styles.intro}>
+          <p>{tiles.model.intro}</p>
+        </div>
         { modelingOptions.isModified && (
           <MLAlert type="info" aria-label="entity-modified-alert" showIcon message={ModelingTooltips.entityEditedAlert}/>
         )}

--- a/marklogic-data-hub-central/ui/src/pages/Run.module.scss
+++ b/marklogic-data-hub-central/ui/src/pages/Run.module.scss
@@ -5,6 +5,12 @@
     width: 100%;
     margin: 0;
     padding: 20px;
+    .intro {
+        width: 100%;
+        p {
+            padding: 10px 0 0 0;
+        }
+    }
 }
 
 .errorHeader, .errorLabel {

--- a/marklogic-data-hub-central/ui/src/pages/Run.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Run.test.tsx
@@ -16,6 +16,7 @@ import authorities from '../assets/authorities.testutils';
 import {RunToolTips} from "../config/tooltips.config";
 import {act} from "react-dom/test-utils";
 import {MemoryRouter} from "react-router-dom";
+import tiles from '../config/tiles.config'
 
 jest.mock('axios');
 jest.setTimeout(30000);
@@ -66,6 +67,9 @@ describe('Verify links back to step details', () => {
         });
         const existingFlowName = data.flows.data[0].name;
         let steps = data.flows.data[0].steps;
+
+        expect(getByText(tiles.run.intro)).toBeInTheDocument(); // tile intro text
+
         // Click expand icon
         await act(() => {
             fireEvent.click(getByLabelText("icon: right"));

--- a/marklogic-data-hub-central/ui/src/pages/Run.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Run.tsx
@@ -6,7 +6,7 @@ import axios from 'axios'
 import { AuthoritiesContext } from "../util/authorities";
 import { UserContext } from '../util/user-context';
 import { useHistory } from 'react-router-dom';
-
+import tiles from '../config/tiles.config'
 
 const { Panel } = Collapse;
 
@@ -414,6 +414,9 @@ const Run = (props) => {
   return (
     <div>
         <div className={styles.runContainer}>
+            <div className={styles.intro}>
+                <p>{tiles.run.intro}</p>
+            </div>
             <Flows
                 flows={flows}
                 steps={steps}


### PR DESCRIPTION
Also added tests of intro text display across tile views.

Intro text is stored in the config file for tiles.

Screencast is here: https://drive.google.com/file/d/1tXsvwKT0OBxl5l0fKkFFEs2lePbVj62y/view

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

