### PR TITLE
DHFPROD-4543:Map empty or null value to null when using parseDate and parseDateTime

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/mapping-functions/core.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/mapping-functions/core.sjs
@@ -91,8 +91,12 @@ function parseDate(value, pattern) {
   if (pattern != null) {
     pattern = pattern.toString().replace(", ", ",");
   }
-  if (value != null) {
+
+  if(isNullOrEmpty(value)){
     value = value.toString().replace(", ", ",");
+  }
+  else{
+    return null;
   }
 
   if(standardFormats.includes(pattern.trim())){
@@ -151,6 +155,13 @@ function parseDateTime(value, pattern) {
   let supportedFormats = ["YYYYMMDDThhmmss", "DD/MM/YYYY-hh:mm:ss", "DD/MM/YYYY hh:mm:ss", "YYYY/MM/DD-hh:mm:ss" , "YYYY/MM/DD hh:mm:ss"];
   let response;
   let errorMsg = `The pattern '${pattern}' cannot be applied to the value '${value}'`;
+
+  if(isNullOrEmpty(value)){
+    value = value.toString();
+  }
+  else{
+    return null;
+  }
   if(supportedFormats.includes(pattern.trim())){
     try {
       response = xdmp.parseYymmdd(pattern.replace("YYYY","yyyy").replace("DD","dd"), value);
@@ -168,6 +179,22 @@ function parseDateTime(value, pattern) {
   }
   return response;
 }
+
+function isNullOrEmpty(value) {
+  if (value) {
+    if(typeof value === "object" && xdmp.nodeKind(value) === "null"){
+      return false;
+    }
+    if(!value.toString() || !value.toString().trim()){
+      return false;
+    }
+  }
+  else{
+    return false;
+  }
+  return true;
+}
+
 // END date/dateTime functions
 
 module.exports = {

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping-functions/parseDate.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping-functions/parseDate.sjs
@@ -22,7 +22,11 @@ function testMoreParseDate() {
     test.assertEqual(xs.date("1996-07-16"), core.parseDate("1996.07.16", "yyyy.MM.dd")),
 
     test.assertEqual(null, core.parseDate("07.16.1996", "Mon DD,YYYY")),
-    test.assertEqual(null, core.parseDate("notADate", "Mon DD,YYYY"))
+    test.assertEqual(null, core.parseDate("notADate", "Mon DD,YYYY")),
+    test.assertEqual(null, core.parseDate(null, "Mon DD,YYYY")),
+    test.assertEqual(null, core.parseDate("", "Mon DD,YYYY")),
+    test.assertEqual(null, core.parseDate(undefined, "Mon DD,YYYY")),
+    test.assertEqual(null, core.parseDate(" ", "Mon DD,YYYY"))
   ];
 }
 

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping-functions/parseDateTime.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping-functions/parseDateTime.sjs
@@ -11,5 +11,9 @@ let expectedDateTime = xs.dateTime(`2014-01-06T18:13:50${serverTimezone}`);
   test.assertTrue(expectedDateTime.eq(core.parseDateTime("2014/01/06-18:13:50", "YYYY/MM/DD-hh:mm:ss"))),
   test.assertTrue(expectedDateTime.eq(core.parseDateTime("2014/01/06 18:13:50", "YYYY/MM/DD hh:mm:ss"))),
   test.assertTrue(expectedDateTime.eq(core.parseDateTime("2014.01.06 AD at 18:13:50", "yyyy.MM.dd G 'at' HH:mm:ss"))),
-  test.assertThrowsError(xdmp.function(xs.QName("dt.parseDateTime")), "2014/01/06T18:13:50", "YYYY/MM/DDThh:mm:ss", null)
+  test.assertThrowsError(xdmp.function(xs.QName("dt.parseDateTime")), "2014/01/06T18:13:50", "YYYY/MM/DDThh:mm:ss", null),
+  test.assertEqual(null, core.parseDateTime(null, "DD/MM/YYYY-hh:mm:ss")),
+  test.assertEqual(null, core.parseDateTime("", "DD/MM/YYYY-hh:mm:ss")),
+  test.assertEqual(null, core.parseDate(undefined, "DD/MM/YYYY-hh:mm:ss")),
+  test.assertEqual(null, core.parseDateTime(" ", "DD/MM/YYYY-hh:mm:ss"))
 ];


### PR DESCRIPTION

### Description

Map empty or null value to null when using parseDate and parseDateTime
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

