### PR TITLE
DHFPROD-5944: Refactored bulk ingest tests to ml-unit-test

### DIFF
--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/WriteDataTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/WriteDataTest.java
@@ -31,29 +31,8 @@ public class WriteDataTest extends AbstractSparkConnectorTest {
         verifyFruitCount(3, "The commit call should result in the 3rd fruit being ingested");
     }
 
-
     @Test
-    public void testBulkIngestWithoutUriPrefix() throws IOException {
-        DataWriter<InternalRow> dataWriter = buildDataWriter(new Options(getHubPropertiesAsMap()).withBatchSize(1));
-        dataWriter.write(buildRow("pineapple", "green"));
-
-        String uriQuery = "cts.uris('', null, cts.andQuery([\n" +
-            "  cts.jsonPropertyValueQuery('fruitName', 'pineapple')\n" +
-            "]))";
-
-        EvalResultIterator uriQueryResult = getHubClient().getStagingClient().newServerEval().javascript(uriQuery).eval();
-        assertTrue(uriQueryResult.hasNext());
-        String uri = uriQueryResult.next().getString();
-
-        assertTrue(uri.endsWith(".json"));
-
-        assertFalse(uri.startsWith("/"), "If the user wants the URI to start with a forward slash, the user must provide one. " +
-            "If the user doesn't, then it's assumed that the user doesn't want a forward slash at the start of the URI, so the endpoint will not add one automatically.");
-        assertFalse(uriQueryResult.hasNext());
-    }
-
-    @Test
-    public void ingestWithoutCustomApiWithCustomWorkunit(){
+    public void ingestWithoutCustomApiWithCustomWorkunit() {
         ObjectNode customWorkUnit = objectMapper.createObjectNode();
         customWorkUnit.put("userDefinedValue", 0);
 

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/ingestion/bulkIngester.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/ingestion/bulkIngester.sjs
@@ -51,11 +51,17 @@ if(work.sourcename != null || work.sourcetype != null){
   headers.sources = sources
 }
 
-const inputs =
-  (input instanceof Sequence) ? input.toArray().map(item => fn.head(xdmp.fromJSON(item))) :
-    (input instanceof Document) ? [fn.head(xdmp.fromJSON(input))] :
-      [{UNKNOWN: input}];
-inputs.forEach(record => {
+var inputArray;
+if (input instanceof Sequence) {
+  inputArray = input.toArray().map(item => fn.head(xdmp.fromJSON(item)));
+} else if (input instanceof Document) {
+  inputArray = [fn.head(xdmp.fromJSON(input))];
+} else {
+  // Assumed to be an array at this point, which is the case for unit tests
+  inputArray = fn.head(xdmp.fromJSON(input));
+}
+
+inputArray.forEach(record => {
   state.next = state.next + 1;
   const uri = (uriPrefix) +  sem.uuidString() + '.json';
   record = ingest.main({uri: uri, value: record}, {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/ingestion/BulkIngestTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/ingestion/BulkIngestTest.java
@@ -1,15 +1,8 @@
 package com.marklogic.hub.dataservices.ingestion;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marklogic.client.DatabaseClient;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.dataservices.InputEndpoint;
-import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.eval.EvalResultIterator;
-import com.marklogic.client.ext.util.DefaultDocumentPermissionsParser;
-import com.marklogic.client.ext.util.DocumentPermissionsParser;
-import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.hub.AbstractHubCoreTest;
@@ -19,182 +12,69 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/**
+ * This test just does some basic smoke testing of the DS endpoint; comprehensive coverage is found in the
+ * marklogic-unit-test test modules. As there's a slight difference in how the endpoint handles one document vs
+ * multiple documents being passed to it, this test verifies both cases.
+ */
 public class BulkIngestTest extends AbstractHubCoreTest {
 
-    DatabaseClient db;
-    Map<String, String> options;
-    String workUnit;
-
-    public static InputStream asInputStream(String value) {
-        return new ByteArrayInputStream(value.getBytes());
-    }
-
-    public void setOptions() {
-        this.options = new HashMap<String, String>();
-    }
+    private InputEndpoint.BulkInputCaller bulkInputCaller;
 
     @BeforeEach
-    public void setupTest() {
-        db = adminHubConfig.newStagingClient(null);
+    void beforeEach() {
+        InputEndpoint endpoint = InputEndpoint.on(
+            getHubClient().getStagingClient(),
+            getHubClient().getModulesClient().newTextDocumentManager().read("/data-hub/5/data-services/ingestion/bulkIngester.api", new StringHandle())
+        );
+
+        ObjectNode workUnit = objectMapper.createObjectNode();
+        workUnit.put("uriprefix", "/bulkJavaTest/");
+
+        bulkInputCaller = endpoint.bulkCaller();
+        bulkInputCaller.setEndpointState("{}".getBytes());
+        bulkInputCaller.setWorkUnit(new JacksonHandle(workUnit));
     }
 
     @Test
-    public void testBulkIngestWithoutOptions() {
+    void writeOneDoc() {
+        Stream<InputStream> input = Stream.of(
+            asInputStream("{\"docNum\":1, \"docName\":\"doc1\"}")
+        );
+        input.forEach(bulkInputCaller::accept);
+        bulkInputCaller.awaitCompletion();
 
-        String prefix = "/bulkIngesterTest";
-        workUnit = "{\"uriprefix\":\"" + prefix + "\"}";
-
-        Output output = runIngest(workUnit);
-        for (String i : output.uris) {
-            checkResults(i);
-        }
+        verifyDocCount(1);
     }
 
     @Test
-    public void testBulkIngestWithAllOptions() {
-
-        workUnit = "";
-        setAllOptions();
-        ObjectMapper objectMapper = new ObjectMapper();
-        try {
-            workUnit = objectMapper.writeValueAsString(options);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-
-        Output output = runIngest(workUnit);
-        for (String i : output.uris) {
-            checkResults(i);
-        }
-    }
-
-    @Test
-    public void testBulkIngestWithEmptyPermissions() {
-
-        workUnit = "";
-        setOptions();
-        options.put("uriprefix", "bulkIngestOptions");
-        options.put("permissions", "");
-        ObjectMapper objectMapper = new ObjectMapper();
-        try {
-            workUnit = objectMapper.writeValueAsString(options);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-
-        Exception exception = assertThrows(RuntimeException.class, () -> {
-            runIngest(workUnit);
-        });
-
-
-    }
-
-    Output runIngest(String workUnit) {
-        String endpointState = "{}";
-        runAsDataHubOperator();
-        InputEndpoint loadEndpt = InputEndpoint.on(adminHubConfig.newStagingClient(null),
-            adminHubConfig.newModulesDbClient().newTextDocumentManager().read("/data-hub/5/data-services/ingestion/bulkIngester.api", new StringHandle()));
-
-        InputEndpoint.BulkInputCaller loader = loadEndpt.bulkCaller();
-        loader.setEndpointState(new ByteArrayInputStream(endpointState.getBytes()));
-        loader.setWorkUnit(new ByteArrayInputStream(workUnit.getBytes()));
-
+    void writeTwoDocs() {
         Stream<InputStream> input = Stream.of(
             asInputStream("{\"docNum\":1, \"docName\":\"doc1\"}"),
-            asInputStream("{\"docNum\":2, \"docName\":\"doc2\"}"),
-            asInputStream("{\"docNum\":3, \"docName\":\"doc3\"}")
+            asInputStream("{\"docNum\":2, \"docName\":\"doc2\"}")
         );
-        input.forEach(loader::accept);
-        loader.awaitCompletion();
+        input.forEach(bulkInputCaller::accept);
+        bulkInputCaller.awaitCompletion();
 
-        String uriQuery = "cts.uriMatch('/bulkIngesterTest**')";
-        EvalResultIterator uriQueryResult = db.newServerEval().javascript(uriQuery).eval();
-
-        Output output = new Output();
-        uriQueryResult.iterator().forEachRemaining(item -> {
-            output.uris.add(item.getString());
-        });
-        return output;
+        verifyDocCount(2);
     }
 
-    void setAllOptions() {
-        setOptions();
-        options.put("uriprefix", "bulkIngestOptions");
-        options.put("collections", "docs");
-        options.put("sourcename", "glue");
-        options.put("sourcetype", "xml");
-        options.put("permissions", "data-hub-common,read,data-hub-operator,update");
+    private void verifyDocCount(int expectedCount) {
+        EvalResultIterator iter = getHubClient().getStagingClient().newServerEval().javascript("cts.uriMatch('/bulkJavaTest/**')").eval();
+        final List<String> uris = new ArrayList<>();
+        while (iter.hasNext()) {
+            uris.add(iter.next().getString());
+        }
+
+        assertEquals(expectedCount, uris.size());
     }
 
-    void checkResults(String uri) {
-        JSONDocumentManager jd = db.newJSONDocumentManager();
-        JsonNode doc = jd.read(uri, new JacksonHandle()).get();
-        assertNotNull("Could not find file ", uri);
-        assertNotNull("document " + uri + " is null ", doc);
-
-        verifyDocumentContents(doc);
-        verifyDocumentOptions(uri);
-    }
-
-    void verifyDocumentContents(JsonNode doc) {
-        String user = "test-data-hub-operator";
-
-        if (!isVersionCompatibleWith520Roles()) {
-            user = "flow-operator";
-        }
-
-        if (options == null) {
-            setOptions();
-        }
-
-        assertNotNull("Could not find createdOn DateTime", doc.get("envelope").get("headers").get("createdOn"));
-        assertEquals(user, doc.get("envelope").get("headers").get("createdBy").asText());
-        assertNotNull("Could not find Triples", doc.get("envelope").get("triples"));
-        assertNotNull("Could not find instance", doc.get("envelope").get("instance"));
-
-        if (options.get("sourcename") != null) {
-            assertEquals(options.get("sourcename"), doc.get("envelope").get("headers").get("sources").get(0).get("name").asText());
-        } else {
-            assertNull(doc.get("envelope").get("headers").get("sources"));
-        }
-
-        if (options.get("sourcetype") != null) {
-            assertEquals(options.get("sourcetype"), doc.get("envelope").get("headers").get("sources").get(0).get("datahubSourceType").asText());
-        } else {
-            assertNull(doc.get("envelope").get("headers").get("sources"));
-        }
-    }
-
-    void verifyDocumentOptions(String uri) {
-        JSONDocumentManager jd = db.newJSONDocumentManager();
-        DocumentMetadataHandle docMetaData = jd.readMetadata(uri, new DocumentMetadataHandle());
-
-        DocumentPermissionsParser documentPermissionParser = new DefaultDocumentPermissionsParser();
-        DocumentMetadataHandle permissionMetadata = new DocumentMetadataHandle();
-
-        if (options.get("permissions") == null) {
-            options.put("permissions", "data-hub-common,read,data-hub-common,update");
-        }
-
-        documentPermissionParser.parsePermissions(options.get("permissions"), permissionMetadata.getPermissions());
-        assertEquals(permissionMetadata.getPermissions(), docMetaData.getPermissions());
-
-        if (options.get("collections") != null) {
-            assertEquals(options.get("collections"), docMetaData.getCollections().toArray()[0].toString());
-        } else {
-            assertTrue("Expected zero Collection", docMetaData.getCollections().isEmpty());
-        }
-    }
-
-    class Output {
-        List<String> uris = new ArrayList();
+    private InputStream asInputStream(String value) {
+        return new ByteArrayInputStream(value.getBytes());
     }
 }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/ingestion/ingestOnlySourceName.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/ingestion/ingestOnlySourceName.sjs
@@ -1,0 +1,21 @@
+const test = require("/test/test-helper.xqy");
+const hubTest = require("/test/data-hub-test-helper.sjs");
+const ingestionService = require("../lib/ingestionService.sjs");
+
+ingestionService.ingest(
+  {
+    "sourcename": "bulkSourceName",
+    "collections": "bulkSourceTest"
+  },
+  {}, [{"testDoc": "one"}]
+);
+
+const record = hubTest.getRecordInCollection("bulkSourceTest");
+const envelope = record.document.envelope;
+
+[
+  test.assertEqual(1, envelope.headers.sources.length),
+  test.assertEqual("bulkSourceName", envelope.headers.sources[0].name),
+  test.assertFalse(envelope.headers.sources[0].hasOwnProperty("datahubSourceType"),
+    "datahubSourceType should not be set since sourcetype was not set")
+];

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/ingestion/ingestOnlySourceType.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/ingestion/ingestOnlySourceType.sjs
@@ -1,0 +1,21 @@
+const test = require("/test/test-helper.xqy");
+const hubTest = require("/test/data-hub-test-helper.sjs");
+const ingestionService = require("../lib/ingestionService.sjs");
+
+ingestionService.ingest(
+  {
+    "sourcetype": "bulkSourceType",
+    "collections": "bulkSourceTest"
+  },
+  {}, [{"testDoc": "one"}]
+);
+
+const record = hubTest.getRecordInCollection("bulkSourceTest");
+const envelope = record.document.envelope;
+
+[
+  test.assertEqual(1, envelope.headers.sources.length),
+  test.assertEqual("bulkSourceType", envelope.headers.sources[0].datahubSourceType),
+  test.assertFalse(envelope.headers.sources[0].hasOwnProperty("name"),
+    "name should not be set if sourcename was not set")
+];

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/ingestion/ingestWithAllWorkUnitParams.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/ingestion/ingestWithAllWorkUnitParams.sjs
@@ -1,0 +1,40 @@
+'use strict';
+
+const test = require("/test/test-helper.xqy");
+const hubTest = require("/test/data-hub-test-helper.sjs");
+const ingestionService = require("../lib/ingestionService.sjs");
+
+// Intended to test every possible param in a workUnit in a single test
+// Please add to this as new params are defined
+
+const workUnit = {
+  collections: "bulkOne,bulkTwo",
+  permissions: "rest-reader,read,rest-extension-user,update",
+  uriprefix: "/bulkTest/",
+  sourcename: "bulkSourceName",
+  sourcetype: "bulkSourceType"
+};
+
+ingestionService.ingest(workUnit, {}, [{"testDoc": "one"}]);
+
+const record = hubTest.getRecordInCollection("bulkOne");
+const envelope = record.document.envelope;
+
+[
+  test.assertTrue(record.uri.endsWith(".json"), "The endpoint only supports JSON, so .json should be the suffix of the URI"),
+
+  test.assertEqual(xdmp.getCurrentUser(), envelope.headers.createdBy),
+  test.assertTrue(envelope.headers.createdOn != null),
+  test.assertEqual(1, envelope.headers.sources.length),
+  test.assertEqual("bulkSourceName", envelope.headers.sources[0].name),
+  test.assertEqual("bulkSourceType", envelope.headers.sources[0].datahubSourceType),
+  test.assertEqual("one", envelope.instance.testDoc, "The ingested data should have been wrapped in envelope/instance"),
+
+  test.assertEqual(2, record.collections.length),
+  test.assertEqual("bulkOne", record.collections[0]),
+  test.assertEqual("bulkTwo", record.collections[1]),
+
+  test.assertEqual(2, Object.keys(record.permissions).length),
+  test.assertEqual("read", record.permissions["rest-reader"][0]),
+  test.assertEqual("update", record.permissions["rest-extension-user"][0])
+];

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/ingestion/ingestWithOnlyCollections.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/ingestion/ingestWithOnlyCollections.sjs
@@ -1,0 +1,21 @@
+const test = require("/test/test-helper.xqy");
+const hubTest = require("/test/data-hub-test-helper.sjs");
+const ingestionService = require("../lib/ingestionService.sjs");
+
+const workUnit = {
+  collections: "bulkOne,bulkTwo"
+};
+
+ingestionService.ingest(workUnit, {}, [{"testDoc": "one"}]);
+
+const doc = hubTest.getRecordInCollection("bulkOne");
+const envelope = doc.document.envelope;
+
+[
+  test.assertFalse(doc.uri.startsWith("/"), "If no uriprefix is specified, a '/' should be added by default, as the user may not want that"),
+  test.assertFalse(doc.uri.startsWith("null"), "If no uriprefix is specified, the URI should not start with 'null'"),
+
+  test.assertEqual(2, doc.collections.length),
+  test.assertEqual("bulkOne", doc.collections[0]),
+  test.assertEqual("bulkTwo", doc.collections[1])
+];

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/ingestion/ingestWithOnlyUriPrefix.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/ingestion/ingestWithOnlyUriPrefix.sjs
@@ -1,0 +1,24 @@
+const test = require("/test/test-helper.xqy");
+const hubTest = require("/test/data-hub-test-helper.sjs");
+const ingestionService = require("../lib/ingestionService.sjs");
+
+ingestionService.ingest({uriprefix: "/bulkTest/"}, {}, [
+  {"testDoc": "one"},
+  {"testDoc": "two"}
+]);
+
+const uris = xdmp.eval('cts.uriMatch("/bulkTest/**")').toArray();
+
+const assertions = [
+  test.assertEqual(2, uris.length)
+];
+
+uris.forEach(uri => {
+  const record = hubTest.getRecord(uri);
+  assertions.push(
+    test.assertEqual(0, record.collections.length,
+      "Since no collections were specified, the URI should not in any collections by default")
+  );
+});
+
+assertions;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/ingestion/ingestionWithNullParams.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/ingestion/ingestionWithNullParams.sjs
@@ -1,0 +1,33 @@
+'use strict';
+
+const test = require("/test/test-helper.xqy");
+const hubTest = require("/test/data-hub-test-helper.sjs");
+const ingestionService = require("../lib/ingestionService.sjs");
+
+// Including collections so there's an easy way to find the doc
+const workUnit = {
+  collections: "bulkTest",
+  permissions: null,
+  uriprefix: null,
+  sourcename: null,
+  sourcetype: null
+};
+
+ingestionService.ingest(workUnit, {}, [{"testDoc": "one"}]);
+
+const record = hubTest.getRecordInCollection("bulkTest");
+const envelope = record.document.envelope;
+
+[
+  test.assertFalse(record.uri.startsWith("null"),
+    "When uriprefix is null, the string 'null' should not be added to the URI as a prefix"),
+
+  test.assertEqual(null, envelope.headers.sources,
+    "No sources should have been created since sourcename and sourcetype are both null"),
+  test.assertEqual("one", envelope.instance.testDoc, "The ingested data should have been wrapped in envelope/instance"),
+
+  // Should use default permissions
+  test.assertEqual(1, Object.keys(record.permissions).length),
+  test.assertEqual("read", record.permissions["data-hub-common"][0]),
+  test.assertEqual("update", record.permissions["data-hub-common"][1])
+];

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/ingestion/setup.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/ingestion/setup.xqy
@@ -1,0 +1,3 @@
+xquery version "1.0-ml";
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+hub-test:reset-hub()

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/lib/ingestionService.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/lib/ingestionService.sjs
@@ -1,0 +1,10 @@
+function ingest(workUnit, endpointState, input) {
+  return fn.head(xdmp.invoke(
+    "/data-hub/5/data-services/ingestion/bulkIngester.sjs",
+    {workUnit, endpointState, input}
+  ));
+}
+
+module.exports = {
+  ingest
+};


### PR DESCRIPTION
### Description

Added some helpers to data-hub-test-helpers.sjs while I was at it. 

Made one tweak to the endpoint to support workUnit being passed in via xdmp.invoke for test purposes. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

