### PR TITLE
DHFPROD-5989: Added couple spark tests for null options

### DIFF
--- a/marklogic-data-hub-spark-connector/src/main/java/com/marklogic/hub/spark/sql/sources/v2/writer/HubDataWriter.java
+++ b/marklogic-data-hub-spark-connector/src/main/java/com/marklogic/hub/spark/sql/sources/v2/writer/HubDataWriter.java
@@ -129,16 +129,16 @@ public class HubDataWriter extends LoggingObject implements DataWriter<InternalR
             try {
                 endpointParams = (ObjectNode) objectMapper.readTree(params.get("ingestendpointparams"));
             } catch (IOException e) {
-                throw new RuntimeException("Unable to parse ingestendpointparams, cause: " + e.getMessage(), e);
+                throw new IllegalArgumentException("Unable to parse ingestendpointparams, cause: " + e.getMessage(), e);
             }
         } else {
             endpointParams = objectMapper.createObjectNode();
         }
 
         boolean doesNotHaveApiPath = (!endpointParams.hasNonNull("apiPath") || StringUtils.isEmpty(endpointParams.get("apiPath").asText()));
-        boolean hasWorkUnitOrEndpointState = endpointParams.has("workUnit") || endpointParams.has("endpointState");
+        boolean hasWorkUnitOrEndpointState = endpointParams.hasNonNull("workUnit") || endpointParams.hasNonNull("endpointState");
         if (doesNotHaveApiPath && hasWorkUnitOrEndpointState) {
-            throw new RuntimeException("Cannot set workUnit or endpointState in ingestionendpointparams unless apiPath is defined as well.");
+            throw new IllegalArgumentException("Cannot set workUnit or endpointState in ingestionendpointparams unless apiPath is defined as well.");
         }
 
         if (doesNotHaveApiPath) {

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/AbstractSparkConnectorTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/AbstractSparkConnectorTest.java
@@ -6,6 +6,7 @@ import com.marklogic.hub.test.AbstractHubTest;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.sources.v2.DataSourceOptions;
 import org.apache.spark.sql.sources.v2.writer.DataSourceWriter;
 import org.apache.spark.sql.sources.v2.writer.DataWriter;
 import org.apache.spark.sql.sources.v2.writer.DataWriterFactory;
@@ -123,21 +124,29 @@ public abstract class AbstractSparkConnectorTest extends AbstractHubTest {
     }
 
     /**
-     * Spark will do all of this in the real world - i.e. a user will specify the entry class and the set of options.
-     * But in a test, we need to do that ourselves. So we create the DataSource class, build up the params, and then
-     * call the factory/writer methods ourselves.
+     * Convenience method for building a DataWriter based on our Options convenience class.
      *
      * @param options
      * @return
      */
     protected DataWriter<InternalRow> buildDataWriter(Options options) {
+        return buildDataWriter(options.toDataSourceOptions());
+    }
+
+    /**
+     * Spark will do all of this in the real world - i.e. a user will specify the entry class and the set of options.
+     * But in a test, we need to do that ourselves. So we create the DataSource class, build up the params, and then
+     * call the factory/writer methods ourselves.
+     *
+     * @param dataSourceOptions
+     * @return
+     */
+    protected DataWriter<InternalRow> buildDataWriter(DataSourceOptions dataSourceOptions) {
         HubDataSource dataSource = new HubDataSource();
         final String writeUUID = "doesntMatter";
         final SaveMode saveModeDoesntMatter = SaveMode.Overwrite;
 
-        // Get the set of DHF properties used to connect to ML as a map, and then add connector-specific params
-
-        Optional<DataSourceWriter> dataSourceWriter = dataSource.createWriter(writeUUID, FRUIT_SCHEMA, saveModeDoesntMatter, options.toDataSourceOptions());
+        Optional<DataSourceWriter> dataSourceWriter = dataSource.createWriter(writeUUID, FRUIT_SCHEMA, saveModeDoesntMatter, dataSourceOptions);
         DataWriterFactory<InternalRow> dataWriterFactory = dataSourceWriter.get().createWriterFactory();
 
         final int partitionIdDoesntMatter = 0;


### PR DESCRIPTION
### Description

Also changed to IllegalArgumentException as a more descriptive version of RuntimeException

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

