### PR TITLE
DHFPROD-6097: Disabling the Parallel Run

### DIFF
--- a/marklogic-data-hub-spark-connector/src/test/resources/junit-platform.properties
+++ b/marklogic-data-hub-spark-connector/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.execution.parallel.enabled = false
+#junit.jupiter.execution.parallel.mode.default = concurrent


### PR DESCRIPTION
### Description
Disabling the parallel run as the next test picks up before assertions.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [NA] Added Tests
  

- ##### Reviewer:

- [NA] Reviewed Tests

