### PR TITLE
DHFPROD-5244: Add Custom Merge Type to Merge Rule form

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/merging/add-merge-rule/add-merge-rule-dialog.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/add-merge-rule/add-merge-rule-dialog.module.scss
@@ -32,8 +32,6 @@
 
 .questionCircle {
     font-size: 12px;
-    vertical-align: top;
-    margin-top: 6px;
     color: #7F86B5;
 }
 
@@ -48,10 +46,17 @@
 .submitButtonsForm {
     text-align: right;
     margin-bottom: -15px;
-    margin-right: 5px;
 }
 
 .submitButtons {
     text-align: right;
-    width: 162%;
+    width: 150%;
+}
+
+.mergeTypeSelect {
+    width: 400px !important;
+}
+
+.input{
+    width: 400px !important;
 }

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/add-merge-rule/add-merge-rule-dialog.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/add-merge-rule/add-merge-rule-dialog.test.tsx
@@ -10,7 +10,7 @@ describe('Add Merge Rule Dialog component', () => {
   afterEach(cleanup);
 
   test('Verify Add Merge Rule dialog renders correctly', () => {
-    const { getByText, getByTestId, getByLabelText } = render(
+    const { getByText, getByTestId, getByLabelText, queryByLabelText } = render(
     <CurationContext.Provider value={customerMergingStep}>
         <AddMergeRuleDialog
           {...mergingData}
@@ -26,11 +26,38 @@ describe('Add Merge Rule Dialog component', () => {
 
     fireEvent.click(getByText('Select property'));
     fireEvent.click(getByText('customerId'));
-    fireEvent.click(getByText('Cancel'));
-    expect(mergingData.setOpenAddMergeRuleDialog).toHaveBeenCalledTimes(1);
 
-    expect(getByText('Save')).toBeInTheDocument();
-    expect(getByLabelText('Close')).toBeEnabled();
+    //Confirming that URI, function and namespace fields are not available now, because Custom merge type is not selected yet.
+    expect(queryByLabelText('uri-input')).not.toBeInTheDocument();
+    expect(queryByLabelText('function-input')).not.toBeInTheDocument();
+    expect(queryByLabelText('namespace-input')).not.toBeInTheDocument();
+
+    //Selecting the merge type to Custom
+    fireEvent.click(getByLabelText('mergeType-select'));
+    fireEvent.click(getByTestId('mergeTypeOptions-Custom'));
+
+    //Initializing the required elements to be re-used later.
+    let uri = getByLabelText('uri-input');
+    let functionValue = getByLabelText('function-input');
+    let saveButton = getByText('Save');
+
+    //Checking if URI, function and namespace fields are available now, since merge type is Custom.
+    expect(uri).toBeInTheDocument();
+    expect(functionValue).toBeInTheDocument();
+    expect(getByLabelText('namespace-input')).toBeInTheDocument();
+    
+    fireEvent.click(saveButton); //Will throw an error because URI and Function are mandatory fields.
+
+    //verify if the below error messages are displayed properly
+    expect(getByText('URI is required')).toBeInTheDocument();
+    expect(getByText('Function is required')).toBeInTheDocument();
+
+    //Enter the values for URI and Function fields and see if the save button gets enabled.
+    fireEvent.change(uri, { target: {value: 'Customer/Cust1.json'}});
+    fireEvent.change(functionValue, { target: {value: 'Compare'}});
+
+    fireEvent.click(saveButton); //Modal will close now
+    expect(mergingData.setOpenAddMergeRuleDialog).toHaveBeenCalledTimes(1);
 });
 
 })

--- a/marklogic-data-hub-central/ui/src/config/tooltips.config.js
+++ b/marklogic-data-hub-central/ui/src/config/tooltips.config.js
@@ -144,6 +144,12 @@ const SecurityTooltips = {
   missingPermission: 'Contact your security administrator for access.'
 }
 
+const MergeRuleTooltips = {
+    uri : 'The path to the custom module that contains the merge function to run.',
+    function : 'The merge function to run.',
+    namespace : 'The namespace of the module that contains the function to run.'
+}
+
 export {
     AdvancedSettings,
     NewFlowTooltips,
@@ -160,5 +166,6 @@ export {
     NewCustomTooltips,
     AdvCustomTooltips,
     SecurityTooltips,
-    MatchingStepDetailText
+    MatchingStepDetailText,
+    MergeRuleTooltips
 }


### PR DESCRIPTION
### Description
Added few dummy fields in the merge rule modal related to "Merge Type" property, only when chosen as 'Custom'.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

