### PR TITLE
DHFPROD-5944: Added test for invalid permissions

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils.sjs
@@ -212,15 +212,19 @@ class HubUtils {
      return newInstance;
   }
 
-  parsePermissions(permissionsTest = "") {
-    let permissionParts = permissionsTest.split(",").filter((val) => val);
-    let permissions = [];
-    let permissionRoles = permissionParts.filter((val, index) => !(index % 2));
-    let permissionCapabilities = permissionParts.filter((val, index) => index % 2);
-    for (let i = 0; i < permissionRoles.length; i++) {
-      permissions.push(xdmp.permission(permissionRoles[i], permissionCapabilities[i]));
+  parsePermissions(permissionsString = "") {
+    try {
+      let permissionParts = permissionsString.split(",").filter((val) => val);
+      let permissions = [];
+      let permissionRoles = permissionParts.filter((val, index) => !(index % 2));
+      let permissionCapabilities = permissionParts.filter((val, index) => index % 2);
+      for (let i = 0; i < permissionRoles.length; i++) {
+        permissions.push(xdmp.permission(permissionRoles[i], permissionCapabilities[i]));
+      }
+      return permissions;
+    } catch (e) {
+      throw Error("Unable to parse permissions: " + permissionsString + "; it must fit the pattern of role1,capability1,role2,capability2,etc; cause: " + e.stack);
     }
-    return permissions;
   }
 
   // this function can be used to create xquery/xpath templates that are safe from injection attacks


### PR DESCRIPTION
### Description

Added try/catch to hubUtils.parsePermissions, which will benefit the other clients of this function who are currently getting somewhat vague error messages

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

