### PR TITLE
DHFPROD-5969: Check if step exists in flow when adding

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/mapping.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/mapping.spec.tsx
@@ -113,7 +113,7 @@ describe('Mapping', () => {
 
     curatePage.openExistingFlowDropdown('Order', mapStep);
     curatePage.getExistingFlowFromDropdown(flowName).click();
-    curatePage.addStepToFlowConfirmationMessage(mapStep, flowName);
+    curatePage.addStepToFlowConfirmationMessage();
     curatePage.confirmAddStepToFlow(mapStep, flowName)
 
     runPage.runStep(mapStep).click();
@@ -199,7 +199,7 @@ describe('Mapping', () => {
 
     curatePage.openExistingFlowDropdown('Order', mapStep);
     curatePage.getExistingFlowFromDropdown(flowName).click();
-    curatePage.addStepToFlowConfirmationMessage(mapStep, flowName);
+    curatePage.addStepToFlowConfirmationMessage();
     curatePage.confirmAddStepToFlow(mapStep, flowName)
 
     runPage.runStep(mapStep).click();

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestion.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestion.spec.tsx
@@ -199,7 +199,7 @@ describe('Default ingestion ', () => {
         cy.waitForAsyncRequest();
         loadPage.stepName(stepName).should('be.visible');
         loadPage.addStepToExistingFlow(stepName, flowName);
-        loadPage.addStepToFlowConfirmationMessage(stepName, flowName).should('be.visible');
+        loadPage.addStepToFlowConfirmationMessage().should('be.visible');
         loadPage.confirmationOptions('Yes').click();
         cy.verifyStepAddedToFlow('Load', stepName);
 

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/curate.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/curate.tsx
@@ -102,8 +102,12 @@ class CuratePage {
         return cy.get('[role="disabled-delete-mapping button"]');
     }
 
-    addStepToFlowConfirmationMessage(stepName: string, flowName: string) {
-      return cy.findByText(`Are you sure you want to add "${stepName}" to flow "${flowName}"?`)
+    addStepToFlowConfirmationMessage() {
+        return cy.findByLabelText('step-not-in-flow');
+    }
+
+    addStepExistingToFlowConfirmationMessage() {
+        return cy.findByLabelText('step-in-flow');
     }
 
     confirmAddStepToFlow(stepName: string, flowName: string) {

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/load.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/load.tsx
@@ -75,9 +75,14 @@ class LoadPage {
         return cy.findByText(`Are you sure you want to delete "${stepName}"`);
     }
 
-    addStepToFlowConfirmationMessage(stepName: string, flowName: string) {
-        return cy.findByText(`Are you sure you want to add "${stepName}" to flow "${flowName}"?`)
+    addStepToFlowConfirmationMessage() {
+        return cy.findByLabelText('step-not-in-flow');
     }
+
+    addStepExistingToFlowConfirmationMessage() {
+        return cy.findByLabelText('step-in-flow');
+    }
+    
     pagination() {
 
     }

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/common.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/common.data.ts
@@ -38,6 +38,33 @@ const flows = [
     }
 ];
 
+const flowsAdd = [
+    {
+        name: 'FlowStepNoExist',
+        steps: [
+            {
+                stepNume: '1',
+                stepName: 'testLoad456', // has step NOT IN loadData
+                stepDefinitionType: 'Load Data',
+                stepId: 'testLoad456-ingestion',
+                format: 'xml'
+            },
+        ]
+    },
+    {
+        name: 'FlowStepExist',
+        steps: [
+            {
+                  stepNume: '2',
+                  stepName: 'testLoadXML', // has step IN loadData
+                  stepDefinitionType: 'Load Data',
+                  stepId: 'testLoadXML-ingestion',
+                  format: 'xml'
+            },
+        ]
+    },
+];
+
 const loadData = {
   data: [
     {
@@ -407,6 +434,7 @@ const data = {
     canWrite: true
   },
   flows: flows,
+  flowsAdd: flowsAdd,
   loadData: loadData,
   mapProps: mapProps,
   newMap: newMap,

--- a/marklogic-data-hub-central/ui/src/components/load/load-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-card.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, fireEvent, wait, cleanup, waitForElement, screen} from '@testing-library/react';
+import {render, fireEvent, wait, cleanup, screen} from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import LoadCard from './load-card';
 import data from '../../assets/mock-data/common.data';
@@ -7,7 +7,7 @@ import ingestionData from '../../assets/mock-data/ingestion.data';
 import axiosMock from 'axios';
 import mocks from '../../api/__mocks__/mocks.data';
 import { AuthoritiesService, AuthoritiesContext } from '../../util/authorities';
-import {ModelingTooltips, SecurityTooltips} from "../../config/tooltips.config";
+import {SecurityTooltips} from "../../config/tooltips.config";
 
 jest.mock('axios');
 
@@ -31,7 +31,7 @@ describe('Load Card component', () => {
     cleanup();
   })
 
-  test('Load Card - Add step to an existing Flow', async () => {
+  test('Load Card - Add step to an existing flow where step DOES NOT exist', async () => {
     const authorityService = new AuthoritiesService();
     authorityService.setAuthorities(['readIngestion', 'writeIngestion', 'writeFlow']);
     const { getByText, getByLabelText, getByTestId } = render(
@@ -39,7 +39,7 @@ describe('Load Card component', () => {
         <AuthoritiesContext.Provider value={authorityService}>
           <LoadCard
             {...data.loadData}
-            flows={data.flows}
+            flows={data.flowsAdd}
             canWriteFlow={true}
             addStepToFlow={jest.fn()}
             addStepToNew={jest.fn()} />
@@ -62,17 +62,48 @@ describe('Load Card component', () => {
     //Click on the select field to open the list of existing flows.
     fireEvent.click(getByTestId('testLoadXML-flowsList'));
 
-    //Choose FlowA from the dropdown
-    fireEvent.click(getByText('FlowA'));
+    //Choose FlowStepNoExist from the dropdown
+    fireEvent.click(getByText('FlowStepNoExist'));
 
-    //Click on 'Yes' button
-    fireEvent.click(getByTestId('testLoadXML-to-FlowA-Confirm'));
+    //Dialog appears, click 'Yes' button
+    expect(getByLabelText('step-not-in-flow')).toBeInTheDocument();
+    fireEvent.click(getByTestId('testLoadXML-to-FlowStepNoExist-Confirm'));
 
     //Check if the /tiles/run/add route has been called
     wait(() => {
       expect(mockHistoryPush).toHaveBeenCalledWith('/tiles/run/add');
     })
     //TODO- E2E test to check if the Run tile is loaded or not.
+    
+  });
+
+  test('Load Card - Add step to an existing flow where step DOES exist', async () => {
+    const authorityService = new AuthoritiesService();
+    authorityService.setAuthorities(['readIngestion', 'writeIngestion', 'writeFlow']);
+    const { getByText, getByLabelText, getByTestId } = render(
+      <MemoryRouter>
+        <AuthoritiesContext.Provider value={authorityService}>
+          <LoadCard
+            {...data.loadData}
+            flows={data.flowsAdd}
+            canWriteFlow={true}
+            addStepToFlow={jest.fn()}
+            addStepToNew={jest.fn()} />
+        </AuthoritiesContext.Provider>
+      </MemoryRouter>
+    )
+
+    fireEvent.mouseOver(getByText('testLoadXML')); // Hover over the Load Card to get more options
+
+    //Click on the select field to open the list of existing flows.
+    fireEvent.click(getByTestId('testLoadXML-flowsList'));
+
+    //Choose FlowStepExist from the dropdown
+    fireEvent.click(getByText('FlowStepExist'));
+
+    //Dialog appears, click 'Yes' button
+    expect(getByLabelText('step-in-flow')).toBeInTheDocument();
+    fireEvent.click(getByTestId('testLoadXML-to-FlowStepExist-Confirm'));
     
   });
 
@@ -133,7 +164,7 @@ describe('Load Card component', () => {
     const mockAddStepToNew = jest.fn();
     const mockCreateLoadArtifact = jest.fn();
     const mockDeleteLoadArtifact = jest.fn();
-    const {getByText, getByTestId} = render(<MemoryRouter><AuthoritiesContext.Provider value={authorityService}><LoadCard
+    const {getByText, getAllByText, getByTestId} = render(<MemoryRouter><AuthoritiesContext.Provider value={authorityService}><LoadCard
       addStepToFlow={mockAddStepToFlow}
       addStepToNew={mockAddStepToNew}
       canReadOnly={authorityService.canReadLoad()}
@@ -155,7 +186,8 @@ describe('Load Card component', () => {
     fireEvent.click(getByText('Yes'));
     expect(mockAddStepToFlow).toBeCalledTimes(1);
     // adding to new flow
-    fireEvent.mouseOver(getByText(loadStepName));
+    const loadSteps = getAllByText(loadStepName);
+    fireEvent.mouseOver(loadSteps[0]);
     expect(getByTestId(`${loadStepName}-toNewFlow`)).toBeInTheDocument();
     // TODO calling addStepToNew not implemented yet
   });

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.test.tsx
@@ -174,7 +174,7 @@ describe('Load data component', () => {
 
   })
 
-  test('Load List - Add step to an existing Flow', async () => {
+  test('Load List - Add step to an existing flow where step DOES NOT exist', async () => {
     const authorityService = new AuthoritiesService();
     authorityService.setAuthorities(['readIngestion', 'writeIngestion', 'writeFlow']);
     const { getByText, getByLabelText, getByTestId } = render(
@@ -182,7 +182,7 @@ describe('Load data component', () => {
         <AuthoritiesContext.Provider value={authorityService}>
           <LoadList
             {...data.loadData}
-            flows={data.flows}
+            flows={data.flowsAdd}
             canWriteFlow={true}
             addStepToFlow={jest.fn()}
             addStepToNew={jest.fn()} />
@@ -202,10 +202,11 @@ describe('Load data component', () => {
     //Click on the select field to open the list of existing flows.
     fireEvent.click(getByTestId('testLoadXML-flowsList'));
 
-    //Choose FlowA from the dropdown
-    fireEvent.click(getByText('FlowA'));
+    //Choose FlowStepNoExist from the dropdown
+    fireEvent.click(getByText('FlowStepNoExist'));
 
-    //Click on 'Yes' button
+    //Dialog appears, click 'Yes' button
+    expect(getByLabelText('step-not-in-flow')).toBeInTheDocument();
     fireEvent.click(getByLabelText('Yes'));
 
     //Check if the /tiles/run/add route has been called
@@ -215,6 +216,40 @@ describe('Load data component', () => {
     //TODO- E2E test to check if the Run tile is loaded or not.
 
   })
+
+  test('Load List - Add step to an existing flow where step DOES exist', async () => {
+    const authorityService = new AuthoritiesService();
+    authorityService.setAuthorities(['readIngestion', 'writeIngestion', 'writeFlow']);
+    const { getByText, getByLabelText, getByTestId } = render(
+      <MemoryRouter>
+        <AuthoritiesContext.Provider value={authorityService}>
+          <LoadList
+            {...data.loadData}
+            flows={data.flowsAdd}
+            canWriteFlow={true}
+            addStepToFlow={jest.fn()}
+            addStepToNew={jest.fn()} />
+        </AuthoritiesContext.Provider>
+      </MemoryRouter>
+    )
+
+    fireEvent.mouseOver(getByLabelText('testLoadXML-add-icon')); // Hover over the Add to Flow Icon to get more options
+
+    //Verify if the flow related options are availble on mouseOver
+    await waitForElement(() => expect(getByTestId(`testLoadXML-toNewFlow`))); // check if option 'Add to a new Flow' is visible
+    await waitForElement(() => expect(getByTestId(`testLoadXML-toExistingFlow`))); // check if option 'Add to an existing Flow' is visible
+
+    //Click on the select field to open the list of existing flows.
+    fireEvent.click(getByTestId('testLoadXML-flowsList'));
+
+    //Choose FlowStepExist from the dropdown
+    fireEvent.click(getByText('FlowStepExist'));
+
+    //Dialog appears, click 'Yes' button
+    expect(getByLabelText('step-in-flow')).toBeInTheDocument();
+    fireEvent.click(getByLabelText('Yes'));
+    
+  });
 
   test('Load List - Add step to an new Flow', async () => {
     const authorityService = new AuthoritiesService();

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.tsx
@@ -42,6 +42,7 @@ const LoadList: React.FC<Props> = (props) => {
     const [loadArtifactName, setLoadArtifactName] = useState('');
     const [stepData,setStepData] = useState({});
     const [openLoadSettings, setOpenLoadSettings] = useState(false);
+    const [selected, setSelected] = useState({}); // track Add Step selections so we can reset on cancel
 
     const pageSizeOptions = props.data.length > 40 ? ['10', '20', '30', '40', props.data.length] : ['10', '20', '30', '40'];
 
@@ -83,18 +84,29 @@ const LoadList: React.FC<Props> = (props) => {
     const onCancel = () => {
         setDialogVisible(false);
         setAddDialogVisible(false);
+        setSelected({}); // reset menus on cancel
     }
 
 
     function handleSelect(obj) {
+        let selectedNew = {...selected};
+        selectedNew[obj.loadName] = obj.flowName;
+        setSelected(selectedNew);
         handleStepAdd(obj.loadName, obj.flowName);
     }
 
+    const isStepInFlow = (loadName, flowName) => {
+        let result = false;
+        let flow;
+        if (props.flows) flow = props.flows.find(f => f.name === flowName);
+        if (flow) result = flow['steps'].findIndex(s => s.stepName === loadName) > -1;
+        return result;
+    }
 
     const handleStepAdd = (loadName, flowName) => {
-        setAddDialogVisible(true);
         setLoadArtifactName(loadName);
         setFlowName(flowName);
+        setAddDialogVisible(true);
     }
 
     const onAddOk = async (lName, fName) => {
@@ -118,11 +130,14 @@ const LoadList: React.FC<Props> = (props) => {
             cancelText={<div aria-label="No">No</div>}
             onOk={() => onAddOk(loadArtifactName, flowName)}
             onCancel={() => onCancel()}
-            width={350}
+            width={400}
             maskClosable={false}
         >
-            <div style={{fontSize: '16px', padding: '10px'}}>
-                Are you sure you want to add "{loadArtifactName}" to flow "{flowName}"?
+            <div aria-label="add-step-confirmation" style={{fontSize: '16px', padding: '10px'}}>
+                { isStepInFlow(loadArtifactName, flowName) ?
+                    <p aria-label="step-in-flow">The step <strong>{loadArtifactName}</strong> is already in the flow <strong>{flowName}</strong>. Add another instance of the step?</p> :
+                    <p aria-label="step-not-in-flow">Are you sure you want to add the step <strong>{loadArtifactName}</strong> to the flow <strong>{flowName}</strong>?</p>
+                }
             </div>
         </Modal>
     );
@@ -143,6 +158,7 @@ const LoadList: React.FC<Props> = (props) => {
                     <div className={styles.stepLinkSelect} onClick={(event) => { event.stopPropagation(); event.preventDefault(); }}>
                         <Select
                             style={{ width: '100%' }}
+                            value={selected[name] ? selected[name] : undefined}
                             onChange={(flowName) => handleSelect({flowName: flowName, loadName: name})}
                             placeholder="Select Flow"
                             defaultActiveFirstOption={false}


### PR DESCRIPTION
### Description

- Handle existing step check when adding Load and Map steps to flows.
- Display warning in confirmation dialog.
- Also track menu selections in state so menus can be reset.
- Update tests to test for when step exists: mapping-card, load-card, load-list
- Refactor of mapping-card.test to remove redundant code.

Screncasts:

Load Card: https://drive.google.com/file/d/1hQwG0AOSpTJJ5GcIw8Yw5c5wzVauhmce/view
Load List: https://drive.google.com/file/d/1WYwvIJgt2Xu0qv4R5trp-ZucQ0JrTX_5/view
Map Card: https://drive.google.com/file/d/1FbpuoDMnWeUCIig0EK6pIfImx6nrVhuG/view


#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

