### PR TITLE
DHFPROD-5964: Update Zero State Explorer switch

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/load/switch-view.scss
+++ b/marklogic-data-hub-central/ui/src/components/load/switch-view.scss
@@ -1,4 +1,9 @@
-.ant-radio-group-large .ant-radio-button-wrapper {
+#switch-view .ant-radio-group-large .ant-radio-button-wrapper {
     height: 40px;
     font-size: 24px;
+    border-color: #999;
+}
+
+#switch-view .ant-radio-group-large .ant-radio-button-wrapper.ant-radio-button-wrapper-checked {
+    border-color: #5B69AF;
 }

--- a/marklogic-data-hub-central/ui/src/components/load/switch-view.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/switch-view.test.tsx
@@ -1,9 +1,32 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render, fireEvent, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
 import SwitchView from './switch-view';
 
-describe('View selector component', () => {
-  it('should render correctly', () => {
-    shallow(<SwitchView handleSelection/>);
+export type ViewType =  'card' | 'list';
+
+describe('Switch view component', () => {
+
+  const INITIAL_VIEW: ViewType = 'card';
+
+  afterEach(cleanup);
+
+  test('Verify styles of selected buttons', () => {
+
+    const { getByLabelText } = render(
+      <SwitchView handleSelection={() => null} defaultView={INITIAL_VIEW} />
+    );
+
+    expect(getByLabelText('switch-view')).toBeInTheDocument();
+
+    expect(getByLabelText('switch-view-card')).toHaveProperty('checked', true);
+    expect(getByLabelText('switch-view-list')).toHaveProperty('checked', false);
+
+    fireEvent.click(getByLabelText('switch-view-list'));
+    
+    expect(getByLabelText('switch-view-card')).toHaveProperty('checked', false);
+    expect(getByLabelText('switch-view-list')).toHaveProperty('checked', true);
+
   });
+
 });

--- a/marklogic-data-hub-central/ui/src/components/load/switch-view.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/switch-view.tsx
@@ -3,7 +3,6 @@ import { Menu } from 'antd';
 import { MLRadio } from '@marklogic/design-system';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faThLarge, faTable } from '@fortawesome/free-solid-svg-icons';
-import styles from './switch-view.module.scss';
 import './switch-view.scss';
 
 interface Props {
@@ -20,20 +19,20 @@ const SwitchView: React.FC<Props> = (props) => {
     }
 
     return (
-        <div aria-label="switch-view" className={styles.switchView}>
+        <div id="switch-view" aria-label="switch-view">
             <MLRadio.MLGroup
                 buttonStyle="outline"
                 defaultValue={view}
                 name="radiogroup"
                 onChange={e => onChange(e.target.value)}
                 size="large"
-                style={{ color: '#CCC' }}
+                style={{ color: '#999' }}
             >
                 <MLRadio.MLButton aria-label="switch-view-card" value={'card'}>
-                    <i>{view !== 'card' ? <FontAwesomeIcon icon={faThLarge} style={{ color: '#CCC' }} /> : <FontAwesomeIcon icon={faThLarge} />}</i>
+                    <i>{view !== 'card' ? <FontAwesomeIcon icon={faThLarge} style={{ color: '#999' }} /> : <FontAwesomeIcon icon={faThLarge} />}</i>
                 </MLRadio.MLButton>
                 <MLRadio.MLButton aria-label="switch-view-list" value={'list'}>
-                    <i>{view !== 'list' ? <FontAwesomeIcon icon={faTable} style={{ color: '#CCC' }} /> : <FontAwesomeIcon icon={faTable} />}</i>
+                    <i>{view !== 'list' ? <FontAwesomeIcon icon={faTable} style={{ color: '#999' }} /> : <FontAwesomeIcon icon={faTable} />}</i>
                 </MLRadio.MLButton>
             </MLRadio.MLGroup>
         </div>

--- a/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.scss
+++ b/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.scss
@@ -1,0 +1,10 @@
+#zero-state-explorer .ant-radio-button-wrapper {
+    border: solid 1px #999;
+    color: #999;
+    background: #FFF;;
+}
+#zero-state-explorer .ant-radio-button-wrapper.ant-radio-button-wrapper-checked {
+    border: solid 1px #5B69AF;
+    color: #5B69AF;
+    background: #FFF;
+}

--- a/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.tsx
+++ b/marklogic-data-hub-central/ui/src/components/zero-state-explorer/zero-state-explorer.tsx
@@ -5,9 +5,10 @@ import { SearchContext } from '../../util/search-context';
 import graphic from './explore_visual_big.png';
 import { QueryOptions } from '../../types/query-types';
 import { MLButton, MLRadio } from '@marklogic/design-system';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faStream, faTable } from '@fortawesome/free-solid-svg-icons'
-import tiles from '../../config/tiles.config'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faStream, faTable } from '@fortawesome/free-solid-svg-icons';
+import tiles from '../../config/tiles.config';
+import './zero-state-explorer.scss';
 
 const ZeroStateExplorer = (props) => {
 
@@ -86,7 +87,7 @@ const ZeroStateExplorer = (props) => {
 }
 
   return (
-    <div className={styles.container} >
+    <div id="zero-state-explorer" className={styles.container} >
       <div className={styles.zeroContent}>
         <Row>
           <Col span={18}>
@@ -135,11 +136,11 @@ const ZeroStateExplorer = (props) => {
                         onChange={e => onViewChange(e.target.value)}
                         size="medium"
                       >
-                        <MLRadio.MLButton aria-label="switch-view-table" value={'table'} style={{ height: '30px', fontSize: '14px'}}>
-                          <i style={{ fontSize: '16px', marginLeft: '-5px', marginRight: '5px'}}><FontAwesomeIcon icon={faTable} /></i>Table
+                        <MLRadio.MLButton aria-label="switch-view-table" value={'table'} style={{ height: '32px', fontSize: '14px'}}>
+                          <i style={{ fontSize: '16px', marginLeft: '-6px', marginRight: '5px'}}><FontAwesomeIcon icon={faTable} /></i>Table
                       </MLRadio.MLButton>
-                        <MLRadio.MLButton aria-label="switch-view-snippet" value={'snippet'} style={{ height: '30px', fontSize: '14px'}}>
-                          <i style={{ fontSize: '16px', marginLeft: '-5px', marginRight: '5px'}}><FontAwesomeIcon icon={faStream} /></i>Snippet
+                        <MLRadio.MLButton aria-label="switch-view-snippet" value={'snippet'} style={{ height: '32px', fontSize: '14px'}}>
+                          <i style={{ fontSize: '16px', marginLeft: '-6px', marginRight: '5px'}}><FontAwesomeIcon icon={faStream} /></i>Snippet
                       </MLRadio.MLButton>
                       </MLRadio.MLGroup>
                     </div>


### PR DESCRIPTION
### Description

Remove background color and use #999 gray for Zero State Explorer switch.
Also update gray of Load switch to #999.
Remove switch-view.module.scss file since not used.
Add RTL tests to switch-view.test.

Screencast: https://drive.google.com/file/d/1Jep9LJKJa7Yn0US3HgyG6FukngC1rxVM/view

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

