### PR TITLE
DHFPROD-6113: Removing need to include skipUi and skipWeb

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,10 +48,8 @@ that the values for mlSecurityUsername and mlSecurityPassword are correct, as th
 instance of Data Hub. Also, ensure that you do not have a Data Hub instance already deployed to the MarkLogic that you 
 will connect to. Then, run the following Gradle task from the root project:
 
-    ./gradlew -Pskipui= bootstrap
+    ./gradlew -i bootstrap
     
-The "skipui=" property tells Gradle to skip building the QuickStart web application, which is not needed right now. 
-
 After two or three minutes, the bootstrap process will finish, and the test instance of Data Hub will be installed in MarkLogic. 
 
 #### Running tests 
@@ -87,11 +85,8 @@ these instructions:
 1. Publish the Data Hub library and Data Hub Gradle plugin to your local Maven repository (defaults to ~/.m2/repository).
 
   ```bash
-  ./gradlew publishToMavenLocal -PskipWeb= 
+  ./gradlew publishToMavenLocal 
   ```
-
-The "skipWeb" property is used to skip compilation of the UI code in the ./marklogic-data-hub-central and ./web subprojects. 
-Typically, this is not needed for testing out the Data Hub library or Gradle plugin.
 
 2. In the build.gradle file for the project that will use the library, add your local Maven repository as a repository if it's not alreaded included:
 
@@ -111,7 +106,7 @@ Typically, this is not needed for testing out the Data Hub library or Gradle plu
 The version is defined in gradle.properties in the marklogic-data-hub root project directory. You can override this if 
 desired when publishing to your local Maven repository - e.g.
 
-    ./gradlew publishToMavenLocal -PskipWeb= -Pversion=myVersion
+    ./gradlew publishToMavenLocal -Pversion=myVersion
 
 
 ### Testing changes to the Data Hub Gradle plugin 
@@ -123,7 +118,7 @@ another project. To do so, follow the steps below.
 1. Publish the Data Hub library and Gradle plugin to your local Maven repository (defaults to ~/.m2/repository).
 
   ```bash
-  ./gradlew publishToMavenLocal -PskipWeb=
+  ./gradlew publishToMavenLocal
   ```
 
 2. Then add the following to the build.gradle file of the project where you'd like to test your just-published Data Hub 

--- a/marklogic-data-hub-central/build.gradle
+++ b/marklogic-data-hub-central/build.gradle
@@ -17,7 +17,6 @@ plugins {
 }
 
 apply plugin: "org.springframework.boot"
-apply plugin: "maven-publish"
 apply plugin: "io.spring.dependency-management"
 apply plugin: "war"
 apply plugin: "com.github.node-gradle.node"
@@ -185,28 +184,22 @@ task copyUiFiles(type: Copy, dependsOn: deleteSpringBootUiFiles, group: taskGrou
     into springBootUiPath
 }
 
-// Before the Spring Boot jar is built, build the UI files and copy them over
-if (!(
-    gradle.startParameter.taskNames*.toLowerCase().contains("publishplugins") ||
-        gradle.startParameter.taskNames*.toLowerCase().contains("bintrayUpload") ||
-        gradle.startParameter.taskNames*.toLowerCase().contains("javadoc") ||
-        // bootRun doesn't need the UI, as it's assumed that the UI is being run separately via npm start
-        gradle.startParameter.taskNames*.toLowerCase().contains("bootrun") ||
-        gradle.startParameter.taskNames*.toLowerCase().contains("generateschemapojos") ||
-        project.hasProperty('skipui')
-)
-) {
+// When creating the HC war file, need to build the UI files and add them to the classpath so that the war file includes them
+ext {
+    def taskNames = gradle.startParameter.taskNames*.toLowerCase()
+    shouldBuildUiFiles = taskNames.contains("build") || taskNames.contains("buildrpm") || taskNames.contains("bootwar")
+}
+if (shouldBuildUiFiles) {
+    println "Building UI!"
     tasks.processResources.dependsOn(buildUi, copyUiFiles)
 }
 
+
 test {
-	exclude 'com/marklogic/hub/curation/integrationtests/**'
-	exclude 'com/marklogic/hub/central/integrationtests/**'
-    exclude 'com/marklogic/hub/curation/controllers/fullcycle/**'
 	useJUnitPlatform()
 }
 
-tasks.buildRpm.dependsOn(buildUi, copyUiFiles, bootWar)
+tasks.buildRpm.dependsOn bootWar
 
 task testUI(type: NpmTask, dependsOn: installDependencies, group: taskGroup){
     description = "Runs the UI unit tests"

--- a/marklogic-data-hub-spark-connector/README.md
+++ b/marklogic-data-hub-spark-connector/README.md
@@ -1,4 +1,0 @@
-When building/compiling this project via Gradle, include -Pskipui= so that the core DHF project - ./marklogic-data-hub - 
-does not build its trace-ui UI code, which is not needed for this project - e.g.:
-
-    ../gradlew clean compileJava -Pskipui=

--- a/marklogic-data-hub-spark-connector/build.gradle
+++ b/marklogic-data-hub-spark-connector/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "java-library"
-    id 'maven-publish'
     id 'com.github.johnrengelman.shadow' version '5.2.0'
 }
 
@@ -59,22 +58,4 @@ shadowJar {
     relocate('okio', 'marklogic.okio')
     relocate('com.fasterxml', 'marklogic.com.fasterxml')
 }
-
-publishing {
-    publications {
-        allJava(MavenPublication) {
-            from components.java
-            artifact shadowJar
-            // Removes the connector's dependencies, as the expectation is that if a client wants to
-            // depend on this project, they'll depend on the "all" shadow jar, which contains all the necessary
-            // classes, including relocated ones.q
-            pom.withXml {
-                asNode().dependencies.dependency.each { dep ->
-                    if(dep.artifactId.last().value().last() in ["marklogic-data-hub-api"]) {
-                        assert dep.parent().remove(dep)
-                    }
-                }
-            }
-        }
-    }
-}
+build.dependsOn shadowJar

--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -227,26 +227,10 @@ task generateDataServiceInterfaces {
     }
 }
 
-if (!(
-    gradle.startParameter.taskNames*.toLowerCase().contains("bootrun") ||
-        gradle.startParameter.taskNames*.toLowerCase().contains("test") ||
-        gradle.startParameter.taskNames*.toLowerCase().contains("testunit") ||
-        gradle.startParameter.taskNames*.toLowerCase().contains("publishplugins") ||
-        gradle.startParameter.taskNames*.toLowerCase().contains("publishtomavenlocal") ||
-        gradle.startParameter.taskNames*.toLowerCase().contains("bintrayupload") ||
-        gradle.startParameter.taskNames*.toLowerCase().contains("javadoc") ||
-        gradle.startParameter.taskNames*.toLowerCase().contains("bootjar") ||
-        gradle.startParameter.taskNames*.toLowerCase().contains("marklogic-data-hub:bootjar") ||
-        gradle.startParameter.taskNames*.toLowerCase().contains("clientjar") ||
-        gradle.startParameter.taskNames*.toLowerCase().contains("marklogic-data-hub:clientjar") ||
-        gradle.startParameter.taskNames*.toLowerCase().contains("generatedataservice") ||
-        // Added for Hub Central
-        gradle.startParameter.taskNames*.toLowerCase().contains("bootrun") ||
-        gradle.startParameter.taskNames*.toLowerCase().contains("buildrpm") ||
-
-        project.hasProperty('skipui')
-)
-) {
+// When publishing the DHF core jar, or building it for release, it needs to have the compiled trace-ui files in it so
+// that the trace-ui feature is available for those users that are aware of it. Otherwise, copyUIAssets is not executed as it can take a couple
+// minutes to finish, and it's not typically needed during local development.
+if (gradle.startParameter.taskNames*.toLowerCase().contains("publish") || gradle.startParameter.taskNames*.toLowerCase().contains("build")) {
     processResources.dependsOn copyUIAssets
 }
 

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -24,7 +24,6 @@ plugins {
     id "com.github.node-gradle.node" version "2.2.4"
     id 'org.springframework.boot' version '2.1.3.RELEASE'
 }
-apply plugin: 'maven-publish'
 apply plugin: 'io.spring.dependency-management'
 apply plugin: 'war'
 
@@ -217,44 +216,11 @@ task stopBootrun {
 
 e2eUI.finalizedBy stopBootrun
 
-if (!(
-  gradle.startParameter.taskNames*.toLowerCase().contains("bootrun") ||
-    gradle.startParameter.taskNames*.toLowerCase().contains("test") ||
-    gradle.startParameter.taskNames*.toLowerCase().contains("publishplugins") ||
-    gradle.startParameter.taskNames*.toLowerCase().contains("bintrayUpload") ||
-    gradle.startParameter.taskNames*.toLowerCase().contains("javadoc") ||
-    project.hasProperty('skipui')
-)
-) {
+// Need to ensure the UI files are built and included in the war file
+if (gradle.startParameter.taskNames*.toLowerCase().contains("bootwar"))
+{
   processResources.dependsOn copyIndexHtml
 }
-publishing {
-  publications {
-    if(!project.hasProperty('skipWeb')) {
-      mavenWeb(MavenPublication) {
-        group = "com.marklogic"
-        version = "${version}"
-        from components.web
-        artifact bootWar
-
-      }
-    }
-  }
-  repositories {
-    maven {
-      if(project.hasProperty("mavenUser")) {
-        credentials {
-          username mavenUser
-          password mavenPassword
-        }
-      }
-      url publishUrl
-    }
-  }
-}
-
-//removing test dependency on e2e tests
-//test.dependsOn e2eUI
 
 bootRun {
   environment 'spring.profiles.active', 'dev'


### PR DESCRIPTION
### Description

The UI files for core will only be built when running "publish" now. 

Same goes for HC, except only when "bootWar" is run ("publish" seems to have no impact for HC). 

Removed the Spark README, as the only thing it was doing was mentioning the need to include skipui. We'll add it back once we have stuff to say in it. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

