### PR TITLE
DHFPROD-6040: Decrease font size of service name in header

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/header/header.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/header/header.module.scss
@@ -35,7 +35,7 @@ header.container {
   }
 }
 .serviceName {
-    font: 400 22px/48px 'HelveticaNeue-Light', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font: 400 18px/51px 'HelveticaNeue-Light', 'Helvetica Neue', Helvetica, Arial, sans-serif;
     text-decoration: none;
     color: white;
 }


### PR DESCRIPTION
### Description

Minor style update approved by @jbelonoj. Shrink service name text in header slightly: 22px -> 18px

(Line height also adjusted slightly for consistency across header.) No test updates required.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests (N/A)
  

- ##### Reviewer:

- [x] Reviewed Tests (N/A)

