### PR TITLE
DHFPROD-6116: Fixing QS on 5.4-develop

### DIFF
--- a/web/src/main/java/com/marklogic/hub/web/WebApplication.java
+++ b/web/src/main/java/com/marklogic/hub/web/WebApplication.java
@@ -28,7 +28,14 @@ import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableAsync
-@ComponentScan(basePackages = "com.marklogic.hub")
+@ComponentScan(basePackages = {
+    // DHF core packages
+    "com.marklogic.hub.impl", "com.marklogic.hub.legacy.impl", "com.marklogic.hub.deploy.commands",
+    "com.marklogic.hub.job.impl", "com.marklogic.hub.flow.impl", "com.marklogic.hub.step", "com.marklogic.hub.util",
+
+    // Webapp components
+    "com.marklogic.hub.web"
+})
 public class WebApplication extends SpringBootServletInitializer {
 
     /**

--- a/web/src/main/java/com/marklogic/hub/web/web/CurrentProjectController.java
+++ b/web/src/main/java/com/marklogic/hub/web/web/CurrentProjectController.java
@@ -87,9 +87,6 @@ public class CurrentProjectController implements FileSystemEventListener, Valida
     private HubConfigImpl hubConfig;
 
     @Autowired
-    private HubProjectImpl hubProject;
-
-    @Autowired
     private SimpMessagingTemplate template;
 
     @Autowired
@@ -242,7 +239,7 @@ public class CurrentProjectController implements FileSystemEventListener, Valida
             enableWatcherService(mappingsDir);
             //watch ml-modules/root/custom-modules/ingestion|mapping|mastering dirs
             for (StepDefinition.StepDefinitionType stepType : StepDefinition.StepDefinitionType.values()) {
-                enableWatcherService(hubProject.getCustomModulesDir().resolve(stepType.toString().toLowerCase()).toFile());
+                enableWatcherService(hubConfig.getHubProject().getCustomModulesDir().resolve(stepType.toString().toLowerCase()).toFile());
             }
             watcherService.addListener(this);
         }
@@ -319,7 +316,7 @@ public class CurrentProjectController implements FileSystemEventListener, Valida
         disableWatcherService(hubConfig.getHubMappingsDir().toFile());
         disableWatcherService(hubConfig.getFlowsDir().toFile());
         disableWatcherService(hubConfig.getStepDefinitionsDir().toFile());
-        disableWatcherService(hubProject.getCustomModulesDir().toFile());
+        disableWatcherService(hubConfig.getHubProject().getCustomModulesDir().toFile());
         watcherService.removeListener(this);
         mappingManagerService.unsetMappingValidators();
     }

--- a/web/src/test/java/com/marklogic/hub/web/web/CurrentProjectControllerTest.java
+++ b/web/src/test/java/com/marklogic/hub/web/web/CurrentProjectControllerTest.java
@@ -1,0 +1,20 @@
+package com.marklogic.hub.web.web;
+
+import com.marklogic.hub.web.AbstractWebTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class CurrentProjectControllerTest extends AbstractWebTest {
+
+    @Autowired
+    CurrentProjectController controller;
+
+    @Test
+    void testGetEnvironment() throws Exception {
+        String environment = controller.getEnvironment();
+        assertNotNull(environment, "This test was added to provide at least minimal coverage of the " +
+            "controller class to ensure that it autowires up correctly");
+    }
+}


### PR DESCRIPTION
### Description

WebApplication was ending up with 2 HubConfigImpl instances due to ComponentScan'ing all of com.marklogic.hub. I was going to just mark the HubConfigImpl in WebApplication as @Primary, but figured it's safer / easier-to-understand if the packages are listed out. 

Also fixed an issue in CurrentProjectController, which was autowiring in HubProject. Added a simple test to ensure that this class can be autowired successfully. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

