### PR TITLE
DHFPROD-6119: Ant Design components are fixed to body element

### DIFF
--- a/marklogic-data-hub-central/ui/src/App.scss
+++ b/marklogic-data-hub-central/ui/src/App.scss
@@ -149,6 +149,9 @@ tr.ant-table-row:hover > td {
 
 .ant-tooltip {
   white-space: pre-wrap;
+  width: max-content;
+  font-style: normal;
+  font-weight: normal;
 }
 
 .ant-popover {
@@ -260,3 +263,6 @@ ul.ant-cascader-menu:nth-child(2) {
     margin-top: 18px;
 }
 
+.ant-select-dropdown-menu-item{
+  text-align: left;
+}

--- a/marklogic-data-hub-central/ui/src/components/column-selector/column-selector.tsx
+++ b/marklogic-data-hub-central/ui/src/components/column-selector/column-selector.tsx
@@ -173,7 +173,7 @@ const ColumnSelector: React.FC<Props> = (props) => {
 
   return (
     <div className={styles.fixedPopup}>
-      <MLTooltip title='Select the columns to display.'>
+      <MLTooltip title='Select the columns to display.' placement="topRight">
         <Popover placement="leftTop" content={content} trigger="click" visible={props.popoverVisibility} className={styles.fixedPopup}>
           <FontAwesomeIcon onClick={() => props.setPopoverVisibility(true)} className={styles.columnIcon} icon={faColumns} size="lg" data-testid='column-selector-tooltip'/>
         </Popover>

--- a/marklogic-data-hub-central/ui/src/components/date-facet/date-facet.tsx
+++ b/marklogic-data-hub-central/ui/src/components/date-facet/date-facet.tsx
@@ -70,6 +70,7 @@ const DateFacet: React.FC<Props> = (props) => {
                 onChange={onChange}
                 value={datePickerValue}
                 key={props.name}
+                getCalendarContainer={() => document.getElementById('sideBarContainer') || document.body}
             />
         </div>
     )

--- a/marklogic-data-hub-central/ui/src/components/entities/entity-tiles.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/entity-tiles.tsx
@@ -260,7 +260,7 @@ const EntityTiles = (props) => {
     const handleCollapseChange = (keys) => Array.isArray(keys) ? setActiveEntityTypes(keys):setActiveEntityTypes([keys]);
 
     return (
-        <div className={styles.entityTilesContainer}>
+        <div id="entityTilesContainer" className={styles.entityTilesContainer}>
 
         <Collapse activeKey={activeEntityTypes} onChange={handleCollapseChange} defaultActiveKey={locationEntityType}>
             { Object.keys(props.entityModels).sort().map((entityType, index) => (

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
@@ -693,6 +693,7 @@ const MappingCard: React.FC<Props> = (props) => {
                                                 defaultActiveFirstOption={false}
                                                 disabled={!props.canWriteFlow}
                                                 data-testid={`${elem.name}-flowsList`}
+                                                getPopupContainer={() => document.getElementById('entityTilesContainer') || document.body}
                                             >
                                                 { props.flows && props.flows.length > 0 ? props.flows.map((f,i) => (
                                                     <Option aria-label={`${f.name}-option`} value={f.name} key={i}>{f.name}</Option>

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
@@ -617,7 +617,8 @@ const SourceToEntityMap = (props) => {
             title: <span>XPath Expression <Popover
                 content={xPathDocLinks}
                 trigger="click"
-                placement="top" ><Icon type="question-circle" className={styles.questionCircle} theme="filled" /></Popover>
+                placement="top"
+                getPopupContainer={() => document.getElementById('parentContainer') || document.body}><Icon type="question-circle" className={styles.questionCircle} theme="filled" /></Popover>
             </span>,
             dataIndex: 'key',
             key: 'key',
@@ -1188,7 +1189,7 @@ const SourceToEntityMap = (props) => {
             </span>
             <br/>
             <hr/>
-            <div className={styles.parentContainer}>
+            <div id="parentContainer" className={styles.parentContainer}>
                 <SplitPane
                     style={splitStyle}
                     paneStyle={splitPaneStyles.pane}
@@ -1211,6 +1212,7 @@ const SourceToEntityMap = (props) => {
                                 content={srcDetails}
                                 trigger="click"
                                 placement="right"
+                                getPopupContainer={() => document.getElementById('parentContainer') || document.body}
                             ><Icon type="question-circle" className={styles.questionCircle} theme="filled" /></Popover></p>
                         </div>
                         {props.isLoading === true ? <div className={styles.spinRunning}>
@@ -1246,6 +1248,7 @@ const SourceToEntityMap = (props) => {
                                         dataSource={srcData}
                                         tableLayout="unset"
                                         rowKey={(record) => record.rowKey}
+                                        getPopupContainer={() => document.getElementById('srcContainer') || document.body}
                                     />
                             </div> }
                     </div>
@@ -1272,6 +1275,7 @@ const SourceToEntityMap = (props) => {
                             dataSource={props.entityTypeProperties}
                             tableLayout="unset"
                             rowKey={(record: any) => record.key}
+                            getPopupContainer={() => document.getElementById('entityContainer') || document.body}
                         />
                     </div>
                 </SplitPane>

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.tsx
@@ -238,7 +238,7 @@ const LoadList: React.FC<Props> = (props) => {
             key: 'actions',
             render: (text, row) => (
                 <span>
-                    <Dropdown data-testid={`${row.name}-dropdown`} overlay={menu(row.name)} trigger={['hover']} disabled = {!props.canWriteFlow}>
+                    <Dropdown data-testid={`${row.name}-dropdown`} overlay={menu(row.name)} trigger={['hover']} disabled = {!props.canWriteFlow} placement="bottomCenter">
                         {props.canWriteFlow ? <span className={'AddToFlowIcon'} aria-label = {row.name+'-add-icon'}></span> : <MLTooltip title={'Add to Flow: ' + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: '225px'}}><span aria-label = {row.name+'-disabled-add-icon'} className={'disabledAddToFlowIcon'}></span></MLTooltip>}
                     </Dropdown>
                     <MLTooltip title={'Settings'} placement="bottom"><Icon type="setting" data-testid={row.name+'-settings'} onClick={() => OpenLoadSettingsDialog(row)} className={styles.settingsIcon} /></MLTooltip>

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
@@ -240,7 +240,7 @@ const PropertyTable: React.FC<Props> = (props) => {
         let structuredTypeName = Array.isArray(textParse) ? textParse[textParse.length-1] : text
 
         const addIcon = props.canWriteEntityModel ? (
-          <MLTooltip title={ModelingTooltips.addStructuredProperty}>
+          <MLTooltip title={ModelingTooltips.addStructuredProperty} placement="topRight">
             <FontAwesomeIcon
               data-testid={'add-struct-'+ structuredTypeName}
               className={styles.addIcon}

--- a/marklogic-data-hub-central/ui/src/components/queries/saving/save-queries-dropdown/save-queries-dropdown.tsx
+++ b/marklogic-data-hub-central/ui/src/components/queries/saving/save-queries-dropdown/save-queries-dropdown.tsx
@@ -93,6 +93,7 @@ const SaveQueriesDropdown: React.FC<Props> = (props) => {
                     return searchOptions.selectedQuery;
                 })()
             }
+            getPopupContainer={() => document.getElementById('dropdownList') || document.body}
         >
             {options}
         </Select>

--- a/marklogic-data-hub-central/ui/src/components/query-export/query-export.tsx
+++ b/marklogic-data-hub-central/ui/src/components/query-export/query-export.tsx
@@ -68,7 +68,7 @@ const QueryExport = (props) => {
     return (
         <div>
             <ExportQueryModal hasStructured={hasStructured} getPreview={getPreview} tableColumns={tableColumns} tableData={tableData} exportModalVisibility={exportModalVisibility} setExportModalVisibility={setExportModalVisibility} columns={props.columns} />
-            <MLTooltip title='Export results with the displayed columns to CSV.'>
+            <MLTooltip title='Export results with the displayed columns to CSV.' placement="topRight">
                 <FontAwesomeIcon style={{ cursor: 'pointer' }} icon={faFileExport} size="lg" onClick={displayModal} data-testid='query-export' />
             </MLTooltip>
         </div>

--- a/marklogic-data-hub-central/ui/src/components/search-result/search-result.tsx
+++ b/marklogic-data-hub-central/ui/src/components/search-result/search-result.tsx
@@ -103,7 +103,7 @@ const SearchResult: React.FC<Props> = (props) => {
                             uri: props.item.uri,
                             entityInstance: props.item.entityInstance
                         }}} id={'instance'} data-cy='instance' >
-                        <MLTooltip title={'Show the processed data'}><FontAwesomeIcon  icon={faExternalLinkAlt} size="sm" data-testid='instance-icon'/></MLTooltip>
+                        <MLTooltip title={'Show the processed data'} placement="topRight"><FontAwesomeIcon  icon={faExternalLinkAlt} size="sm" data-testid='instance-icon'/></MLTooltip>
                     </Link>
                     <Link to={{pathname: "/tiles/explore/detail",state: {selectedValue:'source',
                             entity : searchOptions.entityTypeIds ,
@@ -118,7 +118,7 @@ const SearchResult: React.FC<Props> = (props) => {
                             uri: props.item.uri,
                             entityInstance: props.item.entityInstance
                         }}} id={'source'} data-cy='source' >
-                        <MLTooltip title={'Show the complete ' + fileTypeVal.toUpperCase()}><FontAwesomeIcon  icon={faCode} size="sm" data-testid='source-icon'/></MLTooltip>
+                        <MLTooltip title={'Show the complete ' + fileTypeVal.toUpperCase()} placement="topRight"><FontAwesomeIcon  icon={faCode} size="sm" data-testid='source-icon'/></MLTooltip>
                     </Link>
                 </div>
                 <span className={styles.entityName} data-cy='entity-name'>{itemEntityName}</span>

--- a/marklogic-data-hub-central/ui/src/components/sidebar/sidebar.tsx
+++ b/marklogic-data-hub-central/ui/src/components/sidebar/sidebar.tsx
@@ -612,8 +612,8 @@ const Sidebar: React.FC<Props> = (props) => {
               id="date-select"
               value={dateRangeValue}
               onChange={value => handleOptionSelect(value)}
-            >{
-                dateRangeOptions.map((timeBucket, index) => {
+              getPopupContainer={() => document.getElementById('date-select') || document.body}
+            >{dateRangeOptions.map((timeBucket, index) => {
                   return <Option key={index} value={timeBucket}>
                     {timeBucket}
                   </Option>

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.tsx
@@ -15,6 +15,7 @@ import Detail from "./Detail";
 import { AuthoritiesContext } from "../util/authorities";
 import { SearchContext } from '../util/search-context';
 import { useHistory, useLocation } from 'react-router-dom';
+import { ConfigProvider } from 'antd';
 
 export type TileId = 'load' | 'model' | 'curate' | 'run' | 'explore';
 export type IconType = 'fa' | 'custom';
@@ -107,15 +108,26 @@ const TilesView = (props) => {
             { (searchOptions.view !== null) ?  (
                 <div className={styles.tilesViewContainer}>
                     { (selection !== '') ?  (
-                    <Tiles
-                        id={selection}
-                        view={searchOptions.view}
-                        currentNode={currentNode}
-                        options={options}
-                        onMenuClick={onMenuClick}
-                        onTileClose={onTileClose}
-                        newStepToFlowOptions={getNewStepToFlowOptions()}
-                    />
+                    <ConfigProvider	
+                        getPopupContainer={(node) => {
+                            if(node) {
+                                return node.parentNode ?  node.parentNode as HTMLElement : document.body;
+                            }
+                             else {
+                                return document.body
+                            }
+                        }}
+                    >
+                        <Tiles
+                            id={selection}
+                            view={searchOptions.view}
+                            currentNode={currentNode}
+                            options={options}
+                            onMenuClick={onMenuClick}
+                            onTileClose={onTileClose}
+                            newStepToFlowOptions={getNewStepToFlowOptions()}
+                        />
+                    </ConfigProvider>
                     ) : null }
                 </div> ) :
                 <Overview enabled={enabled}/>


### PR DESCRIPTION
### Description
This is just fixing implementation detail for ant design components, to fix the issue where some components like tooltip, popovers etc., were being fixed to the body element. No tests are required here.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [N/A] Added Tests
  

- ##### Reviewer:

- [N/A] Reviewed Tests

