### PR TITLE
DHFPROD-6121: Set the right target database in mapping step navigation

### DIFF
--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/FlowControllerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/FlowControllerTest.java
@@ -126,6 +126,7 @@ public class FlowControllerTest extends AbstractMvcTest {
                 .andDo(result -> {
                     JsonNode response = parseJsonResponse(result);
                 assertEquals(mappingInfo.targetEntityType, response.path("stepResponses").path("1").path("targetEntityType").asText(), "Info for the step should specify the Target Entity Type; response: " + response);
+                assertEquals("final", response.path("stepResponses").path("1").path("targetDatabase").asText(), "Step response should specify the target database since the step options contain the targetDatabase; response: " + response);
             });
 
         // Remove the step

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/JobsControllerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/JobsControllerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.marklogic.hub.central.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.hub.DatabaseKind;
+import com.marklogic.hub.central.AbstractHubCentralTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JobsControllerTest extends AbstractHubCentralTest {
+
+    @Autowired
+    JobsController jobsController;
+
+    @Test
+    public void testProcessedTargetDatabase() throws JsonProcessingException {
+        String jobString = "{\n" +
+                "   \"jobId\":\"38c44855-1850-4673-941b-1a73beae8148\",\n" +
+                "   \"stepResponses\":{\n" +
+                "      \"1\":{\n" +
+                "         \"targetDatabase\":\"" + getHubClient().getDbName(DatabaseKind.STAGING) + "\"\n" +
+                "      },\n" +
+                "      \"2\":{\n" +
+                "         \"targetDatabase\":\"" + getHubClient().getDbName(DatabaseKind.FINAL) + "\"\n" +
+                "      },\n" +
+                "      \"3\":{\n" +
+                "         \"targetDatabase\":\"testDatabase\"\n" +
+                "      }\n" +
+                "   }\n" +
+                "}";
+
+        JsonNode jobNode = jobsController.processTargetDatabase(objectMapper.readTree(jobString));
+
+        assertEquals("staging", jobNode.path("stepResponses").path("1").path("targetDatabase").asText());
+        assertEquals("final", jobNode.path("stepResponses").path("2").path("targetDatabase").asText());
+        assertEquals("testDatabase", jobNode.path("stepResponses").path("3").path("targetDatabase").asText());
+    }
+}

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/curation/flows.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/curation/flows.data.ts
@@ -40,6 +40,7 @@ const jobRespFailedWithError = {
               "stepDefinitionType": "mapping",
               "stepOutput": stepFailedWithError,
               "targetEntityType": "http://example.org/Customer-0.0.1/Customer",
+              "targetDatabase": "final",
               "fullOutput": null,
               "status": "completed step 2",
               "totalEvents": 3,

--- a/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
+++ b/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
@@ -383,14 +383,14 @@ const Flows: React.FC<Props> = (props) => {
     function handleMouseOver(e, name) {
         setShowLinks(name);
     }
-    const showStepRunResponse = async (step) =>{
-        try{
+
+    const showStepRunResponse = async (step) => {
+        try {
             let response = await axios.get('/api/jobs/' + step.jobId);
-            if(response.status === 200){
-                props.showStepRunResponse(step.stepName, step.stepDefinitionType, "", step.jobId, response.data);
+            if (response.status === 200) {
+                props.showStepRunResponse(step, step.jobId, response.data);
             }
-        }
-        catch(error){
+        } catch (error) {
             handleError(error);
         }
     };
@@ -406,7 +406,7 @@ const Flows: React.FC<Props> = (props) => {
         else if (step.lastRunStatus === "completed step " + step.stepNumber) {
             tooltipText = "Step last ran successfully on "+ stepEndTime;
             return(
-                <MLTooltip overlayStyle={{maxWidth: '200px'}} title= {tooltipText} placement="bottom"  >
+                <MLTooltip overlayStyle={{maxWidth: '200px'}} title= {tooltipText} placement="bottom" onClick={(e) => showStepRunResponse(step)}>
                     <Icon type="check-circle" theme="filled" className={styles.successfulRun} />
                 </MLTooltip>
             );

--- a/marklogic-data-hub-central/ui/src/pages/Browse.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Browse.tsx
@@ -164,8 +164,11 @@ const Browse: React.FC<Props> = ({ location }) => {
         location.state['sortOrder']);
       location.state['tableView'] ? toggleTableView(true) : toggleTableView(false);
     }
-    else if (location.state && location.state.hasOwnProperty('entityName') && location.state.hasOwnProperty('jobId')) {
-      setLatestJobFacet(location.state['jobId'], location.state['entityName']);
+    else if (location.state
+      && location.state.hasOwnProperty('entityName')
+      && location.state.hasOwnProperty('targetDatabase')
+      && location.state.hasOwnProperty('jobId')) {
+      setLatestJobFacet(location.state['jobId'], location.state['entityName'], location.state['targetDatabase']);
     }
     else if (location.state && location.state.hasOwnProperty('entity')) {
       setEntityClearQuery(location.state['entity']);

--- a/marklogic-data-hub-central/ui/src/pages/Run.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Run.test.tsx
@@ -396,7 +396,14 @@ describe('Verify step display', () => {
         // Error 2 is present
         expect(getByText("Error 2")).toBeInTheDocument();
         expect(await(waitForElement(() => getByText("Error 2")))).toBeInTheDocument();
-        fireEvent.click(getByText('Close'));
+
+        // Navigate to Explore tile
+        let exploreButton = await(waitForElement(() => getByText("Explore Curated Data")));
+        fireEvent.click(exploreButton);
+        await wait(() => {
+            expect(mockHistoryPush).toHaveBeenCalledWith({"pathname": "/tiles/explore",
+                "state": {"entityName": "Customer", "targetDatabase": "final", "jobId": "350da405-c1e9-4fa7-8269-d9aefe3b4b9a"}});
+        });
     });
 
 });
@@ -666,7 +673,7 @@ describe('Verify map/match/merge/master step failures in a flow', () => {
         }
         await wait(() => {
             expect(mockHistoryPush).toHaveBeenCalledWith({"pathname": "/tiles/explore",
-                "state": {"entityName": "Customer", "jobId": "350da405-c1e9-4fa7-8269-d9aefe3b4b9a"}});
+                "state": {"entityName": "Customer", "targetDatabase": "final", "jobId": "350da405-c1e9-4fa7-8269-d9aefe3b4b9a"}});
         });
         //TODO- E2E test to check if the explore tile is loaded or not.*/
     });

--- a/marklogic-data-hub-central/ui/src/util/json-utils.tsx
+++ b/marklogic-data-hub-central/ui/src/util/json-utils.tsx
@@ -1,0 +1,11 @@
+export const getFromPath = (path, object) => {
+  let val = object;
+  for (let i = 0; i < path.length; i++) {
+    if (val == null) {
+      return;
+    }
+    val = val[path[i]];
+  }
+
+  return val;
+};

--- a/marklogic-data-hub-central/ui/src/util/search-context.tsx
+++ b/marklogic-data-hub-central/ui/src/util/search-context.tsx
@@ -53,7 +53,7 @@ interface ISearchContextInterface {
   setEntity: (option: string) => void;
   setNextEntity: (option: string) => void;
   setEntityClearQuery: (option: string) => void;
-  setLatestJobFacet: (vals: string, option: string) => void;
+  setLatestJobFacet: (vals: string, entityName: string, targetDatabase: string) => void;
   clearFacet: (constraint: string, val: string) => void;
   clearAllFacets: () => void;
   clearDateFacet: () => void;
@@ -243,17 +243,18 @@ const SearchProvider: React.FC<{ children: any }> = ({ children }) => {
     });
   };
 
-  const setLatestJobFacet = (vals: string, option: string) => {
+  const setLatestJobFacet = (vals: string, entityName: string, targetDatabase: string) => {
     let facets = {};
     facets = { createdByJob: { dataType: "string", stringValues: [vals] } };
     setSearchOptions({
       ...searchOptions,
       start: 1,
       selectedFacets: facets,
-      entityTypeIds: [option],
+      entityTypeIds: [entityName],
       pageNumber: 1,
       pageLength: searchOptions.pageSize,
-      zeroState: false
+      zeroState: false,
+      database: targetDatabase
     });
   };
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/RunStepResponse.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/RunStepResponse.java
@@ -25,6 +25,7 @@ import com.marklogic.hub.step.impl.Step;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class RunStepResponse {
     private String jobId;
@@ -34,6 +35,7 @@ public class RunStepResponse {
     private String stepDefinitionName;
     private String stepDefinitionType;
     private String targetEntityType;
+    private String targetDatabase;
 
     public List<String> stepOutput;
     private Map<String, Object> fullOutput;
@@ -90,6 +92,7 @@ public class RunStepResponse {
         if (targetEntityTextNode != null) {
             this.targetEntityType = targetEntityTextNode.asText();
         }
+        Optional.of(step.getOptions()).map(optionMap -> (TextNode) optionMap.get("targetDatabase")).ifPresent(node -> this.targetDatabase = node.asText());
         return this;
     }
 
@@ -196,12 +199,21 @@ public class RunStepResponse {
         return targetEntityType;
     }
 
+    public String getTargetDatabase() {
+        return targetDatabase;
+    }
+
+    public void setTargetDatabase(String targetDatabase) {
+        this.targetDatabase = targetDatabase;
+    }
+
     @Override
     public String toString() {
-        return String.format("[flowName: %s, stepName: %s, stepDefinitionName: %s, stepDefinitionType: %s, targetEntityType: %s, success: %s, " +
-                "status: %s, totalEvents: %d, successfulEvents: %d, " + "failedEvents: %d, successfulBatches: %d, " +
-                "failedBatches: %d, stepStartTime: %s , stepEndTime: %s]", flowName, stepName, stepDefinitionName,
-            stepDefinitionType, targetEntityType, String.valueOf(success), status, totalEvents, successfulEvents, failedEvents,
+        return String.format("[flowName: %s, stepName: %s, stepDefinitionName: %s, stepDefinitionType: %s, " +
+                        "targetEntityType: %s, targetDatabase: %s, success: %s, status: %s, totalEvents: %d, " +
+                        "successfulEvents: %d, " + "failedEvents: %d, successfulBatches: %d, failedBatches: %d, " +
+                        "stepStartTime: %s , stepEndTime: %s]", flowName, stepName, stepDefinitionName,
+            stepDefinitionType, targetEntityType, targetDatabase, success, status, totalEvents, successfulEvents, failedEvents,
             successfulBatches, failedBatches, stepStartTime, stepEndTime);
     }
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/step/RunStepResponseTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/step/RunStepResponseTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.marklogic.hub.step;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marklogic.hub.flow.Flow;
+import com.marklogic.hub.flow.impl.FlowImpl;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class RunStepResponseTest {
+
+    @Test
+    public void testTargetDatabase() throws IOException {
+        String flowString = "{\n" +
+                "   \"name\":\"testFlow\",\n" +
+                "   \"steps\":{\n" +
+                "      \"1\":{\n" +
+                "         \"name\":\"ingest\",\n" +
+                "         \"stepDefinitionName\":\"default-ingestion\",\n" +
+                "         \"stepDefinitionType\":\"INGESTION\",\n" +
+                "         \"options\":{\n" +
+                "            \"targetDatabase\":\"data-hub-STAGING\"\n" +
+                "         }\n" +
+                "      },\n" +
+                "      \"2\":{\n" +
+                "         \"name\":\"map\",\n" +
+                "         \"stepDefinitionName\":\"entity-services-mapping\",\n" +
+                "         \"stepDefinitionType\":\"MAPPING\",\n" +
+                "         \"options\":{\n" +
+                "            \"targetDatabase\":\"data-hub-FINAL\"\n" +
+                "         }\n" +
+                "      },\n" +
+                "      \"3\":{\n" +
+                "         \"name\":\"match\",\n" +
+                "         \"stepDefinitionName\":\"default-matching\",\n" +
+                "         \"stepDefinitionType\":\"MATCHING\",\n" +
+                "         \"options\":{\n" +
+                "            \n" +
+                "         }\n" +
+                "      }\n" +
+                "   }\n" +
+                "}";
+
+        Flow flow = new FlowImpl();
+        flow.deserialize(new ObjectMapper().readTree(flowString));
+
+        assertEquals("data-hub-STAGING", RunStepResponse.withFlow(flow).withStep("1").getTargetDatabase());
+        assertEquals("data-hub-FINAL", RunStepResponse.withFlow(flow).withStep("2").getTargetDatabase());
+        assertNull(RunStepResponse.withFlow(flow).withStep("3").getTargetDatabase());
+    }
+}


### PR DESCRIPTION
### Description
- Added "targetDatabase" key with the value being the name of the database to RunStepResponse.
- The JobsController then replaces the targetDatabase name with the Database kind (staging/final) so the FE can set the correct database for data exploration.
- Also added the functionality to "explore curated data" by clicking on the status icon for the step.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

