### PR TITLE
DHFPROD-5437: Typeahead search for collection source query field in m…

### DIFF
--- a/marklogic-data-hub-central/ui/src/App.scss
+++ b/marklogic-data-hub-central/ui/src/App.scss
@@ -200,6 +200,16 @@ ul.ant-cascader-menu:nth-child(2) {
   width: auto;
 }
 
+/* Mapping - Create/Edit step Typeahead search  */
+
+.ant-select-dropdown-menu-item-active:not(.ant-select-dropdown-menu-item-disabled) {
+  background-color: #E9F7FE;
+}
+
+.ant-select-auto-complete.ant-select .ant-select-selection--single {
+  width: 95%;
+}
+
 
 /* Styles for MLtable */
 
@@ -255,4 +265,3 @@ ul.ant-cascader-menu:nth-child(2) {
 .ant-modal-confirm-body{
     margin-top: 18px;
 }
-

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/create-edit-mapping-dialog/create-edit-mapping-dialog.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/create-edit-mapping-dialog/create-edit-mapping-dialog.module.scss
@@ -26,6 +26,24 @@
     margin-bottom: 22px;
 }
 
+.questionCircleColl {
+    font-size: 12px;
+    color: #7F86B5;
+    float: right;
+    position: relative;
+    z-index: 100;
+    margin-top: -25px;
+}
+
+.searchIcon {
+    float: right;
+    margin-right: 25px;
+    font-size: 20px;
+    position: relative;
+    margin-top: -30px;
+    color: #bfbfbf;
+}
+
 .asterisk{
     color: #DB4f59;
 }

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/create-edit-mapping-dialog/create-edit-mapping-dialog.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/create-edit-mapping-dialog/create-edit-mapping-dialog.tsx
@@ -1,17 +1,20 @@
-import { Modal, Form, Input, Icon, Radio } from "antd";
-import React, { useState, useEffect } from "react";
+import { Modal, Form, Input, Icon, Radio, AutoComplete } from "antd";
+import React, { useState, useEffect, useContext } from "react";
 import styles from './create-edit-mapping-dialog.module.scss';
 import { NewMapTooltips } from '../../../../config/tooltips.config';
+import { UserContext } from '../../../../util/user-context';
 import { MLButton, MLTooltip } from '@marklogic/design-system';
-
+import axios from "axios"; 
 
 const CreateEditMappingDialog = (props) => {
 
+  const { handleError } = useContext(UserContext)
   const [mapName, setMapName] = useState('');
   const [description, setDescription] = useState(props.mapData && props.mapData != {} ? props.mapData.description : '');
   //const [collections, setCollections] = useState<any[]>([]);
   const [collections, setCollections] = useState('');
-  const [selectedSource, setSelectedSource] = useState(props.mapData && props.mapData != {} ? props.mapData.selectedSource : 'collection');
+  const [collectionOptions, setCollectionOptions] = useState(['a','b']);
+  const [selectedSource, setSelectedSource] = useState(props.mapData && props.mapData != {} ? props.mapData.selectedSource : 'collection')
   const [srcQuery, setSrcQuery] = useState(props.mapData && props.mapData != {} ? props.mapData.sourceQuery : '');
   const [isQuerySelected, setIsQuerySelected] = useState(false);
   //To check submit validity
@@ -156,7 +159,6 @@ const CreateEditMappingDialog = (props) => {
       };
     }
 
-
     setIsValid(true);
 
     //Call create Mapping artifact API function
@@ -171,7 +173,60 @@ const CreateEditMappingDialog = (props) => {
       setIsNameDuplicate(true);
       setIsValid(false);
     }
-  };
+  }
+
+   const handleSearch = async (value: any) => {
+    let databaseName = 'staging';
+    if(props.sourceDatabase){
+      databaseName = props.sourceDatabase.split('-')[2].toLowerCase();
+    }
+    if(value && value.length > 2){
+      try {
+        let data = {
+            "referenceType": "collection",
+            "entityTypeId": " ",
+            "propertyPath": " ",
+            "limit": 10,
+            "dataType": "string",
+            "pattern": value,
+        }
+        const response = await axios.post(`/api/entitySearch/facet-values?database=${databaseName}`, data)
+        setCollectionOptions(response.data);
+      } catch (error) {
+        console.log(error)
+        handleError(error);
+    }
+
+    }else{
+      setCollectionOptions([]);
+    }
+  }
+
+  const handleFocus = () => {
+      setCollectionOptions([]);
+  }
+
+  const handleTypeaheadChange = (data: any) => {
+    if (data === ' ') {
+        setCollectionsTouched(false);
+    }
+    else {
+      setCollectionsTouched(true);
+      setCollections(data);
+      if (props.mapData && props.mapData.collection) {
+        if (props.mapData.collection === data) {
+          setCollectionsTouched(false);
+        }
+      }
+      if (data.length > 0) {
+        if (mapName) {
+         setIsValid(true);
+        }
+      } else {
+        setIsValid(false);
+      }
+    }
+  }
 
   const handleChange = (event) => {
     if (event.target.id === 'name') {
@@ -374,8 +429,8 @@ const CreateEditMappingDialog = (props) => {
           Source Query:&nbsp;<span className={styles.asterisk}>*</span>
           &nbsp;
             </span>} labelAlign="left"
-            validateStatus={(collections || srcQuery || (!isSelectedSourceTouched && !isCollectionsTouched && !isSrcQueryTouched)) ? '' : 'error'}
-            help={(collections || srcQuery || (!isSelectedSourceTouched && !isCollectionsTouched && !isSrcQueryTouched)) ? '' : 'Collection or Query is required'}
+            validateStatus={((collections && selectedSource === 'collection') || (srcQuery && selectedSource !== 'collection') || (!isSelectedSourceTouched && !isCollectionsTouched && !isSrcQueryTouched)) ? '' : 'error'}
+            help={((collections && selectedSource === 'collection') || (srcQuery && selectedSource !== 'collection') || (!isSelectedSourceTouched && !isCollectionsTouched && !isSrcQueryTouched)) ? '' : 'Collection or Query is required'}
             >
           <Radio.Group
             id="srcType"
@@ -385,18 +440,23 @@ const CreateEditMappingDialog = (props) => {
             disabled={!props.canReadWrite}
           >
           </Radio.Group>
-          {selectedSource === 'collection' ? <div ><span className={styles.srcCollectionInput}><Input
+          {selectedSource === 'collection' ? <div ><span className={styles.srcCollectionInput}><AutoComplete
             id="collList"
             //mode="tags"
             className={styles.input}
-            placeholder="Enter collection name"
+            dataSource={collectionOptions}
+            aria-label="collection-input"
+            placeholder= {<span>Enter collection name</span>}
             value={collections}
             disabled={!props.canReadWrite}
-            onChange={handleChange}
+            onSearch={handleSearch}
+            onFocus= {handleFocus}
+            onChange={handleTypeaheadChange}
           >
             {/* {collectionsList} */}
-          </Input>&nbsp;&nbsp;<MLTooltip title={NewMapTooltips.sourceQuery}>
-            <Icon type="question-circle" className={styles.questionCircle} theme="filled" />
+          </AutoComplete>&nbsp;&nbsp;{props.canReadWrite ? <Icon className={styles.searchIcon} type="search" theme="outlined"/> : ''}
+          <MLTooltip title={NewMapTooltips.sourceQuery}>
+            <Icon type="question-circle" className={styles.questionCircleColl} theme="filled" />
           </MLTooltip></span></div> : <span><TextArea
             id="srcQuery"
             placeholder="Enter source query"

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
@@ -101,9 +101,11 @@ const MappingCard: React.FC<Props> = (props) => {
         setNewMap(true);
     };
 
-    const OpenEditStepDialog = (index) => {
+    const OpenEditStepDialog = async (name, index) => {
         setTitle('Edit Mapping Step');
+        let settingsData = await axios.get(`/api/steps/mapping/${name}`);
         setMapData(prevState => ({ ...prevState, ...props.data[index]}));
+        setSourceDatabaseName(settingsData.data.sourceDatabase);
         setNewMap(true);
     };
 
@@ -640,7 +642,7 @@ const MappingCard: React.FC<Props> = (props) => {
                         >
                             <Card
                                 actions={[
-                                    <MLTooltip title={'Edit'} placement="bottom"><Icon className={styles.editIcon} type="edit" key ="last" role="edit-mapping button" data-testid={elem.name+'-edit'} onClick={() => OpenEditStepDialog(index)}/></MLTooltip>,
+                                    <MLTooltip title={'Edit'} placement="bottom"><Icon className={styles.editIcon} type="edit" key ="last" role="edit-mapping button" data-testid={elem.name+'-edit'} onClick={() => OpenEditStepDialog(elem.name, index)}/></MLTooltip>,
                                     <MLTooltip title={'Step Details'} placement="bottom"><i style={{ fontSize: '16px', marginLeft: '-5px', marginRight: '5px'}}><FontAwesomeIcon icon={faSlidersH} onClick={() => openSourceToEntityMapping(elem.name,index)} data-testid={`${elem.name}-stepDetails`}/></i></MLTooltip>,
                                     <MLTooltip title={'Settings'} placement="bottom"><Icon type="setting" key="setting" role="settings-mapping button" data-testid={elem.name+'-settings'} onClick={() => OpenMappingSettingsDialog(index)}/></MLTooltip>,
                                     props.canReadWrite ? <MLTooltip title={'Delete'} placement="bottom"><i key ="last" role="delete-mapping button" data-testid={elem.name+'-delete'} onClick={() => handleCardDelete(elem.name)}><FontAwesomeIcon icon={faTrashAlt} className={styles.deleteIcon} size="lg"/></i></MLTooltip> : <MLTooltip title={'Delete: ' + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: '200px'}}><i role="disabled-delete-mapping button" data-testid={elem.name+'-disabled-delete'} onClick={(event) => event.preventDefault()}><FontAwesomeIcon icon={faTrashAlt} className={styles.disabledDeleteIcon} size="lg"/></i></MLTooltip>,
@@ -693,6 +695,7 @@ const MappingCard: React.FC<Props> = (props) => {
                 createMappingArtifact={props.createMappingArtifact}
                 deleteMappingArtifact={props.deleteMappingArtifact}
                 mapData={mapData}
+                sourceDatabase={sourceDatabaseName}
                 canReadWrite={props.canReadWrite}
                 canReadOnly={props.canReadOnly}/>
                 {deleteConfirmation}

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/create-edit-matching-dialog/create-edit-matching-dialog.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/create-edit-matching-dialog/create-edit-matching-dialog.module.scss
@@ -26,6 +26,24 @@
     margin-bottom: 22px;
 }
 
+.questionCircleColl {
+    font-size: 12px;
+    color: #7F86B5;
+    float: right;
+    position: relative;
+    z-index: 100;
+    margin-top: -25px;
+}
+
+.searchIcon {
+    float: right;
+    margin-right: 25px;
+    font-size: 20px;
+    position: relative;
+    margin-top: -30px;
+    color: #bfbfbf;
+}
+
 .asterisk{
     color: #DB4f59;
 }

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/create-edit-matching-dialog/create-edit-matching-dialog.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/create-edit-matching-dialog/create-edit-matching-dialog.test.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
-import { render, fireEvent, cleanup } from '@testing-library/react';
+import { render, fireEvent, cleanup, wait } from '@testing-library/react';
 import CreateEditMatchingDialog from './create-edit-matching-dialog';
 import data from "../../../../assets/mock-data/curation/matching.data";
+import axiosMock from 'axios';
+import {stringSearchResponse} from "../../../../assets/mock-data/explore/facet-props";
 
+
+jest.mock('axios');
 describe('Create/Edit Matching artifact component', () => {
 
-    afterEach(cleanup);
-
+  afterEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+});
     test('Verify Edit Matching dialog renders correctly for a read only user', () => {
         const { getByText, getByPlaceholderText, getByLabelText } = render(<CreateEditMatchingDialog {...data.editMatching} canReadOnly={true} canReadWrite={false}/>);
 
@@ -17,7 +23,8 @@ describe('Create/Edit Matching artifact component', () => {
         expect(getByLabelText('Collection')).toBeChecked();
         expect(getByLabelText('Collection')).toBeDisabled();
         expect(getByLabelText('Query')).toBeDisabled();
-        expect(getByPlaceholderText('Enter collection name')).toBeDisabled();
+        const collInput = document.querySelector(('#collList .ant-input'))
+        expect(collInput).toBeDisabled();
 
         expect(getByText('Save')).toBeDisabled();
         expect(getByText('Cancel')).toBeEnabled();
@@ -32,7 +39,7 @@ describe('Create/Edit Matching artifact component', () => {
         expect(getByPlaceholderText('Enter description')).toBeInTheDocument();
         expect(getByLabelText('Collection')).toBeInTheDocument();
         expect(getByLabelText('Query')).toBeInTheDocument();
-        expect(getByPlaceholderText('Enter collection name')).toBeInTheDocument();
+        expect(getByLabelText('collection-input')).toBeInTheDocument();
         expect(getByText('Save')).toBeDisabled();
         expect(getByText('Cancel')).toBeEnabled();
         //Collection radio button should be selected by default
@@ -53,18 +60,40 @@ describe('Create/Edit Matching artifact component', () => {
         expect(saveButton).toBeDisabled();
     });
 
-    test('Verify able to type in input fields', () => {
+    test('Verify able to type in input fields and typeahead search in collections field', async () => {
+        axiosMock.post['mockImplementationOnce'](jest.fn(() => Promise.resolve({status: 200, data: stringSearchResponse})));
         const { getByText, getByLabelText, getByPlaceholderText } = render(<CreateEditMatchingDialog {...data.newMatching} />);
 
         const descInput = getByPlaceholderText('Enter description');
-        const collInput = getByPlaceholderText('Enter collection name');
-        expect(collInput).toBeInTheDocument();
+        const collInput = document.querySelector(('#collList .ant-input'))
         const saveButton = getByText('Save');
         saveButton.onclick = jest.fn();
 
         fireEvent.change(descInput, { target: {value: 'test description'}});
         expect(descInput).toHaveValue('test description');
-        fireEvent.change(collInput, { target: {value: 'testCollection'}});
+        await wait(() => {
+            if(collInput){
+              fireEvent.change(collInput, { target: {value: 'ada'} });
+            }
+          });
+          let url = "/api/entitySearch/facet-values?database=staging";
+          let payload = {
+              'referenceType':"collection",
+              'entityTypeId':" ",
+              'propertyPath':" ",
+              'limit':10,
+              'dataType':"string",
+              'pattern':'ada'
+          };
+          expect(axiosMock.post).toHaveBeenCalledWith(url, payload);
+          expect(axiosMock.post).toHaveBeenCalledTimes(1);
+          expect(getByText('Adams Cole')).toBeInTheDocument();
+          
+        await wait(() => {
+            if(collInput){
+              fireEvent.change(collInput, { target: {value: 'testCollection'} });
+            }
+          });
         expect(collInput).toHaveValue('testCollection');
         fireEvent.click(getByLabelText('Query'));
         const queryInput = getByPlaceholderText('Enter source query');
@@ -118,7 +147,8 @@ describe('Create/Edit Matching artifact component', () => {
         expect(getByPlaceholderText('Enter description')).toHaveValue('Description of testMatching');
 
         expect(getByLabelText('Collection')).toBeChecked();
-        expect(getByPlaceholderText('Enter collection name')).toHaveValue('matching-collection');
+        const collInput = document.querySelector(('#collList .ant-input'))
+        expect(collInput).toHaveValue('matching-collection');
 
         fireEvent.click(getByLabelText('Query'));
         expect(getByPlaceholderText('Enter source query')).toHaveTextContent("cts.collectionQuery(['matching-collection'])");


### PR DESCRIPTION
…apping step

### Description

- Added typeahead search to Collections field in 'create mapping' and 'create matching' dialogs

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

