### PR TITLE
DHFPROD-6096: Spark connector now handles write failures and aborts

### DIFF
--- a/marklogic-data-hub-spark-connector/spark-test-project/src/main/resources/log4j.properties
+++ b/marklogic-data-hub-spark-connector/spark-test-project/src/main/resources/log4j.properties
@@ -4,12 +4,18 @@
 # Root logger option
 log4j.rootLogger=WARN, stdout
 
+log4j.logger.test=INFO, stdout
+log4j.additivity.test=false
+
 log4j.logger.com.marklogic.hub=DEBUG, stdout
 log4j.additivity.com.marklogic.hub=false
+
+log4j.logger.com.marklogic.client.dataservices=TRACE, stdout
+log4j.additivity.com.marklogic.client.dataservices=false
 
 # Direct log messages to stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1} - %m%n
 

--- a/marklogic-data-hub-spark-connector/src/main/java/com/marklogic/hub/spark/sql/sources/v2/writer/AtLeastOneWriteFailedMessage.java
+++ b/marklogic-data-hub-spark-connector/src/main/java/com/marklogic/hub/spark/sql/sources/v2/writer/AtLeastOneWriteFailedMessage.java
@@ -1,0 +1,10 @@
+package com.marklogic.hub.spark.sql.sources.v2.writer;
+
+import org.apache.spark.sql.sources.v2.writer.WriterCommitMessage;
+
+/**
+ * Indicates that at least one write failed, which allows the DataSourceWriter to know whether the job finished with or
+ * without errors.
+ */
+public class AtLeastOneWriteFailedMessage implements WriterCommitMessage {
+}

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/HandleAbortedWriterTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/HandleAbortedWriterTest.java
@@ -1,0 +1,37 @@
+package com.marklogic.hub.spark.sql.sources.v2;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HandleAbortedWriterTest extends AbstractSparkConnectorTest {
+
+    @Test
+    void dataWriterIsAborted() {
+        initializeDataWriter(newFruitOptions());
+        assertEquals("started", getJobDocumentStatus());
+
+        hubDataWriter.write(buildRow("apple", "red"));
+        hubDataWriter.abort();
+        logger.info("This test is only verifying that abort doesn't throw an error. It is expected to interrupt " +
+            "the BulkInputCaller, but it's not clear what impact that has - as of Java Client 5.3.0, it's possible to " +
+            "keep using the caller by calling accept and awaitCompletion on it.");
+
+        assertEquals("started", getJobDocumentStatus(), "Aborting the DataWriter won't impact the job document; it's " +
+            "still on the DataSourceWriter to take care of updating the job doc");
+    }
+
+    @Test
+    void dataSourceWriterIsAborted() {
+        initializeDataWriter(newFruitOptions());
+        assertEquals("started", getJobDocumentStatus());
+
+        writeRows(buildRow("apple", "red"), buildRow("blueberry", "blue"));
+        assertEquals(2, getFruitCount(), "Just verifying the two fruits were written");
+
+        dataSourceWriter.abort(null);
+        assertEquals("canceled", getJobDocumentStatus(), "If the DataSourceWriter is aborted for any reason, the job " +
+            "document should have a status of 'canceled'. Note that this does not imply whether any writes failed. " +
+            "But that is a limitation of the JobStatus class in DHF.");
+    }
+}

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/HandleFailedWriteTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/HandleFailedWriteTest.java
@@ -1,0 +1,71 @@
+package com.marklogic.hub.spark.sql.sources.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.client.io.BytesHandle;
+import com.marklogic.client.io.Format;
+import com.marklogic.hub.spark.sql.sources.v2.writer.AtLeastOneWriteFailedMessage;
+import org.apache.spark.sql.sources.v2.writer.WriterCommitMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HandleFailedWriteTest extends AbstractSparkConnectorTest {
+
+    @BeforeEach
+    void setupCustomIngestionEndpointThatThrowsAnErrorForBanana() {
+        installCustomIngestionEndpoint();
+
+        String moduleTextThatCanThrowError = "declareUpdate(); const ds = require('/data-hub/5/data-services/ds-utils.sjs'); var input; " +
+            "let role = 'data-hub-operator'; " +
+            "var inputArray; " +
+            "if (input instanceof Sequence) { " +
+            "  inputArray = input.toArray().map(item => fn.head(xdmp.fromJSON(item))); " +
+            "} else { " +
+            "  inputArray = [fn.head(xdmp.fromJSON(input))]; " +
+            "} " +
+            "for (var fruit of inputArray) {" +
+            "  if (fruit.fruitName == 'banana') { ds.throwServerError('Throwing error because fruitName is banana'); }" +
+            "  else {" +
+            "    xdmp.documentInsert('/test/' + fruit.fruitName + '.json', fruit, [xdmp.permission(role, 'read'), xdmp.permission(role, 'update')], 'fruits');" +
+            "  }" +
+            "}";
+
+        getHubClient().getModulesClient().newDocumentManager().write(CUSTOM_INGESTION_ENDPOINT_PATH,
+            new BytesHandle(moduleTextThatCanThrowError.getBytes()).withFormat(Format.TEXT));
+
+    }
+
+    @Test
+    void errorDispositionShouldDefaultToSkipCall() {
+        initializeDataWriter(newFruitOptions().withIngestApiPath(CUSTOM_INGESTION_API_PATH));
+
+        WriterCommitMessage message = writeRowsAndCommitWithSourceWriter(
+            buildRow("apple", "red"),
+            buildRow("banana", "yellow"),
+            buildRow("carrot", "orange")
+        );
+
+        assertTrue(message instanceof AtLeastOneWriteFailedMessage,
+            "Because the call to write a banana failed, and because the default error disposition is SKIP_CALL, the " +
+                "call to write a carrot after banana should have completed, but a FailedWriteSkipMessage should " +
+                "have been returned so that the DataSourceWriter knows that the job finished but with errors");
+
+        verifyJobFinishedWithErrors();
+        verifyOneFruitWasWritten();
+    }
+
+    private void verifyJobFinishedWithErrors() {
+        JsonNode job = getJobDocument();
+        assertEquals("finished_with_errors", job.get("job").get("jobStatus").asText(),
+            "Since the DataSourceWriter received at least one FailedWriteSkipMessage, the job should have a status " +
+                "of finished_with_errors");
+    }
+
+    private void verifyOneFruitWasWritten() {
+        assertEquals(1, getFruitCount(), "With a batch size of 2 (as defined in the custom endpoint API file), " +
+            "the first batch containing banana should have failed, but the second batch containing only carrot " +
+            "should have worked");
+    }
+}

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/Options.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/Options.java
@@ -14,7 +14,6 @@ import java.util.Map;
  */
 public class Options {
 
-    private Integer batchSize;
     private String uriPrefix;
     private String ingestApiPath;
     private String collections;
@@ -38,9 +37,6 @@ public class Options {
             params.putAll(hubProperties);
         }
 
-        if (batchSize != null) {
-            params.put("batchsize", batchSize + "");
-        }
         if (uriPrefix != null) {
             params.put("uriprefix", uriPrefix);
         }
@@ -77,11 +73,6 @@ public class Options {
         }
 
         return new DataSourceOptions(params);
-    }
-
-    public Options withBatchSize(Integer batchSize) {
-        this.batchSize = batchSize;
-        return this;
     }
 
     public Options withUriPrefix(String uriPrefix) {
@@ -123,5 +114,4 @@ public class Options {
         this.ingestEndpointState = ingestEndpointState;
         return this;
     }
-
 }

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/WriteDataWithOptionsTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/WriteDataWithOptionsTest.java
@@ -3,11 +3,8 @@ package com.marklogic.hub.spark.sql.sources.v2;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.JacksonHandle;
-import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.sources.v2.writer.DataWriter;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -16,10 +13,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class WriteDataWithOptionsTest extends AbstractSparkConnectorTest {
 
     @Test
-    void ingestDocsWithCollection() throws IOException {
+    void ingestDocsWithCollection() {
         String collections = "fruits,stuff";
-        DataWriter<InternalRow> dataWriter = buildDataWriter(newFruitOptions().withCollections(collections));
-        dataWriter.write(buildRow("pineapple", "green"));
+        initializeDataWriter(newFruitOptions().withCollections(collections));
+        writeRows(buildRow("pineapple", "green"));
 
         DocumentMetadataHandle metadata = getFirstFruitMetadata();
         assertEquals(2, metadata.getCollections().size());
@@ -34,30 +31,30 @@ public class WriteDataWithOptionsTest extends AbstractSparkConnectorTest {
     }
 
     @Test
-    void ingestDocsWithSourceName() throws IOException {
+    void ingestDocsWithSourceName() {
         String sourceName = "spark";
-        DataWriter<InternalRow> dataWriter = buildDataWriter(newFruitOptions().withSourceName(sourceName));
-        dataWriter.write(buildRow("pineapple", "green"));
+        initializeDataWriter(newFruitOptions().withSourceName(sourceName));
+        writeRows(buildRow("pineapple", "green"));
 
         JsonNode doc = getHubClient().getStagingClient().newJSONDocumentManager().read(getFruitUris()[0], new JacksonHandle()).get();
         assertEquals(sourceName, doc.get("envelope").get("headers").get("sources").get(0).get("name").asText());
     }
 
     @Test
-    void ingestDocsWithSourceType() throws IOException {
+    void ingestDocsWithSourceType() {
         String sourceType = "fruits";
-        DataWriter<InternalRow> dataWriter = buildDataWriter(newFruitOptions().withSourceType(sourceType));
-        dataWriter.write(buildRow("pineapple", "green"));
+        initializeDataWriter(newFruitOptions().withSourceType(sourceType));
+        writeRows(buildRow("pineapple", "green"));
 
         JsonNode doc = getHubClient().getStagingClient().newJSONDocumentManager().read(getFruitUris()[0], new JacksonHandle()).get();
         assertEquals(sourceType, doc.get("envelope").get("headers").get("sources").get(0).get("datahubSourceType").asText());
     }
 
     @Test
-    void ingestDocsWithPermissions() throws IOException {
+    void ingestDocsWithPermissions() {
         String permissions = "rest-extension-user,read,rest-reader,update";
-        DataWriter<InternalRow> dataWriter = buildDataWriter(newFruitOptions().withPermissions(permissions));
-        dataWriter.write(buildRow("pineapple", "green"));
+        initializeDataWriter(newFruitOptions().withPermissions(permissions));
+        writeRows(buildRow("pineapple", "green"));
 
         DocumentMetadataHandle.DocumentPermissions perms = getFirstFruitMetadata().getPermissions();
         assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("rest-extension-user").iterator().next());

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/WriteJobsDataTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/WriteJobsDataTest.java
@@ -2,21 +2,16 @@ package com.marklogic.hub.spark.sql.sources.v2;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.marklogic.client.io.DocumentMetadataHandle;
-import org.apache.avro.data.Json;
-import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.sources.v2.writer.DataWriter;
 import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class WriteJobsDataTest extends AbstractSparkConnectorTest {
 
     @Test
-    void ingestDocsWithJobDoc() throws IOException {
-        DataWriter<InternalRow> dataWriter = buildDataWriter(newFruitOptions());
-        dataWriter.write(buildRow("pineapple", "green"));
+    void ingestDocsWithJobDoc() {
+        initializeDataWriter(newFruitOptions());
+        writeRows(buildRow("pineapple", "green"));
 
         DocumentMetadataHandle metadata = getFirstFruitMetadata();
         String jobId = metadata.getMetadataValues().get("datahubCreatedByJob");
@@ -45,7 +40,7 @@ public class WriteJobsDataTest extends AbstractSparkConnectorTest {
         assertEquals(DocumentMetadataHandle.Capability.UPDATE, perms.get("flow-operator-role").iterator().next());
         assertEquals(DocumentMetadataHandle.Capability.UPDATE, perms.get("data-hub-job-internal").iterator().next());
 
-        dataSourceWriter.get().commit(null);
+        dataSourceWriter.commit(null);
 
         jobDoc = getJobDoc(jobUri);
         assertEquals("finished", jobDoc.get("job").get("jobStatus").asText());

--- a/marklogic-data-hub-spark-connector/src/test/resources/log4j.properties
+++ b/marklogic-data-hub-spark-connector/src/test/resources/log4j.properties
@@ -4,8 +4,11 @@
 # Root logger option
 log4j.rootLogger=WARN, stdout
 
-log4j.logger.com.marklogic.hub=INFO, stdout
+log4j.logger.com.marklogic.hub=DEBUG, stdout
 log4j.additivity.com.marklogic.hub=false
+
+log4j.logger.com.marklogic.client.dataservices=TRACE, stdout
+log4j.additivity.com.marklogic.client.dataservices=false
 
 # Direct log messages to stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/marklogic-data-hub-spark-connector/bulkIngester.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/marklogic-data-hub-spark-connector/bulkIngester.api
@@ -15,5 +15,8 @@
             "multiple": true,
             "nullable": true
         }
-    ]
+    ],
+    "$bulk": {
+        "inputBatchSize": 100
+    }
 }


### PR DESCRIPTION
### Description

Also removed the concept of batchSize - the BulkInputCaller already supports this itself, we don't need to maintain a list of records in HubDataWriter. 

As a result of this, rewrote a lot of the tests so that HubDataWriter.commit is called after all the fruit rows are written. This ensures that any pending writes are flushed.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

