### PR TITLE
DHFPROD-6117:Handle duplicate custom mapping functions

### DIFF
--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping-functions/getMappingFunctions.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping-functions/getMappingFunctions.sjs
@@ -10,6 +10,7 @@ const mlFunctions = esMappingLib.getMarkLogicMappingFunctions();
   test.assertTrue(findFunction("document-uri") == null),
   test.assertTrue(findFunction("sum")["signature"].includes("sum")),
   test.assertTrue(findFunction("fn:sum") == null, "'fn:' has been stripped from the function name and signature"),
+  test.assertTrue(echoCount() == 1 || echoCount() == 0, "echo() function if present should be present only once"),
   test.assertTrue(xpathFunctions.length >= 116,
     "As of 10.0-4 server, there are 116 mapping xpath functions (accounting for all excluded ones); " +
     "there may be more in a future version, but we expect at least that many to exist; actual length: " + xpathFunctions.length),
@@ -22,4 +23,14 @@ function findFunction(functionName){
   return xpathFunctions.find(func => {
     return func.functionName == functionName
   });
+}
+
+function echoCount(){
+  let count = 0;
+  mlFunctions.forEach((func) =>{
+    if(func.functionName == 0){
+      count ++;
+    }
+  })
+  return count;
 }


### PR DESCRIPTION
### Description
Handle duplicate custom mapping functions. This failure https://jenkins.marklogic.com/blue/organizations/jenkins/Datahub_CI/detail/PR-4759/10/tests was because there were 2 custom mapping functions of name 'echo'.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

