### PR TITLE
DHFPROD-6153: Added logging for when connector writes a module

### DIFF
--- a/marklogic-data-hub-spark-connector/src/main/java/com/marklogic/hub/spark/sql/sources/v2/DefaultSource.java
+++ b/marklogic-data-hub-spark-connector/src/main/java/com/marklogic/hub/spark/sql/sources/v2/DefaultSource.java
@@ -205,6 +205,7 @@ class HubDataSourceWriter extends LoggingObject implements StreamWriter {
             try {
                 DocumentManager modMgr = hubClient.getModulesClient().newDocumentManager();
                 DocumentMetadataHandle metadata = buildDocumentMetadata();
+                logger.info("Loading module: " + modulePath);
                 modMgr.write(modulePath, metadata, new InputStreamHandle(new ClassPathResource(modulePath).getInputStream()).withFormat(format));
             } catch (IOException e) {
                 throw new RuntimeException("Unable to write endpoint at path: " + modulePath + "; cause: " + e.getMessage(), e);


### PR DESCRIPTION
### Description

This seems important to see in the logging, particularly when running on DHF 5.2.x

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

