### PR TITLE
DHFPROD-6163:Add the AWS Glue job info in the job document.

### DIFF
--- a/marklogic-data-hub-spark-connector/src/main/java/com/marklogic/hub/spark/sql/sources/v2/DefaultSource.java
+++ b/marklogic-data-hub-spark-connector/src/main/java/com/marklogic/hub/spark/sql/sources/v2/DefaultSource.java
@@ -249,6 +249,11 @@ class HubDataSourceWriter extends LoggingObject implements StreamWriter {
             if(options.get("additionalexternalmetadata")!=null) {
                 externalMetadata = (ObjectNode) objectMapper.readTree(options.get("additionalexternalmetadata"));
             }
+        } catch(Exception e) {
+                throw new IllegalArgumentException("Unable to parse additionalExternalMetadata option as a JSON object; " +
+                    "cause: " + e.getMessage(), e);
+        }
+        try{
             externalMetadata.set("sparkSchema", objectMapper.readTree(schema.json()));
 
         } catch (Exception e) {

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/Options.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/Options.java
@@ -26,6 +26,7 @@ public class Options {
     private String finalizeJobApiPath;
     private Map<String, String> hubProperties;
     private JsonNode additionalExternalMetadata;
+    private String additionalExternalMetadataAsString;
 
     public Options() {
     }
@@ -85,6 +86,9 @@ public class Options {
         if(additionalExternalMetadata != null) {
             params.put("additionalexternalmetadata", additionalExternalMetadata.toString());
         }
+        if(additionalExternalMetadataAsString !=null) {
+            params.put("additionalexternalmetadata", additionalExternalMetadataAsString);
+        }
 
         return new DataSourceOptions(params);
     }
@@ -139,8 +143,13 @@ public class Options {
         return this;
     }
 
-    public Options withExternalMetadata(JsonNode externalMetadata){
-        this.additionalExternalMetadata = externalMetadata;
+    public Options withAdditionalExternalMetadata(JsonNode additionalExternalMetadata){
+        this.additionalExternalMetadata = additionalExternalMetadata;
+        return this;
+    }
+
+    public Options withAdditionalExternalMetadataAsString(String additionalExternalMetadataAsString){
+        this.additionalExternalMetadataAsString = additionalExternalMetadataAsString;
         return this;
     }
 }

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/WriteJobsDataTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/WriteJobsDataTest.java
@@ -51,9 +51,9 @@ public class WriteJobsDataTest extends AbstractSparkConnectorTest {
 
     @Test
     void testDocsWithAdditionalExternalMetadata() {
-        ObjectNode externalMetadata = objectMapper.createObjectNode();
-        externalMetadata.put("jobName", "testJob");
-        initializeDataWriter(newFruitOptions().withExternalMetadata(externalMetadata));
+        ObjectNode additionalExternalMetadata = objectMapper.createObjectNode();
+        additionalExternalMetadata.put("jobName", "testJob");
+        initializeDataWriter(newFruitOptions().withAdditionalExternalMetadata(additionalExternalMetadata));
         writeRows(buildRow("pineapple", "green"));
 
         DocumentMetadataHandle metadata = getFirstFruitMetadata();
@@ -66,6 +66,17 @@ public class WriteJobsDataTest extends AbstractSparkConnectorTest {
         assertNotNull(jobDoc.get("job").get("externalMetadata"));
         assertNotNull(jobDoc.get("job").get("externalMetadata").get("jobName"));
         assertEquals("testJob", jobDoc.get("job").get("externalMetadata").get("jobName").asText());
+
+    }
+
+    @Test
+    void testDocsWithInvalidAdditionalExternalMetadata() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> initializeDataWriter(newFruitOptions().withAdditionalExternalMetadataAsString("testString")),
+            "Expected an error because additionalExternalMetadata is a String instead of Json"
+        );
+        assertTrue(ex.getMessage().contains("Unable to parse additionalExternalMetadata option as a JSON object; cause: Unrecognized token 'testString': " +
+            "was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')"));
 
     }
 


### PR DESCRIPTION
### Description - Adding exception.  Thrown when additionalExternalMetadata is invalid.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

