### PR TITLE
DHFPROD-5961: Add run icon and 'run in flow' menu to all steps

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/mapping.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/mapping.spec.tsx
@@ -204,6 +204,41 @@ describe('Mapping', () => {
 
     runPage.runStep(mapStep).click();
     cy.verifyStepRunResult('success','Mapping', mapStep);
+
+    tiles.closeRunMessage().click();
+    runPage.deleteStep(mapStep).click();
+    loadPage.confirmationOptions('Yes').click();
+
+    //Verify Run Map step in an existing Flow
+    toolbar.getCurateToolbarIcon().click();
+    cy.waitUntil(() => curatePage.getEntityTypePanel('Customer').should('be.visible'));
+    curatePage.toggleEntityTypeId('Order');
+    curatePage.runStepInCardView(mapStep).click();
+    curatePage.runStepInExistingFlow(mapStep, flowName);
+    curatePage.addStepToFlowRunConfirmationMessage().should('be.visible');
+    curatePage.confirmAddStepToFlow(mapStep, flowName);
+    //Step should automatically run
+    cy.verifyStepRunResult('success','Mapping', mapStep);
+    tiles.closeRunMessage().click();
+
+    //Delete the flow
+    runPage.deleteFlow(flowName).click();
+    runPage.deleteFlowConfirmationMessage(flowName).should('be.visible');
+    loadPage.confirmationOptions('Yes').click();
+
+    //Verify Run Map step in a new Flow
+    toolbar.getCurateToolbarIcon().click();
+    cy.waitUntil(() => curatePage.getEntityTypePanel('Customer').should('be.visible'));
+    curatePage.toggleEntityTypeId('Order');
+    curatePage.runStepInCardView(mapStep).click();
+    curatePage.runInNewFlow(mapStep).click({force: true});
+    cy.findByText('New Flow').should('be.visible');
+    runPage.setFlowName(flowName);
+    runPage.setFlowDescription(`${flowName} description`);
+    loadPage.confirmationOptions('Save').click();
+    //Step should automatically run
+    cy.verifyStepRunResult('success','Mapping', mapStep);
+
     runPage.explorerLink().click()
     browsePage.getTableViewInstanceIcon().click();
 

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestion.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestion.spec.tsx
@@ -101,6 +101,7 @@ describe('Default ingestion ', () => {
     it('Verifies CRUD functionality from card view and run in a flow', () => {
         let stepName = 'cyCardView';
         let flowName= 'newE2eFlow';
+        let flowName2= 'newE2eFlow2';
         //Verify Cancel
         loadPage.loadView('th-large').click();
         loadPage.addNewButton('card').click();
@@ -172,16 +173,46 @@ describe('Default ingestion ', () => {
         runPage.setFlowDescription(`${flowName} description`);
         loadPage.confirmationOptions('Save').click();
         cy.verifyStepAddedToFlow('Load', stepName);
+        runPage.deleteStep(stepName).click();
+        loadPage.confirmationOptions('Yes').click();
 
-        //Run the flow with invalid input
-        runPage.runStep(stepName).click();
+        //Verify Run Load step in an Existing Flow
+        cy.waitUntil(() => toolbar.getLoadToolbarIcon()).click();
+        cy.waitUntil(() => loadPage.addNewButton('card').should('be.visible'));
+        loadPage.runStepInCardView(stepName).click();
+        loadPage.runStepInExistingFlow(stepName, flowName);
+        loadPage.addStepToFlowRunConfirmationMessage().should('be.visible');
+        loadPage.confirmationOptions('Yes').click();
+        cy.verifyStepAddedToFlow('Load', stepName);
+        //Upload file to start running, test with invalid input
         cy.uploadFile('input/test-1');
         cy.verifyStepRunResult('failed','Ingestion', stepName)
-            .should('contain.text', 'Document is not JSON');
+        .should('contain.text', 'Document is not JSON');
         tiles.closeRunMessage().click();
 
         //Run the flow with JSON input
         runPage.runStep(stepName).click();
+        cy.uploadFile('input/test-1.json');
+        cy.verifyStepRunResult('success','Ingestion', stepName);
+        tiles.closeRunMessage().click();
+        runPage.deleteStep(stepName).click();
+        loadPage.confirmationOptions('Yes').click();
+        //Delete the flow
+        runPage.deleteFlow(flowName).click();
+        runPage.deleteFlowConfirmationMessage(flowName).should('be.visible');
+        loadPage.confirmationOptions('Yes').click();
+
+        //Verify Run Load step in a New Flow
+        cy.waitUntil(() => toolbar.getLoadToolbarIcon()).click();
+        cy.waitUntil(() => loadPage.addNewButton('card').should('be.visible'));
+        loadPage.runStepInCardView(stepName).click();
+        loadPage.runInNewFlow(stepName).click({force: true});
+        cy.findByText('New Flow').should('be.visible');
+        runPage.setFlowName(flowName);
+        runPage.setFlowDescription(`${flowName} description`);
+        loadPage.confirmationOptions('Save').click();
+        cy.verifyStepAddedToFlow('Load', stepName);
+        //Upload file to start running
         cy.uploadFile('input/test-1.json');
         cy.verifyStepRunResult('success','Ingestion', stepName);
         tiles.closeRunMessage().click();

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/curate.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/curate.tsx
@@ -81,6 +81,23 @@ class CuratePage {
         return cy.findByTestId(`${stepName}-edit`);
     }
 
+    runStepInCardView(stepName: string) {
+        return cy.findByTestId(`${stepName}-run`);
+    }
+
+    runInNewFlow(stepName: string) {
+        return cy.findByTestId(`${stepName}-run-toNewFlow`);
+    };
+
+    runExistingFlowsList(stepName: string) {
+        return cy.findByTestId(`${stepName}-run-flowsList`);
+    }
+
+    runStepInExistingFlow(stepName: string, flowName: string) {
+        this.runExistingFlowsList(stepName).click({force: true});
+        cy.findByLabelText(`${flowName}-run-option`).click({force:true});
+    }
+
     verifyStepNameIsVisible(stepName: string) {
         cy.get('#name').should('be.visible');
         cy.findByText(stepName).should('be.visible');
@@ -106,8 +123,16 @@ class CuratePage {
         return cy.findByLabelText('step-not-in-flow');
     }
 
+    addStepToFlowRunConfirmationMessage() {
+        return cy.findByLabelText('step-not-in-flow-run');
+    }
+
     addStepExistingToFlowConfirmationMessage() {
         return cy.findByLabelText('step-in-flow');
+    }
+
+    addStepExistingToFlowRunConfirmationMessage() {
+        return cy.findByLabelText('step-in-flow-run');
     }
 
     confirmAddStepToFlow(stepName: string, flowName: string) {

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/load.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/load.tsx
@@ -79,10 +79,18 @@ class LoadPage {
         return cy.findByLabelText('step-not-in-flow');
     }
 
+    addStepToFlowRunConfirmationMessage() {
+        return cy.findByLabelText('step-not-in-flow-run');
+    }
+
     addStepExistingToFlowConfirmationMessage() {
         return cy.findByLabelText('step-in-flow');
     }
     
+    addStepExistingToFlowRunConfirmationMessage() {
+        return cy.findByLabelText('step-in-flow-run');
+    }
+        
     pagination() {
 
     }
@@ -237,6 +245,23 @@ class LoadPage {
         return cy.findByTestId(`${stepName}-edit`);
     }
 
+    runStepInCardView(stepName: string) {
+        return cy.findByTestId(`${stepName}-run`);
+    }
+
+    runInNewFlow(stepName: string) {
+        return cy.findByTestId(`${stepName}-run-toNewFlow`);
+    };
+
+    runExistingFlowsList(stepName: string) {
+        return cy.findByTestId(`${stepName}-run-flowsList`);
+    }
+
+    runStepInExistingFlow(stepName: string, flowName: string) {
+        this.runExistingFlowsList(stepName).click({force: true});
+        cy.findByLabelText(`${flowName}-run-option`).click({force: true});
+    }
+
     addToNewFlow(stepName: string) {
         return cy.findByTestId(`${stepName}-toNewFlow`);
     }
@@ -253,7 +278,7 @@ class LoadPage {
     addStepToExistingFlow(stepName: string, flowName: string) {
         this.stepName(stepName).trigger('mouseover');
         this.existingFlowsList(stepName).click();
-        cy.findByLabelText(flowName).click();
+        cy.findByLabelText(`${flowName}-option`).click();
     }
 
 }

--- a/marklogic-data-hub-central/ui/src/App.tsx
+++ b/marklogic-data-hub-central/ui/src/App.tsx
@@ -55,7 +55,7 @@ const App: React.FC<Props> = ({history, location}) => {
     if (user.authenticated){
       if (location.pathname === '/') {
         history.push(user.pageRoute);
-      } else if (location.pathname === '/tiles/run/add'){
+      } else if (location.pathname === '/tiles/run/add' || location.pathname === '/tiles/run/add-run'){
         history.push('/tiles/run');
       } else {
         history.push(location.pathname);
@@ -117,7 +117,10 @@ const App: React.FC<Props> = ({history, location}) => {
                 <TilesView id='run'/>
               </PrivateRoute>
               <PrivateRoute path="/tiles/run/add" exact>
-                <TilesView id='run' addingStepToFlow='true' />
+                <TilesView id='run' addingStepToFlow='true' startRunStep={false}/>
+              </PrivateRoute>
+              <PrivateRoute path="/tiles/run/add-run" exact>
+                <TilesView id='run' addingStepToFlow='true' startRunStep={true}/>
               </PrivateRoute>
               <PrivateRoute path="/tiles/explore" exact>
                 <TilesView id='explore'/>

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.module.scss
@@ -1,7 +1,7 @@
-.loadContainer{
+.loadContainer {
     margin-top: 3vh;
 }
-.cardStyle{
+.cardStyle {
     width: 330px;
     margin-top: 9px;
     text-align: left;
@@ -14,12 +14,12 @@
     border: 1px solid #67749c;
 }
 
-.mapNameStyle{
+.mapNameStyle {
     font-size: 20px;
     padding-bottom: 2px;
 }
 
-.lastUpdatedStyle{
+.lastUpdatedStyle {
     font-size: 13px;
     margin-bottom: 0px;
 }
@@ -33,7 +33,7 @@
     font-size: 13px;
     margin-top: 10px;
 }
-.fileCount{
+.fileCount {
     display: block;
     text-align: right;
     font-size: 24px;
@@ -42,7 +42,7 @@
     margin-right: 0px;
 }
 
-.addNewCard{
+.addNewCard {
     width: 330px;
     margin-top: 9px;
     border: 1px solid #d7d6d6;
@@ -50,7 +50,7 @@
     text-align: center;
     align-content: center;
 }
-.plusIcon{
+.plusIcon {
     font-size: 80px;
     margin-top: 14px;
     color: #67749c;
@@ -69,11 +69,16 @@
     text-align: left;
 }
 
-.disabledDeleteIcon {
-    font-size: 21px;
+.disabledIcon {
+    font-size: 19px;
     opacity: 0.5;
     padding-bottom: 2px;
-    cursor: not-allowed;
+    cursor: not-allowed !important;
+}
+
+.runIcon {
+    font-size: 19px;
+    padding-top: 2px;
 }
 
 .cardLinks {
@@ -113,4 +118,17 @@
 .cardLinkSelect {
     margin-top: 7px;
     margin-bottom: 10px;
+}
+
+.stepLink {
+    color: #44499C;
+}
+
+.stepLinkExisting {
+    color: rgba(0, 0, 0, 0.65);
+}
+
+
+.stepLinkSelect {
+    margin-top: 5px;
 }

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
@@ -203,7 +203,7 @@ describe("Mapping Card component", () => {
        expect(getByText(AdvancedSettingsMessages.targetPermissions.incorrectFormat)).toBeInTheDocument();
   });
 
-  test('Verify Card sort order and adding the step to an existing flow where step DOES NOT exist', async () => {
+  test('Verify Card sort order, adding the step to an existing flow, and running the step in an existing flow where step DOES NOT exist', async () => {
     const authorityService = new AuthoritiesService();
     authorityService.setAuthorities(['readMapping', 'writeMapping', 'writeFlow']);
     let mapping = data.mappings.data[0].artifacts.concat(data.mappings.data[1].artifacts);
@@ -243,7 +243,7 @@ describe("Mapping Card component", () => {
 
     // Open menu, choose flow
     fireEvent.click(getByTestId('Mapping2-flowsList'));
-    fireEvent.click(getByText('testFlow'));
+    fireEvent.click(getByLabelText('testFlow-option'));
 
     // Dialog appears, click 'Yes' button
     expect(getByLabelText('step-not-in-flow')).toBeInTheDocument();
@@ -253,9 +253,26 @@ describe("Mapping Card component", () => {
     wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith('/tiles/run/add'); })
     // TODO- E2E test to check if the Run tile is loaded or not.
 
+   
+    //Verify run step in an existing flow where step does not exist yet
+
+    //Click play button 'Run' icon
+    fireEvent.click(getByTestId('Mapping2-run'));
+
+    //'Run in an existing Flow'
+    fireEvent.click(getByTestId('Mapping2-run-flowsList'));
+    fireEvent.click(getByLabelText('testFlow-run-option'));
+
+    //Dialog appears, click 'Yes' button
+    expect(getByLabelText('step-not-in-flow-run')).toBeInTheDocument();
+    fireEvent.click(getByTestId('Mapping2-to-testFlow-Confirm'));
+
+    //Check if the /tiles/run/add-run route has been called
+    wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith('/tiles/run/add-run'); })
+
   });
 
-  test('Adding the step to an existing flow where step DOES exist', async () => {
+  test('Adding the step to an existing flow and running the step in an existing flow where step DOES exist', async () => {
     const authorityService = new AuthoritiesService();
     authorityService.setAuthorities(['readMapping', 'writeMapping', 'writeFlow']);
     let getByText, getByLabelText, getByTestId;
@@ -284,6 +301,22 @@ describe("Mapping Card component", () => {
     //Check if the /tiles/run/add route has been called
     wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith('/tiles/run/add'); })
     //TODO- E2E test to check if the Run tile is loaded or not.
+
+    //Verify run step in an existing flow where step does exist
+
+    //Click play button 'Run' icon
+    fireEvent.click(getByTestId('Mapping1-run'));
+
+    //'Run in an existing Flow'
+    fireEvent.click(getByTestId('Mapping1-run-flowsList'));
+    fireEvent.click(getByLabelText('testFlow-run-option'));
+
+    //Dialog appears, click 'Yes' button
+    expect(getByLabelText('step-in-flow-run')).toBeInTheDocument();
+    fireEvent.click(getByTestId('Mapping1-to-testFlow-Confirm'));
+
+    //Check if the /tiles/run/add-run route has been called
+    wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith('/tiles/run/add-run'); })
 
   });
 
@@ -322,6 +355,17 @@ describe("Mapping Card component", () => {
       expect(mockHistoryPush).toHaveBeenCalledWith('/tiles/run/add');
     })
 
+    //Verify run step in an new flow 
+
+    //Click play button 'Run' icon
+    fireEvent.click(getByTestId('Mapping1-run'));
+
+    //'Run in a new Flow'
+    fireEvent.click(getByTestId('Mapping1-run-toNewFlow'));
+
+    //Check if the /tiles/run/add-run route has been called
+    wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith('/tiles/run/add-run'); })
+
   });
 
   test('Verify Mapping card allows step to be added to flow with writeFlow authority', async () => {
@@ -357,12 +401,12 @@ describe("Mapping Card component", () => {
 
   });
 
-  test('Verify Mapping card does not allow a step to be added to flow with readFlow authority only', async () => {
+  test('Verify Mapping card does not allow a step to be added to flow or run in a flow with readFlow authority only', async () => {
     const authorityService = new AuthoritiesService();
     authorityService.setAuthorities(['readMapping','readFlow']);
     const mappingStepName = mapping[0].name;
     const mockAddStepToFlow = jest.fn();
-    const {getByText, queryByText, queryByTestId} = render(
+    const {getByText, queryByText, queryByTestId, getByRole } = render(
       <MemoryRouter><AuthoritiesContext.Provider value={authorityService}><MappingCard
         {...mappingProps}
         canReadOnly={authorityService.canReadMapping()}
@@ -382,6 +426,13 @@ describe("Mapping Card component", () => {
     // test adding to new flow
     expect(queryByTestId(`${mappingStepName}-toNewFlow`)).not.toBeInTheDocument();
     expect(queryByTestId(`${mappingStepName}-disabledToNewFlow`)).toBeInTheDocument();
+
+     // test run icon displays correct tooltip when disabled
+     fireEvent.mouseOver(getByRole('disabled-run-mapping'));
+     await wait (() => expect(getByText('Run: ' + SecurityTooltips.missingPermission)).toBeInTheDocument());
+ 
+     await fireEvent.click(getByRole('disabled-run-mapping'));
+     expect(queryByTestId('Mapping1-run-flowsList')).not.toBeInTheDocument();
 
   });
 });

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
@@ -1,6 +1,6 @@
 import React, {CSSProperties, useState, useEffect, useContext} from 'react';
 import styles from './mapping-card.module.scss';
-import {Card, Icon, Tooltip, Row, Col, Modal, Select} from 'antd';
+import {Card, Icon, Tooltip, Dropdown, Row, Col, Modal, Select, Menu} from 'antd';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {faTrashAlt} from '@fortawesome/free-regular-svg-icons';
 import sourceFormatOptions from '../../../config/formats.config';
@@ -59,6 +59,7 @@ const MappingCard: React.FC<Props> = (props) => {
     const [sortedMapping, setSortedMappings] = useState(props.data)
     const [selected, setSelected] = useState({}); // track Add Step selections so we can reset on cancel
     const [selectVisible, setSelectVisible] = useState(false);
+    const [addRun, setAddRun] = useState(false);
 
     //For Entity table
     const [entityTypeProperties, setEntityTypeProperties] = useState<any[]>([]);
@@ -181,13 +182,13 @@ const MappingCard: React.FC<Props> = (props) => {
             setIsLoading(true);
             let response = await getUris(stepName,20);
               if (response.status === 200) {
-               if(response.data.length > 0){
+               if (response.data.length > 0) {
                    setDisableURINavRight(response.data.length > 1 ? false : true);
                    setDocUris(response.data);
                    setSourceURI(response.data[0]);
                    fetchSrcDocFromUri(stepName ,response.data[0]);
               }
-               else{
+               else {
                    setIsLoading(false);
                }
             }
@@ -207,15 +208,15 @@ const MappingCard: React.FC<Props> = (props) => {
             let srcDocResp = await getDoc(stepName, uri);
             if (srcDocResp.status === 200) {
                 let parsedDoc: any;
-                if(typeof(srcDocResp.data) === 'string'){
+                if (typeof(srcDocResp.data) === 'string') {
                     parsedDoc = getParsedXMLDoc(srcDocResp);
                     setSourceFormat('xml');
                 } else {
                     parsedDoc = srcDocResp.data;
                     setSourceFormat('json');
                 }
-                if(parsedDoc['envelope']){
-                    if(parsedDoc['envelope'].hasOwnProperty('@xmlns')){
+                if (parsedDoc['envelope']) {
+                    if (parsedDoc['envelope'].hasOwnProperty('@xmlns')) {
 
                         let nmspcURI = parsedDoc['envelope']['@xmlns']
                         let indCheck = nmspcURI.lastIndexOf('/');
@@ -231,7 +232,7 @@ const MappingCard: React.FC<Props> = (props) => {
                 let sDta = generateNestedDataSource(docRoot,nestedDoc);
                 setSourceData([]);
                 setSourceData([...sDta]);
-                if(typeof(srcDocResp.data) === 'string'){
+                if (typeof(srcDocResp.data) === 'string') {
                     let mData = await props.getMappingArtifactByMapName(props.entityModel.entityTypeId,props.data[index].name);
                     updateMappingWithNamespaces(mData);
                 }
@@ -374,7 +375,7 @@ const MappingCard: React.FC<Props> = (props) => {
 
                 if (val && val.constructor && val.constructor.name === "Object") {
                     let tempNS = parentNamespace;
-                    if(val.hasOwnProperty('@xmlns')){
+                    if (val.hasOwnProperty('@xmlns')) {
                         parentNamespace = updateParentNamespace(val);
                         currentDefaultNamespace = val['@xmlns'];
                     }
@@ -385,7 +386,7 @@ const MappingCard: React.FC<Props> = (props) => {
                     generateNestedDataSource(val, propty.children, parentNamespace, currentDefaultNamespace);
                     nestedDoc.push(propty);
 
-                    if(parentNamespace !== tempNS){
+                    if (parentNamespace !== tempNS) {
                         parentNamespace = tempNS;
                     }
                 } else if (val && Array.isArray(val)) {
@@ -417,7 +418,7 @@ const MappingCard: React.FC<Props> = (props) => {
                         val.forEach(obj => {
                             let tempNS = parentNamespace;
                             let childDefaultNamespace = currentDefaultNamespace;
-                            if(obj.constructor.name === "Object" && obj.hasOwnProperty('@xmlns')){
+                            if (obj.constructor.name === "Object" && obj.hasOwnProperty('@xmlns')) {
                                 parentNamespace = updateParentNamespace(obj);
                                 childDefaultNamespace = obj['@xmlns'];
                             }
@@ -426,7 +427,7 @@ const MappingCard: React.FC<Props> = (props) => {
 
                             generateNestedDataSource(obj, propty.children, parentNamespace, childDefaultNamespace);
                             nestedDoc.push(propty);
-                            if(parentNamespace !== tempNS){
+                            if (parentNamespace !== tempNS) {
                                 parentNamespace = tempNS;
                             }
                         });
@@ -510,7 +511,7 @@ const MappingCard: React.FC<Props> = (props) => {
                 let dataTp = getDatatype(val);
                 parentKey = parentKey ? parentKey + '/' + key : key;
                 EntitYTableKeyIndex = EntitYTableKeyIndex + 1;
-                if(val.$ref || val.items.$ref) {
+                if (val.$ref || val.items.$ref) {
                     let ref = val.$ref ? val.$ref : val.items.$ref;
                     tgtRefs[parentKey] = ref;
                 }
@@ -583,6 +584,15 @@ const MappingCard: React.FC<Props> = (props) => {
         let selectedNew = {...selected};
         selectedNew[obj.loadName] = obj.flowName;
         setSelected(selectedNew);
+        setAddRun(false);
+        handleStepAdd(obj.mappingName, obj.flowName);
+    }
+
+    function handleSelectAddRun(obj) {
+        let selectedNew = {...selected};
+        selectedNew[obj.loadName] = obj.flowName;
+        setSelected(selectedNew);
+        setAddRun(true);
         handleStepAdd(obj.mappingName, obj.flowName);
     }
 
@@ -602,16 +612,62 @@ const MappingCard: React.FC<Props> = (props) => {
     const onAddOk = async (lName, fName) => {
         await props.addStepToFlow(lName, fName, 'mapping')
         setAddDialogVisible(false);
-
-        history.push({
-            pathname: '/tiles/run/add',
-            state: {
-                flowName: fName,
-                flowsDefaultKey: [props.flows.findIndex(el => el.name === fName)],
-                existingFlow: true
-            }
-        })
+        
+        if (addRun) {
+            history.push({
+                pathname: '/tiles/run/add-run',
+                state: {
+                    flowName: fName,
+                    flowsDefaultKey: [props.flows.findIndex(el => el.name === fName)],
+                    existingFlow: true,
+                    stepToAdd : mappingArtifactName,
+                    stepDefinitionType : 'mapping'
+                }
+            })
+        } else {
+            history.push({
+                pathname: '/tiles/run/add',
+                state: {
+                    flowName: fName,
+                    flowsDefaultKey: [props.flows.findIndex(el => el.name === fName)],
+                    existingFlow: true
+                }
+            })
+        }
     }
+
+    const menu = (name) => (
+        <Menu style={{right: '80px'}}>
+            <Menu.Item key="0">
+                { <Link data-testid="link" id="tiles-add-run" to={
+                                        {pathname: '/tiles/run/add-run',
+                                        state: {
+                                            stepToAdd : name,
+                                            stepDefinitionType : 'mapping',
+                                            existingFlow : false
+                                        }}}><div className={styles.stepLink} data-testid={`${name}-run-toNewFlow`}>Run step in a new flow</div></Link>}
+            </Menu.Item>
+            <Menu.Item key="1">
+                <div className={styles.stepLinkExisting} data-testid={`${name}-run-toExistingFlow`}>Run step in an existing flow
+                    <div className={styles.stepLinkSelect} onClick={(event) => { event.stopPropagation(); event.preventDefault(); }}>
+                        <Select
+                            style={{ width: '100%' }}
+                            value={selected[name] ? selected[name] : undefined}
+                            onChange={(flowName) => handleSelectAddRun({flowName: flowName, mappingName: name})}
+                            placeholder="Select Flow"
+                            defaultActiveFirstOption={false}
+                            disabled={!props.canWriteFlow}
+                            data-testid={`${name}-run-flowsList`}
+                        >
+                            { props.flows && props.flows.length > 0 ? props.flows.map((f,i) => (
+                                <Option aria-label={`${f.name}-run-option`} value={f.name} key={i}>{f.name}</Option>
+                            )) : null}
+                        </Select>
+                    </div>
+                </div>
+            </Menu.Item>
+        </Menu>
+    );
 
     const addConfirmation = (
         <Modal
@@ -625,8 +681,8 @@ const MappingCard: React.FC<Props> = (props) => {
         >
             <div aria-label="add-step-confirmation" style={{fontSize: '16px', padding: '10px'}}>
                 { isStepInFlow(mappingArtifactName, flowName) ?
-                    <p aria-label="step-in-flow">The step <strong>{mappingArtifactName}</strong> is already in the flow <strong>{flowName}</strong>. Add another instance of the step?</p> :
-                    <p aria-label="step-not-in-flow">Are you sure you want to add the step <strong>{mappingArtifactName}</strong> to the flow <strong>{flowName}</strong>?</p>
+                    !addRun ? <p aria-label="step-in-flow">The step <strong>{mappingArtifactName}</strong> is already in the flow <strong>{flowName}</strong>. Would you like to add another instance?</p> : <p aria-label="step-in-flow-run">The step <strong>{mappingArtifactName}</strong> is already in the flow <strong>{flowName}</strong>. Would you like to add another instance and run it?</p>
+                    : !addRun ? <p aria-label="step-not-in-flow">Are you sure you want to add the step <strong>{mappingArtifactName}</strong> to the flow <strong>{flowName}</strong>?</p> : <p aria-label="step-not-in-flow-run">Are you sure you want to add the step <strong>{mappingArtifactName}</strong> to the flow <strong>{flowName}</strong> and run it?</p> 
                 }
             </div>
         </Modal>
@@ -655,7 +711,10 @@ const MappingCard: React.FC<Props> = (props) => {
                                     <MLTooltip title={'Edit'} placement="bottom"><Icon className={styles.editIcon} type="edit" key ="last" role="edit-mapping button" data-testid={elem.name+'-edit'} onClick={() => OpenEditStepDialog(index)}/></MLTooltip>,
                                     <MLTooltip title={'Step Details'} placement="bottom"><i style={{ fontSize: '16px', marginLeft: '-5px', marginRight: '5px'}}><FontAwesomeIcon icon={faSlidersH} onClick={() => openSourceToEntityMapping(elem.name,index)} data-testid={`${elem.name}-stepDetails`}/></i></MLTooltip>,
                                     <MLTooltip title={'Settings'} placement="bottom"><Icon type="setting" key="setting" role="settings-mapping button" data-testid={elem.name+'-settings'} onClick={() => OpenMappingSettingsDialog(index)}/></MLTooltip>,
-                                    props.canReadWrite ? <MLTooltip title={'Delete'} placement="bottom"><i key ="last" role="delete-mapping button" data-testid={elem.name+'-delete'} onClick={() => handleCardDelete(elem.name)}><FontAwesomeIcon icon={faTrashAlt} className={styles.deleteIcon} size="lg"/></i></MLTooltip> : <MLTooltip title={'Delete: ' + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: '200px'}}><i role="disabled-delete-mapping button" data-testid={elem.name+'-disabled-delete'} onClick={(event) => event.preventDefault()}><FontAwesomeIcon icon={faTrashAlt} className={styles.disabledDeleteIcon} size="lg"/></i></MLTooltip>,
+                                    <Dropdown data-testid={`${elem.name}-dropdown`} overlay={menu(elem.name)} trigger={['click']} disabled = {!props.canWriteFlow}>    
+                                    {props.canReadWrite ?<MLTooltip title={'Run'} placement="bottom"><i aria-label="icon: run"><Icon type="play-circle" theme="filled" className={styles.runIcon} data-testid={elem.name+'-run'}/></i></MLTooltip> : <MLTooltip title={'Run: ' + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: '200px'}}><i role="disabled-run-mapping button" data-testid={elem.name+'-disabled-run'}><Icon type="play-circle" theme="filled" onClick={(event) => event.preventDefault()} className={styles.disabledIcon}/></i></MLTooltip>}
+                                    </Dropdown>,
+                                    props.canReadWrite ? <MLTooltip title={'Delete'} placement="bottom"><i key ="last" role="delete-mapping button" data-testid={elem.name+'-delete'} onClick={() => handleCardDelete(elem.name)}><FontAwesomeIcon icon={faTrashAlt} className={styles.deleteIcon} size="lg"/></i></MLTooltip> : <MLTooltip title={'Delete: ' + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: '200px'}}><i role="disabled-delete-mapping button" data-testid={elem.name+'-disabled-delete'} onClick={(event) => event.preventDefault()}><FontAwesomeIcon icon={faTrashAlt} className={styles.disabledIcon} size="lg"/></i></MLTooltip>,
                                 ]}
                                 className={styles.cardStyle}
                                 size="small"

--- a/marklogic-data-hub-central/ui/src/components/flows/flows.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/flows/flows.module.scss
@@ -5,11 +5,11 @@
         width: 100%;
         display: flex;
         justify-content: flex-end;
-        .createButton,.createButtonDisabled {
+        .createButton, .createButtonDisabled {
             width: 110px;
             margin-bottom: 20px;
         }
-        .createButtonDisabled{
+        .createButtonDisabled {
             border-color: #f5f5f5;
         }
         .createButtonDisabled:hover {
@@ -52,6 +52,17 @@
                 display: inline-block;
                 padding-right: 10px;
                 color: #3b458f;
+                font-size: 20px;
+                cursor: pointer;
+            }
+
+            .run:hover {
+                position: relative;
+                top: 1px;
+                display: inline-block;
+                padding-right: 10px;
+                color: #5B69AF;
+                border-color: #5B69AF;                
                 font-size: 20px;
                 cursor: pointer;
             }
@@ -158,7 +169,7 @@
     }
 }
 
-.cardStyle{
+.cardStyle {
     width: 300px;
     margin-right: 20px;
     ul {
@@ -166,7 +177,7 @@
         background: #ffffff;
     }
 
-    li:last-child{
+    li:last-child {
         margin: 0px;
         padding-bottom: 8px;
         height: 33.3px;

--- a/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
+++ b/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
@@ -57,6 +57,7 @@ const StepDefinitionTypeTitles = {
 const Flows: React.FC<Props> = (props) => {
     const { handleError } = useContext(UserContext);
     const [newFlow, setNewFlow] = useState(false);
+    const [addedFlowName, setAddedFlowName] = useState('');
     const [title, setTitle] = useState('');
     const [flowData, setFlowData] = useState({});
     const [dialogVisible, setDialogVisible] = useState(false);
@@ -73,18 +74,50 @@ const Flows: React.FC<Props> = (props) => {
     const [openNewFlow, setOpenNewFlow] = useState(props.newStepToFlowOptions?.addingStepToFlow && !props.newStepToFlowOptions?.existingFlow);
     const [activeKeys, setActiveKeys] = useState(JSON.stringify(props.newStepToFlowOptions?.flowsDefaultKey) !== JSON.stringify(["-1"]) ? props.newStepToFlowOptions?.flowsDefaultKey : ['-1']);
     const [showLinks, setShowLinks] = useState('');
+    const [startRun, setStartRun] = useState(false);
     const [latestJobData, setLatestJobData] = useState<any>({});
     const [createAdd, setCreateAdd] = useState(true);
 
 
     useEffect(() => {
-        if (JSON.stringify(props.flowsDefaultActiveKey) !== JSON.stringify([])) {
+        if (JSON.stringify(props.flowsDefaultActiveKey) !== JSON.stringify([]) && props.flowsDefaultActiveKey.length >= activeKeys.length) {
             setActiveKeys([...props.flowsDefaultActiveKey]);
         }
         // Get the latest job info when a step is added to an existing flow from Curate or Load Tile
-        if(JSON.stringify(props.flows) !== JSON.stringify([])){
-            if(props.newStepToFlowOptions && props.newStepToFlowOptions.flowsDefaultKey && props.newStepToFlowOptions.flowsDefaultKey != -1){
+        if (JSON.stringify(props.flows) !== JSON.stringify([])) {
+            if (props.newStepToFlowOptions && props.newStepToFlowOptions.addingStepToFlow && props.newStepToFlowOptions.flowsDefaultKey && props.newStepToFlowOptions.flowsDefaultKey != -1) {
                 getFlowWithJobInfo(props.newStepToFlowOptions.flowsDefaultKey);
+                if (startRun && props.newStepToFlowOptions.existingFlow) {
+                        //run step after step is added to an existing flow
+                        if (props.newStepToFlowOptions.stepDefinitionType === 'ingestion') {
+                            setShowUploadError(false);
+                            setRunningStep(props.flows[props.newStepToFlowOptions.flowsDefaultKey].steps[props.flows[props.newStepToFlowOptions.flowsDefaultKey].steps.length - 1]);
+                            setRunningFlow(props.newStepToFlowOptions?.flowName);
+                            openFilePicker();
+                            setStartRun(false);
+                        } else {
+                            props.runStep(props.newStepToFlowOptions?.flowName, props.flows[props.newStepToFlowOptions.flowsDefaultKey].steps[props.flows[props.newStepToFlowOptions.flowsDefaultKey].steps.length - 1]);
+                            setStartRun(false);
+                        }
+                }
+            }
+            //run step after step is added to a new flow
+            if (props.newStepToFlowOptions && !props.newStepToFlowOptions.existingFlow && startRun && addedFlowName) {
+                let index = props.flows.findIndex(i => i.name === addedFlowName);
+                if (props.flows[index].steps[0]) {
+                    if (props.flows[index].steps[0].stepDefinitionType === 'ingestion') {
+                        setShowUploadError(false);
+                        setRunningStep(props.flows[index].steps[0]);
+                        setRunningFlow(addedFlowName);
+                        openFilePicker();
+                        setAddedFlowName('');  
+                        setStartRun(false);
+                    } else {
+                        props.runStep(addedFlowName, props.flows[index].steps[0]);
+                        setAddedFlowName('');  
+                        setStartRun(false);
+                    }
+                }
             }
         }
         if (activeKeys === undefined) {
@@ -98,10 +131,16 @@ const Flows: React.FC<Props> = (props) => {
     // Get the latest job info after a step (in a flow) run
     useEffect(()=>{
         let num = props.flows.findIndex((flow) => flow.name === props.runEnded.flowId);
-        if(num >= 0){
+        if (num >= 0) {
             getFlowWithJobInfo(num);
         }
     },[props.runEnded])
+
+    useEffect(() => {
+        if (props.newStepToFlowOptions && props.newStepToFlowOptions.startRunStep) {
+            setStartRun(true);
+        }
+    },[props.newStepToFlowOptions])
 
     // For role-based privileges
     const authorityService = useContext(AuthoritiesContext);
@@ -390,7 +429,7 @@ const Flows: React.FC<Props> = (props) => {
     const showStepRunResponse = async (step) =>{
         try{
             let response = await axios.get('/api/jobs/' + step.jobId)
-            if(response.status === 200){
+            if (response.status === 200) {
                 props.showStepRunResponse(step.stepName, step.stepDefinitionType, "", step.jobId, response.data);
             }
         }
@@ -401,10 +440,10 @@ const Flows: React.FC<Props> = (props) => {
 
     const lastRunResponse = (step) => {
         let stepEndTime, tooltipText;
-        if(step.stepEndTime){
+        if (step.stepEndTime) {
             stepEndTime = new Date(step.stepEndTime).toLocaleString();
         }
-        if(!step.lastRunStatus){
+        if (!step.lastRunStatus) {
             return ;
         }
         else if (step.lastRunStatus === "completed step " + step.stepNumber) {
@@ -571,7 +610,7 @@ const Flows: React.FC<Props> = (props) => {
     const handlePanelInteraction = (key) => {
         /* Request to get latest job info for the flow will be made when someone opens the pane for the first time
         or opens a new pane. Closing the pane shouldn't send any requests*/
-        if(!activeKeys || (key.length > activeKeys.length && key.length > 0)) {
+        if (!activeKeys || (key.length > activeKeys.length && key.length > 0)) {
             getFlowWithJobInfo(key[key.length - 1]);
         }
         setActiveKeys([...key])
@@ -613,6 +652,7 @@ const Flows: React.FC<Props> = (props) => {
                     newFlow={newFlow || openNewFlow}
                     title={title}
                     setNewFlow={setNewFlow}
+                    setAddedFlowName={setAddedFlowName}
                     createFlow={props.createFlow}
                     createAdd={createAdd}
                     updateFlow={props.updateFlow}

--- a/marklogic-data-hub-central/ui/src/components/flows/new-flow-dialog/new-flow-dialog.tsx
+++ b/marklogic-data-hub-central/ui/src/components/flows/new-flow-dialog/new-flow-dialog.tsx
@@ -38,14 +38,14 @@ const NewFlowDialog = (props) => {
 
   const onCancel = () => {
     props.setNewFlow(false);
-    if(props.newStepToFlowOptions && props.newStepToFlowOptions.addingStepToFlow){
+    if(props.newStepToFlowOptions && props.newStepToFlowOptions.addingStepToFlow) {
       props.setOpenNewFlow(false);
     }
   }
 
   const onOk = () => {
     props.setNewFlow(false);
-    if(props.newStepToFlowOptions && props.newStepToFlowOptions.addingStepToFlow){
+    if(props.newStepToFlowOptions && props.newStepToFlowOptions.addingStepToFlow) {
       props.setOpenNewFlow(false);
     }
   }
@@ -61,9 +61,10 @@ const NewFlowDialog = (props) => {
       await props.updateFlow(dataPayload, flowName);
     } else {
       await props.createFlow(dataPayload);
-      if(props.createAdd && props.newStepToFlowOptions && props.newStepToFlowOptions.addingStepToFlow){
+      if(props.createAdd && props.newStepToFlowOptions && props.newStepToFlowOptions.addingStepToFlow) {
         await props.addStepToFlow(props.newStepToFlowOptions.newStepName, flowName, props.newStepToFlowOptions.stepDefinitionType);
         props.setOpenNewFlow(false);
+        props.setAddedFlowName(flowName);
       }
     }
     props.setNewFlow(false);

--- a/marklogic-data-hub-central/ui/src/components/load/load-card.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/load/load-card.module.scss
@@ -1,10 +1,10 @@
-.loadCard{
+.loadCard {
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
     padding-top: 10px;
 }
-.cardStyle{
+.cardStyle {
     width: 300px;
     margin-top: 9px;
     text-align: left;
@@ -14,12 +14,12 @@
     margin-bottom: 10px;
 }
 
-.stepNameStyle{
+.stepNameStyle {
     font-size: 20px;
     padding-bottom: 2px;
 }
 
-.lastUpdatedStyle{
+.lastUpdatedStyle {
     font-size: 13px;
     margin-bottom: 0px;
 }
@@ -34,7 +34,7 @@
     align-items: flex-start;
     cursor: pointer;
 }
-.addNewCard{
+.addNewCard {
     width: 300px;
     margin-top: 9px;
     border: 1px solid #d7d6d6;
@@ -42,7 +42,7 @@
     text-align: center;
     align-content: center;
 }
-.plusIcon{
+.plusIcon {
     font-size: 80px;
     margin-top: 16px;
     color: #67749c;
@@ -61,11 +61,16 @@
     text-align: left;
 }
 
-.disabledDeleteIcon {
-    font-size: 21px;
+.disabledIcon {
+    font-size: 19px;
     opacity: 0.5;
     padding-bottom: 2px;
-    cursor: not-allowed;
+    cursor: not-allowed !important;
+}
+
+.runIcon {
+    font-size: 19px;
+    padding-top: 2px;
 }
 
 .cardLinks {
@@ -111,4 +116,17 @@
     float: left;
     width: auto;
     padding-bottom: 100%;
+}
+
+.stepLink {
+    color: #44499C;
+}
+
+.stepLinkExisting {
+    color: rgba(0, 0, 0, 0.65);
+}
+
+
+.stepLinkSelect {
+    margin-top: 5px;
 }

--- a/marklogic-data-hub-central/ui/src/components/load/load-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-card.tsx
@@ -1,7 +1,7 @@
 import React, {CSSProperties, useContext, useState, useEffect} from 'react';
 import styles from './load-card.module.scss';
 import { useHistory } from 'react-router-dom';
-import {Card, Icon, Tooltip, Popover, Row, Col, Modal, Select} from 'antd';
+import {Card, Icon, Tooltip, Popover, Row, Col, Modal, Select, Dropdown, Menu} from 'antd';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
 import {faTrashAlt} from '@fortawesome/free-regular-svg-icons';
@@ -45,6 +45,7 @@ const LoadCard: React.FC<Props> = (props) => {
     const [selected, setSelected] = useState({}); // track Add Step selections so we can reset on cancel
     const [selectVisible, setSelectVisible] = useState(false);
     const [openLoadSettings, setOpenLoadSettings] = useState(false);
+    const [addRun, setAddRun] = useState(false);
 
     useEffect(() => {
        let sortedArray = props.data.length > 1 ? sortStepsByUpdated(props.data) : props.data;
@@ -130,6 +131,15 @@ const LoadCard: React.FC<Props> = (props) => {
         let selectedNew = {...selected};
         selectedNew[obj.loadName] = obj.flowName;
         setSelected(selectedNew);
+        setAddRun(false);
+        handleStepAdd(obj.loadName, obj.flowName);
+    }
+
+    function handleSelectAddRun(obj) {
+        let selectedNew = {...selected};
+        selectedNew[obj.loadName] = obj.flowName;
+        setSelected(selectedNew);
+        setAddRun(true);
         handleStepAdd(obj.loadName, obj.flowName);
     }
 
@@ -151,21 +161,67 @@ const LoadCard: React.FC<Props> = (props) => {
         await props.addStepToFlow(lName, fName)
         setAddDialogVisible(false);
 
-        history.push({
-            pathname: '/tiles/run/add',
-            state: {
-                flowName: fName,
-                flowsDefaultKey: [props.flows.findIndex(el => el.name === fName)],
-                existingFlow: true
-            }
-        })
-    }
+        if(addRun) {
+            history.push({
+                pathname: '/tiles/run/add-run',
+                state: {
+                    flowName: fName,
+                    flowsDefaultKey: [props.flows.findIndex(el => el.name === fName)],
+                    existingFlow: true,
+                    stepToAdd : loadArtifactName,
+                    stepDefinitionType : 'ingestion'
+                }
+            })
+        }else {
+            history.push({
+                pathname: '/tiles/run/add',
+                state: {
+                    flowName: fName,
+                    flowsDefaultKey: [props.flows.findIndex(el => el.name === fName)],
+                    existingFlow: true
+                }
+            })
+        }
+    }   
 
     const onCancel = () => {
         setDialogVisible(false);
         setAddDialogVisible(false);
         setSelected({}); // reset menus on cancel
     }
+
+    const menu = (name) => (
+        <Menu style={{right: '80px'}}>
+            <Menu.Item key="0">
+                { <Link data-testid="link" id="tiles-run-add" to={
+                                        {pathname: '/tiles/run/add-run',
+                                        state: {
+                                            stepToAdd : name,
+                                            stepDefinitionType : 'ingestion',
+                                            existingFlow : false
+                                        }}}><div className={styles.stepLink} data-testid={`${name}-run-toNewFlow`}>Run step in a new flow</div></Link>}
+            </Menu.Item>
+            <Menu.Item key="1">
+                <div className={styles.stepLinkExisting} data-testid={`${name}-run-toExistingFlow`}>Run step in an existing flow
+                    <div className={styles.stepLinkSelect} onClick={(event) => { event.stopPropagation(); event.preventDefault(); }}>
+                        <Select
+                            style={{ width: '100%' }}
+                            value={selected[name] ? selected[name] : undefined}
+                            onChange={(flowName) => handleSelectAddRun({flowName: flowName, loadName: name})}
+                            placeholder="Select Flow"
+                            defaultActiveFirstOption={false}
+                            disabled={!props.canWriteFlow}
+                            data-testid={`${name}-run-flowsList`}
+                        >
+                            { props.flows && props.flows.length > 0 ? props.flows.map((f,i) => (
+                                <Option aria-label={`${f.name}-run-option`} value={f.name} key={i}>{f.name}</Option>
+                            )) : null}
+                        </Select>
+                    </div>
+                </div>
+            </Menu.Item>
+        </Menu>
+    );
 
     const deleteConfirmation = (
         <Modal
@@ -197,8 +253,8 @@ const LoadCard: React.FC<Props> = (props) => {
         >
             <div aria-label="add-step-confirmation" style={{fontSize: '16px', padding: '10px'}}>
                 { isStepInFlow(loadArtifactName, flowName) ?
-                    <p aria-label="step-in-flow">The step <strong>{loadArtifactName}</strong> is already in the flow <strong>{flowName}</strong>. Add another instance of the step?</p> :
-                    <p aria-label="step-not-in-flow">Are you sure you want to add the step <strong>{loadArtifactName}</strong> to the flow <strong>{flowName}</strong>?</p>
+                    !addRun ? <p aria-label="step-in-flow">The step <strong>{loadArtifactName}</strong> is already in the flow <strong>{flowName}</strong>. Would you like to add another instance?</p> : <p aria-label="step-in-flow-run">The step <strong>{loadArtifactName}</strong> is already in the flow <strong>{flowName}</strong>. Would you like to add another instance and run it?</p>
+                    : !addRun ? <p aria-label="step-not-in-flow">Are you sure you want to add the step <strong>{loadArtifactName}</strong> to the flow <strong>{flowName}</strong>?</p> : <p aria-label="step-not-in-flow-run">Are you sure you want to add the step <strong>{loadArtifactName}</strong> to the flow <strong>{flowName}</strong> and run it?</p> 
                 }
             </div>
         </Modal>
@@ -225,7 +281,10 @@ const LoadCard: React.FC<Props> = (props) => {
                             actions={[
                             <MLTooltip title={'Settings'} placement="bottom"><Icon type="setting" key="setting" data-testid={elem.name+'-settings'} onClick={() => OpenLoadSettingsDialog(index)}/></MLTooltip>,
                             <MLTooltip title={'Edit'} placement="bottom"><Icon type="edit" key="edit" data-testid={elem.name+'-edit'} onClick={() => OpenEditStepDialog(index)}/></MLTooltip>,
-                                props.canReadWrite ?<MLTooltip title={'Delete'} placement="bottom"><i aria-label="icon: delete"><FontAwesomeIcon icon={faTrashAlt} className={styles.deleteIcon} size="lg"  data-testid={elem.name+'-delete'} onClick={() => handleCardDelete(elem.name)}/></i></MLTooltip> : <MLTooltip title={'Delete: ' + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: '200px'}}><i data-testid={elem.name+'-disabled-delete'}><FontAwesomeIcon icon={faTrashAlt} onClick={(event) => event.preventDefault()} className={styles.disabledDeleteIcon} size="lg"/></i></MLTooltip>,
+                            <Dropdown data-testid={`${elem.name}-dropdown`} overlay={menu(elem.name)} trigger={['click']} disabled = {!props.canWriteFlow}>    
+                                {props.canReadWrite ?<MLTooltip title={'Run'} placement="bottom"><i aria-label="icon: run"><Icon type="play-circle" theme="filled" className={styles.runIcon} data-testid={elem.name+'-run'}/></i></MLTooltip> : <MLTooltip title={'Run: ' + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: '200px'}}><i role="disabled-run-load button" data-testid={elem.name+'-disabled-run'}><Icon type="play-circle" theme="filled" onClick={(event) => event.preventDefault()} className={styles.disabledIcon}/></i></MLTooltip>}
+                            </Dropdown>,
+                                props.canReadWrite ?<MLTooltip title={'Delete'} placement="bottom"><i aria-label="icon: delete"><FontAwesomeIcon icon={faTrashAlt} className={styles.deleteIcon} size="lg"  data-testid={elem.name+'-delete'} onClick={() => handleCardDelete(elem.name)}/></i></MLTooltip> : <MLTooltip title={'Delete: ' + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: '200px'}}><i data-testid={elem.name+'-disabled-delete'}><FontAwesomeIcon icon={faTrashAlt} onClick={(event) => event.preventDefault()} className={styles.disabledIcon} size="lg"/></i></MLTooltip>,
                             ]}
                             className={styles.cardStyle}
                             size="small"
@@ -256,7 +315,7 @@ const LoadCard: React.FC<Props> = (props) => {
                                             disabled={!props.canWriteFlow}
                                         >
                                             { props.flows && props.flows.length > 0 ? props.flows.map((f,i) => (
-                                                <Option aria-label={f.name} value={f.name} key={i}>{f.name}</Option>
+                                                <Option aria-label={`${f.name}-option`} value={f.name} key={i}>{f.name}</Option>
                                             )) : null}
                                         </Select>
                                     </div> : null}

--- a/marklogic-data-hub-central/ui/src/pages/Run.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Run.tsx
@@ -342,7 +342,6 @@ const Run = (props) => {
 
     // POST /flows​/{flowId}​/steps​/{stepId}
     const runStep = async (flowId, stepDetails, formData) => {
-        setNewFlowName('');
         const stepNumber = stepDetails.stepNumber;
         const stepName = stepDetails.stepName;
         const stepType = stepDetails.stepDefinitionType;

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.tsx
@@ -95,6 +95,8 @@ const TilesView = (props) => {
     const getNewStepToFlowOptions = () => {
         return !props.addingStepToFlow ? { addingStepToFlow: false } : {
             addingStepToFlow: true,
+            startRunStep: props.startRunStep,
+            flowName : location.state?.flowName,
             newStepName: location.state?.stepToAdd,
             stepDefinitionType: location.state?.stepDefinitionType,
             existingFlow: location.state?.existingFlow || false,


### PR DESCRIPTION
### Description

- Added option to run a Load/Curate step in a new flow or run in an existing flow from Card view via Run icon
- Added RTL and Cypress tests for the respective scenarios
- Design reviewed by @jbelonoj, note: Run tooltip will briefly cover the Run menu, but discussed that this is the best option for now.
- note: There is a known bug with adding/running a same step to an existing flow where job details get corrupted. @srinathgit is working on a fix.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

