### PR TITLE
DHFPROD-5997: Fixing logic for determining step success

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/bulk/fixCreatedByStep.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/bulk/fixCreatedByStep.sjs
@@ -90,7 +90,6 @@ if (uris.length == 0) {
             {database: xdmp.database(config.JOBDATABASE)}
           ));
           if (influencedByTriple) {
-            console.log("Using influencedBy!");
             stepName = sem.tripleObject(influencedByTriple);
           }
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/ExcludeAlreadyProcessedItemsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/ExcludeAlreadyProcessedItemsTest.java
@@ -2,6 +2,8 @@ package com.marklogic.hub.flow;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.marklogic.hub.AbstractHubCoreTest;
+import com.marklogic.hub.job.JobStatus;
+import com.marklogic.hub.step.RunStepResponse;
 import com.marklogic.hub.test.ReferenceModelProject;
 import org.junit.jupiter.api.Test;
 
@@ -101,9 +103,15 @@ public class ExcludeAlreadyProcessedItemsTest extends AbstractHubCoreTest {
 
         // Run the step again, verify nothing is processed
         response = runFlow(new FlowInputs(flowName, stepNumber).withOptions(buildExcludeOptions()));
-        assertEquals(0, response.getStepResponses().get(stepNumber).getSuccessfulEvents(),
+        assertEquals(JobStatus.FINISHED.toString(), response.getJobStatus(), "Even though no items were processed, " +
+            "no errors occurred, so the status should still be finished");
+
+        RunStepResponse stepResponse = response.getStepResponses().get(stepNumber);
+        assertEquals(JobStatus.COMPLETED_PREFIX + stepNumber, stepResponse.getStatus(), "Even though no items were " +
+            "processed, the step did complete, so the status should reflect that");
+        assertEquals(0, stepResponse.getSuccessfulEvents(),
             "All 3 items have already been processed, so no items should have been processed this time");
-        assertEquals(3, response.getStepResponses().get(stepNumber).getTotalEvents());
+        assertEquals(3, stepResponse.getTotalEvents());
     }
 
     private void verifyFirstBatchDocument(String flowName, String stepId) {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/RunFlowWithInvalidStepDefTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/RunFlowWithInvalidStepDefTest.java
@@ -21,11 +21,13 @@ public class RunFlowWithInvalidStepDefTest extends AbstractHubCoreTest {
         RunFlowResponse response = flowRunner.runFlow("invalidStepDef");
         flowRunner.awaitCompletion();
 
+        logger.info(response.toJson());
+
         assertEquals(JobStatus.FAILED.toString(), response.getJobStatus(),
             "The job should have failed because the only step in the flow references a step definition that " +
                 "does not exist");
         String message = response.getStepResponses().get("1").getStepOutput().get(0);
-        assertTrue(message.contains("Could not find a step definition with name 'doesntExist' and type 'CUSTOM' for step '1' in flow 'invalidStepDef'"),
+        assertTrue(message.contains("A step with name \\\"doesntExist\\\" and type of \\\"CUSTOM\\\" was not found"),
             "Did not find expected message in: " + message);
     }
 }


### PR DESCRIPTION
### Description

The problem was that CollectorImpl was not throwing an exception when the collector failed. It instead returned a single item - the error message (the serialized JSON object from the REST API). That was then processed by the step, which resulted in zero successful items - but also zero failed items. 

Now that the collector properly throws an error, QueryStepRunner can say that if there are no failed items, then the step completed successfully. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

