### PR TITLE
DHFPROD-6138: Set columns for join table to nullable to avoid error w…

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-entities.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-entities.xqy
@@ -562,8 +562,8 @@ declare function hent:fix-tde($nodes as node()*, $entity-model-contexts as xs:st
                     return
                       element tde:column {
                         $column/@*,
+                        hent:fix-tde($column/(tde:name|tde:scalar-type), $entity-model-contexts, $uber-definitions),
                         if (fn:starts-with($column/tde:name, $join-prefix)) then (
-                          hent:fix-tde($column/(tde:name|tde:scalar-type), $entity-model-contexts, $uber-definitions),
                           let $tde-val := fn:string($column/tde:val)
                           let $primary-key := $uber-definitions => map:get($tde-val) => map:get("primaryKey")
                           return
@@ -572,12 +572,12 @@ declare function hent:fix-tde($nodes as node()*, $entity-model-contexts as xs:st
                                 $generated-primary-key-expression
                               else
                                 $tde-val || "/" || $primary-key
-                            },
-                          $default-nullable,
-                          $default-invalid-values,
-                          hent:fix-tde($column/(tde:default|tde:reindexing|tde:collation), $entity-model-contexts, $uber-definitions)
+                            }
                         ) else
-                          hent:fix-tde($column/node(), $entity-model-contexts, $uber-definitions)
+                          hent:fix-tde($column/tde:val, $entity-model-contexts, $uber-definitions),
+                        $default-nullable,
+                        $default-invalid-values,
+                        hent:fix-tde($column/(tde:default|tde:reindexing|tde:collation), $entity-model-contexts, $uber-definitions)
                       }
                   }
                 }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/generateTDE.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/generateTDE.sjs
@@ -1,0 +1,107 @@
+const hent = require("/data-hub/5/impl/hub-entities.xqy");
+const test = require("/test/test-helper.xqy");
+
+function generateTdeWithViewJoin() {
+    const input =
+        [{
+            "info": {
+                "title": "Customer",
+                "version": "0.0.1",
+                "baseUri": "http://example.org/"
+            },
+            "definitions": {
+                "Customer": {
+                    "required": [
+                        "name"
+                    ],
+                    "pii": ["shipping"],
+                    "primaryKey": "customerId",
+                    "properties": {
+                        "customerId": {
+                            "datatype": "integer",
+                            "sortable": true
+                        },
+                        "billing": {
+                            "datatype": "array",
+                            "items": {
+                                "$ref": "#/definitions/Address"
+                            }
+                        }
+                    }
+                },
+                "Address": {
+                    "required": [ ],
+                    "pii": [ ],
+                    "elementRangeIndex": [ ],
+                    "rangeIndex": [ ],
+                    "wordLexicon": [ ],
+                    "properties": {
+                        "street": {
+                            "datatype": "array",
+                            "items": {
+                                "datatype": "string",
+                                "collation": "http://marklogic.com/collation/codepoint"
+                            }
+                        },
+                        "city": {
+                            "datatype": "string",
+                            "collation": "http://marklogic.com/collation/codepoint"
+                        },
+                        "state": {
+                            "datatype": "string",
+                            "collation": "http://marklogic.com/collation/codepoint"
+                        },
+                        "zip": {
+                            "$ref": "#/definitions/Zip"
+                        }
+                    }
+                },
+                "Zip": {
+                    "required": [ ],
+                    "properties": {
+                        "fiveDigit": {
+                            "datatype": "string",
+                            "collation": "http://marklogic.com/collation/codepoint"
+                        },
+                        "plusFour": {
+                            "datatype": "string",
+                            "collation": "http://marklogic.com/collation/codepoint"
+                        }
+                    }
+                }
+            }
+        }];
+    const tde = hent.dumpTde(input);
+    const tdeDescription = xdmp.describe(tde, Sequence.from([]), Sequence.from([]));
+    // testing multi-value join
+    const billingJoinTemplate = fn.head(tde.xpath('//*:templates/*:template[*:context = "./billing/Address"]'));
+    const billingJoinTemplateExists = fn.exists(billingJoinTemplate)
+    const assertions = [
+        test.assertTrue(billingJoinTemplateExists, `Billing Join template should exist. TDE: ${tdeDescription}`)
+    ];
+    if (billingJoinTemplateExists) {
+        for (const columnNode of billingJoinTemplate.xpath("*:rows/*:row/*:columns/*:column")) {
+            const columnNodeDesc = xdmp.describe(columnNode, Sequence.from([]), Sequence.from([]));
+            assertions.push(test.assertTrue(xs.boolean(fn.head(columnNode.xpath('*:nullable'))), `All columns should be nullable. ${columnNodeDesc}`));
+            assertions.push(test.assertEqual('ignore', fn.string(fn.head(columnNode.xpath('*:invalid-values'))), `All columns should ignore invalid values ${columnNodeDesc}`));
+        }
+    }
+    // testing single value join
+    const zipJoinTemplate = fn.head(tde.xpath('.//*:templates/*:template[*:context = ".//Zip"]'));
+    const zipJoinTemplateExists = fn.exists(zipJoinTemplate)
+    assertions.push(
+        test.assertTrue(zipJoinTemplateExists, `Zip Join template should exist. TDE: ${tdeDescription}`)
+    );
+    if (zipJoinTemplateExists) {
+        for (const columnNode of zipJoinTemplate.xpath("*:rows/*:row/*:columns/*:column")) {
+            const columnNodeDesc = xdmp.describe(columnNode, Sequence.from([]), Sequence.from([]));
+            assertions.push(test.assertTrue(xs.boolean(fn.head(columnNode.xpath('*:nullable'))), `All columns should be nullable. ${columnNodeDesc}`));
+            assertions.push(test.assertEqual('ignore', fn.string(fn.head(columnNode.xpath('*:invalid-values'))), `All columns should ignore invalid values ${columnNodeDesc}`));
+        }
+    }
+    return assertions;
+
+}
+
+[]
+    .concat(generateTdeWithViewJoin());


### PR DESCRIPTION
…ith PII fields

### Description

If the join property is PII then there will be an error on the mapping step when applying the TDE index if the column isn't nullable.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests

