### PR TITLE
DHFPROD-6168:Ensure we can get latest job details if a step is added more than once to a flow

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/flow/getFlowWithLatestJobInfo.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/flow/getFlowWithLatestJobInfo.sjs
@@ -30,13 +30,19 @@ fn.head(datahub.hubUtils.queryLatest(function() {
     jobQueries.push(cts.collectionQuery('Job'));
     jobQueries.push(cts.jsonPropertyValueQuery("flow",flowWithStepDetails.name));
     jobQueries.push(cts.jsonPropertyValueQuery("stepName",step.stepName));
+    //A flow may contain same step more then once. 'status' in step response always contains step number
+    jobQueries.push(cts.jsonPropertyWordQuery("status",step.stepNumber));
+
     let latestJob = fn.head(fn.subsequence(cts.search(cts.andQuery(jobQueries),[cts.indexOrder(cts.jsonPropertyReference("timeStarted"), "descending")]), 1, 1));
     if(latestJob) {
       latestJob = latestJob.toObject();
-      step.jobId = latestJob.job.jobId;
-      let stepRunResponse = latestJob.job.stepResponses[step.stepNumber];
-      step.lastRunStatus = stepRunResponse.status;
-      step.stepEndTime = stepRunResponse.stepEndTime;
+      let stepRunResponses = latestJob.job.stepResponses;
+      if(stepRunResponses && stepRunResponses[step.stepNumber]){
+        let stepRunResponse = stepRunResponses[step.stepNumber];
+        step.jobId = latestJob.job.jobId;
+        step.lastRunStatus = stepRunResponse.status;
+        step.stepEndTime = stepRunResponse.stepEndTime;
+      }
     }
   });
 }, datahub.config.JOBDATABASE));

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/flow/test-data/jobs/job3.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/flow/test-data/jobs/job3.json
@@ -1,0 +1,32 @@
+{
+  "job": {
+    "jobId": "175da405-c1e9-4fa7-8269-d9cdfe3b4b9a",
+    "flow": "flowWithStepDetails",
+    "user": "admin",
+    "lastAttemptedStep": "4",
+    "lastCompletedStep": "4",
+    "jobStatus": "finished",
+    "timeStarted": "2020-06-28T23:11:28.802106Z",
+    "timeEnded": "2020-06-28T23:11:31.026434Z",
+    "stepResponses": {
+      "4": {
+        "flowName": "flowWithStepDetails",
+        "stepName": "testMapper",
+        "stepDefinitionName": "entity-services-mapping",
+        "stepDefinitionType": "mapping",
+        "stepOutput":  null,
+        "targetEntityType": "http://example.org/Customer-0.0.1/Customer",
+        "fullOutput": null,
+        "status": "completed step 4",
+        "totalEvents": 3,
+        "successfulEvents": 3,
+        "failedEvents": 0,
+        "successfulBatches": 3,
+        "failedBatches": 0,
+        "success": true,
+        "stepStartTime": "2020-06-28T23:11:28.836606Z",
+        "stepEndTime": "2020-06-28T23:11:30.836606Z"
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/flow/test-data/jobs/job4.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/flow/test-data/jobs/job4.json
@@ -1,0 +1,32 @@
+{
+  "job": {
+    "jobId": "567da405-c1e9-4fa7-8269-d9cdfe3b4b9a",
+    "flow": "flowWithStepDetails",
+    "user": "pari",
+    "lastAttemptedStep": "4",
+    "lastCompletedStep": "4",
+    "jobStatus": "finished",
+    "timeStarted": "2019-06-28T23:11:28.802106Z",
+    "timeEnded": "2019-06-28T23:11:31.026434Z",
+    "stepResponses": {
+      "4": {
+        "flowName": "flowWithStepDetails",
+        "stepName": "testMapper",
+        "stepDefinitionName": "entity-services-mapping",
+        "stepDefinitionType": "mapping",
+        "stepOutput":  null,
+        "targetEntityType": "http://example.org/Customer-0.0.1/Customer",
+        "fullOutput": null,
+        "status": "completed step 4",
+        "totalEvents": 3,
+        "successfulEvents": 3,
+        "failedEvents": 0,
+        "successfulBatches": 3,
+        "failedBatches": 0,
+        "success": true,
+        "stepStartTime": "2019-06-28T23:11:28.836606Z",
+        "stepEndTime": "2019-06-28T23:11:30.836606Z"
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/flow/test-data/jobs/job5.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/flow/test-data/jobs/job5.json
@@ -1,0 +1,48 @@
+{
+  "job": {
+    "jobId": "350e45u9-c1e9-4fa7-8269-d9aefe3b4b9a",
+    "flow": "flowWithStepDetails",
+    "user": "pari",
+    "lastAttemptedStep": "5",
+    "lastCompletedStep": "5",
+    "jobStatus": "finished",
+    "timeStarted": "2020-06-27T23:11:22.802106Z",
+    "timeEnded": "2020-06-27T23:11:33.026434Z",
+    "stepResponses": {
+      "3": {
+        "flowName": "flowWithStepDetails",
+        "stepName": "testIngestion",
+        "stepDefinitionName": "default-ingestion",
+        "stepDefinitionType": "ingestion",
+        "stepOutput": null,
+        "fullOutput": null,
+        "status": "completed step 3",
+        "totalEvents": 829,
+        "successfulEvents": 829,
+        "failedEvents": 0,
+        "successfulBatches": 9,
+        "failedBatches": 0,
+        "success": true,
+        "stepStartTime": "2020-06-27T23:11:22.836606Z",
+        "stepEndTime": "2020-06-27T23:11:27.462273Z"
+      },
+      "5": {
+        "flowName": "flowWithStepDetails",
+        "stepName": "testIngestion",
+        "stepDefinitionName": "default-ingestion",
+        "stepDefinitionType": "ingestion",
+        "stepOutput": null,
+        "fullOutput": null,
+        "status": "completed step 5",
+        "totalEvents": 829,
+        "successfulEvents": 829,
+        "failedEvents": 0,
+        "successfulBatches": 9,
+        "failedBatches": 0,
+        "success": true,
+        "stepStartTime": "2020-06-27T23:11:27.836606Z",
+        "stepEndTime": "2020-06-27T23:11:32.572273Z"
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/flow/testGetFlowWithLatestJobInfo.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/flow/testGetFlowWithLatestJobInfo.sjs
@@ -11,12 +11,13 @@ flowService.addStepToFlow(flowName, "mapping", mappingName);
 
 stepService.createDefaultIngestionStep(ingestionName);
 flowService.addStepToFlow(flowName, "ingestion", ingestionName);
-
+flowService.addStepToFlow(flowName, "mapping", mappingName);
+flowService.addStepToFlow(flowName, "ingestion", ingestionName);
 const flow = flowService.getFlowWithLatestJobInfo(flowName);
 
 [
   test.assertEqual(flowName, flow.name),
-  test.assertEqual(3, flow.steps.length, "Expecting the inline ingestion and referenced mapping and ingestion steps"),
+  test.assertEqual(5, flow.steps.length, "Expecting the inline ingestion and referenced mapping and ingestion steps"),
   test.assertEqual("1", flow.steps[0].stepNumber),
   test.assertEqual("ingestData", flow.steps[0].stepName),
   test.assertEqual("INGESTION", flow.steps[0].stepDefinitionType),
@@ -34,7 +35,21 @@ const flow = flowService.getFlowWithLatestJobInfo(flowName);
   test.assertEqual("3", flow.steps[2].stepNumber),
   test.assertEqual(ingestionName, flow.steps[2].stepName),
   test.assertEqual("ingestion", flow.steps[2].stepDefinitionType),
-  test.assertEqual(undefined, flow.steps[2].lastRunStatus),
-  test.assertEqual(undefined, flow.steps[2].jobId),
-  test.assertEqual(undefined, flow.steps[2].stepEndTime)
+  test.assertEqual("completed step 3", flow.steps[2].lastRunStatus),
+  test.assertEqual("350e45u9-c1e9-4fa7-8269-d9aefe3b4b9a", flow.steps[2].jobId),
+  test.assertEqual("2020-06-27T23:11:27.462273Z", flow.steps[2].stepEndTime),
+
+  test.assertEqual("4", flow.steps[3].stepNumber),
+  test.assertEqual(mappingName, flow.steps[3].stepName),
+  test.assertEqual("mapping", flow.steps[3].stepDefinitionType),
+  test.assertEqual("completed step 4", flow.steps[3].lastRunStatus),
+  test.assertEqual("175da405-c1e9-4fa7-8269-d9cdfe3b4b9a", flow.steps[3].jobId),
+  test.assertEqual("2020-06-28T23:11:30.836606Z", flow.steps[3].stepEndTime),
+
+  test.assertEqual("5", flow.steps[4].stepNumber),
+  test.assertEqual(ingestionName, flow.steps[4].stepName),
+  test.assertEqual("ingestion", flow.steps[4].stepDefinitionType),
+  test.assertEqual("completed step 5", flow.steps[4].lastRunStatus),
+  test.assertEqual("350e45u9-c1e9-4fa7-8269-d9aefe3b4b9a", flow.steps[4].jobId),
+  test.assertEqual("2020-06-27T23:11:32.572273Z", flow.steps[4].stepEndTime),
 ];

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/flow/testGetFlowsWithStepDetails.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/flow/testGetFlowsWithStepDetails.sjs
@@ -8,12 +8,14 @@ const flowName = "flowWithStepDetails";
 const mappingName = "testMapper";
 const ingestionName = "testIngestion";
 
+
 stepService.createDefaultMappingStep(mappingName);
 flowService.addStepToFlow(flowName, "mapping", mappingName);
 
 stepService.createDefaultIngestionStep(ingestionName);
 flowService.addStepToFlow(flowName, "ingestion", ingestionName);
-
+flowService.addStepToFlow(flowName, "mapping", mappingName);
+flowService.addStepToFlow(flowName, "ingestion", ingestionName);
 const flows = flowService.getFlowsWithStepDetails();
 const flow = flows[0];
 
@@ -22,7 +24,7 @@ const flow = flows[0];
   test.assertEqual(flowName, flow.name),
   test.assertFalse(flow.hasOwnProperty("description"), "Descripton isn't present because the flow doesn't have one"),
 
-  test.assertEqual(3, flow.steps.length, "Expecting the inline ingestion and referenced mapping and ingestion steps"),
+  test.assertEqual(5, flow.steps.length, "Expecting the inline ingestion and referenced mapping and ingestion steps"),
 
   test.assertEqual("1", flow.steps[0].stepNumber),
   test.assertEqual("ingestData", flow.steps[0].stepName),
@@ -40,5 +42,18 @@ const flow = flows[0];
   test.assertEqual(ingestionName, flow.steps[2].stepName),
   test.assertEqual("ingestion", flow.steps[2].stepDefinitionType),
   test.assertEqual("json", flow.steps[2].sourceFormat),
-  test.assertEqual(ingestionName + "-ingestion", flow.steps[2].stepId)
+  test.assertEqual(ingestionName + "-ingestion", flow.steps[2].stepId),
+
+  test.assertEqual("4", flow.steps[3].stepNumber),
+  test.assertEqual(mappingName, flow.steps[3].stepName),
+  test.assertEqual("mapping", flow.steps[3].stepDefinitionType),
+  test.assertEqual(undefined, flow.steps[3].sourceFormat),
+  test.assertEqual("http://example.org/Customer-0.0.1/Customer", flow.steps[3].targetEntityType),
+  test.assertEqual(mappingName + "-mapping", flow.steps[3].stepId),
+
+  test.assertEqual("5", flow.steps[4].stepNumber),
+  test.assertEqual(ingestionName, flow.steps[4].stepName),
+  test.assertEqual("ingestion", flow.steps[4].stepDefinitionType),
+  test.assertEqual("json", flow.steps[4].sourceFormat),
+  test.assertEqual(ingestionName + "-ingestion", flow.steps[4].stepId),
 ];


### PR DESCRIPTION
### Description
Same as #4810 for 5.3.0. Ensure we can get latest job details if a step is added more than once to a flow
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

