### PR TITLE
DHFPROD-5997: Fix for determining failed batches

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
@@ -406,7 +406,11 @@ public class QueryStepRunner implements StepRunner {
                         }
                     }
 
-                    if (response.errorCount < response.totalCount) {
+                    // Prior to DHFPROD-5997 / 5.4.0, if the count of errors and total count of events were both zero,
+                    // then the batch was considered to have failed. I don't think this could have possibly happened though
+                    // prior to 5997. Now that 5997 can filter out items after they've been collected, failed batches is
+                    // only incremented if there are actually errors (which seems intuitive too). 
+                    if (response.errorCount < 1) {
                         stepMetrics.getSuccessfulBatches().addAndGet(1);
                     } else {
                         stepMetrics.getFailedBatches().addAndGet(1);

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/ExcludeAlreadyProcessedItemsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/ExcludeAlreadyProcessedItemsTest.java
@@ -112,6 +112,11 @@ public class ExcludeAlreadyProcessedItemsTest extends AbstractHubCoreTest {
         assertEquals(0, stepResponse.getSuccessfulEvents(),
             "All 3 items have already been processed, so no items should have been processed this time");
         assertEquals(3, stepResponse.getTotalEvents());
+        assertEquals(1, stepResponse.getSuccessfulBatches(),
+            "Even though no items were processed, the batch should be regarded as having completed successfully, " +
+                "since no errors were thrown. This represents a change from prior to this ticket - DHFPROD-5977 - " +
+                "where the number of items that failed and that were processed were both zero, the batch was " +
+                "considered to have failed, even though an error was not thrown.");
     }
 
     private void verifyFirstBatchDocument(String flowName, String stepId) {


### PR DESCRIPTION
Made what I think is a fix to QueryStepRunner so that if the count of failed items and total items in a batch are both zero, then the batch is considered successful. A batch is now only considered to have failed if there's at least one item that threw an error, which seems to make good sense. 

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

