### PR TITLE
DHFPROD-6184:  Write records via URI Template using spark connector

### DIFF
--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/Options.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/Options.java
@@ -15,6 +15,7 @@ import java.util.Map;
 public class Options {
 
     // All connector-specific options
+    private String uriTemplate;
     private String uriPrefix;
     private String writeRecordsApiPath;
     private String collections;
@@ -49,6 +50,9 @@ public class Options {
         Map<String, String> params = new HashMap<>();
         if (hubProperties != null) {
             params.putAll(hubProperties);
+        }
+        if (uriTemplate != null) {
+            params.put("uritemplate", uriTemplate);
         }
 
         if (uriPrefix != null) {
@@ -109,8 +113,12 @@ public class Options {
         if (sqlCondition != null) {
             params.put("sqlcondition", sqlCondition);
         }
-
         return new DataSourceOptions(params);
+    }
+
+    public Options withUriTemplate(String uriTemplate) {
+        this.uriTemplate = uriTemplate;
+        return this;
     }
 
     public Options withUriPrefix(String uriPrefix) {

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/writer/WriteDataWithUriTemplateTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/writer/WriteDataWithUriTemplateTest.java
@@ -1,0 +1,75 @@
+package com.marklogic.hub.spark.sql.sources.v2.writer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.hub.spark.sql.sources.v2.AbstractSparkConnectorTest;
+import org.junit.jupiter.api.Test;
+import org.apache.spark.sql.sources.v2.writer.WriterCommitMessage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class WriteDataWithUriTemplateTest extends AbstractSparkConnectorTest {
+
+    @Test
+    void testInvalidUriTemplate1() {
+        String uriTemplate = "{property1.json";
+        RuntimeException e = assertThrows(RuntimeException.class, () -> initializeDataWriter(newFruitOptions().withUriTemplate(uriTemplate)));
+        assertEquals("Unclosed token in uritemplate={property1.json.",e.getMessage());
+    }
+
+    @Test
+    void testInvalidUriTemplate2() {
+        String uriTemplate = "property2}.json";
+        RuntimeException e = assertThrows(RuntimeException.class, () -> initializeDataWriter(newFruitOptions().withUriTemplate(uriTemplate)));
+        assertEquals("Closing curly bracket found without opening bracket. uritemplate=property2}.json.",e.getMessage());
+    }
+
+    @Test
+    void testInvalidUriTemplate3() {
+        String uriTemplate = "{{property1}property2}.json";
+        RuntimeException e = assertThrows(RuntimeException.class, () -> initializeDataWriter(newFruitOptions().withUriTemplate(uriTemplate)));
+        assertEquals("Nested tokens in uritemplate={{property1}property2}.json.",e.getMessage());
+    }
+
+    @Test
+    void testInvalidUriTemplate4() {
+        String uriTemplate = "{{property1}.json";
+        RuntimeException e = assertThrows(RuntimeException.class, () -> initializeDataWriter(newFruitOptions().withUriTemplate(uriTemplate)));
+        assertEquals("Nested tokens in uritemplate={{property1}.json.",e.getMessage());
+    }
+
+    @Test
+    void testInvalidUriTemplate5() {
+        String uriTemplate = "/a/b/c/{}.json";
+        RuntimeException e = assertThrows(RuntimeException.class, () -> initializeDataWriter(newFruitOptions().withUriTemplate(uriTemplate)));
+        assertEquals("UriTemplate has empty tokens. uritemplate=/a/b/c/{}.json.",e.getMessage());
+    }
+
+    @Test
+    void ingestDocWithUriTemplate() {
+        initializeDataWriter(newFruitOptions().withUriTemplate("/fruit/{fruitColor}/{fruitName}.json"));
+        writeRows(buildRow("pineapple", "green"));
+        String uri = getFruitUris()[0];
+        assertEquals("/fruit/green/pineapple.json",uri);
+    }
+
+    @Test
+    void ingestDocWithUriTemplateNullInContent() {
+        initializeDataWriter(newFruitOptions().withUriTemplate("/fruit/{fruitColor}/{fruitName}.json"));
+        WriterCommitMessage response = writeRows(buildRow("pineapple",null));
+        assertNotNull(response);
+        assertEquals(AtLeastOneWriteFailedMessage.class,response.getClass());
+    }
+
+    @Test
+    void ingestDocWithUriTemplateUndefinedInContent() {
+        initializeDataWriter(newFruitOptions().withUriTemplate("/fruit/{fruitColor}/{fruitName}/{doesnotexist}.json"));
+        WriterCommitMessage response = writeRows(buildRow("pineapple",null));
+        assertNotNull(response);
+        assertEquals(AtLeastOneWriteFailedMessage.class,response.getClass());
+    }
+}


### PR DESCRIPTION
This Pull request introduces a "uritemplate" option. With this option you can add a uri template e.g. "/my/uri/prefix/{property1}/{property2}.json

See: https://project.marklogic.com/jira/browse/DHFPROD-6184 
