### PR TITLE
DHFPROD-5734: Change Close button to Save/Cancel buttons in Edit Flow

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/flows/new-flow-dialog/new-flow-dialog.tsx
+++ b/marklogic-data-hub-central/ui/src/components/flows/new-flow-dialog/new-flow-dialog.tsx
@@ -155,19 +155,17 @@ const NewFlowDialog = (props) => {
         <br /><br />
         <Form.Item className={styles.submitButtonsForm}>
           <div className={styles.submitButtons}>
-            {props.canWriteFlow ?
             <><MLButton aria-label="Cancel" onClick={() => onCancel()}>Cancel</MLButton>
             &nbsp;&nbsp;
             <MLButton
               aria-label="Save"
               type="primary"
               htmlType="submit"
+              disabled={!props.canWriteFlow}
               onClick={handleSubmit}
             >
               Save
-            </MLButton></> :
-            <MLButton onClick={() => onCancel()}>Close</MLButton>
-            }
+            </MLButton></>
           </div>
         </Form.Item>
       </Form>

--- a/marklogic-data-hub-central/ui/src/pages/Run.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Run.test.tsx
@@ -569,8 +569,8 @@ describe('Verify Run CRUD operations', () => {
         fireEvent.click(getByText(existingFlowName));
         expect(getByPlaceholderText('Enter name')).toBeDisabled();
         expect(getByPlaceholderText('Enter description')).toBeDisabled();
-        expect(queryByText('Save')).not.toBeInTheDocument();
-        fireEvent.click(getByText('Close'));
+        expect(queryByText('Save')).toBeDisabled();
+        fireEvent.click(getByText('Cancel'));
 
     });
 });

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.test.tsx
@@ -273,8 +273,8 @@ describe('Tiles View component tests for Developer user', () => {
         expect(queryByText('Yes')).not.toBeInTheDocument();
         // test description
         fireEvent.click(getByText('testFlow'));
-        expect(queryByText('Save')).not.toBeInTheDocument();
-        fireEvent.click(getByText('Close'));
+        expect(queryByText('Save')).toBeDisabled();
+        fireEvent.click(getByText('Cancel'));
 
         // test run
         fireEvent.click(getByLabelText('icon: right'));


### PR DESCRIPTION
### Description

For users with only reader role, replace Close button in the Edit Flow dialog with the enabled Close and disabled Save buttons seen in similar dialogs.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

