### PR TITLE
DHFPROD-6234:Fix failing tests in 9.0-x server

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/entity/EntityManagerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/entity/EntityManagerTest.java
@@ -17,6 +17,7 @@ package com.marklogic.hub.entity;
 
 import com.marklogic.hub.AbstractHubCoreTest;
 import com.marklogic.hub.HubConfig;
+import com.marklogic.hub.MarkLogicVersion;
 import com.marklogic.hub.impl.EntityManagerImpl;
 import com.marklogic.hub.util.FileUtil;
 import com.marklogic.rest.util.Fragment;
@@ -221,7 +222,15 @@ public class EntityManagerTest extends AbstractHubCoreTest {
 
         String stagingOptions = getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE);
         String finalOptions = getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE);
-        Stream.of(stagingOptions, finalOptions).forEach(option -> assertNull(option, "Expected the option to not be deployed since there is a conflicting constraint for 'Collection'."));
+        Stream<String> optionsString = Stream.of(stagingOptions, finalOptions);
+        MarkLogicVersion version = new MarkLogicVersion(getHubClient().getManageClient());
+        if(version.supportsRangeIndexConstraints()){
+            optionsString.forEach(option -> assertNull(option, "Expected the option to not be deployed since there is a conflicting constraint for 'Collection'."));
+        }
+        else{
+            optionsString.forEach(option -> assertNotNull(option, "Expected the option to be deployed since entity constraint is not generated in this marklogic version."));
+        }
+
 
         String stagingExplorerOptions = getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubConfig.EXP_STAGING_ENTITY_QUERY_OPTIONS_FILE);
         String finalExplorerOptions = getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubConfig.EXP_FINAL_ENTITY_QUERY_OPTIONS_FILE);

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/marklogic-data-hub-spark-connector/writeRecords/ingestionWithNullParams.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/marklogic-data-hub-spark-connector/writeRecords/ingestionWithNullParams.sjs
@@ -33,6 +33,7 @@ const envelope = record.document.envelope;
 
   //should add default metadata
   test.assertExists(record.metadata.datahubCreatedOn),
-  test.assertEqual("test-data-hub-developer",record.metadata.datahubCreatedBy),
+  test.assertExists(record.metadata.datahubCreatedBy),
+  test.assertNotEqual('', record.metadata.datahubCreatedBy),
   test.assertExists(record.metadata.datahubCreatedByJob)
 ];


### PR DESCRIPTION
### Description
Fix failing tests in 9.0-x server. This PR fixes 3 failing tests in https://jenkins.marklogic.com/blue/organizations/jenkins/Datahub_CI/detail/develop/1611/tests/.  


deployExplorerOptionsWithoutContainerConstraint() – com.marklogic.hub.entity.EntityManagerTest test is failing in 9.0-x.
@rjrudin, @akshaysonvane , @ryanjdew ,
It looks like we do not generate entity constraints in 9.0-x server. 
Not sure what should be done here, should the test be excluded in 9.0-x ?
 
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

