### PR TITLE
DHFPROD-6101: Enhance the /api/steps/mapping/{stepName}/testingDoc endpoint to return "sourceProperties"

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mapping/getDocumentForTesting.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mapping/getDocumentForTesting.sjs
@@ -19,13 +19,83 @@ xdmp.securityAssert('http://marklogic.com/data-hub/privileges/read-mapping', 'ex
 
 const core = require('/data-hub/5/artifacts/core.sjs')
 const ds = require("/data-hub/5/data-services/ds-utils.sjs");
+const xmlToJson = require('./xmlToJsonForMapping.sjs');
 
 var stepName, uri;
+
+function _isSourceJson(format) {
+  return format.toUpperCase() === 'JSON'
+}
+
+function _isValidQName(name) {
+  try {
+    fn.QName('', name);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function _isObject(value) {
+  // Added key criteria as typeof(value) returned 'object' for some scalar values.
+  return (value && typeof(value) === 'object' && Object.keys(value).length > 0) === true;
+}
+
+function _isAtomic(value) {
+  return !_isObject(value);
+}
+
+function _isArray(value) {
+  // False negatives from Array.isArray(value)
+  return value && value.hasOwnProperty('0');
+}
+
+function _getXPath(leadingPath, nextPart, value, format, isArray) {
+  // Account for invalid QNames, which is possible when the source format is JSON.
+  let funcStart = '';
+  let funcEnd = '';
+  if (_isSourceJson(format) && !_isValidQName(nextPart)) {
+    // Array of atomic values
+    if (isArray && value.length > 0 && _isAtomic(value[0])) {
+      funcStart = "array-node('";
+      funcEnd = "')/node()";
+    } else {
+      // Either not an array, an empty array, or an array of object values.
+      funcStart = "node('";
+      funcEnd = "')";
+    }
+  }
+  return `${leadingPath}/${funcStart}${nextPart}${funcEnd}`;
+}
+
+// Recursive function used to populate the sourceProperties portion/array of the return.
+function _flatten(sourceData, sourceFormat, flatArray, flatArrayKey = '', level = 0) {
+  let value, isObject, isArray, xpath;
+  for (let key of Object.keys(sourceData)) {
+    // sourceProperties is not to receive the #text properties.
+    if (key === xmlToJson.PROP_NAME_FOR_TEXT) { continue }
+
+    value = sourceData[key];
+    isObject = _isObject(value);
+    isArray = _isArray(value);
+    xpath = _getXPath(flatArrayKey, key, value, sourceFormat, isArray);
+    flatArray.push({
+      name: key,
+      xpath: xpath,
+      struct: isObject,
+      level: level
+    })
+    if (isObject && !isArray) {
+      _flatten(value, sourceFormat, flatArray, `${flatArrayKey}/${key}`, level + 1);
+    }
+  }
+}
 
 const rtn = {
   data: null,
   namespaces: {},
-  format: null
+  format: null,
+  sourceProperties: []
 }
 
 // Offer the mapping step to define the doc's database.
@@ -43,7 +113,7 @@ if (doc === null) {
 
 // Populate return object.
 rtn.format = doc.documentFormat;
-if (rtn.format.toUpperCase() === 'JSON') {
+if (_isSourceJson(rtn.format)) {
   rtn.data = (doc.root.hasOwnProperty('envelope') && doc.root.envelope.hasOwnProperty('instance')) ?
     doc.root.envelope.instance :
     doc.root;
@@ -52,9 +122,10 @@ if (rtn.format.toUpperCase() === 'JSON') {
   if (xmlNode === null) {
     xmlNode = doc.root;
   }
-  const transformResult = require('./xmlToJsonForMapping.sjs').transform(xmlNode);
+  const transformResult = xmlToJson.transform(xmlNode);
   rtn.data = transformResult.data;
   rtn.namespaces = transformResult.namespaces;
 }
+_flatten(rtn.data, rtn.format, rtn.sourceProperties);
 
 rtn;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/lib/mappingService.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/lib/mappingService.sjs
@@ -1,5 +1,7 @@
 'use strict';
 
+const test = require("/test/test-helper.xqy");
+
 // Utils for getDocumentForTesting's tests.
 const DocumentForTestingUtils = {
   STEP_NAME: 'prospect2CustomerMappingStep',
@@ -20,6 +22,42 @@ const DocumentForTestingUtils = {
     return fn.head(require("/test/data-hub-test-helper.sjs").runWithRolesAndPrivileges(['hub-central-mapping-reader'], [],
       "/data-hub/5/data-services/mapping/getDocumentForTesting.sjs", {stepName, uri}
     ));
+  },
+  // May return zero or more.
+  getSourcePropertiesByName: function (sourceProperties, name) {
+    const matches = [];
+    if (Array.isArray(sourceProperties)) {
+      for (let property of sourceProperties) {
+        if (name === property.name) {
+          matches.push(property);
+        }
+      }
+    }
+    return matches;
+  },
+  // This function does not evaluate XPath expressions; rather, a string comparison is performed.
+  getSourcePropertyByXPath: function (sourceProperties, xpath) {
+    let winner = null;
+    if (Array.isArray(sourceProperties)) {
+      for (let property of sourceProperties) {
+        if (xpath === property.xpath) {
+          winner = property;
+          break;
+        }
+      }
+    }
+    return winner;
+  },
+  getSourcePropertyAssertions: function (sourceProperties, name, xpath, struct, level) {
+    const property = this.getSourcePropertyByXPath(sourceProperties, xpath);
+    if (!property) {
+      test.fail(`No source property with XPath of "${xpath}" in ${JSON.stringify(sourceProperties)}`)
+    }
+    return [
+      test.assertEqual(name, property.name, `Unexpected "name" value for the source property with the "${xpath}" xpath`),
+      test.assertTrue(struct === property.struct, `Expected ${struct} for the "struct" value for the source property with the "${xpath}" xpath but got ${property.struct}`),
+      test.assertEqual(level, property.level, `Unexpected "level" value for the source property with the "${xpath}" xpath`)
+    ];
   }
 }
 

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/envelopedXmlTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/envelopedXmlTest.sjs
@@ -3,7 +3,7 @@
 const test = require("/test/test-helper.xqy");
 const utils = require('/test/suites/data-hub/5/data-services/lib/mappingService.sjs').DocumentForTestingUtils;
 
-const assertions = [];
+let assertions = [];
 
 const result = utils.invokeService(utils.STEP_NAME, '/content/envelopedCustomerDoc.xml');
 const data = result.data;
@@ -12,7 +12,7 @@ const expectedNamespaces = {
   "OrderNS":"https://www.w3schools.com/OrderNS"
 }
 
-assertions.concat([
+assertions = assertions.concat([
   test.assertExists(data, "Top-level 'data' property does not exist"),
   test.assertExists(data['OrderNS:Order'], "The data's first property is expected to be 'OrderNS:Order' but was given '" + Object.keys(data).join("' and '") + "'"),
   test.assertExists(data['OrderNS:Order']['RequiredDate'], "Expected RequiredDate (no namespace) within OrderNS:Order but found '" + Object.keys(data['OrderNS:Order']).join("' and '") + "'"),

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/nonExistentDocTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/nonExistentDocTest.sjs
@@ -3,7 +3,7 @@
 const test = require("/test/test-helper.xqy");
 const utils = require('/test/suites/data-hub/5/data-services/lib/mappingService.sjs').DocumentForTestingUtils;
 
-const assertions = [];
+let assertions = [];
 const uri = '/uri/to/non-existent/doc.json';
 
 // Using try/catch as an alternative to test.assertThrowsError*().
@@ -11,8 +11,7 @@ try {
   utils.invokeService(utils.STEP_NAME, uri);
   assertions.push(test.fail('Exception not thrown when attempting to process a non-existent document.'));
 } catch (e) {
-  xdmp.log(JSON.stringify(e));
-  assertions.concat([
+  assertions = assertions.concat([
     test.assertTrue(e.data && Array.isArray(e.data) && e.data.length === 2,
       "Expected exception object's 'data' property to be an array of two items"),
     test.assertEqual('404', e.data[0], 'Expected an exception code of 404'),

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/startWithJsonTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/startWithJsonTest.sjs
@@ -3,15 +3,39 @@
 const test = require("/test/test-helper.xqy");
 const utils = require('/test/suites/data-hub/5/data-services/lib/mappingService.sjs').DocumentForTestingUtils;
 
-const assertions = [];
+let assertions = [];
 
 const result = utils.invokeService(utils.STEP_NAME, '/content/sampleCustomerDoc.json');
-assertions.concat([
+
+// Tests for data section.
+assertions = assertions.concat([
   test.assertExists(result.data, 'Top-level "data" property does not exist'),
   test.assertEqual(204, Number(result.data.CustOrders.CustomerID)),
-  test.assertEqual('Sparrow', String(result.data.CustOrders.Nicknames.Nickname[1])),
-  test.assertEqualJson({}, result.namespaces, 'The "namespaces" property should be an empty object for JSON input.'),
-  test.assertEqual('JSON', String(result.format), 'The "format" property should be set to "JSON".')
+  test.assertEqual('Sparrow', String(result.data.CustOrders.Nicknames.Nickname[1]))
 ]);
+
+// Test(s) for namespaces section.
+assertions.push(test.assertEqualJson({}, result.namespaces, 'The "namespaces" property should be an empty object for JSON input.'));
+
+// Test(s) for format section.
+assertions.push(test.assertEqual('JSON', String(result.format), 'The "format" property should be set to "JSON".'));
+
+// Tests for sourceProperties section.
+const sourceProperties = result.sourceProperties;
+// Array with valid QName (should not include array-node()
+let name = 'Nickname';
+assertions = assertions.concat(utils.getSourcePropertyAssertions(sourceProperties, name, `/CustOrders/Nicknames/${name}`, true, 2));
+// Invalid QNames
+name = '$id';
+assertions = assertions.concat(utils.getSourcePropertyAssertions(sourceProperties, name, `/CustOrders/invalidQNames/node('${name}')`, false, 2));
+name = '$array-of-objects';
+assertions = assertions.concat(utils.getSourcePropertyAssertions(sourceProperties, name, `/CustOrders/invalidQNames/node('${name}')`, true, 2));
+name = '$array-of-values';
+assertions = assertions.concat(utils.getSourcePropertyAssertions(sourceProperties, name, `/CustOrders/invalidQNames/array-node('${name}')/node()`, true, 2));
+name = 'invalidLocalName:asdf';
+assertions = assertions.concat(utils.getSourcePropertyAssertions(sourceProperties, name, `/CustOrders/OddPropertyNames/node('${name}')`, false, 2));
+// Unicode character in property name.
+name = 'propName\u{EFFFF}IncludesUnicode';
+assertions = assertions.concat(utils.getSourcePropertyAssertions(sourceProperties, name, `/CustOrders/OddPropertyNames/${name}`, false, 2));
 
 assertions;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/startWithXmlTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/startWithXmlTest.sjs
@@ -2,8 +2,9 @@
 
 const test = require("/test/test-helper.xqy");
 const utils = require('/test/suites/data-hub/5/data-services/lib/mappingService.sjs').DocumentForTestingUtils;
+const xmlToJson = require('/data-hub/5/data-services/mapping/xmlToJsonForMapping.sjs');
 
-const assertions = [];
+let assertions = [];
 
 const result = utils.invokeService(utils.STEP_NAME, '/content/sampleCustomerDoc.xml');
 const orderProp = result.data['OrderNS:Order'];
@@ -27,7 +28,7 @@ const expectedNamespaces = {
   "Gamma2": "https://www.amazon.com/Gamma"
 };
 
-assertions.concat([
+assertions = assertions.concat([
   test.assertExists(result.data, 'Top-level "data" property does not exist'),
   test.assertExists(orderProp, "The data's first property is expected to be 'OrderNS:Order'"),
   // Are the namespaces of these attributes correct in the output?
@@ -42,9 +43,9 @@ assertions.concat([
   test.assertTrue(Array.isArray(orderProp['OD:OrderDetails']['OD:OrderDetail']) && orderProp['OD:OrderDetails']['OD:OrderDetail'].length === 2,
     "OD:OrderDetail should be an array with two items but is " + JSON.stringify(orderProp['OD:OrderDetails']['OD:OrderDetail'])),
   test.assertExists(orderProp['OD:OrderDetails']['OD:OrderDetail'][0]['Wash:UnitPrice'],
-    "The first OD:OrderDetails element should have a Wash:UnitPrice child."),
+    "The first OD:OrderDetails element should have a Wash:UnitPrice child"),
   test.assertExists(orderProp['OD:OrderDetails']['OD:OrderDetail'][1]['Cali:UnitPrice'],
-    "The second OD:OrderDetails element should have a Cali:UnitPrice child."),
+    "The second OD:OrderDetails element should have a Cali:UnitPrice child"),
   // ShippedDate should be an array.
   test.assertExists(orderProp['OrderNS:ShippedDate']),
   test.assertTrue(Array.isArray(orderProp['OrderNS:ShippedDate']) && orderProp['OrderNS:ShippedDate'].length === 2,
@@ -52,7 +53,7 @@ assertions.concat([
   // Verify the default namespace changed.
   test.assertExists(orderProp['SV:ShipVia']),
   // Verify the default namespace immediately reverted.
-  test.assertExists(orderProp['OrderNS:ShipPostalCode'], "Looks like the default namespace did not revert."),
+  test.assertExists(orderProp['OrderNS:ShipPostalCode'], "Looks like the default namespace did not revert"),
   // More should and should-not-be array tests
   test.assertEqual("Should *not* be in an array.", String(orderProp['Gamma:Element1']),
     "Gamma:Element1 should just be a string as next Element1 is in a different namespace"),
@@ -66,41 +67,41 @@ assertions.concat([
   // EmptyElementWithoutAttributes
   test.assertExists(markupScenariosProp['OrderNS:EmptyElementWithoutAttributes']),
   test.assertEqual('', String(markupScenariosProp['OrderNS:EmptyElementWithoutAttributes']),
-    'Expected the OrderNS:EmptyElementWithoutAttributes property value to be an empty string.'),
+    'Expected the OrderNS:EmptyElementWithoutAttributes property value to be an empty string'),
   // EmptyElementWithAttribute
   test.assertExists(markupScenariosProp['OrderNS:EmptyElementWithAttribute']),
   test.assertEqual('hello', String(markupScenariosProp['OrderNS:EmptyElementWithAttribute']['@attr']),
-    'Expected OrderNS:EmptyElementWithAttribute to have the "@attr" property set to "hello".'),
+    'Expected OrderNS:EmptyElementWithAttribute to have the "@attr" property set to "hello"'),
   // NoTextOrAttrs
   test.assertExists(markupScenariosProp['OrderNS:NoTextOrAttrs']),
   test.assertEqual('', String(markupScenariosProp['OrderNS:NoTextOrAttrs']),
-    'Expected the OrderNS:NoTextOrAttrs property value to be an empty string.'),
+    'Expected the OrderNS:NoTextOrAttrs property value to be an empty string'),
   // JustText
   test.assertExists(markupScenariosProp['OrderNS:JustText']),
   test.assertEqual('Hello', String(markupScenariosProp['OrderNS:JustText']),
-    'Expected the OrderNS:JustText property value to be "Hello".'),
+    'Expected the OrderNS:JustText property value to be "Hello"'),
   // JustAttr
   test.assertExists(markupScenariosProp['OrderNS:JustAttr']),
   test.assertEqual('Howdy', String(markupScenariosProp['OrderNS:JustAttr']['@attr']),
-    'Expected OrderNS:JustAttr to have the "@attr" property set to "Howdy".'),
+    'Expected OrderNS:JustAttr to have the "@attr" property set to "Howdy"'),
   // AttrAndText
   test.assertExists(markupScenariosProp['OrderNS:AttrAndText']),
   test.assertEqual('Some Text', String(markupScenariosProp['OrderNS:AttrAndText']['#text']),
-    'Expected OrderNS:AttrAndText to have text of "Some Text".'),
+    'Expected OrderNS:AttrAndText to have text of "Some Text"'),
   test.assertEqual('myattr', String(markupScenariosProp['OrderNS:AttrAndText']['@attr']),
-    'Expected OrderNS:AttrAndText to have the "@attr" property set to "myattr".'),
+    'Expected OrderNS:AttrAndText to have the "@attr" property set to "myattr"'),
   // AttrTextAndChild
   test.assertExists(markupScenariosProp['OrderNS:AttrTextAndChild']),
   test.assertEqual('How aredoing?', String(markupScenariosProp['OrderNS:AttrTextAndChild']['#text']),
-    'Expected OrderNS:AttrTextAndChild to have text of "How aredoing?".'),
+    'Expected OrderNS:AttrTextAndChild to have text of "How aredoing?"'),
   test.assertEqual('woohoo!', String(markupScenariosProp['OrderNS:AttrTextAndChild']['@attr']),
-    'Expected OrderNS:AttrTextAndChild to have the "@attr" property set to "woohoo!".'),
+    'Expected OrderNS:AttrTextAndChild to have the "@attr" property set to "woohoo!"'),
   test.assertEqual('you', String(markupScenariosProp['OrderNS:AttrTextAndChild']['OrderNS:b']),
-    'Expected OrderNS:AttrTextAndChild to have a property named "b" with a value of "you".'),
+    'Expected OrderNS:AttrTextAndChild to have a property named "b" with a value of "you"'),
   // MultipleTextNodes
   test.assertExists(markupScenariosProp['OrderNS:MultipleTextNodes']),
   test.assertEqual('1st text node2nd text node', String(markupScenariosProp['OrderNS:MultipleTextNodes']['#text']),
-    'While not desired, expected the two text nodes in OrderNS:MultipleTextNodes to be concatenated.'),
+    'While not desired, expected the two text nodes in OrderNS:MultipleTextNodes to be concatenated'),
   // ExampleWithCDATA
   test.assertExists(markupScenariosProp['OrderNS:ExampleWithCDATA']),
   test.assertEqual('Text outside Text inside More text outside', String(markupScenariosProp['OrderNS:ExampleWithCDATA']),
@@ -111,5 +112,87 @@ assertions.concat([
   // And finally the format test.
   test.assertEqual('XML', String(result.format))
 ]);
+
+/*
+ * BEGIN: source property tests
+ */
+const sourceProperties = result.sourceProperties;
+
+// First source property.
+let xpath = '/OrderNS:Order';
+let prop = sourceProperties[0];
+assertions = assertions.concat([
+  test.assertEqual(xpath.substr(1), prop.name, "Unexpected name for the first source property"),
+  test.assertEqual(xpath, prop.xpath, "Unexpected xpath for the first source property"),
+  test.assertTrue(prop.struct, `Expected true for the first source property's struct property but got "${prop.struct}"`),
+  test.assertEqual(0, prop.level, 'Unexpected level for the first source property')
+]);
+
+// Test struct=false and level=1
+xpath = '/OrderNS:Order/OrderNS:RequiredDate';
+prop = utils.getSourcePropertyByXPath(sourceProperties, xpath);
+assertions = assertions.concat([
+  test.assertFalse(prop.struct, `Unexpected struct for the ${xpath} source property`),
+  test.assertEqual(1, prop.level, `Unexpected level for the ${xpath} source property`)
+]);
+
+// Namespace changed
+xpath = '/OrderNS:Order/OD:OrderDetails';
+prop = utils.getSourcePropertyByXPath(sourceProperties, xpath);
+assertions.push(test.assertExists(prop, `Expected to find a source property where xpath=${xpath} but did not`));
+
+// Attribute without namespace prefix.
+let name = '@in';
+let props = utils.getSourcePropertiesByName(sourceProperties, name);
+assertions = assertions.concat([
+  test.assertTrue(props.length === 1, `Expected 1 source property where name=${name} but found ${props.length}`),
+  test.assertEqual(`/OrderNS:Order/OD:OrderDetails/${name}`, props[0].xpath, `Unexpected xpath property value for the "${name}" source property`),
+  test.assertFalse(props[0].struct, `Unexpected struct for the "${name}" source property`),
+  test.assertEqual(2, props[0].level, `Unexpected level for the "${name}" source property`)
+])
+
+// Attribute with namespace prefix.
+xpath = '/OrderNS:Order/OD:OrderDetails/@OtherNS:out';
+prop = utils.getSourcePropertyByXPath(sourceProperties, xpath);
+assertions.push(test.assertExists(prop, `Expected to find a source property where xpath=${xpath} but did not`));
+
+// Array (struct=true)
+xpath = '/OrderNS:Order/OD:OrderDetails/OD:OrderDetail';
+prop = utils.getSourcePropertyByXPath(sourceProperties, xpath);
+assertions = assertions.concat([
+  test.assertExists(prop, `Expected to find a source property where xpath=${xpath} but did not`),
+  test.assertTrue(prop.struct, `Unexpected struct for the "${xpath}" source property`)
+]);
+
+// Level 3
+xpath = '/OrderNS:Order/OrderNS:MarkupScenarios/OrderNS:AttrTextAndChild/OrderNS:b';
+prop = utils.getSourcePropertyByXPath(sourceProperties, xpath);
+assertions = assertions.concat([
+  test.assertExists(prop, `Expected to find a source property where xpath=${xpath} but did not`),
+  test.assertEqual(3, prop.level, `Unexpected level for the "${xpath}" source property`)
+]);
+
+// Verify there are the correct number of properties where name=@attr but that they each have a unique xpath.
+let expectedCount = 4;
+let uniqueXPaths = [];
+name = '@attr';
+props = utils.getSourcePropertiesByName(sourceProperties, name);
+for (let p of props) {
+  if (!uniqueXPaths.some(val => val === p.xpath)) {
+    uniqueXPaths.push(p.xpath);
+  }
+}
+assertions.push(test.assertEqual(expectedCount, props.length,
+  `Expected ${expectedCount} source properties where name=${name} but found ${props.length}`))
+assertions.push(test.assertEqual(expectedCount, uniqueXPaths.length,
+  `Expected ${expectedCount} unique XPaths on source properties where name=${name} but found ${uniqueXPaths.length}`))
+
+// Verify #text data properties didn't also become source properties.
+const textNodes = utils.getSourcePropertiesByName(sourceProperties, xmlToJson.PROP_NAME_FOR_TEXT);
+assertions.push(test.assertTrue(textNodes.length === 0,
+  `sourceProperties not expected to include "name" properties with a value of "${xmlToJson.PROP_NAME_FOR_TEXT}" yet ${textNodes.length} were found`));
+/*
+ * END: source property tests
+ */
 
 assertions;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/test-data/content/sampleCustomerDoc.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/test-data/content/sampleCustomerDoc.json
@@ -12,6 +12,15 @@
             "Jack",
             "Sparrow"
           ]
+        },
+        "invalidQNames": {
+          "$id": "123",
+          "$array-of-values": ["one", "two"],
+          "$array-of-objects": [{"test": "object"}]
+        },
+        "OddPropertyNames": {
+          "propName\uDB7F\uDFFFIncludesUnicode": true,
+          "invalidLocalName:asdf": true
         }
       }
     }


### PR DESCRIPTION
### Description
This is an extension of DHFPROD-6098, "Create endpoint for fetching source document for mapping UI".

It adds the sourceProperties property to the endpoint's return.

Full endpoint path: /api/steps/mapping/{stepName}/testingDoc

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests

