### PR TITLE
DHFPROD-6033: Add Step Details and Step Settings links

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/mapping.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/mapping.spec.tsx
@@ -96,7 +96,6 @@ describe('Mapping', () => {
     advancedSettingsDialog.setStepProcessor('curateTile/orderDateProcessor');
 
     // add customHook to mapping step
-    //curatePage.stepSettings(mapStep).click();
     advancedSettingsDialog.setCustomHook('curateTile/customUriHook');
 
     advancedSettingsDialog.saveSettings(mapStep).click();
@@ -116,6 +115,12 @@ describe('Mapping', () => {
     sourceToEntityMap.setXpathExpressionInput('discount', 'head(OrderDetails/Discount)');
     sourceToEntityMap.setXpathExpressionInput('shipRegion', 'ShipRegion');
     sourceToEntityMap.setXpathExpressionInput('shippedDate', 'ShippedDate');
+
+    // link to settings and back 
+    sourceToEntityMap.stepSettingsLink().click();
+    cy.waitUntil(() => createEditMappingDialog.stepDetailsLink().click());
+    cy.waitUntil(() => sourceToEntityMap.expandCollapseEntity().should('be.visible'));
+
     // close modal
     cy.get('body').type('{esc}');
 

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/mapping/create-edit-mapping-dialog.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/mapping/create-edit-mapping-dialog.tsx
@@ -42,6 +42,10 @@ class CreateEditMappingDialog {
     cy.get('#srcQuery').type(str);
   }
 
+  stepDetailsLink() {
+    return cy.findByLabelText(`stepDetails`);
+  }
+
   saveButton() {
     return cy.findByTestId('mapping-dialog-save');
   }

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/mapping/source-to-entity-map.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/mapping/source-to-entity-map.tsx
@@ -55,6 +55,10 @@ class SourceToEntityMap {
     return cy.findByTestId('submitSearch-name');
   }
 
+  stepSettingsLink() {
+    return cy.findByLabelText(`stepSettings`);
+  }
+
   /**
    * Get property icon from dropdown list by Entity type property name
    * @param propertyName

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/curation/common.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/curation/common.data.ts
@@ -337,12 +337,13 @@ const mapProps = {
   docNotFound: false,
   entityTypeTitle: 'Person',
   extractCollectionFromSrcQuery: jest.fn(),
-  mapFunctions: mapFunctions
+  mapFunctions: mapFunctions,
+  openStepSettings: jest.fn()
 };
 
 const newMap = {
   tabKey: '1',
-  isNewStep: true,
+  isEditing: false,
   openStepSettings: true,
   setOpenStepSettings: jest.fn(),
   createMappingArtifact: jest.fn(),
@@ -359,7 +360,7 @@ const newMap = {
 
 const editMap = {
   tabKey: '1',
-  isNewStep: false,
+  isEditing: true,
   openStepSettings: true,
   setOpenStepSettings: jest.fn(),
   createLoadArtifact: jest.fn(),

--- a/marklogic-data-hub-central/ui/src/components/entities/custom/custom-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/custom/custom-card.tsx
@@ -51,7 +51,7 @@ const CustomCard: React.FC<Props> = (props) => {
             )) : <span></span> }</Row>
             <Steps
                 // Basic Settings
-                isNewStep={false}
+                isEditing={true}
                 stepData={stepData}
                 canReadWrite={props.canReadWrite}
                 canReadOnly={props.canReadOnly}

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/create-edit-mapping/create-edit-mapping.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/create-edit-mapping/create-edit-mapping.tsx
@@ -11,7 +11,7 @@ interface Props {
   tabKey: string;
   openStepSettings: boolean;
   setOpenStepSettings: any;
-  isNewStep: boolean;
+  isEditing: boolean;
   canReadWrite: boolean;
   canReadOnly: boolean;
   createMappingArtifact: any;
@@ -88,7 +88,7 @@ const CreateEditMapping: React.FC<Props> = (props) => {
 
   useEffect(() => {
     // Edit step
-    if (props.stepData && JSON.stringify(props.stepData) != JSON.stringify({}) && !props.isNewStep) {
+    if (props.stepData && JSON.stringify(props.stepData) != JSON.stringify({}) && props.isEditing) {
       initStep();
     } 
     // New step
@@ -323,7 +323,7 @@ const CreateEditMapping: React.FC<Props> = (props) => {
             setDescriptionTouched(false);
           }
         }
-        if (props.isNewStep) {
+        if (!props.isEditing) {
           if (event.target.value === '') {
             setDescriptionTouched(false);
           }

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
@@ -57,7 +57,7 @@ const MappingCard: React.FC<Props> = (props) => {
     const [selectVisible, setSelectVisible] = useState(false);
     const [addRun, setAddRun] = useState(false);
     const [openStepSettings, setOpenStepSettings] = useState(false);
-    const [isNewStep, setIsNewStep] = useState(false);
+    const [isEditing, setIsEditing] = useState(false);
 
     //For Entity table
     const [entityTypeProperties, setEntityTypeProperties] = useState<any[]>([]);
@@ -96,12 +96,12 @@ const MappingCard: React.FC<Props> = (props) => {
     },[props.data]);
 
     const OpenAddNew = () => {
-        setIsNewStep(true);
+        setIsEditing(false);
         setOpenStepSettings(true);
     }
 
     const OpenStepSettings = (index) => {
-        setIsNewStep(false);
+        setIsEditing(true);
         //setStepData(prevState => ({ ...prevState, ...props.data[index]}));
         setMapData(prevState => ({ ...prevState, ...props.data[index]}));
         setOpenStepSettings(true);
@@ -576,6 +576,10 @@ const MappingCard: React.FC<Props> = (props) => {
             setMappingVisible(true);
       };
 
+    const openStepDetails = (name) => {
+        // need step's name and array index to option mapping details
+        openSourceToEntityMapping(name, props.data.findIndex(el => el.name === name));
+    }
 
     function handleSelect(obj) {
         let selectedNew = {...selected};
@@ -785,11 +789,12 @@ const MappingCard: React.FC<Props> = (props) => {
                 namespaces={namespaces}
                 mapIndex={mapIndex}
                 tgtEntityReferences={tgtEntityReferences}
-                isLoading={isLoading}/>
+                isLoading={isLoading}
+                openStepSettings={OpenStepSettings}/>
             {addConfirmation}
             <Steps
                 // Basic Settings
-                isNewStep={isNewStep}
+                isEditing={isEditing}
                 createStep={createMappingArtifact}
                 stepData={mapData}
                 sourceDatabase={sourceDatabaseName}
@@ -803,6 +808,7 @@ const MappingCard: React.FC<Props> = (props) => {
                 updateStep={updateMappingArtifact}
                 activityType={activityType}
                 targetEntityType={props.entityModel.entityTypeId}
+                openStepDetails={openStepDetails}
             />
         </div>
     );

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.module.scss
@@ -482,3 +482,15 @@ hr {
   #browse-buttons{
     border: 1px solid rgba(0, 0, 0, 0.961);
   }
+
+  .stepSettingsLink {
+    position: absolute;
+    top: 18px;
+    right: 66px;
+    color: #44499C;
+    cursor: pointer;
+    .stepSettingsLabel {
+        display: inline-block;
+        margin-left: 6px;
+    }
+}

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
@@ -29,7 +29,7 @@ describe('RTL Source-to-entity map tests', () => {
     });
 
     test('RTL tests with source data',  () => {
-        const { getByTestId,  getByText, queryByText, rerender } = render(<SourceToEntityMap {...data.mapProps} mappingVisible={true}/>);
+        const { getByTestId, getByText, getByLabelText, queryByText, rerender } = render(<SourceToEntityMap {...data.mapProps} mappingVisible={true}/>);
         expect(getByText('Source Data')).toBeInTheDocument();
         expect(getByText('proteinId')).toBeInTheDocument();
         expect(getByText('emptyString')).toBeInTheDocument();
@@ -43,6 +43,12 @@ describe('RTL Source-to-entity map tests', () => {
         expect(getByTestId("srcContainer")).toHaveClass("sourceContainer");
         expect(getByText('Entity: Person')).toBeInTheDocument();
         expect(getByText('Test')).toBeEnabled();
+        
+        // Link to Settings
+        const settingsLink = getByLabelText('stepSettings');
+        settingsLink.onclick = jest.fn();
+        fireEvent.click(settingsLink);
+        expect(settingsLink.onclick).toHaveBeenCalledTimes(1);
 
         // Check datatype class names for source values
         expect(getByTestId("emptyString-srcValue").children[0].className.includes('datatype-string')).toBe(true);

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
@@ -1163,6 +1163,11 @@ const SourceToEntityMap = (props) => {
         }
     };
 
+    const handleStepSettings = () => {
+        onCancel();
+        props.openStepSettings(props.mapIndex);
+    }
+
     return (<Modal
             visible={props.mappingVisible}
             onCancel={() => onCancel()}
@@ -1173,6 +1178,12 @@ const SourceToEntityMap = (props) => {
             bodyStyle={{paddingBottom:0}}
             destroyOnClose={true}
         >
+
+            <div className={styles.stepSettingsLink} onClick={() => handleStepSettings()}>
+                <Icon type="edit" role="step-settings button" aria-label={'stepSettings'} />
+                <span className={styles.stepSettingsLabel}>Step Settings</span>
+            </div>
+
             <div className={styles.header}>
                 <span className={styles.headerTitle}>{props.mapName}</span>
                 {errorInSaving ? success() : <span className={styles.noMessage}></span>}

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/matching-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/matching-card.tsx
@@ -40,50 +40,26 @@ const MatchingCard: React.FC<Props> = (props) => {
   const [showLinks, setShowLinks] = useState('');
   const [stepArtifact, setStepArtifact] = useState({});
 
-  const [showCreateEditStepModal, toggleCreateEditStepModal] = useState(false);
-  const [isEditing, toggleIsEditing] = useState(false);
   const [editStepArtifact, setEditStepArtifact] = useState({});
   const [ matchingData, setMatchingData ] = useState({});
-
-  const [showStepSettings, toggleStepSettings] = useState(false);
 
   const [confirmType, setConfirmType] = useState<ConfirmationType>(ConfirmationType.AddStepToFlow);
   const [showConfirmModal, toggleConfirmModal] = useState(false);
   const [confirmBoldTextArray, setConfirmBoldTextArray] = useState<string[]>([]);
 
   const [openStepSettings, setOpenStepSettings] = useState(false);
-  const [isNewStep, setIsNewStep] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
 
   const OpenAddNew = () => {
-    setIsNewStep(true);
+    setIsEditing(false);
     setOpenStepSettings(true);
   }
-
-  const openAddStepDialog = () => {
-    setEditStepArtifact({});
-    toggleIsEditing(false);
-    toggleCreateEditStepModal(true);
-  };
 
   const OpenStepSettings = (index) => {
-    setIsNewStep(false);
-    //setStepData(prevState => ({ ...prevState, ...props.data[index]}));
+    setIsEditing(true);
     setEditStepArtifact(props.matchingStepsArray[index]);
     setOpenStepSettings(true);
-    toggleIsEditing(true);
-    toggleCreateEditStepModal(true);
   }
-
-  const openEditStepDialog = (index) => {
-    setEditStepArtifact(props.matchingStepsArray[index])
-    toggleIsEditing(true);
-    toggleCreateEditStepModal(true);
-  };
-
-  const stepSettingsClicked = (index) => {
-    setStepArtifact(props.matchingStepsArray[index]);
-    toggleStepSettings(true);
-  };
 
   const createMatchingArtifact = async (payload) => {
     // Update local form state, then save to db
@@ -280,8 +256,7 @@ const updateMatchingArtifact = (payload) => {
       />
       <Steps
           // Basic Settings
-          isNewStep={isNewStep}
-          //createStep={createMappingArtifact}
+          isEditing={isEditing}
           createStep={createMatchingArtifact}
           stepData={editStepArtifact}
           canReadOnly={props.canReadMatchMerge}

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merging-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merging-card.tsx
@@ -41,7 +41,6 @@ const MergingCard: React.FC<Props> = (props) => {
   const [stepArtifact, setStepArtifact] = useState({});
 
   const [showCreateEditStepModal, toggleCreateEditStepModal] = useState(false);
-  const [isEditing, toggleIsEditing] = useState(false);
   const [editStepArtifact, setEditStepArtifact] = useState({});
 
   const [showStepSettings, toggleStepSettings] = useState(false);
@@ -57,33 +56,19 @@ const MergingCard: React.FC<Props> = (props) => {
   },[props.mergingStepsArray]);
 
   const [openStepSettings, setOpenStepSettings] = useState(false);
-  const [isNewStep, setIsNewStep] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
 
   const OpenAddNew = () => {
-    setIsNewStep(true);
+    setIsEditing(false);
     setOpenStepSettings(true);
   }
-
-  const openAddStepDialog = () => {
-    setEditStepArtifact({});
-    toggleIsEditing(false);
-    toggleCreateEditStepModal(true);
-  };
 
   const OpenStepSettings = (index) => {
-    setIsNewStep(false);
-    //setStepData(prevState => ({ ...prevState, ...props.data[index]}));
+    setIsEditing(true);
     setEditStepArtifact(props.mergingStepsArray[index]);
     setOpenStepSettings(true);
-    toggleIsEditing(true);
     toggleCreateEditStepModal(true);
   }
-
-  const openEditStepDialog = (index) => {
-    setEditStepArtifact(props.mergingStepsArray[index])
-    toggleIsEditing(true);
-    toggleCreateEditStepModal(true);
-  };
 
   const stepSettingsClicked = (index) => {
     setStepArtifact(props.mergingStepsArray[index]);
@@ -281,7 +266,7 @@ const MergingCard: React.FC<Props> = (props) => {
       />
       <Steps
         // Basic Settings
-        isNewStep={isNewStep}
+        isEditing={isEditing}
         createStep={createMergingArtifact}
         stepData={editStepArtifact}
         canReadOnly={props.canReadMatchMerge}

--- a/marklogic-data-hub-central/ui/src/components/load/create-edit-load/create-edit-load.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/create-edit-load/create-edit-load.test.tsx
@@ -9,7 +9,7 @@ describe('New/edit load step configuration', () => {
 
   const loadProps = {
     tabKey: '1',
-    isNewStep: false,
+    isEditing: true,
     openStepSettings: true,
     setOpenStepSettings: () => {},
     createLoadArtifact: () => {},

--- a/marklogic-data-hub-central/ui/src/components/load/create-edit-load/create-edit-load.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/create-edit-load/create-edit-load.tsx
@@ -10,7 +10,7 @@ interface Props {
   tabKey: string;
   openStepSettings: boolean;
   setOpenStepSettings: any;
-  isNewStep: boolean;
+  isEditing: boolean;
   canReadWrite: boolean;
   canReadOnly: boolean;
   createLoadArtifact
@@ -59,7 +59,7 @@ const CreateEditLoad: React.FC<Props> = (props) => {
 
   useEffect(() => {
     // Edit step
-    if (props.stepData && JSON.stringify(props.stepData) != JSON.stringify({}) && !props.isNewStep) {
+    if (props.stepData && JSON.stringify(props.stepData) != JSON.stringify({}) && props.isEditing) {
       initStep();
     } 
     // New step
@@ -91,7 +91,7 @@ const CreateEditLoad: React.FC<Props> = (props) => {
       setTobeDisabled(false);
     });
 
-  }, [props.stepData, props.isNewStep]);
+  }, [props.stepData, props.isEditing]);
 
   const onCancel = () => {
     if (hasFormChanged()) {
@@ -117,7 +117,7 @@ const CreateEditLoad: React.FC<Props> = (props) => {
   const hasFormChanged = () => {
     const step = props.stepData;
     // Edit
-    if (step && JSON.stringify(step) != JSON.stringify({}) && !props.isNewStep){
+    if (step && JSON.stringify(step) != JSON.stringify({}) && props.isEditing){
       // Any settings changed (excluding separator)?
       if (
         stepName === step.name && description === step.description && srcFormat === step.sourceFormat 

--- a/marklogic-data-hub-central/ui/src/components/load/load-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-card.tsx
@@ -12,7 +12,6 @@ import { AdvLoadTooltips, SecurityTooltips } from '../../config/tooltips.config'
 import { Link } from 'react-router-dom';
 import { MLTooltip } from '@marklogic/design-system';
 
-
 const { Option } = Select;
 
 interface Props {
@@ -38,10 +37,9 @@ const LoadCard: React.FC<Props> = (props) => {
     const [showLinks, setShowLinks] = useState('');
     const [selected, setSelected] = useState({}); // track Add Step selections so we can reset on cancel
     const [selectVisible, setSelectVisible] = useState(false);
-    const [openLoadSettings, setOpenLoadSettings] = useState(false);
     const [addRun, setAddRun] = useState(false);
     const [openStepSettings, setOpenStepSettings] = useState(false);
-    const [isNewStep, setIsNewStep] = useState(false);
+    const [isEditing, setIsEditing] = useState(false);
 
     useEffect(() => {
         let sortedArray = props.data.length > 1 ? sortStepsByUpdated(props.data) : props.data;
@@ -52,12 +50,12 @@ const LoadCard: React.FC<Props> = (props) => {
     let history = useHistory();
 
     const OpenAddNew = () => {
-        setIsNewStep(true);
+        setIsEditing(false);
         setOpenStepSettings(true);
     }
 
     const OpenStepSettings = (index) => {
-        setIsNewStep(false);
+        setIsEditing(true);
         setStepData(prevState => ({ ...prevState, ...props.data[index]}));
         setOpenStepSettings(true);
     }
@@ -334,7 +332,7 @@ const LoadCard: React.FC<Props> = (props) => {
             {addConfirmation}
             <Steps
                 // Basic Settings
-                isNewStep={isNewStep}
+                isEditing={isEditing}
                 createStep={createLoadArtifact}
                 stepData={stepData}
                 canReadOnly={props.canReadOnly}

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.tsx
@@ -41,7 +41,7 @@ const LoadList: React.FC<Props> = (props) => {
     const [loadArtifactName, setLoadArtifactName] = useState('');
     const [stepData,setStepData] = useState({});
     const [openStepSettings, setOpenStepSettings] = useState(false);
-    const [isNewStep, setIsNewStep] = useState(false);
+    const [isEditing, setIsEditing] = useState(false);
     const [selected, setSelected] = useState({}); // track Add Step selections so we can reset on cancel
     const [addRun, setAddRun] = useState(false);
 
@@ -61,12 +61,12 @@ const LoadList: React.FC<Props> = (props) => {
     let history = useHistory();
 
     const OpenAddNew = () => {
-        setIsNewStep(true);
+        setIsEditing(false);
         setOpenStepSettings(true);
     }
 
     const OpenStepSettings = (record) => {
-        setIsNewStep(false);
+        setIsEditing(true);
         setStepData(prevState => ({ ...prevState, ...record}));
         setOpenStepSettings(true);
     }
@@ -371,7 +371,7 @@ const LoadList: React.FC<Props> = (props) => {
         {addConfirmation}
         <Steps
             // Basic Settings
-            isNewStep={isNewStep}
+            isEditing={isEditing}
             createStep={createLoadArtifact}
             stepData={stepData}
             canReadOnly={props.canReadOnly}

--- a/marklogic-data-hub-central/ui/src/components/steps/steps.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/steps/steps.module.scss
@@ -15,3 +15,15 @@
         margin-top: 70px;
     }
 }
+
+.stepDetailsLink {
+    position: absolute;
+    bottom: 32px;
+    left: 35px;
+    color: #44499C;
+    cursor: pointer;
+    .stepDetailsLabel {
+        display: inline-block;
+        margin-left: 6px;
+    }
+}

--- a/marklogic-data-hub-central/ui/src/components/steps/steps.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/steps/steps.test.tsx
@@ -26,7 +26,7 @@ describe("Steps settings component", () => {
     const stepCustom = {...data.stepLoad.data, stepDefinitionName:'custom-ingestion', name: 'CustomLoad'};
 
     const stepsProps = {
-        isNewStep: false,
+        isEditing: true,
         createStep: jest.fn(),
         updateStep: jest.fn(),
         stepData: {},
@@ -37,7 +37,8 @@ describe("Steps settings component", () => {
         openStepSettings: true,
         setOpenStepSettings: jest.fn(),
         activityType: '',
-        canWrite: true
+        canWrite: true,
+        openStepDetails: jest.fn()
     }
 
     test('Verify rendering of Load step, tab switching, save changes confirmation on tab change', async () => {
@@ -92,6 +93,12 @@ describe("Steps settings component", () => {
 
         expect(getByText('Mapping Step Settings')).toBeInTheDocument();
         expect(getByLabelText('Close')).toBeInTheDocument();
+
+        // Mapping step has link to Details
+        const detailsLink = getByLabelText('stepDetails');
+        detailsLink.onclick = jest.fn();
+        fireEvent.click(detailsLink);
+        expect(detailsLink.onclick).toHaveBeenCalledTimes(1);
 
         // Default Basic tab
         expect(getByText('Basic')).toHaveClass('ant-tabs-tab-active');

--- a/marklogic-data-hub-central/ui/src/components/steps/steps.tsx
+++ b/marklogic-data-hub-central/ui/src/components/steps/steps.tsx
@@ -9,11 +9,14 @@ import ConfirmYesNo from '../common/confirm-yes-no/confirm-yes-no';
 import styles from './steps.module.scss';
 import './steps.scss';
 import { StepType } from '../../types/curation-types';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSlidersH } from '@fortawesome/free-solid-svg-icons'
   
 const { TabPane } = Tabs;
 
 interface Props {
-    isNewStep: boolean;
+    isEditing: boolean;
     createStep?: any;
     updateStep?: any;
     stepData: any;
@@ -27,6 +30,7 @@ interface Props {
     canWrite?: any;
     targetEntityType?: any;
     toggleModal?: any;
+    openStepDetails?: any;
 }
 
 const DEFAULT_TAB = '1';
@@ -87,14 +91,14 @@ const Steps: React.FC<Props> = (props) => {
 
     const createEditLoad = (<CreateEditLoad
         {...createEditDefaults}
-        isNewStep={props.isNewStep}
+        isEditing={props.isEditing}
         createLoadArtifact={props.createStep}
         stepData={props.stepData}
     />);
 
     const createEditMapping = (<CreateEditMapping
         {...createEditDefaults}
-        isNewStep={props.isNewStep}
+        isEditing={props.isEditing}
         createMappingArtifact={props.createStep}
         stepData={props.stepData}
         targetEntityType={props.targetEntityType}
@@ -103,7 +107,7 @@ const Steps: React.FC<Props> = (props) => {
 
     const createEditMatching = (<CreateEditStep
         {...createEditDefaults}
-        isEditing={!props.isNewStep}
+        isEditing={props.isEditing}
         editStepArtifactObject={props.stepData}
         stepType={StepType.Matching}
         targetEntityType={props.targetEntityType}
@@ -112,7 +116,7 @@ const Steps: React.FC<Props> = (props) => {
 
     const createEditMerging = (<CreateEditStep
         {...createEditDefaults}
-        isEditing={!props.isNewStep}
+        isEditing={props.isEditing}
         editStepArtifactObject={props.stepData}
         stepType={StepType.Merging}
         targetEntityType={props.targetEntityType}
@@ -151,7 +155,12 @@ const Steps: React.FC<Props> = (props) => {
                 break;
             default: activity = 'Custom';
         }
-        return props.isNewStep ? 'New ' + activity + ' Step' : activity + ' Step Settings'; 
+        return !props.isEditing ? 'New ' + activity + ' Step' : activity + ' Step Settings'; 
+    }
+
+    const handleStepDetails = (name) => {
+        onCancel();
+        props.openStepDetails(name);
     }
 
     return <Modal
@@ -164,11 +173,11 @@ const Steps: React.FC<Props> = (props) => {
         maskClosable={false}
         destroyOnClose={true}
     >
-        <div className={styles.stepsContainer}>
+        <div aria-label="steps" className={styles.stepsContainer}>
             <header>
                 <div className={styles.title}>{getTitle()}</div>
             </header>
-            { props.isNewStep ? <div className={styles.noTabs}>
+            { !props.isEditing ? <div className={styles.noTabs}>
                 {getCreateEditStep(props.activityType)}
             </div> :
             <div className={styles.tabs}>
@@ -194,6 +203,12 @@ const Steps: React.FC<Props> = (props) => {
                     </TabPane>
                 </Tabs>
             </div> }
+            {/* Step Details link for Mapping steps */}
+            { (props.isEditing && props.activityType === StepType.Mapping) ? 
+            <div className={styles.stepDetailsLink} onClick={() => handleStepDetails(props.stepData.name)}>
+                <FontAwesomeIcon icon={faSlidersH} aria-label={'stepDetails'}/> 
+                <span className={styles.stepDetailsLabel}>Step Details</span>
+            </div> : null }
             {discardChanges}
         </div>
     </Modal>;


### PR DESCRIPTION
### Description

- Added a "Step Details" link in the create/edit mapping dialog to the source-to-entity mapping UI.
- Added a "Step Settings" link in the source-to-entity mapping UI to the mapping step settings dialog.
- Refactored steps settings to consistently use an isEditing property (instead of isNewStep).
- Removed outdated, unused code for step settings.

Added unit and e2e tests for the new links.

Screencast: https://drive.google.com/file/d/1IA4UeKO14T6vAjN8DUpOPi6Uh4F8-U3q/view

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

