### PR TITLE
DHFPROD-6101: Enhance the /api/steps/mapping/{stepName}/testingDoc endpoint to return "sourceProperties"

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mapping/getDocumentForTesting.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mapping/getDocumentForTesting.sjs
@@ -19,13 +19,15 @@ xdmp.securityAssert('http://marklogic.com/data-hub/privileges/read-mapping', 'ex
 
 const core = require('/data-hub/5/artifacts/core.sjs')
 const httpUtils = require("/data-hub/5/impl/http-utils.sjs");
+const sourcePropsLib = require('./sourcePropertiesLib.sjs');
 
 var stepName, uri;
 
-const rtn = {
+const response = {
   data: null,
   namespaces: {},
-  format: null
+  format: null,
+  sourceProperties: []
 }
 
 // Offer the mapping step to define the doc's database.
@@ -42,9 +44,10 @@ if (doc === null) {
 }
 
 // Populate return object.
-rtn.format = doc.documentFormat;
-if (rtn.format.toUpperCase() === 'JSON') {
-  rtn.data = (doc.root.hasOwnProperty('envelope') && doc.root.envelope.hasOwnProperty('instance')) ?
+response.format = doc.documentFormat;
+const isJson = response.format.toUpperCase() === 'JSON';
+if (isJson) {
+  response.data = (doc.root.hasOwnProperty('envelope') && doc.root.envelope.hasOwnProperty('instance')) ?
     doc.root.envelope.instance :
     doc.root;
 } else {
@@ -53,8 +56,9 @@ if (rtn.format.toUpperCase() === 'JSON') {
     xmlNode = doc.root;
   }
   const transformResult = require('./xmlToJsonForMapping.sjs').transform(xmlNode);
-  rtn.data = transformResult.data;
-  rtn.namespaces = transformResult.namespaces;
+  response.data = transformResult.data;
+  response.namespaces = transformResult.namespaces;
 }
+response.sourceProperties = sourcePropsLib.buildSourceProperties(response.data, isJson);
 
-rtn;
+response;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mapping/sourcePropertiesLib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mapping/sourcePropertiesLib.sjs
@@ -1,0 +1,101 @@
+/**
+ Copyright (c) 2020 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the 'License');
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an 'AS IS' BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+// Build and return the sourceProperties portion/array of getDocumentForTesting's return.
+function buildSourceProperties(sourceData, isJson) {
+  const outputArr = [];
+  addSourceProperties(sourceData, isJson, outputArr, '', 0)
+  return outputArr;
+}
+
+// Recursively process sourceData, populating a flat array of its source properties.
+function addSourceProperties(sourceData, isJson, outputArr, outputArrKey = '', level = 0) {
+  let value, valueIsObject, valueIsArray, xpath;
+  for (let key of Object.keys(sourceData)) {
+    // sourceProperties is not to receive the #text properties.
+    if (key === require('./xmlToJsonForMapping.sjs').PROP_NAME_TEXT) { continue }
+
+    value = sourceData[key];
+    valueIsObject = isObject(value);
+    valueIsArray = isArray(value);
+    xpath = makeSafeXPathExpression(outputArrKey, key, value, isJson, valueIsArray);
+    outputArr.push({
+      name: key,
+      xpath: xpath,
+      struct: valueIsObject,
+      level: level
+    })
+    if (valueIsObject && !valueIsArray) {
+      addSourceProperties(value, isJson, outputArr, `${outputArrKey}/${key}`, level + 1);
+    }
+  }
+}
+
+/**
+ * Construct an XPath, accounting for invalid qualified names, which is possible when the source format is JSON.
+ * For example, if nextPart is "$myName" where "$" is not an allowed character in a qualified name, the returned
+ * XPath expression would include "array-node('$myName') when true and values within are believed to be atomic; else,
+ * "node('$myName')" would end the XPath expression.
+ *
+ * @param {string} leadingPath - The beginning of the XPath expression.  Used as given.
+ * @param {string} nextPart - The bit to append to the XPath expression, in one of several ways, influenced by other parameters.
+ * @param {object} value - The value the XPath expression points to.
+ * @param {boolean} isJson - Submit true when the source document's format is JSON.
+ * @param {boolean} isArray - Pre-determination of whether value is an array.
+ * @returns {string} - An XPath expression where an invalid qualified name is wrapped in either array-node() or node().
+ */
+function makeSafeXPathExpression(leadingPath, nextPart, value, isJson, isArray) {
+  let funcStart = '';
+  let funcEnd = '';
+  if (isJson && !isValidQName(nextPart)) {
+    // Array of atomic values
+    if (isArray && value.length > 0 && isAtomic(value[0])) {
+      funcStart = "array-node('";
+      funcEnd = "')/node()";
+    } else {
+      // Either not an array, an empty array, or an array of object values.
+      funcStart = "node('";
+      funcEnd = "')";
+    }
+  }
+  return `${leadingPath}/${funcStart}${nextPart}${funcEnd}`;
+}
+
+function isValidQName(name) {
+  try {
+    fn.QName('', name);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function isObject(value) {
+  // Added key criteria as typeof(value) returned 'object' for some scalar values.
+  return (value && typeof(value) === 'object' && Object.keys(value).length > 0) === true;
+}
+
+function isAtomic(value) {
+  return !isObject(value);
+}
+
+function isArray(value) {
+  // False negatives from Array.isArray(value)
+  return value && value.hasOwnProperty('0');
+}
+
+exports.buildSourceProperties = buildSourceProperties;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mapping/xmlToJsonForMapping.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mapping/xmlToJsonForMapping.sjs
@@ -16,21 +16,28 @@
 'use strict';
 
 // Global constants
-const textStartsWith = '#';
-const textPropName = textStartsWith + 'text';
-const attrStartsWith = '@';
-const outputAttrStartsWith = '@'; // in case this ever needs to vary from the input.
-const nsPrefixDelim = ':';
-const nsAttrStartsWith = attrStartsWith + 'xmlns';
-const defaultNSAttrName = nsAttrStartsWith;
-const nonDefaultNSAttrStartsWith = nsAttrStartsWith + nsPrefixDelim
+const PROP_NAME_TEXT_STARTS_WITH = '#';
+const PROP_NAME_TEXT = PROP_NAME_TEXT_STARTS_WITH + 'text';
+const PROP_NAME_ATTR_STARTS_WITH = '@';
+const DELIM_NS_PREFIX = ':';
+const PROP_NAME_NS_ATTR_STARTS_WITH = PROP_NAME_ATTR_STARTS_WITH + 'xmlns';
+const ATTR_NAME_DEFAULT_NS = PROP_NAME_NS_ATTR_STARTS_WITH;
+const ATTR_NAME_NON_DEFAULT_NS_STARTS_WITH = PROP_NAME_NS_ATTR_STARTS_WITH + DELIM_NS_PREFIX;
+
+// These global variables pertain to collecting namespaces defined within the provided XML.
+// Only performed once upon encountering the first namespace attribute.
+// Not compatible with MSJ.
+let jsonIn;
+let collectedNonDefaultNSs = false;
+const namespaces = {};
+const prefixMap = {};
 
 // Set up for parser
 const parser = require('/data-hub/third-party/fast-xml-parser/src/parser.js');
 const parserOptions = {
-  attributeNamePrefix: attrStartsWith,
+  attributeNamePrefix: PROP_NAME_ATTR_STARTS_WITH,
   attrNodeName: false, //default is 'false'
-  textNodeName: textPropName,
+  textNodeName: PROP_NAME_TEXT,
   ignoreAttributes: false,
   ignoreNameSpace: false,
   allowBooleanAttributes: false,
@@ -44,166 +51,160 @@ const parserOptions = {
   arrayMode: 'strint'
 };
 
-function _isAttr(name) {
-  return name.startsWith(attrStartsWith);
-}
-
-function _isNSAttr(name) {
-  return name.startsWith(nsAttrStartsWith);
-}
-
-function _isObject(value) {
-  return value !== null && typeof(value) === 'object';
-}
-
 /**
- * Get information about the provided value.  Originally intended to help determine if a value is scalar, and if so,
- * serve up additional information so as not to inspect the object multiple times.
+ * Transform the XML to JSON, returning that JSON and namespaces.
  *
- * @param value
- * @returns {{defaultNS: object, isArray: boolean, isScalar: boolean, value: object}}
- * @private
+ * @param xmlNode
+ * @returns {{data: *, namespaces: {}}}
  */
-function _getValueInfo(value) {
-  let isScalar = true;
-  let defaultNS = null;
-  if (_isObject(value)) {
-    for (let key of Object.keys(value)) {
-      if (!key.startsWith(textStartsWith) && !key.startsWith(nsAttrStartsWith)) {
-        isScalar = false;
-      }
-      if (key === defaultNSAttrName) {
-        defaultNS = {
-          prefix: _determineFinalNSPrefix(null, value[key]),
-          uri: value[key]
-        }
-      }
-    }
-  }
-  if (isScalar && value.hasOwnProperty(textPropName)) {
-    value = value[textPropName];
-  }
+function transformXml(xmlNode) {
+  const serializeOptions = {indent: 'no'};
+  jsonIn = parser.parse(xdmp.quote(xmlNode, serializeOptions), parserOptions);
   return {
-    isArray: isScalar ? false : Array.isArray(value),
-    isScalar: isScalar,
-    value: value,
-    defaultNS: defaultNS
+    data: transformJson(jsonIn, null, {}),
+    namespaces: namespaces
   }
 }
 
 // An indirectly recursive function.
-function _transform(jsonIn, defaultNS, jsonOut) {
+function transformJson(jsonIn, defaultNS, jsonOut) {
   for (let key of Object.keys(jsonIn)) {
-    if (_isAttr(key)) {
-      _transformAttr(jsonOut, key, jsonIn[key], defaultNS);
+    if (isAttr(key)) {
+      transformAttr(jsonOut, key, jsonIn[key], defaultNS);
     } else {
-      _transformObject(jsonOut, key, jsonIn[key], defaultNS);
+      transformObject(jsonOut, key, jsonIn[key], defaultNS);
     }
   }
   return jsonOut;
 }
 
-function _transformAttr(jsonOut, attrName, value, defaultNS) {
-  if (_isNSAttr(attrName)) {
-    _conditionallyCollectNonDefaultNSs();
+function transformAttr(jsonOut, attrName, value, defaultNS) {
+  if (isNSAttr(attrName)) {
+    conditionallyCollectNonDefaultNSs();
   } else {
     // Strip input indicator that this is an attribute.
-    if (attrName.startsWith(attrStartsWith)) {
-      attrName = attrName.substr(attrStartsWith.length);
+    if (attrName.startsWith(PROP_NAME_ATTR_STARTS_WITH)) {
+      attrName = attrName.substr(PROP_NAME_ATTR_STARTS_WITH.length);
     }
 
     // Fully qualify the attribute name.
-    attrName = _getQName(attrName, true, defaultNS);
+    attrName = PROP_NAME_ATTR_STARTS_WITH + getQName(attrName, true, defaultNS);
 
-    jsonOut[outputAttrStartsWith + attrName] = value;
+    jsonOut[attrName] = value;
   }
 }
 
-function _transformObject(jsonOut, objName, value, defaultNS) {
+function transformObject(jsonOut, objName, value, defaultNS) {
   // Did the default namespace change?
-  if (value.hasOwnProperty(defaultNSAttrName)) {
-    _conditionallyCollectNonDefaultNSs();
+  if (value.hasOwnProperty(ATTR_NAME_DEFAULT_NS)) {
+    conditionallyCollectNonDefaultNSs();
     defaultNS = {
-      prefix: _determineFinalNSPrefix(null, value[defaultNSAttrName]),
-      uri: value[defaultNSAttrName]
+      prefix: determineFinalNSPrefix(null, value[ATTR_NAME_DEFAULT_NS]),
+      uri: value[ATTR_NAME_DEFAULT_NS]
     }
   }
 
   // Fully qualify the object name.
-  objName = _getQName(objName, false, defaultNS);
+  objName = getQName(objName, false, defaultNS);
 
-  const valueInfo = _getValueInfo(value);
-  if (valueInfo.isScalar === true) {
+  const valueInfo = getValueInfo(value);
+  if (valueInfo.isAtomic) {
     jsonOut[objName] = valueInfo.value;
-  } else if (valueInfo.isArray === true) {
+  } else if (valueInfo.isArray) {
     // Allow this function to modify jsonObj as objName may need to change and output may not end up being an array.
-    defaultNS = _transformArray(jsonOut, objName, value, defaultNS);
+    defaultNS = transformArray(jsonOut, objName, value, defaultNS);
   } else {
     jsonOut[objName] = {};
-    _transform(value, defaultNS, jsonOut[objName]);
+    transformJson(value, defaultNS, jsonOut[objName]);
   }
 }
 
-function _transformArray(jsonOut, objName, value, defaultNS) {
+function transformArray(jsonOut, objName, value, defaultNS) {
   let arr = [], valueInfo;
   for (let i = 0; i < value.length; i++) {
-    valueInfo = _getValueInfo(value[i]);
-    if (valueInfo.isScalar) {
+    valueInfo = getValueInfo(value[i]);
+    if (valueInfo.isAtomic) {
       // When the namespace doesn't change, just add to the array.
-      if (_isSameNS(defaultNS, valueInfo.defaultNS)) {
+      if (isSameNS(defaultNS, valueInfo.defaultNS)) {
         arr.push(valueInfo.value);
       } else {
         // Else, add array to jsonOut and set up for the next one.
-        _addArray(jsonOut, objName, arr);
+        addArray(jsonOut, objName, arr);
         arr = [valueInfo.value];
         defaultNS = valueInfo.defaultNS;
-        objName = _getQName(objName, false, defaultNS, true);
+        objName = getQName(objName, false, defaultNS, true);
       }
     } else {
-      arr.push(_transform(value[i], defaultNS, {}))
+      arr.push(transformJson(value[i], defaultNS, {}))
     }
   }
-  _addArray(jsonOut, objName, arr);
+  addArray(jsonOut, objName, arr);
   return defaultNS;
 }
 
-function _addArray(jsonOut, objName, arr) {
+function addArray(jsonOut, objName, arr) {
   if (arr.length > 0) {
     jsonOut[objName] = arr.length === 1 ? arr[0] : arr;
   }
 }
 
-function _isSameNS(ns1, ns2) {
-  if (ns1 === null && ns2 === null) {
-    return true;
-  } else if ((ns1 !== null && ns2 === null) || (ns1 === null && ns2 !== null)) {
-    return false;
+/**
+ * Get information about the provided value.  Originally intended to help determine if a value is atomic, and if so,
+ * serve up additional information so as not to inspect the object multiple times.
+ *
+ * @param value
+ * @returns {{defaultNS: object, isArray: boolean, isAtomic: boolean, value: object}}
+ * @private
+ */
+function getValueInfo(value) {
+  let isAtomic = true;
+  let defaultNS = null;
+  if (isObject(value)) {
+    for (let key of Object.keys(value)) {
+      if (!key.startsWith(PROP_NAME_TEXT_STARTS_WITH) && !key.startsWith(PROP_NAME_NS_ATTR_STARTS_WITH)) {
+        isAtomic = false;
+      }
+      if (key === ATTR_NAME_DEFAULT_NS) {
+        defaultNS = {
+          prefix: determineFinalNSPrefix(null, value[key]),
+          uri: value[key]
+        }
+      }
+    }
   }
-  return ns1.uri === ns2.uri;
+  if (isAtomic && value.hasOwnProperty(PROP_NAME_TEXT)) {
+    value = value[PROP_NAME_TEXT];
+  }
+  return {
+    isArray: isAtomic ? false : Array.isArray(value),
+    isAtomic: isAtomic,
+    value: value,
+    defaultNS: defaultNS
+  }
 }
 
 // Traverse doc to collect namespaces with prefixes.  Zero or once per request.
-function _conditionallyCollectNonDefaultNSs() {
+function conditionallyCollectNonDefaultNSs() {
   if (collectedNonDefaultNSs === false) {
-    _collectNonDefaultNSs(jsonIn);
+    collectNonDefaultNSs(jsonIn);
     collectedNonDefaultNSs = true;
   }
 }
 
 // Only expected caller is conditionallyCollectNonDefaultNSs()
-function _collectNonDefaultNSs(obj) {
+function collectNonDefaultNSs(obj) {
   for (let key of Object.keys(obj)) {
-    if (_isAttr(key)) {
-      if (key.startsWith(nonDefaultNSAttrStartsWith)) {
-        _determineFinalNSPrefix(key.substr(nonDefaultNSAttrStartsWith.length), obj[key]);
+    if (isAttr(key)) {
+      if (key.startsWith(ATTR_NAME_NON_DEFAULT_NS_STARTS_WITH)) {
+        determineFinalNSPrefix(key.substr(ATTR_NAME_NON_DEFAULT_NS_STARTS_WITH.length), obj[key]);
       }
-    } else if (_isObject(obj[key])) {
-      _collectNonDefaultNSs(obj[key]);
+    } else if (isObject(obj[key])) {
+      collectNonDefaultNSs(obj[key]);
     }
   }
 }
 
-function _determineFinalNSPrefix(currentPrefix, uri) {
+function determineFinalNSPrefix(currentPrefix, uri) {
   let finalPrefix = null;
 
   // Starting point is the current prefix, when given.
@@ -254,7 +255,7 @@ function _determineFinalNSPrefix(currentPrefix, uri) {
   return finalPrefix;
 }
 
-function _getFinalNSPrefix(currentPrefix, uri) {
+function getFinalNSPrefix(currentPrefix, uri) {
   // Non-default namespace (prefix defined)
   if (currentPrefix !== null) {
     if (prefixMap.hasOwnProperty(currentPrefix)) {
@@ -263,12 +264,12 @@ function _getFinalNSPrefix(currentPrefix, uri) {
     return currentPrefix;
   }
   // Default namespace (prefix not defined)
-  return _determineFinalNSPrefix(currentPrefix, uri);
+  return determineFinalNSPrefix(currentPrefix, uri);
 }
 
-function _getQName(name, isAttr, defaultNS, preferDefaultNS = false) {
+function getQName(name, isAttr, defaultNS, preferDefaultNS = false) {
   let finalPrefix = null;
-  const idx = name.indexOf(nsPrefixDelim);
+  const idx = name.indexOf(DELIM_NS_PREFIX);
   if (idx !== -1) {
     const currentPrefix = name.substr(0, idx);
     name = name.substr(idx + 1);
@@ -278,34 +279,35 @@ function _getQName(name, isAttr, defaultNS, preferDefaultNS = false) {
       finalPrefix = defaultNS.prefix;
     } else if (!(isAttr && defaultNS !== null && currentPrefix === defaultNS.prefix)) {
       // Add a prefix as this is not an attribute in the default namespace (no prefix desired in that case).
-      finalPrefix = _getFinalNSPrefix(currentPrefix, null);
+      finalPrefix = getFinalNSPrefix(currentPrefix, null);
     }
-  } else if (!isAttr && name !== textPropName && defaultNS !== null) {
+  } else if (!isAttr && name !== PROP_NAME_TEXT && defaultNS !== null) {
     finalPrefix = defaultNS.prefix;
   }
 
-  return (finalPrefix ? finalPrefix + nsPrefixDelim : '') + name;
+  return (finalPrefix ? finalPrefix + DELIM_NS_PREFIX : '') + name;
 }
 
-// These global variables pertain to collecting namespaces defined within the provided XML.
-// Only performed once upon encountering the first namespace attribute.
-let jsonIn;
-let collectedNonDefaultNSs = false;
-const namespaces = {};
-const prefixMap = {};
-
-/**
- * Transform the XML to JSON, returning that JSON and namespaces.
- *
- * @param xmlNode
- * @returns {{data: *, namespaces: {}}}
- */
-function transform(xmlNode) {
-  const serializeOptions = {indent: 'no'};
-  jsonIn = parser.parse(xdmp.quote(xmlNode, serializeOptions), parserOptions);
-  return {
-    data: _transform(jsonIn, null, {}),
-    namespaces: namespaces
+function isSameNS(ns1, ns2) {
+  if (ns1 === null && ns2 === null) {
+    return true;
+  } else if ((ns1 !== null && ns2 === null) || (ns1 === null && ns2 !== null)) {
+    return false;
   }
+  return ns1.uri === ns2.uri;
 }
-exports.transform = transform;
+
+function isAttr(name) {
+  return name.startsWith(PROP_NAME_ATTR_STARTS_WITH);
+}
+
+function isNSAttr(name) {
+  return name.startsWith(PROP_NAME_NS_ATTR_STARTS_WITH);
+}
+
+function isObject(value) {
+  return value !== null && typeof(value) === 'object';
+}
+
+exports.transform = transformXml;
+exports.PROP_NAME_TEXT = PROP_NAME_TEXT;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/lib/mappingService.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/lib/mappingService.sjs
@@ -1,5 +1,7 @@
 'use strict';
 
+const test = require("/test/test-helper.xqy");
+
 // Utils for getDocumentForTesting's tests.
 const DocumentForTestingUtils = {
   STEP_NAME: 'prospect2CustomerMappingStep',
@@ -20,6 +22,41 @@ const DocumentForTestingUtils = {
     return fn.head(require("/test/data-hub-test-helper.sjs").runWithRolesAndPrivileges(['hub-central-mapping-reader'], [],
       "/data-hub/5/data-services/mapping/getDocumentForTesting.sjs", {stepName, uri}
     ));
+  },
+  // May return zero or more.
+  getSourcePropertiesByName: function (sourceProperties, name) {
+    const matches = [];
+    if (Array.isArray(sourceProperties)) {
+      for (let property of sourceProperties) {
+        if (name === property.name) {
+          matches.push(property);
+        }
+      }
+    }
+    return matches;
+  },
+  // This function does not evaluate XPath expressions; rather, a string comparison is performed.
+  getSourcePropertyByXPath: function (sourceProperties, xpath) {
+    let winner = null;
+    if (Array.isArray(sourceProperties)) {
+      for (let property of sourceProperties) {
+        if (xpath === property.xpath) {
+          winner = property;
+          break;
+        }
+      }
+    }
+    return winner;
+  },
+  addSourcePropertyAssertions: function (assertions, sourceProperties, name, xpath, struct, level) {
+    const property = this.getSourcePropertyByXPath(sourceProperties, xpath);
+    if (!property) {
+      assertions.push(test.fail(`No source property with XPath of "${xpath}" in ${JSON.stringify(sourceProperties)}`));
+    }
+
+    assertions.push(test.assertEqual(name, property.name, `Unexpected "name" value for the source property with the "${xpath}" xpath`));
+    assertions.push(test.assertTrue(struct === property.struct, `Expected ${struct} for the "struct" value for the source property with the "${xpath}" xpath but got ${property.struct}`));
+    assertions.push(test.assertEqual(level, property.level, `Unexpected "level" value for the source property with the "${xpath}" xpath`));
   }
 }
 

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/envelopedXmlTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/envelopedXmlTest.sjs
@@ -12,13 +12,11 @@ const expectedNamespaces = {
   "OrderNS":"https://www.w3schools.com/OrderNS"
 }
 
-assertions.concat([
-  test.assertExists(data, "Top-level 'data' property does not exist"),
-  test.assertExists(data['OrderNS:Order'], "The data's first property is expected to be 'OrderNS:Order' but was given '" + Object.keys(data).join("' and '") + "'"),
-  test.assertExists(data['OrderNS:Order']['RequiredDate'], "Expected RequiredDate (no namespace) within OrderNS:Order but found '" + Object.keys(data['OrderNS:Order']).join("' and '") + "'"),
-  // Make sure this response does not include "":"" (empty string property and value pair due to xmlns="").
-  test.assertEqualJson(expectedNamespaces, result.namespaces, 'The namespaces do not match; expected ' +
-    JSON.stringify(expectedNamespaces) + ' but got ' + JSON.stringify(result.namespaces)),
-]);
+assertions.push(test.assertExists(data, "Top-level 'data' property does not exist"));
+assertions.push(test.assertExists(data['OrderNS:Order'], "The data's first property is expected to be 'OrderNS:Order' but was given '" + Object.keys(data).join("' and '") + "'"));
+assertions.push(test.assertExists(data['OrderNS:Order']['RequiredDate'], "Expected RequiredDate (no namespace) within OrderNS:Order but found '" + Object.keys(data['OrderNS:Order']).join("' and '") + "'"));
+// Make sure this response does not include "":"" (empty string property and value pair due to xmlns="").
+assertions.push(test.assertEqualJson(expectedNamespaces, result.namespaces, 'The namespaces do not match; expected ' +
+  JSON.stringify(expectedNamespaces) + ' but got ' + JSON.stringify(result.namespaces)));
 
 assertions;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/nonExistentDocTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/nonExistentDocTest.sjs
@@ -11,13 +11,10 @@ try {
   utils.invokeService(utils.STEP_NAME, uri);
   assertions.push(test.fail('Exception not thrown when attempting to process a non-existent document.'));
 } catch (e) {
-  xdmp.log(JSON.stringify(e));
-  assertions.concat([
-    test.assertTrue(e.data && Array.isArray(e.data) && e.data.length === 2,
-      "Expected exception object's 'data' property to be an array of two items"),
-    test.assertEqual('404', e.data[0], 'Expected an exception code of 404'),
-    test.assertEqual(`Could not find a document with URI: ${uri}`, e.data[1])
-  ]);
+  assertions.push(test.assertTrue(e.data && Array.isArray(e.data) && e.data.length === 2,
+    "Expected exception object's 'data' property to be an array of two items"));
+  assertions.push(test.assertEqual('404', e.data[0], 'Expected an exception code of 404'));
+  assertions.push(test.assertEqual(`Could not find a document with URI: ${uri}`, e.data[1]));
 }
 
 assertions;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/startWithJsonTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/startWithJsonTest.sjs
@@ -6,12 +6,36 @@ const utils = require('/test/suites/data-hub/5/data-services/lib/mappingService.
 const assertions = [];
 
 const result = utils.invokeService(utils.STEP_NAME, '/content/sampleCustomerDoc.json');
-assertions.concat([
-  test.assertExists(result.data, 'Top-level "data" property does not exist'),
-  test.assertEqual(204, Number(result.data.CustOrders.CustomerID)),
-  test.assertEqual('Sparrow', String(result.data.CustOrders.Nicknames.Nickname[1])),
-  test.assertEqualJson({}, result.namespaces, 'The "namespaces" property should be an empty object for JSON input.'),
-  test.assertEqual('JSON', String(result.format), 'The "format" property should be set to "JSON".')
-]);
+
+// Tests for data section.
+assertions.push(test.assertExists(result.data, 'Top-level "data" property does not exist'));
+assertions.push(test.assertEqual(204, Number(result.data.CustOrders.CustomerID)));
+assertions.push(test.assertEqual('Sparrow', String(result.data.CustOrders.Nicknames.Nickname[1])));
+
+// Test(s) for namespaces section.
+assertions.push(test.assertEqualJson({}, result.namespaces, 'The "namespaces" property should be an empty object for JSON input.'));
+
+// Test(s) for format section.
+assertions.push(test.assertEqual('JSON', String(result.format), 'The "format" property should be set to "JSON".'));
+
+// Tests for sourceProperties section.
+const sourceProperties = result.sourceProperties;
+// Array with valid QName (should not include array-node()
+let name = 'Nickname';
+assertions.push();
+
+utils.addSourcePropertyAssertions(assertions, sourceProperties, name, `/CustOrders/Nicknames/${name}`, true, 2);
+// Invalid QNames
+name = '$id';
+utils.addSourcePropertyAssertions(assertions, sourceProperties, name, `/CustOrders/invalidQNames/node('${name}')`, false, 2);
+name = '$array-of-objects';
+utils.addSourcePropertyAssertions(assertions, sourceProperties, name, `/CustOrders/invalidQNames/node('${name}')`, true, 2);
+name = '$array-of-values';
+utils.addSourcePropertyAssertions(assertions, sourceProperties, name, `/CustOrders/invalidQNames/array-node('${name}')/node()`, true, 2);
+name = 'invalidLocalName:asdf';
+utils.addSourcePropertyAssertions(assertions, sourceProperties, name, `/CustOrders/OddPropertyNames/node('${name}')`, false, 2);
+// Unicode character in property name.
+name = 'propName\u{EFFFF}IncludesUnicode';
+utils.addSourcePropertyAssertions(assertions, sourceProperties, name, `/CustOrders/OddPropertyNames/${name}`, false, 2);
 
 assertions;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/startWithXmlTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/startWithXmlTest.sjs
@@ -2,6 +2,7 @@
 
 const test = require("/test/test-helper.xqy");
 const utils = require('/test/suites/data-hub/5/data-services/lib/mappingService.sjs').DocumentForTestingUtils;
+const xmlToJson = require('/data-hub/5/data-services/mapping/xmlToJsonForMapping.sjs');
 
 const assertions = [];
 
@@ -27,89 +28,159 @@ const expectedNamespaces = {
   "Gamma2": "https://www.amazon.com/Gamma"
 };
 
-assertions.concat([
-  test.assertExists(result.data, 'Top-level "data" property does not exist'),
-  test.assertExists(orderProp, "The data's first property is expected to be 'OrderNS:Order'"),
-  // Are the namespaces of these attributes correct in the output?
-  test.assertEqual("this attr should be 'in' in the output", String(orderProp['OD:OrderDetails']['@in']),
-    "Unexpected value for the 'in' attribute value in " + JSON.stringify(orderProp['OD:OrderDetails'])),
-  test.assertEqual("this attr should be 'in2' in the output", String(orderProp['OD:OrderDetails']['@in2']),
-    "Unexpected value for the 'in2' attribute value in " + JSON.stringify(orderProp['OD:OrderDetails'])),
-  test.assertEqual("this attr should be '@OtherNS:out' in the output", String(orderProp['OD:OrderDetails']['@OtherNS:out']),
-    "Unexpected value for the 'OrderNS:out' attribute value in " + JSON.stringify(orderProp['OD:OrderDetails'])),
-  // The two OrderDetail elements should be an array but namespace of children should be different.
-  test.assertExists(orderProp['OD:OrderDetails']['OD:OrderDetail']),
-  test.assertTrue(Array.isArray(orderProp['OD:OrderDetails']['OD:OrderDetail']) && orderProp['OD:OrderDetails']['OD:OrderDetail'].length === 2,
-    "OD:OrderDetail should be an array with two items but is " + JSON.stringify(orderProp['OD:OrderDetails']['OD:OrderDetail'])),
-  test.assertExists(orderProp['OD:OrderDetails']['OD:OrderDetail'][0]['Wash:UnitPrice'],
-    "The first OD:OrderDetails element should have a Wash:UnitPrice child."),
-  test.assertExists(orderProp['OD:OrderDetails']['OD:OrderDetail'][1]['Cali:UnitPrice'],
-    "The second OD:OrderDetails element should have a Cali:UnitPrice child."),
-  // ShippedDate should be an array.
-  test.assertExists(orderProp['OrderNS:ShippedDate']),
-  test.assertTrue(Array.isArray(orderProp['OrderNS:ShippedDate']) && orderProp['OrderNS:ShippedDate'].length === 2,
-    "OrderNS:ShippedDate should be an array with two items but is " + JSON.stringify(orderProp['OrderNS:ShippedDate'])),
-  // Verify the default namespace changed.
-  test.assertExists(orderProp['SV:ShipVia']),
-  // Verify the default namespace immediately reverted.
-  test.assertExists(orderProp['OrderNS:ShipPostalCode'], "Looks like the default namespace did not revert."),
-  // More should and should-not-be array tests
-  test.assertEqual("Should *not* be in an array.", String(orderProp['Gamma:Element1']),
-    "Gamma:Element1 should just be a string as next Element1 is in a different namespace"),
-  test.assertEqual("Should *not* be in an array.", String(orderProp['Gamma2:Element1']),
-    "Gamma2:Element1 should just be a string as previous Element1 is in a different namespace"),
-  test.assertTrue(Array.isArray(orderProp['OrderNS:Element2']) && orderProp['OrderNS:Element2'].length === 2,
-    "OrderNS:Element2 should be an array with two items but is " + JSON.stringify(orderProp['OrderNS:Element2'])),
-  // Entering MarkupScenarios
-  test.assertExists(markupScenariosProp, 'Missing OrderNS:Order.OrderNS:MarkupScenarios in ' +
-    JSON.stringify(result.data)),
-  // EmptyElementWithoutAttributes
-  test.assertExists(markupScenariosProp['OrderNS:EmptyElementWithoutAttributes']),
-  test.assertEqual('', String(markupScenariosProp['OrderNS:EmptyElementWithoutAttributes']),
-    'Expected the OrderNS:EmptyElementWithoutAttributes property value to be an empty string.'),
-  // EmptyElementWithAttribute
-  test.assertExists(markupScenariosProp['OrderNS:EmptyElementWithAttribute']),
-  test.assertEqual('hello', String(markupScenariosProp['OrderNS:EmptyElementWithAttribute']['@attr']),
-    'Expected OrderNS:EmptyElementWithAttribute to have the "@attr" property set to "hello".'),
-  // NoTextOrAttrs
-  test.assertExists(markupScenariosProp['OrderNS:NoTextOrAttrs']),
-  test.assertEqual('', String(markupScenariosProp['OrderNS:NoTextOrAttrs']),
-    'Expected the OrderNS:NoTextOrAttrs property value to be an empty string.'),
-  // JustText
-  test.assertExists(markupScenariosProp['OrderNS:JustText']),
-  test.assertEqual('Hello', String(markupScenariosProp['OrderNS:JustText']),
-    'Expected the OrderNS:JustText property value to be "Hello".'),
-  // JustAttr
-  test.assertExists(markupScenariosProp['OrderNS:JustAttr']),
-  test.assertEqual('Howdy', String(markupScenariosProp['OrderNS:JustAttr']['@attr']),
-    'Expected OrderNS:JustAttr to have the "@attr" property set to "Howdy".'),
-  // AttrAndText
-  test.assertExists(markupScenariosProp['OrderNS:AttrAndText']),
-  test.assertEqual('Some Text', String(markupScenariosProp['OrderNS:AttrAndText']['#text']),
-    'Expected OrderNS:AttrAndText to have text of "Some Text".'),
-  test.assertEqual('myattr', String(markupScenariosProp['OrderNS:AttrAndText']['@attr']),
-    'Expected OrderNS:AttrAndText to have the "@attr" property set to "myattr".'),
-  // AttrTextAndChild
-  test.assertExists(markupScenariosProp['OrderNS:AttrTextAndChild']),
-  test.assertEqual('How aredoing?', String(markupScenariosProp['OrderNS:AttrTextAndChild']['#text']),
-    'Expected OrderNS:AttrTextAndChild to have text of "How aredoing?".'),
-  test.assertEqual('woohoo!', String(markupScenariosProp['OrderNS:AttrTextAndChild']['@attr']),
-    'Expected OrderNS:AttrTextAndChild to have the "@attr" property set to "woohoo!".'),
-  test.assertEqual('you', String(markupScenariosProp['OrderNS:AttrTextAndChild']['OrderNS:b']),
-    'Expected OrderNS:AttrTextAndChild to have a property named "b" with a value of "you".'),
-  // MultipleTextNodes
-  test.assertExists(markupScenariosProp['OrderNS:MultipleTextNodes']),
-  test.assertEqual('1st text node2nd text node', String(markupScenariosProp['OrderNS:MultipleTextNodes']['#text']),
-    'While not desired, expected the two text nodes in OrderNS:MultipleTextNodes to be concatenated.'),
-  // ExampleWithCDATA
-  test.assertExists(markupScenariosProp['OrderNS:ExampleWithCDATA']),
-  test.assertEqual('Text outside Text inside More text outside', String(markupScenariosProp['OrderNS:ExampleWithCDATA']),
-    'Expected text nodes to be concatenated with CDATA content.'),
-  // Verify the namespace map is correct.
-  test.assertEqualJson(expectedNamespaces, result.namespaces, 'The namespaces do not match; expected ' +
-    JSON.stringify(expectedNamespaces) + ' but got ' + JSON.stringify(result.namespaces)),
-  // And finally the format test.
-  test.assertEqual('XML', String(result.format))
-]);
+assertions.push(test.assertExists(result.data, 'Top-level "data" property does not exist'));
+assertions.push(test.assertExists(orderProp, "The data's first property is expected to be 'OrderNS:Order'"));
+// Are the namespaces of these attributes correct in the output?
+assertions.push(test.assertEqual("this attr should be 'in' in the output", String(orderProp['OD:OrderDetails']['@in']),
+  "Unexpected value for the 'in' attribute value in " + JSON.stringify(orderProp['OD:OrderDetails'])));
+assertions.push(test.assertEqual("this attr should be 'in2' in the output", String(orderProp['OD:OrderDetails']['@in2']),
+  "Unexpected value for the 'in2' attribute value in " + JSON.stringify(orderProp['OD:OrderDetails'])));
+assertions.push(test.assertEqual("this attr should be '@OtherNS:out' in the output", String(orderProp['OD:OrderDetails']['@OtherNS:out']),
+  "Unexpected value for the 'OrderNS:out' attribute value in " + JSON.stringify(orderProp['OD:OrderDetails'])));
+// The two OrderDetail elements should be an array but namespace of children should be different.
+assertions.push(test.assertExists(orderProp['OD:OrderDetails']['OD:OrderDetail']));
+assertions.push(test.assertTrue(Array.isArray(orderProp['OD:OrderDetails']['OD:OrderDetail']) && orderProp['OD:OrderDetails']['OD:OrderDetail'].length === 2,
+  "OD:OrderDetail should be an array with two items but is " + JSON.stringify(orderProp['OD:OrderDetails']['OD:OrderDetail'])));
+assertions.push(test.assertExists(orderProp['OD:OrderDetails']['OD:OrderDetail'][0]['Wash:UnitPrice'],
+  "The first OD:OrderDetails element should have a Wash:UnitPrice child"));
+assertions.push(test.assertExists(orderProp['OD:OrderDetails']['OD:OrderDetail'][1]['Cali:UnitPrice'],
+  "The second OD:OrderDetails element should have a Cali:UnitPrice child"));
+// ShippedDate should be an array.
+assertions.push(test.assertExists(orderProp['OrderNS:ShippedDate']));
+assertions.push(test.assertTrue(Array.isArray(orderProp['OrderNS:ShippedDate']) && orderProp['OrderNS:ShippedDate'].length === 2,
+  "OrderNS:ShippedDate should be an array with two items but is " + JSON.stringify(orderProp['OrderNS:ShippedDate'])));
+// Verify the default namespace changed.
+assertions.push(test.assertExists(orderProp['SV:ShipVia']));
+// Verify the default namespace immediately reverted.
+assertions.push(test.assertExists(orderProp['OrderNS:ShipPostalCode'], "Looks like the default namespace did not revert"));
+// More should and should-not-be array tests
+assertions.push(test.assertEqual("Should *not* be in an array.", String(orderProp['Gamma:Element1']),
+  "Gamma:Element1 should just be a string as next Element1 is in a different namespace"));
+assertions.push(test.assertEqual("Should *not* be in an array.", String(orderProp['Gamma2:Element1']),
+  "Gamma2:Element1 should just be a string as previous Element1 is in a different namespace"));
+assertions.push(test.assertTrue(Array.isArray(orderProp['OrderNS:Element2']) && orderProp['OrderNS:Element2'].length === 2,
+  "OrderNS:Element2 should be an array with two items but is " + JSON.stringify(orderProp['OrderNS:Element2'])));
+// Entering MarkupScenarios
+assertions.push(test.assertExists(markupScenariosProp, 'Missing OrderNS:Order.OrderNS:MarkupScenarios in ' +
+  JSON.stringify(result.data)));
+// EmptyElementWithoutAttributes
+assertions.push(test.assertExists(markupScenariosProp['OrderNS:EmptyElementWithoutAttributes']));
+assertions.push(test.assertEqual('', String(markupScenariosProp['OrderNS:EmptyElementWithoutAttributes']),
+  'Expected the OrderNS:EmptyElementWithoutAttributes property value to be an empty string'));
+// EmptyElementWithAttribute
+assertions.push(test.assertExists(markupScenariosProp['OrderNS:EmptyElementWithAttribute']));
+assertions.push(test.assertEqual('hello', String(markupScenariosProp['OrderNS:EmptyElementWithAttribute']['@attr']),
+  'Expected OrderNS:EmptyElementWithAttribute to have the "@attr" property set to "hello"'));
+// NoTextOrAttrs
+assertions.push(test.assertExists(markupScenariosProp['OrderNS:NoTextOrAttrs']));
+assertions.push(test.assertEqual('', String(markupScenariosProp['OrderNS:NoTextOrAttrs']),
+  'Expected the OrderNS:NoTextOrAttrs property value to be an empty string'));
+// JustText
+assertions.push(test.assertExists(markupScenariosProp['OrderNS:JustText']));
+assertions.push(test.assertEqual('Hello', String(markupScenariosProp['OrderNS:JustText']),
+  'Expected the OrderNS:JustText property value to be "Hello"'));
+// JustAttr
+assertions.push(test.assertExists(markupScenariosProp['OrderNS:JustAttr']));
+assertions.push(test.assertEqual('Howdy', String(markupScenariosProp['OrderNS:JustAttr']['@attr']),
+  'Expected OrderNS:JustAttr to have the "@attr" property set to "Howdy"'));
+// AttrAndText
+assertions.push(test.assertExists(markupScenariosProp['OrderNS:AttrAndText']));
+assertions.push(test.assertEqual('Some Text', String(markupScenariosProp['OrderNS:AttrAndText']['#text']),
+  'Expected OrderNS:AttrAndText to have text of "Some Text"'));
+assertions.push(test.assertEqual('myattr', String(markupScenariosProp['OrderNS:AttrAndText']['@attr']),
+  'Expected OrderNS:AttrAndText to have the "@attr" property set to "myattr"'));
+// AttrTextAndChild
+assertions.push(test.assertExists(markupScenariosProp['OrderNS:AttrTextAndChild']));
+assertions.push(test.assertEqual('How aredoing?', String(markupScenariosProp['OrderNS:AttrTextAndChild']['#text']),
+  'Expected OrderNS:AttrTextAndChild to have text of "How aredoing?"'));
+assertions.push(test.assertEqual('woohoo!', String(markupScenariosProp['OrderNS:AttrTextAndChild']['@attr']),
+  'Expected OrderNS:AttrTextAndChild to have the "@attr" property set to "woohoo!"'));
+assertions.push(test.assertEqual('you', String(markupScenariosProp['OrderNS:AttrTextAndChild']['OrderNS:b']),
+  'Expected OrderNS:AttrTextAndChild to have a property named "b" with a value of "you"'));
+// MultipleTextNodes
+assertions.push(test.assertExists(markupScenariosProp['OrderNS:MultipleTextNodes']));
+assertions.push(test.assertEqual('1st text node2nd text node', String(markupScenariosProp['OrderNS:MultipleTextNodes']['#text']),
+  'While not desired, expected the two text nodes in OrderNS:MultipleTextNodes to be concatenated'));
+// ExampleWithCDATA
+assertions.push(test.assertExists(markupScenariosProp['OrderNS:ExampleWithCDATA']));
+assertions.push(test.assertEqual('Text outside Text inside More text outside', String(markupScenariosProp['OrderNS:ExampleWithCDATA']),
+  'Expected text nodes to be concatenated with CDATA content.'));
+// Verify the namespace map is correct.
+assertions.push(test.assertEqualJson(expectedNamespaces, result.namespaces, 'The namespaces do not match; expected ' +
+  JSON.stringify(expectedNamespaces) + ' but got ' + JSON.stringify(result.namespaces)));
+// And finally the format test.
+assertions.push(test.assertEqual('XML', String(result.format)));
+
+/*
+ * BEGIN: source property tests
+ */
+const sourceProperties = result.sourceProperties;
+
+// First source property.
+let xpath = '/OrderNS:Order';
+let prop = sourceProperties[0];
+assertions.push(test.assertEqual(xpath.substr(1), prop.name, "Unexpected name for the first source property"));
+assertions.push(test.assertEqual(xpath, prop.xpath, "Unexpected xpath for the first source property"));
+assertions.push(test.assertTrue(prop.struct, `Expected true for the first source property's struct property but got "${prop.struct}"`));
+assertions.push(test.assertEqual(0, prop.level, 'Unexpected level for the first source property'));
+
+// Test struct=false and level=1
+xpath = '/OrderNS:Order/OrderNS:RequiredDate';
+prop = utils.getSourcePropertyByXPath(sourceProperties, xpath);
+assertions.push(test.assertFalse(prop.struct, `Unexpected struct for the ${xpath} source property`));
+assertions.push(test.assertEqual(1, prop.level, `Unexpected level for the ${xpath} source property`));
+
+// Namespace changed
+xpath = '/OrderNS:Order/OD:OrderDetails';
+prop = utils.getSourcePropertyByXPath(sourceProperties, xpath);
+assertions.push(test.assertExists(prop, `Expected to find a source property where xpath=${xpath} but did not`));
+
+// Attribute without namespace prefix.
+let name = '@in';
+let props = utils.getSourcePropertiesByName(sourceProperties, name);
+assertions.push(test.assertTrue(props.length === 1, `Expected 1 source property where name=${name} but found ${props.length}`));
+assertions.push(test.assertEqual(`/OrderNS:Order/OD:OrderDetails/${name}`, props[0].xpath, `Unexpected xpath property value for the "${name}" source property`));
+assertions.push(test.assertFalse(props[0].struct, `Unexpected struct for the "${name}" source property`));
+assertions.push(test.assertEqual(2, props[0].level, `Unexpected level for the "${name}" source property`));
+
+// Attribute with namespace prefix.
+xpath = '/OrderNS:Order/OD:OrderDetails/@OtherNS:out';
+prop = utils.getSourcePropertyByXPath(sourceProperties, xpath);
+assertions.push(test.assertExists(prop, `Expected to find a source property where xpath=${xpath} but did not`));
+
+// Array (struct=true)
+xpath = '/OrderNS:Order/OD:OrderDetails/OD:OrderDetail';
+prop = utils.getSourcePropertyByXPath(sourceProperties, xpath);
+assertions.push(test.assertExists(prop, `Expected to find a source property where xpath=${xpath} but did not`));
+assertions.push(test.assertTrue(prop.struct, `Unexpected struct for the "${xpath}" source property`));
+
+// Level 3
+xpath = '/OrderNS:Order/OrderNS:MarkupScenarios/OrderNS:AttrTextAndChild/OrderNS:b';
+prop = utils.getSourcePropertyByXPath(sourceProperties, xpath);
+assertions.push(test.assertExists(prop, `Expected to find a source property where xpath=${xpath} but did not`));
+assertions.push(test.assertEqual(3, prop.level, `Unexpected level for the "${xpath}" source property`));
+
+// Verify there are the correct number of properties where name=@attr but that they each have a unique xpath.
+let expectedCount = 4;
+let uniqueXPaths = [];
+name = '@attr';
+props = utils.getSourcePropertiesByName(sourceProperties, name);
+for (let p of props) {
+  if (!uniqueXPaths.some(val => val === p.xpath)) {
+    uniqueXPaths.push(p.xpath);
+  }
+}
+assertions.push(test.assertEqual(expectedCount, props.length,
+  `Expected ${expectedCount} source properties where name=${name} but found ${props.length}`))
+assertions.push(test.assertEqual(expectedCount, uniqueXPaths.length,
+  `Expected ${expectedCount} unique XPaths on source properties where name=${name} but found ${uniqueXPaths.length}`))
+
+// Verify #text data properties didn't also become source properties.
+const textNodes = utils.getSourcePropertiesByName(sourceProperties, xmlToJson.PROP_NAME_FOR_TEXT);
+assertions.push(test.assertTrue(textNodes.length === 0,
+  `sourceProperties not expected to include "name" properties with a value of "${xmlToJson.PROP_NAME_FOR_TEXT}" yet ${textNodes.length} were found`));
+/*
+ * END: source property tests
+ */
 
 assertions;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/test-data/content/sampleCustomerDoc.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mapping/getDocumentForTesting/test-data/content/sampleCustomerDoc.json
@@ -12,6 +12,15 @@
             "Jack",
             "Sparrow"
           ]
+        },
+        "invalidQNames": {
+          "$id": "123",
+          "$array-of-values": ["one", "two"],
+          "$array-of-objects": [{"test": "object"}]
+        },
+        "OddPropertyNames": {
+          "propName\uDB7F\uDFFFIncludesUnicode": true,
+          "invalidLocalName:asdf": true
         }
       }
     }

--- a/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
+++ b/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
@@ -292,20 +292,22 @@ public abstract class AbstractHubTest extends AbstractHubClientTest {
 
     }
 
+    // Update app config's config and modules dirs when not already in the hub config's project dir.
     private void resolveAppConfigDirectories(HubConfig hubConfig) {
-        String baseDirStr = hubConfig.getProjectDir();
+        String baseDirNormalized = Paths.get(hubConfig.getProjectDir()).normalize().toString();
         AppConfig appConfig = hubConfig.getAppConfig();
         List<ConfigDir> configDirs = appConfig.getConfigDirs();
         for (ConfigDir configDir : configDirs) {
-            String configPath = configDir.getBaseDir().getPath();
-            if (!configPath.contains(baseDirStr)) {
-                configDir.setBaseDir(Paths.get(baseDirStr, configPath).toFile());
+            String configPathNormalized = configDir.getBaseDir().toPath().normalize().toString();
+            if (!configPathNormalized.contains(baseDirNormalized)) {
+                configDir.setBaseDir(Paths.get(baseDirNormalized, configPathNormalized).toFile());
             }
         }
         List<String> modulePaths = appConfig.getModulePaths();
         for (String modulePath : modulePaths) {
-            if (!modulePath.contains(baseDirStr)) {
-                modulePaths.set(modulePaths.indexOf(modulePath), Paths.get(baseDirStr, modulePath).toString());
+            String modulePathNormalized = Paths.get(modulePath).normalize().toString();
+            if (!modulePathNormalized.contains(baseDirNormalized)) {
+                modulePaths.set(modulePaths.indexOf(modulePathNormalized), Paths.get(baseDirNormalized, modulePathNormalized).toString());
             }
         }
     }


### PR DESCRIPTION
### Description
This is an extension of DHFPROD-6098, "Create endpoint for fetching source document for mapping UI", and replaces https://github.com/marklogic/marklogic-data-hub/pull/4862, https://github.com/marklogic/marklogic-data-hub/pull/4867, and https://github.com/marklogic/marklogic-data-hub/pull/4871.

It adds the sourceProperties property to the endpoint's return.

Full endpoint path: /api/steps/mapping/{stepName}/testingDoc

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

