### PR TITLE
DHFPROD-5650: added keyboard controls to tiles toolbar

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/reader.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/reader.spec.tsx
@@ -20,7 +20,7 @@ describe('Entity Modeling: Reader Role', () => {
     cy.contains(Application.title);
     console.log(Cypress.env('mlHost'));
     cy.loginAsTestUserWithRoles("hub-central-entity-model-reader", "hub-central-saved-query-user").withRequest();
-    cy.waitUntil(() => toolbar.getModelToolbarIcon().should('have.css', 'cursor', 'pointer')).click();
+    cy.waitUntil(() => toolbar.getModelToolbarIcon()).click();
     entityTypeTable.waitForTableToLoad();
   });
 

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writer.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writer.spec.tsx
@@ -21,7 +21,7 @@ describe('Entity Modeling: Writer Role', () => {
     cy.contains(Application.title);
     console.log(Cypress.env('mlHost'));
     cy.loginAsTestUserWithRoles("hub-central-entity-model-reader", "hub-central-entity-model-writer", "hub-central-saved-query-user").withRequest();
-    cy.waitUntil(() => toolbar.getModelToolbarIcon().should('have.css', 'cursor', 'pointer')).click();
+    cy.waitUntil(() => toolbar.getModelToolbarIcon()).click();
     entityTypeTable.waitForTableToLoad();
   });
 

--- a/marklogic-data-hub-central/ui/src/components/tiles/toolbar.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/tiles/toolbar.module.scss
@@ -16,7 +16,6 @@
         align-items: center;
         flex-direction: row;
         font-size: 18px;
-        margin: 0 20px 40px 0;
         padding: 0;
         background-color: #FFF;
         border: 1px solid #7F86B5;
@@ -25,9 +24,17 @@
         height: 40px;
         min-height: 40px;
         text-align: center;
-        cursor: pointer;
+        outline: none;
     }
-    .tool[aria-label='tool-curate'] {
-        margin-bottom: 80px;
+    .tool:focus-within {
+        box-shadow: 0px 0px 1px 1px #7F86B5;
+        background-color: #7F86B5;
+        outline: none;
+    }
+    .toolWrapper {
+        height: 80px;
+    }
+    .toolTallWrapper {
+        height: 120px;
     }
 }

--- a/marklogic-data-hub-central/ui/src/components/tiles/toolbar.scss
+++ b/marklogic-data-hub-central/ui/src/components/tiles/toolbar.scss
@@ -13,7 +13,6 @@
     font-family: MLCustomFont;
     font-size: 24px; 
     position: relative;
-    left: -2px;
     background-color: #FFF;
     border: 1px solid #7F86B5;
     border-radius: 4px;
@@ -21,8 +20,13 @@
     height: 40px;
     min-height: 40px;
     text-align: center;
-    cursor: pointer;
-    margin-bottom: 40px;
+    outline: none;
+}
+
+.exploreIcon:focus-within {
+    box-shadow: 0px 0px 1px 1px #7F86B5;
+    background-color: #7F86B5;
+    outline: none;
 }
 
 .loadIcon:before {
@@ -34,7 +38,6 @@
     font-family: MLCustomFont;
     font-size: 24px;
     position: relative;
-    left: -2px;
     background-color: #FFF;
     border: 1px solid #7F86B5;
     border-radius: 4px;
@@ -42,8 +45,13 @@
     height: 40px;
     min-height: 40px;
     text-align: center;
-    cursor: pointer;
-    margin-bottom: 40px;
+    outline: none;
+}
+
+.loadIcon:focus-within {
+    box-shadow: 0px 0px 1px 1px #7F86B5;
+    background-color: #7F86B5;
+    outline: none;
 }
 
 
@@ -56,7 +64,6 @@
     font-family: MLCustomFont;
     font-size: 24px;
     position: relative;
-    left: -2px;
     background-color: #FFF;
     border: 1px solid #7F86B5;
     border-radius: 4px;
@@ -64,8 +71,13 @@
     height: 40px;
     min-height: 40px;
     text-align: center;
-    cursor: pointer;
-    margin-bottom: 40px;
+    outline: none;
+}
+
+.modelIcon:focus-within {
+    box-shadow: 0px 0px 1px 1px #7F86B5;
+    background-color: #7F86B5;
+    outline: none;
 }
 
 .curateIcon:before {
@@ -77,7 +89,6 @@
     font-family: MLCustomFont;
     font-size: 24px;
     position: relative;
-    left: -2px;
     background-color: #FFF;
     border: 1px solid #7F86B5;
     border-radius: 4px;
@@ -85,8 +96,13 @@
     height: 40px;
     min-height: 40px;
     text-align: center;
-    cursor: pointer;
-    margin-bottom: 80px;
+    outline: none;
+}
+
+.curateIcon:focus-within {
+    box-shadow: 0px 0px 1px 1px #7F86B5;
+    background-color: #7F86B5;
+    outline: none;
 }
 
 .runIcon:before {
@@ -98,7 +114,6 @@
     font-family: MLCustomFont;
     font-size: 24px;
     position: relative;
-    left: -2px;
     background-color: #FFF;
     border: 1px solid #7F86B5;
     border-radius: 4px;
@@ -106,6 +121,11 @@
     height: 40px;
     min-height: 40px;
     text-align: center;
-    cursor: pointer;
-    margin-bottom: 40px;
+    outline: none;
+}
+
+.runIcon:focus-within {
+    box-shadow: 0px 0px 1px 1px #7F86B5;
+    background-color: #7F86B5;
+    outline: none;
 }

--- a/marklogic-data-hub-central/ui/src/components/tiles/toolbar.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/tiles/toolbar.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 const history = createMemoryHistory();
+import userEvent from '@testing-library/user-event'
 import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import Toolbar from './toolbar';
@@ -41,7 +42,63 @@ describe('Toolbar component', () => {
 
         enabledTiles.forEach((tile, i) => {
             expect(getByLabelText("tool-" + tile)).not.toHaveStyle('color: grey; opacity: 0.5; cursor: not-allowed;');
+            expect(getByLabelText("tool-" + tile)).toHaveStyle('cursor: pointer;');
         });
+    });
+
+    it('verify tabbing of tile icons', () => {
+        var i: int;
+        let enabledTiles = ['load', 'model', 'curate', 'run', 'explore'];
+        const {getByLabelText} = render(<Router history={history}><Toolbar tiles={tiles} enabled={enabledTiles}/></Router>);
+        expect(getByLabelText("toolbar")).toBeInTheDocument();
+
+        // focus on load tool
+        getByLabelText("tool-load-link").focus();
+        expect(getByLabelText("tool-load-link")).toHaveFocus();
+
+        // press tab and verify each tool is selected in turn
+        for(i = 1; i < 5; ++i) {
+            userEvent.tab();
+            expect(getByLabelText("tool-" + enabledTiles[i] + "-link")).toHaveFocus();
+        }
+
+        // press shift+tab and verify focus reverses direction
+        for(i = 3; i >= 0; --i) {
+            userEvent.tab({shift: true});
+            expect(getByLabelText("tool-" + enabledTiles[i] + "-link")).toHaveFocus();
+        }
+    });
+
+
+    it('verify tabbing of tile icons', () => {
+        var i: int;
+        let enabledTiles = ['load', 'model', 'curate', 'run', 'explore'];
+        const {getByLabelText} = render(<Router history={history}><Toolbar tiles={tiles} enabled={enabledTiles}/></Router>);
+        expect(getByLabelText("toolbar")).toBeInTheDocument();
+
+        // focus on load tool
+        getByLabelText("tool-load-link").focus();
+        expect(getByLabelText("tool-load-link")).toHaveFocus();
+
+        // pressing up arrow while on load does nothing (cannot go further up)
+        fireEvent.keyDown(getByLabelText("tool-load-link"), { key: 'ArrowUp', code: 'ArrowUp' })
+        expect(getByLabelText("tool-load-link")).toHaveFocus();
+
+        // pressing down arrow sequentially moves focus down
+        for(i = 1; i < 5; ++i) {
+            fireEvent.keyDown(getByLabelText("tool-" + enabledTiles[i-1] + "-link"), { key: 'ArrowDown', code: 'ArrowDown' })
+            expect(getByLabelText("tool-" + enabledTiles[i] + "-link")).toHaveFocus();    
+        }
+
+        // pressing down arrow while on explore does nothing (cannot go further down)
+        fireEvent.keyDown(getByLabelText("tool-explore-link"), { key: 'ArrowDown', code: 'ArrowDown' })
+        expect(getByLabelText("tool-explore-link")).toHaveFocus();
+
+        // pressing up arrow sequentially moves focus up
+        for(i = 3; i >= 0; --i) {
+            fireEvent.keyDown(getByLabelText("tool-" + enabledTiles[i+1] + "-link"), { key: 'ArrowUp', code: 'ArrowUp' })
+            expect(getByLabelText("tool-" + enabledTiles[i] + "-link")).toHaveFocus();    
+        }
     });
 
 });

--- a/marklogic-data-hub-central/ui/src/components/tiles/toolbar.tsx
+++ b/marklogic-data-hub-central/ui/src/components/tiles/toolbar.tsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import styles from './toolbar.module.scss';
 import './toolbar.scss';
 import { MLTooltip } from '@marklogic/design-system';
+import { onClosestDiv } from '../../util/test-utils';
 
 
 interface Props {
@@ -15,6 +16,10 @@ interface Props {
 const Toolbar: React.FC<Props> = (props) => {
 
     const tiles = props.tiles; // config/tiles.config.ts
+
+    // array of references used to set focus
+    let tileRefs = new Array();
+    for (var i = 0; i < Object.keys(tiles).length; ++i ) tileRefs.push(React.createRef<HTMLDivElement>());    
 
     const getTooltip = (id) => {
         if (props.enabled && props.enabled.includes(id)) {
@@ -31,59 +36,101 @@ const Toolbar: React.FC<Props> = (props) => {
             cursor: 'not-allowed'
         };
         let enabled: CSSProperties = {
-            color: tiles[id]['color']
+            color: tiles[id]['color'],
+            cursor: 'pointer'
         };
         return (props.enabled && props.enabled.includes(id)) ? enabled : disabled;
     };
+
+    const linkKeyDownHandler = (event, id, index) => {
+        if(event.key == 'ArrowUp' && index > 0) tileRefs[index-1].current.focus();
+        if(event.key == 'ArrowDown' && index < (Object.keys(tiles).length - 1)) tileRefs[index+1].current.focus();
+    };
+
+    const tileOnClickHandler = (id, index) => {
+        if (props.enabled && props.enabled.includes(id)) tileRefs[index].current.click();
+    };
+
+    const linkOnClickHandler = (event, id) => {
+        if (!props.enabled || !props.enabled.includes(id)) event.preventDefault();
+    }
+
+    /**
+        structure of the toolbar:
+            <wrapper>
+                <tool>
+                    <link/>
+                </tool>
+            </wrapper>
+        
+        the wrapper is used for spacing on the toolbar.  every wrapper (except curate) is 80px tall,
+            leaving 40px of space between each tool icon.  this is defined in "./toolbar.module.scss".
+            this object cannot be tabbed to.
+
+        the tool div object is used for highlights.  when the link inside is in focus, a shadow is
+            is drawn around the icon to signify that it is currently selected.  this is defined in
+            "./toolbar.scss".  this object cannot be tabbed to.
+
+        the link object is the actual link to the tile.  clicking on the link will redirect the
+            current webpage to the tile.  pressing up and down arrow keys will go to the next or
+            previous link.  pressing enter will follow the link.  this object is not rendered, but 
+            can be tabbed to.  
+            
+            note that the shadow is drawn on the parent div object when this object is tabbed to or 
+            navigated to using arrow keys.
+    */
 
     return (
         <div id={styles.toolbar} aria-label={'toolbar'}>
             {Object.keys(tiles).map((id, i) => {
                 if (tiles[id]['iconType'] === 'custom') {
                     return (
-                        props.enabled && props.enabled.includes(id) ?
-                            <Link to={
-                                {pathname: `/tiles/${id}`,
-                                state: {
-                                    tileIconClicked : true
-                                }}} aria-label={'tool-' + id + '-link'} key={i}>
-                                <MLTooltip title={getTooltip(id)} placement="leftTop" key={i}>
-                                    <div
-                                        className={tiles[id]['icon']}
-                                        aria-label={'tool-' + id}
-                                        style={getIconStyle(id)}
-                                    />
-                                </MLTooltip>
-                            </Link>
-                            :
+                        <div className={tiles[id]['title'] === 'Curate' ? styles.toolTallWrapper : styles.toolWrapper} aria-label={'tool-' + id + '-wrapper'} tabIndex={-1}> 
                             <MLTooltip title={getTooltip(id)} placement="leftTop" key={i}>
                                 <div
                                     className={tiles[id]['icon']}
                                     aria-label={'tool-' + id}
                                     style={getIconStyle(id)}
-                                />
+                                    tabIndex={-1}
+                                    onClick={(e) => tileOnClickHandler(id, i)}
+                                >
+                                    <Link to={
+                                        {pathname: `/tiles/${id}`,
+                                        state: {
+                                            tileIconClicked : true
+                                        }}}
+                                        aria-label={'tool-' + id + '-link'}
+                                        tabIndex={1}
+                                        ref={tileRefs[i]}
+                                        onClick={(e)=> linkOnClickHandler(e, id)}
+                                        onKeyDown={(e) => linkKeyDownHandler(e, id, i)}
+                                    />
+                                </div>
                             </MLTooltip>
+                        </div>
                     );
                 } else {
                     return (
-                        <MLTooltip title={getTooltip(id)} placement="leftTop" key={i}>
-                            {props.enabled && props.enabled.includes(id) ?
-                                <Link to={'/tiles/' + id} aria-label={'tool-' + id + '-link'} >
-                                    <i
-                                        className={styles.tool}
-                                        aria-label={'tool-' + id}
-                                        style={getIconStyle(id)}
-                                    ><FontAwesomeIcon icon={tiles[id]['icon']} size="lg" />
-                                    </i>
-                                </Link>
-                                :
+                        <div className={styles.toolWrapper} aria-label={'tool-' + id + '-wrapper'} tabIndex={-1}>
+                            <MLTooltip title={getTooltip(id)} placement="leftTop" key={i}>
                                 <i
                                     className={styles.tool}
                                     aria-label={'tool-' + id}
                                     style={getIconStyle(id)}
-                                ><FontAwesomeIcon icon={tiles[id]['icon']} size="lg" />
-                                </i>}
-                        </MLTooltip>
+                                    tabIndex={-1}
+                                    onClick={(e) => tileOnClickHandler(id, i)}
+                                >
+                                    <Link to={'/tiles/' + id}
+                                        aria-label={'tool-' + id + '-link'}
+                                        tabIndex={1}
+                                        ref={tileRefs[i]}
+                                        onClick={(e)=> linkOnClickHandler(e, id)}
+                                        onKeyDown={(e) => linkKeyDownHandler(e, id, i)}
+                                    />
+                                    <FontAwesomeIcon icon={tiles[id]['icon']} size="lg" />
+                                </i>
+                            </MLTooltip>
+                        </div>
                     );
                 }
             })}


### PR DESCRIPTION
### Description
in tiles toolbar:
* added keyboard nagivation via up/down arrow keys
* added a customizable outline to "focused" tile icon
* fixed an issue where tiles link buttons' clickable areas were larger than expected
* fixed a visual issue where tiles icons were slightly off-center
* fixed a visual issue where mouse cursor was set to pointer when icon was disabled
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

