### PR TITLE
DHFPROD-6290:Original gradle properties get reset if runAsUser() is called

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -59,6 +59,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -183,8 +184,15 @@ public class HubTestBase extends AbstractHubTest {
     @Override
     protected HubClient runAsUser(String mlUsername, String mlPassword) {
         hubClient = null;
+        Properties props = hubConfigInterceptor.getHubConfigObjectFactory().getGradleProperties();
+        Properties newProps = new Properties();
 
-        applyMlUsernameAndMlPassword(mlUsername, mlPassword);
+        newProps.setProperty("mlUsername", mlUsername);
+        newProps.setProperty("mlPassword", mlPassword);
+        newProps.setProperty("hubDhs", props.getProperty("hubDhs") == null ? "false" : props.getProperty("hubDhs"));
+        newProps.setProperty("hubSsl", props.getProperty("hubSsl") == null ? "false" : props.getProperty("hubSsl"));
+
+        applyMlUsernameAndMlPassword(newProps);
 
         // Re-initializes the Manage API connection
         getHubConfig().getManageClient().setManageConfig(hubConfig.getManageConfig());

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/test/HubConfigObjectFactory.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/test/HubConfigObjectFactory.java
@@ -93,4 +93,8 @@ public class HubConfigObjectFactory extends BasePooledObjectFactory<HubConfigImp
     public String[] getHosts() {
         return hosts;
     }
+
+    public Properties getGradleProperties(){
+        return gradleProperties;
+    }
 }

--- a/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
+++ b/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
@@ -99,14 +99,9 @@ public abstract class AbstractHubTest extends AbstractHubClientTest {
      * Convenience method for updating the username/password on all configuration objects in HubConfig - specifically,
      * the ones in manageConfig, adminConfig, and the restAdmin* and appServices* ones in appConfig.
      *
-     * @param mlUsername
-     * @param mlPassword
+     * @param props containing some of the original gradle props overriden with user's mlUsername and mlPassword
      */
-    protected void applyMlUsernameAndMlPassword(String mlUsername, String mlPassword) {
-        Properties props = new Properties();
-        props.setProperty("mlUsername", mlUsername);
-        props.setProperty("mlPassword", mlPassword);
-
+    protected void applyMlUsernameAndMlPassword(Properties props) {
         // Need to include this so that when running tests in parallel, this doesn't default back to localhost
         props.setProperty("mlHost", getHubConfig().getHost());
 


### PR DESCRIPTION
### Description
Original gradle properties get reset if runAsUser() is called. Once PR #4890 and this gets merged, most of the java tests should pass in DHS. No new tests needed, existing ones should pass.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [n/a ] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

