### PR TITLE
DHFPROD-6245: Can now specify custom Spark schema when reading rows

### DIFF
--- a/marklogic-data-hub-spark-connector/src/main/java/com/marklogic/hub/spark/sql/sources/v2/reader/HubDataSourceReader.java
+++ b/marklogic-data-hub-spark-connector/src/main/java/com/marklogic/hub/spark/sql/sources/v2/reader/HubDataSourceReader.java
@@ -28,7 +28,7 @@ public class HubDataSourceReader extends LoggingObject implements DataSourceRead
 
     private final Map<String, String> options;
     private final JsonNode initializationResponse;
-    private final StructType schema;
+    private final StructType sparkSchema;
 
     /**
      * The current default for partition count is based on the active SparkSession. The PartitionCountProvider is used
@@ -43,7 +43,7 @@ public class HubDataSourceReader extends LoggingObject implements DataSourceRead
         validateOptions(this.options);
 
         this.initializationResponse = initializeRead(this.options);
-        this.schema = (StructType) StructType.fromJson(initializationResponse.get("schema").toString());
+        this.sparkSchema = (StructType) StructType.fromJson(initializationResponse.get("sparkSchema").toString());
     }
 
     /**
@@ -91,7 +91,7 @@ public class HubDataSourceReader extends LoggingObject implements DataSourceRead
 
         // The same all-lowercase style is used here for consistency with Spark, even though it's not consistent with
         // DHF code conventions
-        Stream.of("view", "schema", "sqlcondition", "selectedcolumns").forEach(key -> inputs.put(key, options.get(key)));
+        Stream.of("view", "schema", "sqlcondition", "selectedcolumns", "sparkschema").forEach(key -> inputs.put(key, options.get(key)));
         inputs.put("numpartitions", determineNumPartitions(options));
 
         if (options.containsKey("serializedplan")) {
@@ -139,7 +139,7 @@ public class HubDataSourceReader extends LoggingObject implements DataSourceRead
 
     @Override
     public StructType readSchema() {
-        return schema;
+        return sparkSchema;
     }
 }
 

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/Options.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/Options.java
@@ -40,6 +40,7 @@ public class Options {
     private String sqlCondition;
     private String selectedColumns;
     private String serializedPlan;
+    private String sparkSchema;
 
     // Has a default value so that tests don't depend on a Spark cluster running to determine minDefaultPartitions
     private String numPartitions = "2";
@@ -122,7 +123,10 @@ public class Options {
             params.put("serializedplan", serializedPlan);
         }
         if (selectedColumns != null) {
-            params.put("selectedColumns", selectedColumns);
+            params.put("selectedcolumns", selectedColumns);
+        }
+        if (sparkSchema != null) {
+            params.put("sparkschema", sparkSchema);
         }
 
         params.put("numpartitions", numPartitions);
@@ -222,6 +226,11 @@ public class Options {
 
     public Options withNumPartitions(String numPartitions) {
         this.numPartitions = numPartitions;
+        return this;
+    }
+
+    public Options withSparkSchema(String sparkSchema) {
+        this.sparkSchema = sparkSchema;
         return this;
     }
 }

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/reader/AbstractSparkReadTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/reader/AbstractSparkReadTest.java
@@ -34,6 +34,14 @@ abstract class AbstractSparkReadTest extends AbstractSparkConnectorTest {
         );
     }
 
+    protected void setupTenSimpleCustomers() {
+        runAsDataHubDeveloper();
+        loadSimpleCustomerTDE();
+
+        runAsDataHubOperator();
+        loadTenSimpleCustomers();
+    }
+
     // TODO Will soon have a nice convenience method for doing this
     protected void loadSimpleCustomerTDE() {
         String template;

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/reader/ReadSimpleCustomersTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/reader/ReadSimpleCustomersTest.java
@@ -20,11 +20,7 @@ public class ReadSimpleCustomersTest extends AbstractSparkReadTest {
 
     @Test
     void differentSqlConditionsAndPartitionCounts() {
-        runAsDataHubDeveloper();
-        loadSimpleCustomerTDE();
-
-        runAsDataHubOperator();
-        loadTenSimpleCustomers();
+        setupTenSimpleCustomers();
 
         verifyRowCountForSqlCondition(null, 10);
         verifyRowCountForSqlCondition("customerId > 3 and customerId < 7", 3);

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/reader/ReadViaSerializedPlanTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/reader/ReadViaSerializedPlanTest.java
@@ -11,11 +11,7 @@ public class ReadViaSerializedPlanTest extends AbstractSparkReadTest {
 
     @Test
     void customerIdLessThanFive() {
-        runAsDataHubDeveloper();
-        loadSimpleCustomerTDE();
-
-        runAsDataHubOperator();
-        loadTenSimpleCustomers();
+        setupTenSimpleCustomers();
 
         List<InternalRow> rows = readRows(newOptions()
             .withSerializedPlan(getCustomerIdLessThanFivePlan()));
@@ -25,11 +21,7 @@ public class ReadViaSerializedPlanTest extends AbstractSparkReadTest {
 
     @Test
     void groupAndOrderByCustomerId() {
-        runAsDataHubDeveloper();
-        loadSimpleCustomerTDE();
-
-        runAsDataHubOperator();
-        loadTenSimpleCustomers();
+        setupTenSimpleCustomers();
 
         List<InternalRow> rows = readRows(newOptions()
             .withSerializedPlan(readStringFromClasspath("serialized-plans/GroupAndOrderByCustomerId.json")));

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/reader/ReadWithCustomSparkSchemaTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/reader/ReadWithCustomSparkSchemaTest.java
@@ -1,0 +1,68 @@
+package com.marklogic.hub.spark.sql.sources.v2.reader;
+
+import com.marklogic.hub.spark.sql.sources.v2.Options;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+import scala.collection.immutable.HashMap;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReadWithCustomSparkSchemaTest extends AbstractSparkReadTest {
+
+    @Test
+    void validCustomSparkSchema() {
+        setupTenSimpleCustomers();
+
+        Options options = newOptions()
+            .withSparkSchema(buildCustomSparkSchema())
+            .withSerializedPlan(buildSerializedPlanThatMatchesCustomSparkSchema());
+
+        verifyRowsConfirmToCustomSparkSchema(options);
+    }
+
+    @Test
+    void invalidJsonForSparkSchema() {
+        Options options = newOptions()
+            .withSparkSchema("not-valid-json")
+            .withSerializedPlan(buildSerializedPlanThatMatchesCustomSparkSchema());
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> readRows(options));
+        assertTrue(ex.getMessage().contains("Unable to initialize read"));
+        assertTrue(ex.getMessage().contains("Unable to read 'sparkschema' input as JSON"),
+            "Expecting the error message from the ML endpoint to identify the exact reason why initialization failed");
+    }
+
+    private String buildCustomSparkSchema() {
+        Metadata metadata = new Metadata(new HashMap<>());
+        return new StructType(new StructField[]{
+            new StructField("myName", DataTypes.StringType, false, metadata),
+            new StructField("myId", DataTypes.IntegerType, false, metadata)
+        }).json();
+    }
+
+    private String buildSerializedPlanThatMatchesCustomSparkSchema() {
+        return getHubClient().getFinalClient().newServerEval().javascript("const op = require('/MarkLogic/optic');\n" +
+            "op.fromView(null, 'Customer', '')\n" +
+            "  .select([\n" +
+            "    op.as('myName', op.col('name')),\n" +
+            "    op.as('myId', op.col('customerId'))\n" +
+            "  ])\n" +
+            "  .export()").evalAs(String.class);
+    }
+
+    private void verifyRowsConfirmToCustomSparkSchema(Options options) {
+        List<InternalRow> rows = readRows(new HubDataSourceReader(options.toDataSourceOptions()));
+        assertEquals(10, rows.size());
+        for (InternalRow row : rows) {
+            int customerId = row.getInt(1);
+            assertEquals("Customer" + customerId, row.getString(0),
+                "Per the custom schema, 'myName' is expected to be the first column and 'myId' is second");
+        }
+    }
+}

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/reader/ReadWithSelectedColumnsTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/reader/ReadWithSelectedColumnsTest.java
@@ -15,11 +15,7 @@ public class ReadWithSelectedColumnsTest extends AbstractSparkReadTest {
      */
     @Test
     void test() {
-        runAsDataHubDeveloper();
-        loadSimpleCustomerTDE();
-
-        runAsDataHubOperator();
-        loadTenSimpleCustomers();
+        setupTenSimpleCustomers();
 
         verifyTwoColumnsSelected();
         verifyOneColumnSelected();


### PR DESCRIPTION
### Description

Did some test refactoring too to avoid some duplication.

Reorganized initializeRead.sjs into commented functions to make it easier to read.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

