### PR TITLE
DHFPROD-6293: Use mem:safe-copy

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/mlpm_modules/XQuery-XML-Memory-Operations/memory-operations-functional.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/mlpm_modules/XQuery-XML-Memory-Operations/memory-operations-functional.xqy
@@ -189,9 +189,7 @@ as node()*
       map:get($transaction-map, "copy")
     )
   else
-    validate lax {
-      map:get($transaction-map, "copy")
-    },
+    mem-op:safe-copy(map:get($transaction-map, "copy")),
   map:clear($transaction-map)
 };
 

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/mlpm_modules/XQuery-XML-Memory-Operations/memory-operations.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/mlpm_modules/XQuery-XML-Memory-Operations/memory-operations.xqy
@@ -1044,14 +1044,15 @@ function mem-op:weighed-operations(
   $operations[. eq "transform"]
 };
 
-declare %private
-function mem-op:safe-copy(
+declare function mem-op:safe-copy(
   $node as node())
 as node()? {
+  (: Initially trying to use lax validation for quick copying. See more on xdmp:copy-on-validate :)
   try {
     validate lax {
       $node
     }
+  (: if that fails due to validation issues, we'll resort to the regular node constructor approach. :)
   } catch * {
     mem-op:reconstruct-node($node,$node/*,(),fn:true())
   }


### PR DESCRIPTION
### Description

This came up due to issues we were seeing on ML-9. https://jenkins.marklogic.com/blue/organizations/jenkins/Datahub_CI/detail/develop/1659/tests/ 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- N/A Added Tests
  

- ##### Reviewer:

- N/A Reviewed Tests

