### PR TITLE
DHFPROD-5623: added focus to switch view buttons in load tile

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/load/switch-view.scss
+++ b/marklogic-data-hub-central/ui/src/components/load/switch-view.scss
@@ -13,3 +13,8 @@
 #switch-view .ant-radio-group-large .ant-radio-button-wrapper:hover {
     color: #7F86B5 ;
   }
+
+.radioGroupView:focus-within {
+    box-shadow: 0 0 1px 1px #7F86b5;
+    background-color: #7f86b5;
+}

--- a/marklogic-data-hub-central/ui/src/components/load/switch-view.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/switch-view.test.tsx
@@ -30,4 +30,46 @@ describe('Switch view component', () => {
     expect(getByLabelText('switch-view-card')).toHaveStyle('color: rgb(127, 134, 181');
   });
 
+  test('Verify integrity of enter and arrow keys navigation', () => {
+
+    const { getByLabelText } = render(
+      <SwitchView handleSelection={() => null} defaultView={INITIAL_VIEW} />
+    );
+
+    expect(getByLabelText('switch-view')).toBeInTheDocument();
+    getByLabelText('switch-view').firstChild.focus();
+
+    // verify default selection
+    expect(getByLabelText('switch-view-card')).toHaveProperty('checked', true);
+    expect(getByLabelText('switch-view-list')).toHaveProperty('checked', false);
+
+    // verify pressing enter switches the view to list
+    fireEvent.keyDown(getByLabelText('switch-view'), { key: 'Enter', code: 'Enter' });
+    expect(getByLabelText('switch-view-card')).toHaveProperty('checked', false);
+    expect(getByLabelText('switch-view-list')).toHaveProperty('checked', true);
+
+    // verify pressing enter again switches the view back to card
+    fireEvent.keyDown(getByLabelText('switch-view'), { key: 'Enter', code: 'Enter' });
+    expect(getByLabelText('switch-view-card')).toHaveProperty('checked', true);
+    expect(getByLabelText('switch-view-list')).toHaveProperty('checked', false);
+
+    // verify pressing right arrow when on card switches view to list
+    fireEvent.keyDown(getByLabelText('switch-view'), { key: 'ArrowRight', code: 'ArrowRight' });
+    expect(getByLabelText('switch-view-card')).toHaveProperty('checked', false);
+    expect(getByLabelText('switch-view-list')).toHaveProperty('checked', true);
+
+    // verify pressing right arrow when on list does not switch view
+    fireEvent.keyDown(getByLabelText('switch-view'), { key: 'ArrowRight', code: 'ArrowRight' });
+    expect(getByLabelText('switch-view-list')).toHaveProperty('checked', true);
+
+    // verify pressing left arrow when on list switches view to card
+    fireEvent.keyDown(getByLabelText('switch-view'), { key: 'ArrowLeft', code: 'ArrowLeft' });
+    expect(getByLabelText('switch-view-card')).toHaveProperty('checked', true);
+    expect(getByLabelText('switch-view-list')).toHaveProperty('checked', false);
+
+    // verify pressing left arrow when on card does not switch view
+    fireEvent.keyDown(getByLabelText('switch-view'), { key: 'ArrowLeft', code: 'ArrowLeft' });
+    expect(getByLabelText('switch-view-card')).toHaveProperty('checked', true);
+  });
+
 });

--- a/marklogic-data-hub-central/ui/src/components/load/switch-view.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/switch-view.tsx
@@ -17,19 +17,58 @@ const SwitchView: React.FC<Props> = (props) => {
         props.handleSelection(val);
     };
 
+    const radioKeyDownHandler = (event) => {
+        if (event.key === 'Enter') {
+            switch (view) {
+                case 'list':
+                    onChange('card');
+                    break;
+                case 'card':
+                    onChange('list');
+                    break;
+                default:
+                    // should not ever reach this code
+                    // do nothing
+                    break;
+            }
+        }
+
+        if (event.key == 'ArrowLeft') {
+            // stops default react radio button controls
+            event.preventDefault();
+
+            if (view === 'list')
+                onChange('card');
+        }
+
+        if (event.key == 'ArrowRight') {
+            event.preventDefault();
+            
+            if (view === 'card')
+                onChange('list');
+        }
+
+        // disable up and down arrow default controls on radio buttons
+        if (event.key == 'ArrowUp' || event.key == 'ArrowDown')
+            event.preventDefault();
+    };
+
     return (
-        <div id="switch-view" aria-label="switch-view">
+        <div id="switch-view" aria-label="switch-view" onKeyDown={radioKeyDownHandler}>
             <MLRadio.MLGroup
                 buttonStyle="outline"
+                className={'radioGroupView'}
                 defaultValue={view}
                 name="radiogroup"
                 onChange={e => onChange(e.target.value)}
                 size="large"
+                style={{ color: '#999' }}
+                tabIndex={0}
             >
-                <MLRadio.MLButton aria-label="switch-view-card" value={'card'}>
+                <MLRadio.MLButton aria-label="switch-view-card" value={'card'} checked={view === 'card'}>
                     <i>{<FontAwesomeIcon icon={faThLarge} />}</i>
                 </MLRadio.MLButton>
-                <MLRadio.MLButton aria-label="switch-view-list" value={'list'}>
+                <MLRadio.MLButton aria-label="switch-view-list" value={'list'} checked={view === 'list'}>
                     <i>{<FontAwesomeIcon icon={faTable} />}</i>
                 </MLRadio.MLButton>
             </MLRadio.MLGroup>


### PR DESCRIPTION
### Description
made radio button group that switches view in Load tile focusable and added outline when focused
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

