### PR TITLE
DHFPROD-5123: Removed unused spring-integration dependency

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -72,7 +72,6 @@ dependencies {
     }
 
     compile group: 'org.springframework.boot', name: 'spring-boot', version: '2.1.15.RELEASE'
-    compile group: 'org.springframework.integration', name: 'spring-integration-http', version: '5.1.11.RELEASE'
     compile group: 'org.springframework.boot', name: 'spring-boot-autoconfigure', version: '2.1.15.RELEASE'
 
     compile 'com.marklogic:mlcp-util:0.9.0'


### PR DESCRIPTION
### Description

This eliminates a security vulnerability as well, as spring-int was bringing in version 5.1.11 of spring dependencies with vulnerabilities. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

