### PR TITLE
DHFPROD-6264: Supporting enableExcludeAlreadyProcessed

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow.sjs
@@ -140,7 +140,7 @@ class Flow {
     if (options.uris) {
       uris = this.datahub.hubUtils.normalizeToArray(options.uris);
 
-      if (options.excludeAlreadyProcessed && xs.boolean(options.excludeAlreadyProcessed)) {
+      if (options.excludeAlreadyProcessed === true || options.excludeAlreadyProcessed === "true") {
         const stepId = flowStep.stepId ? flowStep.stepId : flowStep.name + "-" + flowStep.stepDefinitionType;
         const filteredItems = this.filterItemsAlreadyProcessedByStep(uris, flowName, stepId);
         if (filteredItems.length != uris.length) {
@@ -504,18 +504,15 @@ class Flow {
    * @param writeTransactionInfo
    */
   updateBatchDocument(combinedOptions = {}, items, writeTransactionInfo) {
-    if (!combinedOptions.noBatchWrite) {
+    if (!combinedOptions.noBatchWrite && !combinedOptions.disableJobOutput) {
       let batchStatus = "finished";
       if (this.globalContext.failedItems.length) {
-        if (this.globalContext.completedItems.length) {
-          batchStatus = "finished_with_errors";
-        } else {
-          batchStatus = "failed";
-        }
+        batchStatus = this.globalContext.completedItems.length ? "finished_with_errors" : "failed";
       }
-      if (!combinedOptions.disableJobOutput) {
-        jobsMod.updateBatch(this.datahub,this.globalContext.jobId, this.globalContext.batchId, batchStatus, items, writeTransactionInfo, this.globalContext.batchErrors[0]);
-      }
+      jobsMod.updateBatch(
+        this.datahub, this.globalContext.jobId, this.globalContext.batchId, batchStatus, items,
+        writeTransactionInfo, this.globalContext.batchErrors[0], combinedOptions
+      );
     }
   }
 

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/flows/simpleMapping.flow.json
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/flows/simpleMapping.flow.json
@@ -6,6 +6,7 @@
       "stepDefinitionName": "entity-services-mapping",
       "stepDefinitionType": "MAPPING",
       "options": {
+        "enableExcludeAlreadyProcessed" : true,
         "sourceQuery": "cts.collectionQuery('customer-input')",
         "sourceDatabase": "data-hub-STAGING",
         "targetDatabase": "data-hub-FINAL",

--- a/marklogic-data-hub/src/test/resources/test-projects/simple-customer-flow/flows/simpleCustomerFlow.flow.json
+++ b/marklogic-data-hub/src/test/resources/test-projects/simple-customer-flow/flows/simpleCustomerFlow.flow.json
@@ -6,6 +6,12 @@
     },
     "2": {
       "stepId": "otherCustomerMapping-mapping"
+    },
+    "3": {
+      "stepId": "noExcludeCustomerMapping-mapping"
+    },
+    "4": {
+      "stepId": "excludeFalseCustomerMapping-mapping"
     }
   }
 }

--- a/marklogic-data-hub/src/test/resources/test-projects/simple-customer-flow/steps/mapping/excludeFalseCustomerMapping.step.json
+++ b/marklogic-data-hub/src/test/resources/test-projects/simple-customer-flow/steps/mapping/excludeFalseCustomerMapping.step.json
@@ -1,5 +1,5 @@
 {
-  "name": "simpleCustomerMapping",
+  "name": "excludeFalseCustomerMapping",
   "stepDefinitionName": "entity-services-mapping",
   "stepDefinitionType": "MAPPING",
   "sourceQuery": "cts.collectionQuery('customer-input')",
@@ -7,7 +7,7 @@
   "targetDatabase": "data-hub-FINAL",
   "collections": [
     "Customer",
-    "simple-customer-mapping"
+    "noExclude-customer-mapping"
   ],
   "permissions": "data-hub-common,read,data-hub-common,update",
   "targetFormat": "json",
@@ -20,6 +20,6 @@
   "provenanceGranularityLevel": "off",
   "namespaces": {},
   "selectedSource": "query",
-  "stepId": "simpleCustomerMapping-mapping",
-  "enableExcludeAlreadyProcessed": true
+  "enableExcludeAlreadyProcessed": false,
+  "stepId": "excludeFalseCustomerMapping-mapping"
 }

--- a/marklogic-data-hub/src/test/resources/test-projects/simple-customer-flow/steps/mapping/noExcludeCustomerMapping.step.json
+++ b/marklogic-data-hub/src/test/resources/test-projects/simple-customer-flow/steps/mapping/noExcludeCustomerMapping.step.json
@@ -1,5 +1,5 @@
 {
-  "name": "simpleCustomerMapping",
+  "name": "noExcludeCustomerMapping",
   "stepDefinitionName": "entity-services-mapping",
   "stepDefinitionType": "MAPPING",
   "sourceQuery": "cts.collectionQuery('customer-input')",
@@ -7,7 +7,7 @@
   "targetDatabase": "data-hub-FINAL",
   "collections": [
     "Customer",
-    "simple-customer-mapping"
+    "noExclude-customer-mapping"
   ],
   "permissions": "data-hub-common,read,data-hub-common,update",
   "targetFormat": "json",
@@ -20,6 +20,5 @@
   "provenanceGranularityLevel": "off",
   "namespaces": {},
   "selectedSource": "query",
-  "stepId": "simpleCustomerMapping-mapping",
-  "enableExcludeAlreadyProcessed": true
+  "stepId": "noExcludeCustomerMapping-mapping"
 }

--- a/marklogic-data-hub/src/test/resources/test-projects/simple-customer-flow/steps/mapping/otherCustomerMapping.step.json
+++ b/marklogic-data-hub/src/test/resources/test-projects/simple-customer-flow/steps/mapping/otherCustomerMapping.step.json
@@ -20,5 +20,6 @@
   "provenanceGranularityLevel": "off",
   "namespaces": {},
   "selectedSource": "query",
-  "stepId": "otherCustomerMapping-mapping"
+  "stepId": "otherCustomerMapping-mapping",
+  "enableExcludeAlreadyProcessed": "true"
 }

--- a/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
+++ b/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
@@ -468,8 +468,14 @@ public abstract class AbstractHubTest extends AbstractHubClientTest {
             }
         }
     }
+
     protected int getDocumentCount(DatabaseClient client) {
         String query = "cts.estimate(cts.trueQuery())";
         return Integer.parseInt(client.newServerEval().javascript(query).evalAs(String.class));
+    }
+
+    protected JsonNode findFirstBatchDocument(String jobId) {
+        String query = format("collection('Batch')[/batch/jobId = '%s']", jobId);
+        return getHubClient().getJobsClient().newServerEval().xquery(query).eval(new JacksonHandle()).get();
     }
 }


### PR DESCRIPTION
### Description

processedItemHashes is now only captured if enableExcludeAlreadyProcessed is set to true.

Removed some caching in jobs.sjs that wasn't having any impact, as the functions that were checking the caches were only being called once in a transaction. 


#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

