### PR TITLE
DHFPROD-6200: Reset page options when switching between databases

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explore/scenarios.json.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explore/scenarios.json.tsx
@@ -674,6 +674,25 @@ describe("scenarios for final/staging databases for zero state and explore pages
     browsePage.getSearchText().should("have.value", "Adams");
     browsePage.getTotalDocuments().should("be.equal", 2);
 
+    //Verify if the pagination gets reset upon cliking on database buttons 
+    browsePage.clearSearchText();
+    browsePage.selectEntity('All Entities');
+    browsePage.getPaginationPageSizeOptions().then(attr => {
+      attr[0].click();
+    })
+
+    browsePage.getPageSizeOption('10 / page').click();
+    browsePage.waitForSpinnerToDisappear();
+    browsePage.clickPaginationItem(4);
+    browsePage.waitForSpinnerToDisappear();
+    browsePage.getStagingDatabaseButton().click();
+    browsePage.waitForSpinnerToDisappear();
+    browsePage.getFinalDatabaseButton().click();
+    browsePage.waitForSpinnerToDisappear();
+
+    cy.contains('Showing 1-20 of 36 results', { timeout: 5000 })
+    browsePage.getTotalDocuments().should('be.equal', 36);
+
     //switch to staging database and verify the number of documents for the search string is 0
     browsePage.getStagingDatabaseButton().click();
     browsePage.waitForSpinnerToDisappear();

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/browse.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/browse.tsx
@@ -617,6 +617,14 @@ class BrowsePage {
     cy.get(".ant-input-clear-icon").click();
   }
 
+  getPaginationPageSizeOptions() {
+    return cy.get('.ant-pagination-options .ant-select-selection-selected-value');
+  }
+
+  getPageSizeOption(pageSizeOption: string) {
+    return cy.findByText(pageSizeOption);
+  }
+  
 }
 
 const browsePage = new BrowsePage();

--- a/marklogic-data-hub-central/ui/src/util/search-context.tsx
+++ b/marklogic-data-hub-central/ui/src/util/search-context.tsx
@@ -581,6 +581,8 @@ const SearchProvider: React.FC<{ children: any }> = ({children}) => {
       start: 1,
       query: "",
       pageNumber: 1,
+      pageLength: 20,
+      pageSize: 20,
       selectedFacets: {},
       selectedQuery: "select a query",
       database: option


### PR DESCRIPTION
### Description
Resolving the bug DHFPROD-6200 where the search response page options were not getting reset upon changing the database.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

