### PR TITLE
DHFPROD-6338: Fix runFlow

### DIFF
--- a/marklogic-data-hub-api/src/testFixtures/java/com/marklogic/hub/test/AbstractHubClientTest.java
+++ b/marklogic-data-hub-api/src/testFixtures/java/com/marklogic/hub/test/AbstractHubClientTest.java
@@ -18,7 +18,16 @@ public abstract class AbstractHubClientTest extends TestObject {
 
     protected abstract HubClient getHubClient();
 
-    protected abstract HubClient runAsUser(String username, String password);
+    protected abstract HubClient doRunAsUser(String username, String password);
+
+    protected final HubClient runAsUser(String username, String password) {
+        long start = System.currentTimeMillis();
+        HubClient hubClient = doRunAsUser(username, password);
+        logger.info("Running as user: " + username + "; switching time: " +
+                (System.currentTimeMillis() - start) + "ms");
+
+        return hubClient;
+    }
 
     protected void resetDatabases() {
         // Admin is needed to clear out provenance data

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/AbstractHubCentralTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/AbstractHubCentralTest.java
@@ -126,7 +126,7 @@ public abstract class AbstractHubCentralTest extends AbstractHubTest {
      * @return
      */
     @Override
-    protected HubClient runAsUser(String username, String password) {
+    protected HubClient doRunAsUser(String username, String password) {
         // Need to create the project directory before applying properties
         testHubConfig.createProject(testProjectDirectory);
         testHubConfig.applyProperties(hubCentral.buildPropertySource(username, password));

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/AbstractSparkConnectorTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/AbstractSparkConnectorTest.java
@@ -74,7 +74,7 @@ public abstract class AbstractSparkConnectorTest extends AbstractHubClientTest {
     }
 
     @Override
-    protected HubClient runAsUser(String username, String password) {
+    protected HubClient doRunAsUser(String username, String password) {
         testProperties = new Properties();
         String mlHost = "localhost";
         String hubDhs = "false";

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/CustomStepE2E.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/CustomStepE2E.java
@@ -14,6 +14,7 @@ public class CustomStepE2E extends AbstractHubCoreTest {
     public void testCustomStep() {
         installProjectInFolder("mapping-test");
 
+        makeInputFilePathsAbsoluteInFlow("Admissions");
         RunFlowResponse flowResponse = runFlow(new FlowInputs("Admissions", "1", "2", "3", "4"));
         RunStepResponse ingestionJob = flowResponse.getStepResponses().get("3");
         assertTrue(ingestionJob.isSuccess(), "Custom ingestion job failed: " + ingestionJob.stepOutput);

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -182,7 +182,7 @@ public class HubTestBase extends AbstractHubTest {
     }
 
     @Override
-    protected HubClient runAsUser(String mlUsername, String mlPassword) {
+    protected HubClient doRunAsUser(String mlUsername, String mlPassword) {
         hubClient = null;
         Properties props = hubConfigInterceptor.getHubConfigObjectFactory().getGradleProperties();
         Properties newProps = new Properties();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/ConstrainSourceQueryToJobTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/ConstrainSourceQueryToJobTest.java
@@ -14,10 +14,10 @@ public class ConstrainSourceQueryToJobTest extends AbstractHubCoreTest {
     @Test
     public void test() {
         installReferenceModelProject();
-        runAsDataHubOperator();
-
         final String flowName = "ingestToFinal";
+        makeInputFilePathsAbsoluteInFlow(flowName);
 
+        runAsDataHubOperator();
         RunFlowResponse flowResponse = runFlow(new FlowInputs(flowName, "1").withJobId("job1"));
         RunStepResponse stepResponse = flowResponse.getStepResponses().get("1");
         assertEquals("job1", stepResponse.getJobId());

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/IngestToFinalTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/IngestToFinalTest.java
@@ -23,6 +23,7 @@ public class IngestToFinalTest extends AbstractHubCoreTest {
         final String flowName = "ingestToFinal";
 
         installReferenceModelProject();
+        makeInputFilePathsAbsoluteInFlow(flowName);
         String jobId = runFlow(new FlowInputs(flowName)).getJobId();
 
         JsonNode rawDoc = getFinalDoc("/customers/customer1.json");

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/RunStepWithProcessorsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/RunStepWithProcessorsTest.java
@@ -31,6 +31,9 @@ public class RunStepWithProcessorsTest extends AbstractHubCoreTest {
 
     @Test
     void overrideUriViaIngestionStep() {
+        makeInputFilePathsAbsoluteInFlow("stepProcessors");
+
+        runAsDataHubOperator();
         RunFlowResponse response = runFlow(new FlowInputs("stepProcessors", "4"));
         assertEquals(JobStatus.FINISHED.toString(), response.getJobStatus());
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/impl/RunFlowWithStemmingEnabledTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/impl/RunFlowWithStemmingEnabledTest.java
@@ -32,6 +32,7 @@ public class RunFlowWithStemmingEnabledTest extends AbstractHubCoreTest {
             enableAdvancedStemming(true);
             installProjectInFolder("flow-runner-test");
 
+            makeInputFilePathsAbsoluteInFlow("testFlow");
             RunFlowResponse resp = runFlow(new FlowInputs("testFlow"));
             assertEquals(JobStatus.STOP_ON_ERROR.toString(), resp.getJobStatus().toLowerCase());
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/master/MasterTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/master/MasterTest.java
@@ -54,12 +54,13 @@ public class MasterTest extends AbstractHubCoreTest {
         metadata.getPermissions().add("data-hub-module-writer", DocumentMetadataHandle.Capability.UPDATE);
         getHubConfig().newModulesDbClient().newDocumentManager().write("/custom-modules/no-op.sjs",
             metadata, new BytesHandle(customModuleText.getBytes()).withFormat(Format.TEXT));
-
-        runAsDataHubOperator();
     }
 
     @Test
     public void testMatchEndpoint() {
+        makeInputFilePathsAbsoluteInFlow("myNewFlow");
+
+        runAsDataHubOperator();
         runFlow(new FlowInputs("myNewFlow", "1", "2"));
         JsonNode matchResp = masteringManager.match("/person-1.json", "myNewFlow", "3", Boolean.TRUE, new ObjectMapper().createObjectNode()).get("results");
         assertEquals(7, matchResp.get("total").asInt(), "There should 7 match results");
@@ -68,6 +69,9 @@ public class MasterTest extends AbstractHubCoreTest {
 
     @Test
     public void testMasterStep() {
+        makeInputFilePathsAbsoluteInFlow("myNewFlow");
+
+        runAsDataHubOperator();
         RunFlowResponse flowResponse = runFlow(new FlowInputs("myNewFlow", "1", "2", "3"));
         RunStepResponse masterJob = flowResponse.getStepResponses().get("3");
         assertTrue(masterJob.isSuccess(), "Mastering job failed!");
@@ -97,6 +101,9 @@ public class MasterTest extends AbstractHubCoreTest {
 
     @Test
     public void testMatchMergeSteps() {
+        makeInputFilePathsAbsoluteInFlow("myMatchMergeFlow");
+
+        runAsDataHubOperator();
         RunFlowResponse flowResponse = runFlow(new FlowInputs("myMatchMergeFlow", "1", "2", "3"));
         RunStepResponse matchJob = flowResponse.getStepResponses().get("3");
         assertTrue(matchJob.isSuccess(), "Matching job failed!");
@@ -131,6 +138,9 @@ public class MasterTest extends AbstractHubCoreTest {
 
     @Test
     public void testManualMerge() {
+        makeInputFilePathsAbsoluteInFlow("myNewFlow");
+
+        runAsDataHubOperator();
         runFlow(new FlowInputs("myNewFlow", "1", "2"));
         List<String> docsToMerge = Arrays.asList("/person-1.json", "/person-1-1.json", "/person-1-2.json", "/person-1-3.json");
         JsonNode mergeResults = masteringManager.merge(docsToMerge, "myNewFlow", "3", Boolean.FALSE, new ObjectMapper().createObjectNode());

--- a/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
+++ b/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
@@ -383,7 +383,6 @@ public abstract class AbstractHubTest extends AbstractHubClientTest {
      * @return
      */
     protected RunFlowResponse runFlow(FlowInputs flowInputs) {
-        makeInputFilePathsAbsoluteInFlow(flowInputs.getFlowName());
         FlowRunnerImpl flowRunner = new FlowRunnerImpl(getHubClient());
         RunFlowResponse response = flowRunner.runFlow(flowInputs);
         flowRunner.awaitCompletion();


### PR DESCRIPTION
### Description
- `runFlow` now does not automatically make input file paths absolute in the flow. Use the `makeInputFilePathsAbsoluteInFlow` method separately for flows. This change was necessary because `makeInputFilePathsAbsoluteInFlow` needs to run as developer user which was causing the flow to always run as developer user.
- Also added logging for user switching.
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [X] JIRA_ID included in all the commit messages
- [X] PR title is in the format JIRA_ID:Title
- [X] Rebase the branch with upstream
- [X] Squashed all commits into a single commit
- [N/A] Added Tests
  

- ##### Reviewer:

- [N/A] Reviewed Tests

