### PR TITLE
DHFPROD-5502: Clicking on the hostname to get to the export modal is …

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/common/projectInfo.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/common/projectInfo.tsx
@@ -1,7 +1,7 @@
 class ProjectInfo {
 
   getAboutProject() {
-    return cy.get("#service-name");
+    return cy.get("#info-details");
   }
 
   getDownloadButton() {

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/common/tiles.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/common/tiles.tsx
@@ -34,6 +34,7 @@ class Tiles {
 
   closeRunMessage() {
     cy.wait(500);
+    cy.get("body").type("{esc}");
     return cy.get("body").type("{esc}");
   }
 }

--- a/marklogic-data-hub-central/ui/src/components/header/header.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/header/header.module.scss
@@ -40,6 +40,21 @@ header.container {
     color: white;
 }
 
+.infoIcon { 
+  font-size: 24px !important;
+  color: #b5b8bb;
+  padding-bottom: 15px;
+}
+
+.userIcon {
+  padding-bottom: 15px;
+}
+
+.infoTooltip {
+  top: 62px !important;
+  max-width: 100%;
+}
+
 li.menuLink {
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 16px;
@@ -50,7 +65,7 @@ li.menuLink {
 }
 div.iconsContainerAuth {
   position: absolute;
-  top: 8px;
+  top: 13px;
   right: 10px;
   i:hover {
     cursor: pointer;

--- a/marklogic-data-hub-central/ui/src/components/header/header.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/header/header.test.tsx
@@ -1,11 +1,22 @@
 import React from "react";
-import {render, cleanup} from "@testing-library/react";
+import {render, cleanup, waitForElement} from "@testing-library/react";
 import {BrowserRouter as Router} from "react-router-dom";
 import {UserContext} from "../../util/user-context";
 import Header from "./header";
 import data from "../../assets/mock-data/system-info.data";
 import {userAuthenticated} from "../../assets/mock-data/user-context-mock";
 import {Application} from "../../config/application.config";
+import {fireEvent} from "@testing-library/dom";
+
+
+const getSubElements = (content, node, title) => {
+  const hasText = node => node.textContent === title;
+  const nodeHasText = hasText(node);
+  const childrenDontHaveText = Array.from(node.children).every(
+    child => !hasText(child)
+  );
+  return nodeHasText && childrenDontHaveText;
+};
 
 describe("Header component", () => {
 
@@ -36,14 +47,22 @@ describe("Header component", () => {
         </UserContext.Provider>
       </Router>
     );
-    expect(getByLabelText("header-logo")).toBeInTheDocument();
     expect(getByText(Application.title)).toBeInTheDocument();
-    expect(getByText(data.environment.serviceName)).toBeInTheDocument();
+    expect(getByLabelText("header-logo")).toBeInTheDocument();
     // expect(getByLabelText('icon: search')).toBeInTheDocument();
-    expect(getByLabelText("icon: question-circle")).toBeInTheDocument();
-    expect(getByLabelText("icon: user")).toBeInTheDocument();
+    // expect(getByLabelText('icon: question-circle')).toBeInTheDocument();
+    // expect(getByLabelText('icon: user')).toBeInTheDocument();
     // expect(getByLabelText('icon: setting')).toBeInTheDocument();
 
+    //verify icons and respective tooltips
+    fireEvent.mouseOver(getByLabelText("icon: user"));
+    await waitForElement(() => getByText("User"));
+
+    fireEvent.mouseOver(getByLabelText("icon: question-circle"));
+    await waitForElement(() => getByText("Help"));
+
+    fireEvent.mouseOver(getByLabelText("icon: info-circle"));
+    await waitForElement(() => getByLabelText("info-text"));
 
     //verify correct version specific link when environment hub version data is set to '5.3-SNAPSHOT'
     expect(document.querySelector("#help-link")).toHaveAttribute("href", "https://docs.marklogic.com/datahub/5.3");

--- a/marklogic-data-hub-central/ui/src/components/header/header.tsx
+++ b/marklogic-data-hub-central/ui/src/components/header/header.tsx
@@ -94,6 +94,13 @@ const Header:React.FC<Props> = (props) => {
     </div>
   </div>;
 
+  let infoContainer = <div aria-label="info-text">
+      Data Hub Version: <strong>{props.environment.dataHubVersion}</strong><br/>
+      MarkLogic Version: <strong>{props.environment.marklogicVersion}</strong><br/>
+      Service Name: <strong>{props.environment.serviceName}</strong><br/><br/>
+      Click to see details, to download configuration files, and to clear user data.
+  </div>;
+
   let globalIcons;
   if (user.authenticated) {
     globalIcons =
@@ -105,7 +112,7 @@ const Header:React.FC<Props> = (props) => {
         theme="dark"
       >
         <Menu.Item>
-          <i id="service-name" className={styles.serviceName} onClick={handleSystemInfoDisplay}>{props.environment.serviceName}</i>
+          <MLTooltip title={infoContainer} placement={"bottomLeft"} overlayClassName={styles.infoTooltip}><i id="info-details" onClick={handleSystemInfoDisplay}><Icon type="info-circle" className={styles.infoIcon}/></i></MLTooltip>
         </Menu.Item>
         <div className={styles.vertical}></div>
         {/* <Menu.Item>
@@ -119,7 +126,7 @@ const Header:React.FC<Props> = (props) => {
         </Menu.Item> */}
         <Dropdown overlay={userMenu}>
           <span className="userDropdown">
-            <MLTooltip title="User"><Icon type="user"/></MLTooltip>
+            <MLTooltip title="User"><Icon type="user" className={styles.userIcon}/></MLTooltip>
           </span>
         </Dropdown>
       </Menu>

--- a/marklogic-data-hub-central/ui/src/components/header/system-info.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/header/system-info.module.scss
@@ -29,6 +29,18 @@
     }
   }
 
+  .copyIcon {
+    color: #44499C;
+    margin-left: 15px;
+  }
+
+  .copyIcon:hover {
+    cursor: pointer;
+    color: #44499C;
+    margin-left: 15px;
+  }
+
+
   .cardsContainer {
     width: 100%;
     text-align: center;

--- a/marklogic-data-hub-central/ui/src/components/header/system-info.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/header/system-info.test.tsx
@@ -18,6 +18,12 @@ const getSubElements=(content, node, title) => {
   return nodeHasText && childrenDontHaveText;
 };
 
+Object.assign(navigator, {
+  clipboard: {
+    writeText: () => {},
+  },
+});
+
 describe("Update data load settings component", () => {
 
 
@@ -39,9 +45,9 @@ describe("Update data load settings component", () => {
       />
     </AuthoritiesContext.Provider></Router>);
     expect(getByText(data.environment.serviceName)).toBeInTheDocument();
-    expect(getByText("Data Hub version:")).toBeInTheDocument();
+    expect(getByText("Data Hub Version:")).toBeInTheDocument();
     expect(getByText(data.environment.dataHubVersion)).toBeInTheDocument();
-    expect(getByText("MarkLogic version:")).toBeInTheDocument();
+    expect(getByText("MarkLogic Version:")).toBeInTheDocument();
     expect(getByText(data.environment.marklogicVersion)).toBeInTheDocument();
     expect(getByText("Download Configuration Files")).toBeInTheDocument();
     expect(getByTestId("clearData")).toBeInTheDocument();
@@ -51,17 +57,25 @@ describe("Update data load settings component", () => {
     expect(getByText("Clear")).toBeDisabled();
   });
 
-  test("Verify project info display, user with \"Download\" button enabled", async () => {
+  test("Verify project info display, user with \"Download\" button enabled, and copy service name to clipboard", async () => {
     const authorityService = new AuthoritiesService();
     authorityService.setAuthorities(["downloadProjectFiles"]);
-    const {getByText} = render(<Router><AuthoritiesContext.Provider value={authorityService}>
-      <SystemInfo
+    const {getByText, getByTestId} = render(<Router><AuthoritiesContext.Provider value={authorityService}>
+      <SystemInfo {...data.environment}
         systemInfoVisible={true}
         setSystemInfoVisible={jest.fn()}
       />
     </AuthoritiesContext.Provider></Router>);
     expect(getByText("Download")).toBeEnabled();
     expect(getByText("Clear")).toBeDisabled();
+
+    //verify copy icon and tooltip
+    fireEvent.mouseOver(getByTestId("copyServiceName"));
+    await waitForElement(() => getByText("Copy to clipboard"));
+    jest.spyOn(navigator.clipboard, "writeText");
+    fireEvent.click(getByTestId("copyServiceName"));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(data.environment.serviceName);
+
   });
 
   test("Verify project info display, user with \"Clear\" button enabled", async () => {

--- a/marklogic-data-hub-central/ui/src/components/header/system-info.tsx
+++ b/marklogic-data-hub-central/ui/src/components/header/system-info.tsx
@@ -5,9 +5,9 @@ import axios from "axios";
 import {UserContext} from "../../util/user-context";
 import {AuthoritiesContext} from "../../util/authorities";
 import Axios from "axios";
-import {MLButton, MLSpin} from "@marklogic/design-system";
+import {MLButton, MLSpin, MLTooltip} from "@marklogic/design-system";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faExclamationTriangle} from "@fortawesome/free-solid-svg-icons";
+import {faExclamationTriangle, faCopy} from "@fortawesome/free-solid-svg-icons";
 
 
 
@@ -22,6 +22,7 @@ const SystemInfo = (props) => {
   const [message, setMessage] = useState({show: false});
   const [isLoading, setIsLoading] = useState(false);
   const [clearDataVisible, setClearDataVisible] = useState(false);
+  const [copySuccess, setCopySuccess] = useState("");
 
   useEffect(() => {
     if (!user.authenticated && props.systemInfoVisible) {
@@ -46,6 +47,15 @@ const SystemInfo = (props) => {
         document.body.appendChild(link);
         link.click();
       });
+  };
+
+  const copyToClipBoard = async copyMe => {
+    try {
+      await navigator.clipboard.writeText(copyMe);
+      setCopySuccess("Copied!");
+    } catch (err) {
+      setCopySuccess("Failed to copy!");
+    }
   };
 
   const clear =async () => {
@@ -111,13 +121,13 @@ const SystemInfo = (props) => {
         <div data-testid="alertTrue" className={styles.alertPosition} style={message.show ? {display: "block"} : {display: "none"}}>
           <Alert message={<span><b>Clear All User Data </b>completed successfully</span>} type="success" showIcon />
         </div>
-        <div className={styles.serviceName}>{serviceName}</div>
+        <div className={styles.serviceName}>{serviceName}<MLTooltip title="Copy to clipboard" placement={"bottom"}><FontAwesomeIcon icon={faCopy} data-testid="copyServiceName" className={styles.copyIcon} onClick={() => copyToClipBoard(serviceName)}/></MLTooltip></div>
         <div className={styles.version}>
-          <div className={styles.label}>Data Hub version:</div>
+          <div className={styles.label}>Data Hub Version:</div>
           <div className={styles.value}>{dataHubVersion}</div>
         </div>
         <div className={styles.version}>
-          <div className={styles.label}>MarkLogic version:</div>
+          <div className={styles.label}>MarkLogic Version:</div>
           <div className={styles.value}>{marklogicVersion}</div>
         </div>
         <div className={styles.cardsContainer}>


### PR DESCRIPTION
…not intuitive

### Description

- Service name in header now replaced by info icon
- Info icon shows hub version, marklogic version, and service name on hover
- Added copy icon and 'copy to clipboard' functionality on service name in system info modal (from clicking info icon)
- Included minor cypress test adjustments
- Ran ESLint on affected files.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

