### PR TITLE
DHFPROD-6279: Adjust placement of Match/Merge settings tooltips

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.module.scss
@@ -1,3 +1,7 @@
+.createEditStep {
+    margin-left: 10px;
+}
+
 .modal {
     &.modal-header {
     border-bottom: 0 none;
@@ -27,9 +31,6 @@
     cursor: not-allowed;
 }
 
-.newMatchingForm {
-    margin-left: 10px;
-}
 .questionCircle {
     font-size: 12px;
     color: #7F86B5;

--- a/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.tsx
@@ -409,7 +409,7 @@ const CreateEditStep: React.FC<Props>  = (props) => {
   };
 
   return (
-    <div className={styles.newMatchingForm}>
+    <div className={styles.createEditStep}>
       <Form {...formItemLayout} onSubmit={handleSubmit} colon={false}>
         <Form.Item label={<span>
             Name:&nbsp;<span className={styles.asterisk}>*</span>
@@ -426,7 +426,7 @@ const CreateEditStep: React.FC<Props>  = (props) => {
             disabled={tobeDisabled}
             className={styles.input}
           />&nbsp;&nbsp;
-          <MLTooltip title={NewMatchTooltips.name}>
+          <MLTooltip title={NewMatchTooltips.name} placement={"right"}>
             <Icon type="question-circle" className={styles.questionCircle} theme="filled" />
           </MLTooltip>
         </Form.Item>
@@ -442,7 +442,7 @@ const CreateEditStep: React.FC<Props>  = (props) => {
             disabled={props.canReadOnly && !props.canReadWrite}
             className={styles.input}
           />&nbsp;&nbsp;
-          <MLTooltip title={NewMergeTooltips.description}>
+          <MLTooltip title={NewMergeTooltips.description} placement={"right"}>
             <Icon type="question-circle" className={styles.questionCircle} theme="filled" />
           </MLTooltip>
         </Form.Item>
@@ -476,7 +476,7 @@ const CreateEditStep: React.FC<Props>  = (props) => {
             onChange={handleTypeaheadChange}
           >
             {/* {collectionsList} */}
-          </AutoComplete>&nbsp;&nbsp;{props.canReadWrite ? <Icon className={styles.searchIcon} type="search" theme="outlined"/> : ""}<MLTooltip title={NewMatchTooltips.sourceQuery}>
+          </AutoComplete>&nbsp;&nbsp;{props.canReadWrite ? <Icon className={styles.searchIcon} type="search" theme="outlined"/> : ""}<MLTooltip title={NewMatchTooltips.sourceQuery} placement={"right"}>
             <Icon type="question-circle" className={styles.questionCircleColl} theme="filled" />
           </MLTooltip></span></div> : <span><TextArea
             id="srcQuery"
@@ -485,7 +485,7 @@ const CreateEditStep: React.FC<Props>  = (props) => {
             onChange={handleChange}
             disabled={!props.canReadWrite}
             className={styles.input}
-          ></TextArea>&nbsp;&nbsp;<MLTooltip title={NewMatchTooltips.sourceQuery}>
+          ></TextArea>&nbsp;&nbsp;<MLTooltip title={NewMatchTooltips.sourceQuery} placement={"right"}>
             <Icon type="question-circle" className={styles.questionCircleTextArea} theme="filled" />
           </MLTooltip></span>}
         </Form.Item>
@@ -503,7 +503,7 @@ const CreateEditStep: React.FC<Props>  = (props) => {
               disabled={props.canReadOnly && !props.canReadWrite}
               className={styles.input}
             />&nbsp;&nbsp;
-            <MLTooltip title={NewMergeTooltips.timestampPath}>
+            <MLTooltip title={NewMergeTooltips.timestampPath} placement={"right"}>
               <Icon type="question-circle" className={styles.questionCircle} theme="filled" />
             </MLTooltip>
           </Form.Item> : ""}


### PR DESCRIPTION
Apply same "right" placement as used in other step settings forms. Also update wrapper CSS class name to match component name.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- N/A Added Tests
  

- ##### Reviewer:

- N/A Reviewed Tests

