### PR TITLE
DHFPROD-6323: Added isolated test for zip matching

### DIFF
--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/algorithms/zip-match/setup.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/algorithms/zip-match/setup.xqy
@@ -1,0 +1,8 @@
+xquery version "1.0-ml";
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+hub-test:reset-hub();
+
+xquery version "1.0-ml";
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+import module namespace test = "http://marklogic.com/test" at "/test/test-helper.xqy";
+hub-test:load-artifacts($test:__CALLER_FILE__);

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/algorithms/zip-match/test-data/content/FiveDigitMatch.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/algorithms/zip-match/test-data/content/FiveDigitMatch.json
@@ -1,0 +1,12 @@
+{
+  "envelope": {
+    "instance": {
+      "info": {
+        "title": "Address"
+      },
+      "Address": {
+        "zip": "11111"
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/algorithms/zip-match/test-data/content/NineDigitMatch.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/algorithms/zip-match/test-data/content/NineDigitMatch.json
@@ -1,0 +1,12 @@
+{
+  "envelope": {
+    "instance": {
+      "info": {
+        "title": "Address"
+      },
+      "Address": {
+        "zip": "11111-1234"
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/algorithms/zip-match/test-data/content/NoMatch.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/algorithms/zip-match/test-data/content/NoMatch.json
@@ -1,0 +1,12 @@
+{
+  "envelope": {
+    "instance": {
+      "info": {
+        "title": "Address"
+      },
+      "Address": {
+        "zip": "11112"
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/algorithms/zip-match/test-data/content/NoNineDigitMatch.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/algorithms/zip-match/test-data/content/NoNineDigitMatch.json
@@ -1,0 +1,12 @@
+{
+  "envelope": {
+    "instance": {
+      "info": {
+        "title": "Address"
+      },
+      "Address": {
+        "zip": "2222-11111"
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/algorithms/zip-match/test-data/entities/Address.entity.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/algorithms/zip-match/test-data/entities/Address.entity.json
@@ -1,0 +1,17 @@
+{
+  "info": {
+    "title": "Address",
+    "version": "0.0.1",
+    "baseUri": "http://example.org/"
+  },
+  "definitions": {
+    "Address": {
+      "properties": {
+        "zip": {
+          "datatype": "string",
+          "collation": "http://marklogic.com/collation/codepoint"
+        }
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/algorithms/zip-match/testZipMatch.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/algorithms/zip-match/testZipMatch.sjs
@@ -1,0 +1,54 @@
+const smTest = require("/test/suites/data-hub/5/smart-mastering/lib/masteringTestLib.sjs");
+const test = require("/test/test-helper.xqy");
+
+const assertions = [];
+
+const options = {
+  "targetEntityType": "http://example.org/Address-0.0.1/Address",
+  "matchRulesets": [
+    {
+      "name": "zip",
+      "weight": 10,
+      "matchRules": [
+        {
+          "entityPropertyPath": "zip",
+          "matchType": "zip"
+        }
+      ]
+    }
+  ],
+  "thresholds": [
+    {
+      "thresholdName": "match",
+      "action": "merge",
+      "score": 10
+    }
+  ]
+};
+
+const matchSummary = smTest.match("Address", {"zip": "11111"}, options);
+const uriToProcess = matchSummary.URIsToProcess[0];
+const actionDetails = matchSummary.actionDetails[uriToProcess];
+
+assertions.push(
+  test.assertTrue(uriToProcess.startsWith("/com.marklogic.smart-mastering/merged/"),
+    "Because a merge was found, the URI to process should have a URL that indicates a merged document will be written " +
+    "when the merging step is run"),
+
+  test.assertEqual("merge", actionDetails.action),
+
+  test.assertEqual(3, actionDetails.uris.length, "We expect 3 docs here; the input doc, the FiveDigit doc because " +
+    "it has the same input zip, and the NineDigit doc because it starts with 11111-. " +
+    "NoMatch shouldn't match because it has a slightly different 5 char zip code. " +
+    "NoNineDigitMatch shouldn't match because while it has 11111 in it, it doesn't start with that. " +
+    "Note that in order for NineDigit to match, wildcard searches must be supported by the database. For this test, " +
+    "it's expected that three-character-searches and trailing-wildcard-searches are both enabled so that a query on " +
+    "'11111-*' will match."),
+
+  test.assertEqual("/content/FiveDigitMatch.json", actionDetails.uris[0]),
+  test.assertEqual("/content/NineDigitMatch.json", actionDetails.uris[1],
+    "The URIs are expected to be ordered, so Nine should come after Five"),
+  test.assertEqual(smTest.TEST_DOC_URI, actionDetails.uris[2])
+)
+
+assertions;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/lib/masteringTestLib.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/lib/masteringTestLib.sjs
@@ -1,0 +1,73 @@
+/*
+  Copyright (c) 2020 MarkLogic Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+'use strict';
+
+/**
+ * Contains helper functions for simplifying mastering unit tests.
+ */
+
+const matching = require('/data-hub/5/builtins/steps/mastering/default/matching.sjs');
+
+// Prefixed with "/zzz" so it's almost certainly the last one in a match summary doc
+const TEST_DOC_URI = "/zzz/test-doc.json";
+
+/**
+ * Match a dynamically built entity instance, based on entityTypeName and entityProperties, using the given
+ * matching step options.
+ *
+ * The matching step options can be very minimal - targetEntityType, matchRulesets, and thresholds should do the trick.
+ *
+ * @param entityTypeName entityTypeName and entityProperties are used to dynamically build a valid enveloped
+ * in-memory document that can be matched on
+ * @param entityProperties
+ * @param options the step options
+ * @returns the matchSummary; assumes that only one is present
+ */
+function match(entityTypeName, entityProperties, options) {
+  const content = buildMatchingContent(entityTypeName, entityProperties);
+  return fn.head(matching.main(content, options)).value.matchSummary;
+}
+
+/**
+ * Convenience function for build a content array that the matching step main module accepts. The content array will
+ * contain a single enveloped entity instance based on the given type name and properties.
+ *
+ * @param entityTypeName
+ * @param entityProperties
+ */
+function buildMatchingContent(entityTypeName, entityProperties) {
+  const content = [{
+    "uri": TEST_DOC_URI
+  }];
+  // info/title must exist, assuming the step options will include targetEntityType
+  const value = {
+    "envelope": {
+      "instance": {
+        "info": {
+          "title": entityTypeName
+        }
+      }
+    }
+  };
+  value.envelope.instance[entityTypeName] = entityProperties;
+  content[0].value = xdmp.toJSON(value);
+  return content;
+}
+
+module.exports = {
+  match,
+  TEST_DOC_URI
+}

--- a/marklogic-data-hub/src/test/resources/test-config/databases/README.md
+++ b/marklogic-data-hub/src/test/resources/test-config/databases/README.md
@@ -1,0 +1,6 @@
+The final-database.json file in this directory is used by the applyDatabasePropertiesForTests test function. 
+
+Notes on some of the settings in this final:
+
+- three-character-searches and trailing-wildcard-searches are enabled to support zip matching queries in mastering 
+tests that depend on a trailing wildcard

--- a/marklogic-data-hub/src/test/resources/test-config/databases/final-database.json
+++ b/marklogic-data-hub/src/test/resources/test-config/databases/final-database.json
@@ -1,5 +1,7 @@
 {
   "database-name": "data-hub-FINAL",
+  "three-character-searches": true,
+  "trailing-wildcard-searches": true,
   "path-namespace": [
     {
       "prefix": "es",


### PR DESCRIPTION
### Description

Storing the test under data-hub/5/smart-mastering/algorithms/zipMatch, assuming that we can have a variety of narrow tests for each algorithm in an algorithm-specific directory. 

Added a couple wildcard indexes to the test database to verify that nine-digit zip matches work.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

