### PR TITLE
DHFPROD-6259: Timestamp should be shown by default in priority order slider

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/matching/multi-slider/multi-slider.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/multi-slider/multi-slider.scss
@@ -56,6 +56,30 @@
         background-color: #fff;
     }
 
+    .handleDisabled {
+        position: absolute;
+        z-index: 2;
+        width: 25px;
+        height: 25px;
+        border: solid 3px #8b94c6;
+        text-align: center;
+        pointer-events: none;
+        border-radius: 50%;
+        background-color: #fff;
+    }
+
+    .handleDisabledParent{
+        position: absolute;
+        margin-left: -15px;
+        margin-top: -10px;
+        z-index: 2;
+        width: 25px;
+        height: 25px;
+        text-align: center;
+        cursor: not-allowed !important;
+        border-radius: 50%;
+    }
+
     .tooltipContainer {
 
         position: absolute;
@@ -152,6 +176,56 @@
               white-space: nowrap;
               padding-left: 7px;
               width: 165px;
+              overflow: hidden;
+            }
+        }
+
+        .tooltipDisabled {
+            position: relative;
+            display: block;
+            width: 120px;
+            bottom: 10px;
+            right: 62px;
+            border-radius: 6px;
+            box-shadow: 5px 5px 5px #ccc;
+
+            .tooltipText{
+                margin-top: -30px;
+                width: 120px;
+                background-color: #444;
+                color: #f0f0f0;
+                opacity: 0.8;
+                text-align: center;
+                border-radius: 6px;
+                padding: 3px 0;
+                position: relative;
+                z-index: 1;
+                white-space: nowrap;
+                text-overflow: ellipsis;
+                cursor: not-allowed;
+            }
+
+            .tooltipText::after {
+                content: "";
+                position: absolute;
+                top: 100%;
+                left: 50%;
+                margin-left: -5px;
+                border-width: 5px;
+                border-style: solid;
+                border-color: #444 transparent transparent transparent;
+            }
+
+            span {
+              background-color: inherit;
+              color: inherit;
+            }
+
+            .editText {
+              display: block;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+              width: 120px;
               overflow: hidden;
             }
         }

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/multi-slider/multi-slider.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/multi-slider/multi-slider.tsx
@@ -2,6 +2,8 @@ import React, {useState} from "react";
 import {Icon} from "antd";
 import {Slider, Handles, Ticks} from "@marklogic/react-compound-slider";
 import "./multi-slider.scss";
+import {MLTooltip} from "@marklogic/design-system";
+import {multiSliderTooltips} from "../../../../config/tooltips.config";
 
 const MultiSlider = (props) => {
 
@@ -14,7 +16,8 @@ const MultiSlider = (props) => {
 
   function Handle({handle: {id, value, percent},
     options: options,
-    getHandleProps
+    getHandleProps,
+    disabled
   }) {
 
     const onHover = () => {
@@ -24,35 +27,45 @@ const MultiSlider = (props) => {
     return (
       <>
         <div className={"tooltipContainer"} style={{left: `${percent}%`}}>
-          {activeHandleIdOptions.hasOwnProperty("prop") && options[0].prop === activeHandleIdOptions["prop"] && activeHandleIdOptions.hasOwnProperty("type") && options[0].type === activeHandleIdOptions["type"]? <div className="tooltip">
+          {activeHandleIdOptions.hasOwnProperty("prop") && options[0].prop === activeHandleIdOptions["prop"] && activeHandleIdOptions.hasOwnProperty("type") && options[0].type === activeHandleIdOptions["type"]? <div className={disabled ? "tooltipDisabled" : "tooltip"}>
             {options.map((opt, i) => (
               <div className={activeHandleIdOptions["index"] === id.split("-")[1] ? "activeTooltipText": "tooltipText"} data-testid={`${options[0].prop}-active-tooltip`} key={i}>
                 <span className="editText" data-testid={`edit-${options[0].prop}`} onClick={() => handleEdit({...options[0], sliderType: props.type, index: id.split("-")[1]})}><span>{opt.prop}</span> {opt.type.length ? `-  ${opt.type}` : ""}</span>
-                <div data-testid={`delete-${options[0].prop}`} className="clearIcon" onClick={() => handleDelete({...options[0], sliderType: props.type, index: id.split("-")[1]})}>X</div>
+                {disabled ? null : <div data-testid={`delete-${options[0].prop}`} className="clearIcon" onClick={() => handleDelete({...options[0], sliderType: props.type, index: id.split("-")[1]})}>X</div>}
               </div>)
             )}
           </div>
             :
-            <div className="tooltip">
+            <div className={disabled ? "tooltipDisabled" : "tooltip"}>
               {options.map((opt, i) => (
                 <div className="tooltipText"  data-testid={`${options[0].prop}-tooltip`} key={i}>
                   <span className="editText" data-testid={`edit-${options[0].prop}`} onClick={() => handleEdit({...options[0], sliderType: props.type, index: id.split("-")[1]})}><span aria-label={opt.type.length ? `${opt.prop}-${opt.type}`: `${opt.prop}` }>{opt.prop}</span>  {opt.type.length ? `-  ${opt.type}` : ""}</span>
-                  <div data-testid={`delete-${options[0].prop}`} className="clearIcon" onClick={() => handleDelete({...options[0], sliderType: props.type, index: id.split("-")[1]})}><Icon type="close" /></div>
+                  {disabled ? null : <div data-testid={`delete-${options[0].prop}`} className="clearIcon" onClick={() => handleDelete({...options[0], sliderType: props.type, index: id.split("-")[1]})}><Icon type="close" /></div>}
                 </div>
               ))}
             </div>
           }
         </div>
-        <div
-          className={"handle"}
-          onMouseOver={() => onHover()}
-          data-testid={`${options[0].prop}-active`}
-          style={{
-            left: `${percent}%`,
-          }}
-          {...getHandleProps(id)}
-        >
-        </div>
+        <MLTooltip title={disabled ? multiSliderTooltips.timeStamp : ""} placement="bottom">
+          {disabled ? <div className={"handleDisabledParent"}><div
+            className={"handleDisabled"}
+            data-testid={`${options[0].prop}-active`}
+            style={{
+              left: `${percent}%`,
+            }}
+            {...getHandleProps(id)}
+          >
+          </div></div> : <div
+            className={"handle"}
+            onMouseOver={() => onHover()}
+            data-testid={`${options[0].prop}-active`}
+            style={{
+              left: `${percent}%`,
+            }}
+            {...getHandleProps(id)}
+          >
+          </div> }
+        </MLTooltip>
       </>
     );
   }
@@ -156,6 +169,7 @@ const MultiSlider = (props) => {
                       handle={handle}
                       options={options[index].props}
                       getHandleProps={getHandleProps}
+                      disabled={props.stepType === "merging" && options[index].props[0].prop === "Timestamp" && options[index].props[0].type === "" ? true : false}
                     />
                   );
                 }

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/ruleset-single-modal/ruleset-single-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/ruleset-single-modal/ruleset-single-modal.tsx
@@ -245,7 +245,7 @@ const MatchRulesetModal: React.FC<Props> = (props) => {
     case "exact":
     case "reduce":
     case "zip":
-    {      
+    {
 
       let matchRule: MatchRule = {
         entityPropertyPath: propertyName,

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/add-merge-rule/merge-rule-dialog.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/add-merge-rule/merge-rule-dialog.test.tsx
@@ -1,10 +1,12 @@
 import React from "react";
-import {render, cleanup, fireEvent, screen} from "@testing-library/react";
+import {render, cleanup, fireEvent, screen, waitForElement} from "@testing-library/react";
 import MergeRuleDialog from "./merge-rule-dialog";
 import data from "../../../../assets/mock-data/curation/merging.data";
 import {CurationContext} from "../../../../util/curation-context";
 import {customerMergingStep} from "../../../../assets/mock-data/curation/curation-context-mock";
 import {updateMergingArtifact} from "../../../../api/merging";
+import userEvent from "@testing-library/user-event";
+import {multiSliderTooltips} from "../../../../config/tooltips.config";
 
 
 jest.mock("../../../../api/merging");
@@ -72,8 +74,8 @@ describe("Merge Rule Dialog component", () => {
 
   });
 
-  it("Verify Add Merge Rule dialog with property-specific mergeType renders correctly", () => {
-    const {getByText, getByTestId, getByLabelText, queryByLabelText, getByPlaceholderText} = render(
+  it("Verify Add Merge Rule dialog with property-specific mergeType renders correctly", async () => {
+    const {getByText, getByTestId, getByLabelText, queryByLabelText, getByPlaceholderText, getAllByLabelText} = render(
       <CurationContext.Provider value={customerMergingStep}>
         <MergeRuleDialog
           {...data.mergeRuleDataProps}
@@ -106,6 +108,18 @@ describe("Merge Rule Dialog component", () => {
     expect(getByPlaceholderText("Enter max values")).toBeInTheDocument();
     expect(getByPlaceholderText("Enter max sources")).toBeInTheDocument();
     expect(getByTestId("priorityOrderSlider")).toBeInTheDocument();
+
+    //Verify priority Order slider tooltip
+    userEvent.hover(getAllByLabelText("icon: question-circle")[2]);
+    expect((await(waitForElement(() => getByText(multiSliderTooltips.priorityOrder))))).toBeInTheDocument();
+
+    //Timestamp handle is visible by default
+    let timestampHandle = getByTestId("Timestamp-active");
+    expect(timestampHandle).toHaveClass("handleDisabled");
+    expect(getByLabelText("Timestamp")).toBeInTheDocument();
+    userEvent.hover(timestampHandle);
+    expect((await(waitForElement(() => getByText(multiSliderTooltips.timeStamp))))).toBeInTheDocument();
+
     expect(getByLabelText("add-slider-button")).toBeInTheDocument();
 
     fireEvent.click(saveButton); //Modal will close now

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/add-merge-rule/merge-rule-dialog.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/add-merge-rule/merge-rule-dialog.tsx
@@ -12,9 +12,9 @@ import EntityPropertyTreeSelect from "../../../entity-property-tree-select/entit
 import {Definition} from "../../../../types/modeling-types";
 import {CurationContext} from "../../../../util/curation-context";
 import arrayIcon from "../../../../assets/icon_array.png";
-import {MergeRuleTooltips} from "../../../../config/tooltips.config";
+import {MergeRuleTooltips, multiSliderTooltips} from "../../../../config/tooltips.config";
 import MultiSlider from "../../matching/multi-slider/multi-slider";
-import {MergingStep} from "../../../../types/curation-types";
+import {MergingStep, StepType, defaultPriorityOption} from "../../../../types/curation-types";
 import {updateMergingArtifact} from "../../../../api/merging";
 import {addSliderOptions, parsePriorityOrder, handleSliderOptions, handleDeleteSliderOptions} from "../../../../util/priority-order-conversion";
 import ConfirmYesNo from "../../../common/confirm-yes-no/confirm-yes-no";
@@ -61,7 +61,7 @@ const MergeRuleDialog: React.FC<Props> = (props) => {
   const [maxValueRuleInputTouched, setMaxValueRuleInputTouched] = useState(false);
   const [maxSourcesRuleInput, setMaxSourcesRuleInput] = useState<any>("");
   const [maxSourcesRuleInputTouched, setMaxSourcesRuleInputTouched] = useState(false);
-  const [priorityOrderOptions, setPriorityOrderOptions] = useState<any>([]);
+  const [priorityOrderOptions, setPriorityOrderOptions] = useState<any>([defaultPriorityOption]);
   const [discardChangesVisible, setDiscardChangesVisible] = useState(false);
   const [radioSourcesOptionClicked, setRadioSourcesOptionClicked] = useState(1);
   const [radioValuesOptionClicked, setRadioValuesOptionClicked] = useState(1);
@@ -170,7 +170,7 @@ const MergeRuleDialog: React.FC<Props> = (props) => {
     setStrategyValue(undefined);
     setNamespace("");
     setFunctionValue("");
-    setPriorityOrderOptions([]);
+    setPriorityOrderOptions([defaultPriorityOption]);
     setDropdownOption("Length");
     resetTouched();
   };
@@ -657,7 +657,7 @@ const MergeRuleDialog: React.FC<Props> = (props) => {
                 </MLTooltip>
               </Form.Item>
               <div className={styles.priorityOrderContainer} data-testid={"priorityOrderSlider"}>
-                <div><p className={styles.priorityText}>Priority Order<MLTooltip title={MergeRuleTooltips.priorityOrder}>
+                <div><p className={styles.priorityText}>Priority Order<MLTooltip title={multiSliderTooltips.priorityOrder} placement="right">
                   <Icon type="question-circle" className={styles.questionCircle} theme="filled" />
                 </MLTooltip></p></div>
                 <div className={styles.addButtonContainer}>
@@ -676,7 +676,7 @@ const MergeRuleDialog: React.FC<Props> = (props) => {
                   <MLButton aria-label="add-slider-button" type="primary" size="default" className={styles.addSliderButton} onClick={onAddOptions}>Add</MLButton>
                 </div>
                 <div>
-                  <MultiSlider options={priorityOrderOptions} handleSlider={handleSlider} handleDelete={handleDelete} handleEdit={handleEdit}/>
+                  <MultiSlider options={priorityOrderOptions} handleSlider={handleSlider} handleDelete={handleDelete} handleEdit={handleEdit} stepType={StepType.Merging}/>
                 </div>
               </div>
             </> : ""

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merge-strategy-dialog/merge-strategy-dialog.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merge-strategy-dialog/merge-strategy-dialog.test.tsx
@@ -1,10 +1,12 @@
 import React from "react";
-import {render, cleanup, fireEvent, screen} from "@testing-library/react";
+import {render, cleanup, fireEvent, screen, waitForElement} from "@testing-library/react";
 import data from "../../../../assets/mock-data/curation/merging.data";
 import {CurationContext} from "../../../../util/curation-context";
 import {customerMergingStep} from "../../../../assets/mock-data/curation/curation-context-mock";
 import MergeStrategyDialog from "./merge-strategy-dialog";
 import {updateMergingArtifact} from "../../../../api/merging";
+import userEvent from "@testing-library/user-event";
+import {multiSliderTooltips} from "../../../../config/tooltips.config";
 
 jest.mock("../../../../api/merging");
 const mockMergingUpdate = updateMergingArtifact as jest.Mock;
@@ -18,7 +20,7 @@ describe("Merge Strategy Dialog component", () => {
 
   it("Verify Add Merge Strategy dialog renders correctly", async () => {
     mockMergingUpdate.mockResolvedValueOnce({status: 200, data: {}});
-    const {getByText, getByPlaceholderText, getByTestId, getByLabelText} = render(
+    const {getByText, getByPlaceholderText, getByTestId, getByLabelText, getAllByLabelText} = render(
       <CurationContext.Provider value={customerMergingStep}>
         <MergeStrategyDialog
           {...data.mergeStrategyDataProps}
@@ -39,6 +41,18 @@ describe("Merge Strategy Dialog component", () => {
     fireEvent.change(getByPlaceholderText("Enter max sources"), {target: {value: 2}});
     expect(getByPlaceholderText("Enter max sources")).toHaveAttribute("value", "2");
     expect(getByTestId("prioritySlider")).toBeInTheDocument();
+
+    //Verify priority option slider tooltip
+    userEvent.hover(getAllByLabelText("icon: question-circle")[2]);
+    expect((await(waitForElement(() => getByText(multiSliderTooltips.priorityOrder))))).toBeInTheDocument();
+
+    //Timestamp handle is visible by default
+    let timestampHandle = getByTestId("Timestamp-active");
+    expect(timestampHandle).toHaveClass("handleDisabled");
+    expect(getByLabelText("Timestamp")).toBeInTheDocument();
+    userEvent.hover(timestampHandle);
+    expect((await(waitForElement(() => getByText(multiSliderTooltips.timeStamp))))).toBeInTheDocument();
+
     fireEvent.click(getByLabelText("add-slider-button"));
     let saveButton = getByText("Save");
     //Modal will close now

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merge-strategy-dialog/merge-strategy-dialog.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merge-strategy-dialog/merge-strategy-dialog.tsx
@@ -8,9 +8,9 @@ import styles from "./merge-strategy-dialog.module.scss";
 import {MLButton, MLTooltip, MLSelect} from "@marklogic/design-system";
 import MultiSlider from "../../matching/multi-slider/multi-slider";
 import {CurationContext} from "../../../../util/curation-context";
-import {MergeRuleTooltips} from "../../../../config/tooltips.config";
+import {MergeRuleTooltips, multiSliderTooltips} from "../../../../config/tooltips.config";
 import {addSliderOptions, parsePriorityOrder, handleSliderOptions, handleDeleteSliderOptions} from "../../../../util/priority-order-conversion";
-import {MergingStep} from "../../../../types/curation-types";
+import {MergingStep, StepType, defaultPriorityOption} from "../../../../types/curation-types";
 import {updateMergingArtifact} from "../../../../api/merging";
 import ConfirmYesNo from "../../../common/confirm-yes-no/confirm-yes-no";
 
@@ -37,7 +37,7 @@ const MergeStrategyDialog: React.FC<Props> = (props) => {
   const [maxSources, setMaxSources] = useState<any>("");
   const [maxSourcesTouched, setMaxSourcesTouched] = useState(false);
   const [isCustomStrategy, setIsCustomStrategy] = useState(false);
-  const [priorityOrderOptions, setPriorityOrderOptions] = useState<any>([]);
+  const [priorityOrderOptions, setPriorityOrderOptions] = useState<any>([defaultPriorityOption]);
   const [strategyNameErrorMessage, setStrategyNameErrorMessage] = useState("");
   const [dropdownOption, setDropdownOption] = useState("Length");
   const [dropdownOptionTouched, setDropdownOptionTouched] = useState(false);
@@ -181,7 +181,7 @@ const MergeStrategyDialog: React.FC<Props> = (props) => {
 
   const resetModal = () => {
     setStrategyNameErrorMessage("");
-    setPriorityOrderOptions([]);
+    setPriorityOrderOptions([defaultPriorityOption]);
     setDropdownOption("Length");
     setRadioValuesOptionClicked(1);
     setRadioSourcesOptionClicked(1);
@@ -216,7 +216,7 @@ const MergeStrategyDialog: React.FC<Props> = (props) => {
 
   useEffect(() => {
     if (props.strategyName.length === 0) {
-      setPriorityOrderOptions([]);
+      setPriorityOrderOptions([defaultPriorityOption]);
       setStrategyName("");
     }
     if (props.isEditStrategy && props.strategyName.length) {
@@ -228,7 +228,7 @@ const MergeStrategyDialog: React.FC<Props> = (props) => {
     }
   }, [props.strategyName, curationOptions, props.isEditStrategy, props.sourceNames]);
 
-  let priorityOrderStrategyOptions:any[] = [];
+  let priorityOrderStrategyOptions:any[] = [defaultPriorityOption];
   const parsedEditedFormDetails = (data) => {
     let mergeStrategiesData: any[]  = data.mergeStrategies;
     for (let key of mergeStrategiesData) {
@@ -348,7 +348,7 @@ const MergeStrategyDialog: React.FC<Props> = (props) => {
           </MLTooltip>
         </Form.Item>
         {!isCustomStrategy && <div className={styles.priorityOrderContainer} data-testid={"prioritySlider"}>
-          <div><p className={styles.priorityText}>Priority Order<MLTooltip title={""}>
+          <div><p className={styles.priorityText}>Priority Order<MLTooltip title={multiSliderTooltips.priorityOrder} placement="right">
             <Icon type="question-circle" className={styles.questionCircle} theme="filled" />
           </MLTooltip></p></div>
           <div className={styles.addButtonContainer}>
@@ -367,7 +367,7 @@ const MergeStrategyDialog: React.FC<Props> = (props) => {
             <MLButton aria-label="add-slider-button" type="primary" size="default" className={styles.addSliderButton} onClick={onAddOptions}>Add</MLButton>
           </div>
           <div>
-            <MultiSlider options={priorityOrderOptions} handleSlider={handleSlider} handleDelete={handleDelete} handleEdit={handleEdit}/>
+            <MultiSlider options={priorityOrderOptions} handleSlider={handleSlider} handleDelete={handleDelete} handleEdit={handleEdit} stepType={StepType.Merging}/>
           </div>
         </div>}
         <Form.Item className={styles.submitButtonsForm}>

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.test.tsx
@@ -10,7 +10,7 @@ import {customerMergingStep, customerMergingStepEmpty} from "../../../../assets/
 import MergingStepDetail from "./merging-step-detail";
 import userEvent from "@testing-library/user-event";
 import {updateMergingArtifact} from "../../../../api/merging";
-import {MergeStrategyTooltips} from "../../../../config/tooltips.config";
+import {MergeStrategyTooltips, multiSliderTooltips} from "../../../../config/tooltips.config";
 
 jest.mock("../../../../api/merging");
 const mockMergingUpdate = updateMergingArtifact as jest.Mock;
@@ -48,7 +48,7 @@ describe("Merging Step Detail view component", () => {
 
   it("can render merging step with merge strategies and rulesets", async () => {
 
-    const {getByText, getAllByText} = render(
+    const {getByText, getAllByText, getByLabelText, getByTestId} = render(
       <CurationContext.Provider value={customerMergingStep}>
         <MergingStepDetail />
       </CurationContext.Provider>
@@ -63,6 +63,18 @@ describe("Merging Step Detail view component", () => {
 
     //check table data is rendered correctly
     expect(getByText("customMergeStrategy")).toBeInTheDocument();
+    userEvent.click(getByLabelText("right"));
+
+    //Verify priority option slider tooltip
+    userEvent.hover(getByLabelText("icon: question-circle"));
+    expect((await(waitForElement(() => getByText(multiSliderTooltips.priorityOrder))))).toBeInTheDocument();
+
+    //Timestamp handle is visible by default
+    let timestampHandle = getByTestId("Timestamp-active");
+    expect(timestampHandle).toHaveClass("handleDisabled");
+    expect(getByLabelText("Timestamp")).toBeInTheDocument();
+    userEvent.hover(timestampHandle);
+    expect((await(waitForElement(() => getByText(multiSliderTooltips.timeStamp))))).toBeInTheDocument();
 
     //Verify merge rules table is rendered with data
     // Check table column headers are rendered

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.tsx
@@ -7,9 +7,9 @@ import NumberIcon from "../../../number-icon/number-icon";
 import {MLTable, MLTooltip} from "@marklogic/design-system";
 import {CurationContext} from "../../../../util/curation-context";
 import {
-  MergingStep
+  MergingStep, StepType, defaultPriorityOption
 } from "../../../../types/curation-types";
-import {MergeStrategyTooltips, MergingStepDetailText} from "../../../../config/tooltips.config";
+import {MergeStrategyTooltips, MergingStepDetailText, multiSliderTooltips} from "../../../../config/tooltips.config";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faTrashAlt} from "@fortawesome/free-solid-svg-icons";
 import MultiSlider from "../../matching/multi-slider/multi-slider";
@@ -257,7 +257,7 @@ const MergingStepDetail: React.FC = () => {
   };
 
   const expandedRowRender = (strategyObj) => {
-    let priorityOrderStrategyOptions:any[] = [];
+    let priorityOrderStrategyOptions:any[] = [defaultPriorityOption];
     for (let strategy of mergingStep.mergeStrategies) {
       if (strategy.hasOwnProperty("priorityOrder") && strategy.strategyName === strategyObj.strategyName) {
         for (let key of strategy.priorityOrder.sources) {
@@ -291,10 +291,10 @@ const MergingStepDetail: React.FC = () => {
       }
     }
     return <>
-      <div className={styles.priorityOrderContainer}><p className={styles.priorityText}>Priority Order<MLTooltip title={""}>
+      <div className={styles.priorityOrderContainer}><p className={styles.priorityText}>Priority Order<MLTooltip title={multiSliderTooltips.priorityOrder} placement="right">
         <Icon type="question-circle" className={styles.questionCircle} theme="filled" />
       </MLTooltip></p>
-      <MultiSlider options={priorityOrderStrategyOptions} handleSlider={handleSlider} handleEdit={handleEdit} handleDelete={handleDelete}/>
+      <MultiSlider options={priorityOrderStrategyOptions} handleSlider={handleSlider} handleEdit={handleEdit} handleDelete={handleDelete} stepType={StepType.Merging}/>
       </div>
     </>;
   };

--- a/marklogic-data-hub-central/ui/src/config/tooltips.config.js
+++ b/marklogic-data-hub-central/ui/src/config/tooltips.config.js
@@ -190,6 +190,11 @@ const MergingStepDetailText = {
     'matched entities are combined into the merged entity by default. To define exceptions to this default behavior, create merge strategies and merge rules.'
 }
 
+const multiSliderTooltips = {
+  priorityOrder: 'The length weights and source weights plotted on a continuum from low to high. Each weight indicates the importance of the length or source when merging documents.',
+  timeStamp: 'Timestamp cannot be moved or deleted.'
+}
+
 export {
     AdvancedSettingsTooltips,
     NewFlowTooltips,
@@ -209,5 +214,6 @@ export {
     MatchingStepDetailText,
     MergeRuleTooltips,
     MergingStepDetailText,
-    MergeStrategyTooltips
+    MergeStrategyTooltips,
+    multiSliderTooltips
 }

--- a/marklogic-data-hub-central/ui/src/types/curation-types.ts
+++ b/marklogic-data-hub-central/ui/src/types/curation-types.ts
@@ -92,3 +92,11 @@ export interface MergingStep {
   mergeStrategies: any[],
   mergeRules: any[],
 }
+
+export const defaultPriorityOption = {
+  props: [{
+    prop: "Timestamp",
+    type: ""
+  }],
+  value: 0
+};

--- a/marklogic-data-hub-central/ui/src/util/priority-order-conversion.tsx
+++ b/marklogic-data-hub-central/ui/src/util/priority-order-conversion.tsx
@@ -6,12 +6,14 @@ export const parsePriorityOrder = (priorityOptions) => {
       if (key.props[0].prop === "Length") {
         priorityOrder.lengthWeight = key.value;
       } else {
-        priorityOrder.sources.push(
-          {
-            "sourceName": key.props[0].type,
-            "weight": key.value
-          }
-        );
+        if (key.props[0].type) {
+          priorityOrder.sources.push(
+            {
+              "sourceName": key.props[0].type,
+              "weight": key.value
+            }
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
### Description
Adding default timestamp handle on multi-slider in merging step detail.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

