### PR TITLE
DHFPROD-6357: Add remaining steps to Add Step Dropdown

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/run/runFlow.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/run/runFlow.spec.tsx
@@ -1,6 +1,7 @@
 import {Application} from "../../../support/application.config";
 import {tiles, toolbar} from "../../../support/components/common";
 import runPage from "../../../support/pages/run";
+import loadPage from "../../../support/pages/load";
 import browsePage from "../../../support/pages/browse";
 
 describe("Run Tile tests", () => {
@@ -18,10 +19,37 @@ describe("Run Tile tests", () => {
     cy.resetTestUser();
   });
 
-  it("should load xml merged document and display content", () => {
-    //Verifies DHFPROD-5863
+  it("can create flow and add steps to flow, should load xml merged document and display content", () => {
+
+    const flowName = "testPersonXML";
+    //Verify create flow and add all user-defined steps to flow via Run tile
+    runPage.createFlowButton().click();
+    runPage.newFlowModal().should("be.visible");
+    runPage.setFlowName(flowName);
+    loadPage.confirmationOptions("Save").click();
+    runPage.addStep(flowName).click();
+    runPage.addStepToFlow("loadPersonXML");
+    runPage.verifyStepInFlow("Load", "loadPersonXML");
+    runPage.addStep(flowName).click();
+    runPage.addStepToFlow("mapPersonXML");
+    runPage.verifyStepInFlow("Map", "mapPersonXML");
+    runPage.addStep(flowName).click();
+    runPage.addStepToFlow("match-xml-person");
+    runPage.verifyStepInFlow("Match", "match-xml-person");
+    runPage.addStep(flowName).click();
+    runPage.addStepToFlow("merge-xml-person");
+    runPage.verifyStepInFlow("Merge", "merge-xml-person");
+    runPage.addStep(flowName).click();
+    runPage.addStepToFlow("master-person");
+    runPage.verifyStepInFlow("Master", "master-person");
+    runPage.addStep(flowName).click();
+    runPage.addStepToFlow("generate-dictionary");
+    //Verify scrolling, last step should still be visible in the flow panel
+    runPage.verifyStepInFlow("Custom", "generate-dictionary");
+    //confirm the first load step is no longer visible because panel scrolled to the end
+    cy.findByText("loadPersonXML").should("not.be.visible");
+
     //Run map,match and merge step for Person entity using xml documents
-    runPage.toggleFlowConfig("personXML");
     runPage.runStep("mapPersonXML").click();
     cy.verifyStepRunResult("success", "Mapping", "mapPersonXML");
     tiles.closeRunMessage();
@@ -45,7 +73,7 @@ describe("Run Tile tests", () => {
     browsePage.getFacetApplyButton().click();
     browsePage.waitForSpinnerToDisappear();
     cy.waitForAsyncRequest();
-    browsePage.getTotalDocuments().should("be", 2);
+    browsePage.getTotalDocuments().should("be", 2);	 
     browsePage.getSourceViewIcon().first().click();
     cy.waitForAsyncRequest();
     browsePage.waitForSpinnerToDisappear();

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/run.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/run.tsx
@@ -33,6 +33,21 @@ class RunPage {
     return cy.findByText("New Flow");
   }
 
+  addStep(stepName: string) {
+    return cy.findByLabelText(`addStep-${stepName}`);
+  }
+
+  addStepToFlow(stepName: string) {
+    cy.findByLabelText(`${stepName}-to-flow`).click();
+    return cy.findByLabelText("Yes").click();
+  }
+
+  verifyStepInFlow(stepType: string, stepName: string) {
+    cy.waitForModalToDisappear();
+    cy.findByText(stepType).should("be.visible");
+    cy.findAllByText(stepName).first().should("be.visible");
+  }
+
   runStep(stepName: string) {
     return cy.findByLabelText(`runStep-${stepName}`);
   }

--- a/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
+++ b/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
@@ -347,7 +347,7 @@ const Flows: React.FC<Props> = (props) => {
       <Menu>
         <Menu.ItemGroup title="Load">
           { props.steps && props.steps["ingestionSteps"] && props.steps["ingestionSteps"].length > 0 ? props.steps["ingestionSteps"].map((elem, index) => (
-            <Menu.Item key={index}>
+            <Menu.Item key={index} aria-label={`${elem.name}-to-flow`}>
               <div
                 onClick={() => { handleStepAdd(elem.name, flowName, "ingestion"); }}
               >{elem.name}</div>
@@ -356,9 +356,45 @@ const Flows: React.FC<Props> = (props) => {
         </Menu.ItemGroup>
         <Menu.ItemGroup title="Map">
           { props.steps && props.steps["mappingSteps"] && props.steps["mappingSteps"].length > 0 ? props.steps["mappingSteps"].map((elem, index) => (
-            <Menu.Item key={index}>
+            <Menu.Item key={index} aria-label={`${elem.name}-to-flow`}>
               <div
                 onClick={() => { handleStepAdd(elem.name, flowName, "mapping"); }}
+              >{elem.name}</div>
+            </Menu.Item>
+          )) : null }
+        </Menu.ItemGroup>
+        <Menu.ItemGroup title="Match">
+          { props.steps && props.steps["matchingSteps"] && props.steps["matchingSteps"].length > 0 ? props.steps["matchingSteps"].map((elem, index) => (
+            <Menu.Item key={index} aria-label={`${elem.name}-to-flow`}>
+              <div
+                onClick={() => { handleStepAdd(elem.name, flowName, "matching"); }}
+              >{elem.name}</div>
+            </Menu.Item>
+          )) : null }
+        </Menu.ItemGroup>
+        <Menu.ItemGroup title="Merge">
+          { props.steps && props.steps["mergingSteps"] && props.steps["mergingSteps"].length > 0 ? props.steps["mergingSteps"].map((elem, index) => (
+            <Menu.Item key={index} aria-label={`${elem.name}-to-flow`}>
+              <div
+                onClick={() => { handleStepAdd(elem.name, flowName, "merging"); }}
+              >{elem.name}</div>
+            </Menu.Item>
+          )) : null }
+        </Menu.ItemGroup>
+        <Menu.ItemGroup title="Master">
+          { props.steps && props.steps["masteringSteps"] && props.steps["masteringSteps"].length > 0 ? props.steps["masteringSteps"].map((elem, index) => (
+            <Menu.Item key={index} aria-label={`${elem.name}-to-flow`}>
+              <div
+                onClick={() => { handleStepAdd(elem.name, flowName, "mastering"); }}
+              >{elem.name}</div>
+            </Menu.Item>
+          )) : null }
+        </Menu.ItemGroup>
+        <Menu.ItemGroup title="Custom">
+          { props.steps && props.steps["customSteps"] && props.steps["customSteps"].length > 0 ? props.steps["customSteps"].map((elem, index) => (
+            <Menu.Item key={index} aria-label={`${elem.name}-to-flow`}>
+              <div
+                onClick={() => { handleStepAdd(elem.name, flowName, "custom"); }}
               >{elem.name}</div>
             </Menu.Item>
           )) : null }
@@ -385,7 +421,7 @@ const Flows: React.FC<Props> = (props) => {
           <MLButton
             className={styles.addStep}
             size="default"
-            aria-label={"addStep-"+i}
+            aria-label={`addStep-${name}`}
             style={{}}
             type="primary"
           >Add Step <DownOutlined /></MLButton>


### PR DESCRIPTION
### Description

- Added support for remaining step types to Add Step Dropdown in Run Tile: Match, Merge, Master, Custom
- Added e2e test coverage, unit tests already exist 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

