### PR TITLE
DHFPROD-6210: Fix for ingestion/mapping e2e failures on DHS

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/run/runFlow.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/run/runFlow.spec.tsx
@@ -73,7 +73,7 @@ describe("Run Tile tests", () => {
     browsePage.getFacetApplyButton().click();
     browsePage.waitForSpinnerToDisappear();
     cy.waitForAsyncRequest();
-    browsePage.getTotalDocuments().should("be", 2);	 
+    browsePage.getTotalDocuments().should("be", 2);
     browsePage.getSourceViewIcon().first().click();
     cy.waitForAsyncRequest();
     browsePage.waitForSpinnerToDisappear();

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/common/tiles.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/common/tiles.tsx
@@ -33,9 +33,7 @@ class Tiles {
   }
 
   closeRunMessage() {
-    cy.get("body").type("{esc}");
-    cy.wait(500);
-    return cy.get("body").type("{esc}");
+    return cy.get("div.ant-modal-confirm-btns button").click({multiple: true, force: true});
   }
 }
 


### PR DESCRIPTION
### Description

- Finally able to reproduce the ingestion/mapping failures on DHS (reverting to Google Chrome 70) 
- Verified this solution resolves the problem.
- No need for wait statements or excessive esc buttons.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

