### PR TITLE
DHFPROD-6393: data-hub-common role can now use MLCP

### DIFF
--- a/examples/reference-entity-model/build.gradle
+++ b/examples/reference-entity-model/build.gradle
@@ -66,3 +66,14 @@ task loadCustomersViaMlcp(type: com.marklogic.gradle.task.MlcpTask) {
     transform_module = "/data-hub/5/transforms/mlcp-flow-transform.sjs"
     transform_param = "flow-name=CurateCustomerJSON,step=1"
 }
+
+task exportCustomers(type: com.marklogic.gradle.task.MlcpTask) {
+    description = "Example of using MLCP via Gradle via a minimally-privileged user to export data"
+	classpath = configurations.mlcp
+	command = "EXPORT"
+	port = 8011
+	username = "common-user"
+	password = testPassword
+	output_file_path = "build/export"
+	collection_filter = "Customer"
+}

--- a/examples/reference-entity-model/src/main/ml-config/security/users/common-user.json
+++ b/examples/reference-entity-model/src/main/ml-config/security/users/common-user.json
@@ -1,0 +1,8 @@
+{
+  "user-name": "common-user",
+  "description": "Most limited user that can use Data Hub",
+  "password": "%%testPassword%%",
+  "role": [
+    "data-hub-common"
+  ]
+}

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-common-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-common-writer.json
@@ -44,11 +44,6 @@
       "privilege-name": "xdbc:insert-in",
       "action": "http://marklogic.com/xdmp/privileges/xdbc-insert-in",
       "kind": "execute"
-    },
-    {
-      "privilege-name": "xdmp:with-namespaces",
-      "action": "http://marklogic.com/xdmp/privileges/xdmp-with-namespaces",
-      "kind": "execute"
     }
   ]
 }

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-common.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-common.json
@@ -41,6 +41,11 @@
       "privilege-name": "sem:sparql",
       "action": "http://marklogic.com/xdmp/privileges/sem-sparql",
       "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:with-namespaces",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-with-namespaces",
+      "kind": "execute"
     }
   ]
 }


### PR DESCRIPTION
### Description

Moved xdmp:with-namespaces from data-hub-common-writer to data-hub-common

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

