### PR TITLE
DHFPROD-6268: Setting default values for Identifier, Multiple and PII properties in property modal

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writer.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writer.spec.tsx
@@ -87,6 +87,11 @@ describe("Entity Modeling: Writer Role", () => {
 
     // edit property and change type to relationship
     propertyTable.editProperty("buyer-id");
+
+    //check default value for properties PII and multiple
+    propertyModal.getNoRadio("pii").should("be.checked");
+    propertyModal.getNoRadio("multiple").should("be.checked");
+
     propertyModal.getToggleStepsButton().should("not.exist");
     propertyModal.clearPropertyName();
     propertyModal.newPropertyName("user-id");

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.test.tsx
@@ -35,9 +35,9 @@ const DEFAULT_STRUCTURED_TYPE_OPTIONS: StructuredTypeOptions = {
 const DEFAULT_SELECTED_PROPERTY_OPTIONS: PropertyOptions = {
   propertyType: PropertyType.Basic,
   type: "",
-  identifier: "",
-  multiple: "",
-  pii: "",
+  identifier: "no",
+  multiple: "no",
+  pii: "no",
   sortable: false,
   facetable: false,
   wildcard: false
@@ -106,6 +106,10 @@ describe("Property Modal Component", () => {
     userEvent.click(getByPlaceholderText("Select the property type"));
     userEvent.click(getByText("string"));
 
+    // Verify that the default values for Identifier, Multiple and PII properties is "no".
+    expect(screen.getByLabelText("identifier-no")).toBeChecked();
+    expect(screen.getByLabelText("multiple-no")).toBeChecked();
+
     const identifierRadio = screen.getByLabelText("identifier-yes");
     fireEvent.change(identifierRadio, {target: {value: "yes"}});
     expect(identifierRadio["value"]).toBe("yes");
@@ -115,6 +119,7 @@ describe("Property Modal Component", () => {
     expect(multipleRadio["value"]).toBe("yes");
 
     const piiRadio = screen.getByLabelText("pii-no");
+    expect(piiRadio).toBeChecked();
     fireEvent.change(piiRadio, {target: {value: "no"}});
     expect(piiRadio["value"]).toBe("no");
 
@@ -410,7 +415,7 @@ describe("Property Modal Component", () => {
       propertyType: PropertyType.Basic,
       type: "integer",
       identifier: "yes",
-      multiple: "",
+      multiple: "no",
       pii: "yes",
       sortable: false,
       facetable: false,
@@ -456,6 +461,8 @@ describe("Property Modal Component", () => {
     expect(getByText("Order-Map")).toBeInTheDocument();
 
     expect(getByText("Edit Property")).toBeInTheDocument();
+
+    expect(screen.getByLabelText("multiple-no")).toBeChecked(); //default value
 
     const multipleRadio = screen.getByLabelText("multiple-yes");
     expect(multipleRadio["value"]).toBe("yes");
@@ -712,7 +719,7 @@ describe("Property Modal Component", () => {
       propertyType: PropertyType.Basic,
       type: "integer",
       identifier: "yes",
-      multiple: "",
+      multiple: "no",
       pii: "yes",
       sortable: false,
       facetable: false

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.tsx
@@ -103,9 +103,9 @@ const DEFAULT_DROPDOWN_OPTIONS = [
 const DEFAULT_SELECTED_PROPERTY_OPTIONS: PropertyOptions = {
   propertyType: PropertyType.Basic,
   type: "",
-  identifier: "",
-  multiple: "",
-  pii: "",
+  identifier: "no",
+  multiple: "no",
+  pii: "no",
   facetable: false,
   sortable: false
   //wildcard: false

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
@@ -57,9 +57,9 @@ const DEFAULT_STRUCTURED_TYPE_OPTIONS: StructuredTypeOptions = {
 const DEFAULT_SELECTED_PROPERTY_OPTIONS: PropertyOptions = {
   propertyType: PropertyType.Basic,
   type: "",
-  identifier: "",
-  multiple: "",
-  pii: "",
+  identifier: "no",
+  multiple: "no",
+  pii: "no",
   facetable: false,
   sortable: false
   //wildcard: false
@@ -482,9 +482,9 @@ const PropertyTable: React.FC<Props> = (props) => {
     const propertyOptions: PropertyOptions = {
       propertyType: propertyType,
       type: record.type,
-      identifier: record.identifier ? "yes" : "",
-      multiple: record.multiple ? "yes" : "",
-      pii: record.pii ? "yes" : "",
+      identifier: record.identifier ? "yes" : "no",
+      multiple: record.multiple ? "yes" : "no",
+      pii: record.pii ? "yes" : "no",
       facetable: record.facetable ? true : false,
       sortable: record.sortable ? true : false
       //wildcard: record.wildcard ? true : false


### PR DESCRIPTION
### Description
Making the default value of the properties "Identifier", "Allow multiple values" & "PII" as "no",  to avoid issues given in the ticket DHFPROD-6268.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

