### PR TITLE
DHFPROD-6412: Fixing syntax error when writing prov data

### DIFF
--- a/marklogic-data-hub/src/test/ml-modules/root/test/data-hub-test-helper.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/data-hub-test-helper.xqy
@@ -141,9 +141,17 @@ declare function reset-hub() as empty-sequence()
   clear-jobs-database()
 };
 
+(:
+Clearing via forest-clear can lead to intermittent failures, so just deleting the 
+two known collections. 
+:)
 declare function clear-jobs-database()
 {
-  invoke-in-db(function() {xdmp:collection-delete("Jobs")}, "data-hub-JOBS")
+  invoke-in-db(function() {
+    xdmp:collection-delete("Jobs"),
+    xdmp:collection-delete("http://marklogic.com/provenance-services/record")
+    }, "data-hub-JOBS"
+  )
 };
 
 declare function reset-staging-and-final-databases()
@@ -166,6 +174,11 @@ declare function get-first-batch-document()
 declare function get-modules-document($uri as xs:string)
 {
   invoke-in-db(function() {fn:doc($uri)}, "data-hub-MODULES")
+};
+
+declare function get-first-prov-document()
+{
+  invoke-in-db(function() {fn:collection("http://marklogic.com/provenance-services/record")[1]}, "data-hub-JOBS")
 };
 
 declare function invoke-in-db($function, $database as xs:string)

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/provenance/setup.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/provenance/setup.xqy
@@ -1,0 +1,3 @@
+xquery version "1.0-ml";
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+hub-test:clear-jobs-database();

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/provenance/writeProvenanceThrowsError.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/provenance/writeProvenanceThrowsError.sjs
@@ -1,0 +1,34 @@
+const test = require("/test/test-helper.xqy");
+const hubTest = require("/test/data-hub-test-helper.xqy");
+const DataHubSingleton = require("/data-hub/5/datahub-singleton.sjs");
+const datahub = DataHubSingleton.instance();
+
+const assertions = [];
+const jobId = "job123";
+const flowName = "doesntMatter";
+const flowStep = {"name":"myStep", "stepDefinitionName": "myCustomStep", "stepDefinitionType": "custom"};
+
+// Simulate a processed URI so that prov can be generated
+datahub.flow.writeQueue.push({"uri": "test.json"});
+datahub.flow.globalContext.completedItems = ["test.json"];
+
+// Try writing with an invalid input
+datahub.flow.writeProvenanceData(jobId, flowName,
+  {"name":"myCustomStep", "type": "unrecognized"}, flowStep
+);
+assertions.push(test.assertEqual(null, hubTest.getFirstProvDocument(),
+  "Because the type of the step definition is not a recognized value, a validation error should be logged, and no prov " +
+  "document should have been written (it's not possible though to verify that the error was logged)."
+));
+
+// Verify that a valid input results in a prov doc being written
+datahub.flow.writeProvenanceData(jobId, flowName,
+  {"name":"myCustomStep", "type": "custom"}, flowStep
+);
+assertions.push(
+  test.assertEqual("document", hubTest.getFirstProvDocument().xpath("/*/fn:local-name()"),
+  "Since the inputs to writeProvenanceData were valid, and the prov granularity level defaults to " +
+  "coarse, a single prov document (with root element name of 'document') should have been written"
+));
+
+assertions;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/setup.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/setup.xqy
@@ -1,0 +1,3 @@
+xquery version "1.0-ml";
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+hub-test:clear-jobs-database();

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/teardown.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/teardown.xqy
@@ -1,8 +1,0 @@
-xquery version "1.0-ml";
-
-xdmp:invoke-function(function() {
-  try {
-    xdmp:collection-delete("http://marklogic.com/provenance-services/record")
-  } catch * {()},
-  xdmp:collection-delete("Jobs")
-}, map:entry("database", xdmp:database("data-hub-JOBS")));

--- a/marklogic-data-hub/src/test/resources/test-config/security/amps/clear-jobs-database.json
+++ b/marklogic-data-hub/src/test/resources/test-config/security/amps/clear-jobs-database.json
@@ -1,0 +1,7 @@
+{
+  "local-name" : "clear-jobs-database",
+  "document-uri" : "/test/data-hub-test-helper.xqy",
+  "namespace": "http://marklogic.com/data-hub/test",
+  "modules-database" : "%%mlModulesDbName%%",
+  "role" : [ "admin" ]
+}


### PR DESCRIPTION
### Description

Also improved ML unit test plumbing by making "clear-jobs-database" delete provenance data as well, which depends on an amp. 

One other change to flow.sjs is that previously, a bunch of prov data could be generated, but if the granularity level is off, then nothing was done with it. It seems to make more sense that if the level is off, we can bail right away and not generate all that data. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

