### PR TITLE
DHFPROD-6414: Added JSON schema for Content object

### DIFF
--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/ContentObjectSchema.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/ContentObjectSchema.java
@@ -1,0 +1,229 @@
+
+package com.marklogic.hub.central.schemas;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * ContentObject
+ * <p>
+ * Defines the object that is passed, either by itself or within a sequence, to a step module for processing; the step module then outputs a content object that is used to insert a document
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "uri",
+    "value",
+    "$delete",
+    "context",
+    "provenance"
+})
+public class ContentObjectSchema {
+
+    /**
+     * The identifier for this content object; will be a document URI unless sourceQueryIsScript=true in the step, in which case it can be any value
+     * 
+     */
+    @JsonProperty("uri")
+    @JsonPropertyDescription("The identifier for this content object; will be a document URI unless sourceQueryIsScript=true in the step, in which case it can be any value")
+    private String uri;
+    /**
+     * The document to be processed
+     * 
+     */
+    @JsonProperty("value")
+    @JsonPropertyDescription("The document to be processed")
+    private Value value;
+    /**
+     * If true, then the documented identified by the 'uri' property will be deleted and no document will be inserted
+     * 
+     */
+    @JsonProperty("$delete")
+    @JsonPropertyDescription("If true, then the documented identified by the 'uri' property will be deleted and no document will be inserted")
+    private Boolean $delete;
+    /**
+     * Defines properties that affect how a document is inserted
+     * 
+     */
+    @JsonProperty("context")
+    @JsonPropertyDescription("Defines properties that affect how a document is inserted")
+    private Context context;
+    /**
+     * Defines changes to entity properties by a step
+     * 
+     */
+    @JsonProperty("provenance")
+    @JsonPropertyDescription("Defines changes to entity properties by a step")
+    private Provenance provenance;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * The identifier for this content object; will be a document URI unless sourceQueryIsScript=true in the step, in which case it can be any value
+     * 
+     */
+    @JsonProperty("uri")
+    public String getUri() {
+        return uri;
+    }
+
+    /**
+     * The identifier for this content object; will be a document URI unless sourceQueryIsScript=true in the step, in which case it can be any value
+     * 
+     */
+    @JsonProperty("uri")
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    /**
+     * The document to be processed
+     * 
+     */
+    @JsonProperty("value")
+    public Value getValue() {
+        return value;
+    }
+
+    /**
+     * The document to be processed
+     * 
+     */
+    @JsonProperty("value")
+    public void setValue(Value value) {
+        this.value = value;
+    }
+
+    /**
+     * If true, then the documented identified by the 'uri' property will be deleted and no document will be inserted
+     * 
+     */
+    @JsonProperty("$delete")
+    public Boolean get$delete() {
+        return $delete;
+    }
+
+    /**
+     * If true, then the documented identified by the 'uri' property will be deleted and no document will be inserted
+     * 
+     */
+    @JsonProperty("$delete")
+    public void set$delete(Boolean $delete) {
+        this.$delete = $delete;
+    }
+
+    /**
+     * Defines properties that affect how a document is inserted
+     * 
+     */
+    @JsonProperty("context")
+    public Context getContext() {
+        return context;
+    }
+
+    /**
+     * Defines properties that affect how a document is inserted
+     * 
+     */
+    @JsonProperty("context")
+    public void setContext(Context context) {
+        this.context = context;
+    }
+
+    /**
+     * Defines changes to entity properties by a step
+     * 
+     */
+    @JsonProperty("provenance")
+    public Provenance getProvenance() {
+        return provenance;
+    }
+
+    /**
+     * Defines changes to entity properties by a step
+     * 
+     */
+    @JsonProperty("provenance")
+    public void setProvenance(Provenance provenance) {
+        this.provenance = provenance;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(ContentObjectSchema.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append("uri");
+        sb.append('=');
+        sb.append(((this.uri == null)?"<null>":this.uri));
+        sb.append(',');
+        sb.append("value");
+        sb.append('=');
+        sb.append(((this.value == null)?"<null>":this.value));
+        sb.append(',');
+        sb.append("$delete");
+        sb.append('=');
+        sb.append(((this.$delete == null)?"<null>":this.$delete));
+        sb.append(',');
+        sb.append("context");
+        sb.append('=');
+        sb.append(((this.context == null)?"<null>":this.context));
+        sb.append(',');
+        sb.append("provenance");
+        sb.append('=');
+        sb.append(((this.provenance == null)?"<null>":this.provenance));
+        sb.append(',');
+        sb.append("additionalProperties");
+        sb.append('=');
+        sb.append(((this.additionalProperties == null)?"<null>":this.additionalProperties));
+        sb.append(',');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.provenance == null)? 0 :this.provenance.hashCode()));
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.$delete == null)? 0 :this.$delete.hashCode()));
+        result = ((result* 31)+((this.additionalProperties == null)? 0 :this.additionalProperties.hashCode()));
+        result = ((result* 31)+((this.uri == null)? 0 :this.uri.hashCode()));
+        result = ((result* 31)+((this.value == null)? 0 :this.value.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof ContentObjectSchema) == false) {
+            return false;
+        }
+        ContentObjectSchema rhs = ((ContentObjectSchema) other);
+        return (((((((this.provenance == rhs.provenance)||((this.provenance!= null)&&this.provenance.equals(rhs.provenance)))&&((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context))))&&((this.$delete == rhs.$delete)||((this.$delete!= null)&&this.$delete.equals(rhs.$delete))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.uri == rhs.uri)||((this.uri!= null)&&this.uri.equals(rhs.uri))))&&((this.value == rhs.value)||((this.value!= null)&&this.value.equals(rhs.value))));
+    }
+
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/Context.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/Context.java
@@ -1,0 +1,198 @@
+
+package com.marklogic.hub.central.schemas;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * Defines properties that affect how a document is inserted
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "collections",
+    "originalCollections",
+    "permissions",
+    "metadata"
+})
+public class Context {
+
+    /**
+     * The collections to be included when the document is inserted; not populated when passed to a step module; intended to be populated by a step module
+     * 
+     */
+    @JsonProperty("collections")
+    @JsonPropertyDescription("The collections to be included when the document is inserted; not populated when passed to a step module; intended to be populated by a step module")
+    private List<String> collections = new ArrayList<String>();
+    /**
+     * The collections that exist on the document
+     * 
+     */
+    @JsonProperty("originalCollections")
+    @JsonPropertyDescription("The collections that exist on the document")
+    private List<String> originalCollections = new ArrayList<String>();
+    /**
+     * The permissions to be included when the document is inserted
+     * 
+     */
+    @JsonProperty("permissions")
+    @JsonPropertyDescription("The permissions to be included when the document is inserted")
+    private List<Permission> permissions = new ArrayList<Permission>();
+    /**
+     * The metadata keys and values to be included when the document is inserted
+     * 
+     */
+    @JsonProperty("metadata")
+    @JsonPropertyDescription("The metadata keys and values to be included when the document is inserted")
+    private Metadata metadata;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * The collections to be included when the document is inserted; not populated when passed to a step module; intended to be populated by a step module
+     * 
+     */
+    @JsonProperty("collections")
+    public List<String> getCollections() {
+        return collections;
+    }
+
+    /**
+     * The collections to be included when the document is inserted; not populated when passed to a step module; intended to be populated by a step module
+     * 
+     */
+    @JsonProperty("collections")
+    public void setCollections(List<String> collections) {
+        this.collections = collections;
+    }
+
+    /**
+     * The collections that exist on the document
+     * 
+     */
+    @JsonProperty("originalCollections")
+    public List<String> getOriginalCollections() {
+        return originalCollections;
+    }
+
+    /**
+     * The collections that exist on the document
+     * 
+     */
+    @JsonProperty("originalCollections")
+    public void setOriginalCollections(List<String> originalCollections) {
+        this.originalCollections = originalCollections;
+    }
+
+    /**
+     * The permissions to be included when the document is inserted
+     * 
+     */
+    @JsonProperty("permissions")
+    public List<Permission> getPermissions() {
+        return permissions;
+    }
+
+    /**
+     * The permissions to be included when the document is inserted
+     * 
+     */
+    @JsonProperty("permissions")
+    public void setPermissions(List<Permission> permissions) {
+        this.permissions = permissions;
+    }
+
+    /**
+     * The metadata keys and values to be included when the document is inserted
+     * 
+     */
+    @JsonProperty("metadata")
+    public Metadata getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * The metadata keys and values to be included when the document is inserted
+     * 
+     */
+    @JsonProperty("metadata")
+    public void setMetadata(Metadata metadata) {
+        this.metadata = metadata;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(Context.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append("collections");
+        sb.append('=');
+        sb.append(((this.collections == null)?"<null>":this.collections));
+        sb.append(',');
+        sb.append("originalCollections");
+        sb.append('=');
+        sb.append(((this.originalCollections == null)?"<null>":this.originalCollections));
+        sb.append(',');
+        sb.append("permissions");
+        sb.append('=');
+        sb.append(((this.permissions == null)?"<null>":this.permissions));
+        sb.append(',');
+        sb.append("metadata");
+        sb.append('=');
+        sb.append(((this.metadata == null)?"<null>":this.metadata));
+        sb.append(',');
+        sb.append("additionalProperties");
+        sb.append('=');
+        sb.append(((this.additionalProperties == null)?"<null>":this.additionalProperties));
+        sb.append(',');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.metadata == null)? 0 :this.metadata.hashCode()));
+        result = ((result* 31)+((this.originalCollections == null)? 0 :this.originalCollections.hashCode()));
+        result = ((result* 31)+((this.additionalProperties == null)? 0 :this.additionalProperties.hashCode()));
+        result = ((result* 31)+((this.collections == null)? 0 :this.collections.hashCode()));
+        result = ((result* 31)+((this.permissions == null)? 0 :this.permissions.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.metadata == rhs.metadata)||((this.metadata!= null)&&this.metadata.equals(rhs.metadata)))&&((this.originalCollections == rhs.originalCollections)||((this.originalCollections!= null)&&this.originalCollections.equals(rhs.originalCollections))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.collections == rhs.collections)||((this.collections!= null)&&this.collections.equals(rhs.collections))))&&((this.permissions == rhs.permissions)||((this.permissions!= null)&&this.permissions.equals(rhs.permissions))));
+    }
+
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/Metadata.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/Metadata.java
@@ -1,0 +1,71 @@
+
+package com.marklogic.hub.central.schemas;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * The metadata keys and values to be included when the document is inserted
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+
+})
+public class Metadata {
+
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(Metadata.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append("additionalProperties");
+        sb.append('=');
+        sb.append(((this.additionalProperties == null)?"<null>":this.additionalProperties));
+        sb.append(',');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.additionalProperties == null)? 0 :this.additionalProperties.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Metadata) == false) {
+            return false;
+        }
+        Metadata rhs = ((Metadata) other);
+        return ((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties)));
+    }
+
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/Permission.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/Permission.java
@@ -1,0 +1,129 @@
+
+package com.marklogic.hub.central.schemas;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "roleId",
+    "capability"
+})
+public class Permission {
+
+    /**
+     * MarkLogic-defined ID of the role associated with this permission
+     * 
+     */
+    @JsonProperty("roleId")
+    @JsonPropertyDescription("MarkLogic-defined ID of the role associated with this permission")
+    private String roleId;
+    /**
+     * Either read, update, insert, or execute
+     * 
+     */
+    @JsonProperty("capability")
+    @JsonPropertyDescription("Either read, update, insert, or execute")
+    private String capability;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * MarkLogic-defined ID of the role associated with this permission
+     * 
+     */
+    @JsonProperty("roleId")
+    public String getRoleId() {
+        return roleId;
+    }
+
+    /**
+     * MarkLogic-defined ID of the role associated with this permission
+     * 
+     */
+    @JsonProperty("roleId")
+    public void setRoleId(String roleId) {
+        this.roleId = roleId;
+    }
+
+    /**
+     * Either read, update, insert, or execute
+     * 
+     */
+    @JsonProperty("capability")
+    public String getCapability() {
+        return capability;
+    }
+
+    /**
+     * Either read, update, insert, or execute
+     * 
+     */
+    @JsonProperty("capability")
+    public void setCapability(String capability) {
+        this.capability = capability;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(Permission.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append("roleId");
+        sb.append('=');
+        sb.append(((this.roleId == null)?"<null>":this.roleId));
+        sb.append(',');
+        sb.append("capability");
+        sb.append('=');
+        sb.append(((this.capability == null)?"<null>":this.capability));
+        sb.append(',');
+        sb.append("additionalProperties");
+        sb.append('=');
+        sb.append(((this.additionalProperties == null)?"<null>":this.additionalProperties));
+        sb.append(',');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.capability == null)? 0 :this.capability.hashCode()));
+        result = ((result* 31)+((this.additionalProperties == null)? 0 :this.additionalProperties.hashCode()));
+        result = ((result* 31)+((this.roleId == null)? 0 :this.roleId.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Permission) == false) {
+            return false;
+        }
+        Permission rhs = ((Permission) other);
+        return ((((this.capability == rhs.capability)||((this.capability!= null)&&this.capability.equals(rhs.capability)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.roleId == rhs.roleId)||((this.roleId!= null)&&this.roleId.equals(rhs.roleId))));
+    }
+
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/Provenance.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/Provenance.java
@@ -1,0 +1,49 @@
+
+package com.marklogic.hub.central.schemas;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * Defines changes to entity properties by a step
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+
+})
+public class Provenance {
+
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(Provenance.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Provenance) == false) {
+            return false;
+        }
+        Provenance rhs = ((Provenance) other);
+        return true;
+    }
+
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/Value.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/schemas/Value.java
@@ -1,0 +1,71 @@
+
+package com.marklogic.hub.central.schemas;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * The document to be processed
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+
+})
+public class Value {
+
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(Value.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append("additionalProperties");
+        sb.append('=');
+        sb.append(((this.additionalProperties == null)?"<null>":this.additionalProperties));
+        sb.append(',');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.additionalProperties == null)? 0 :this.additionalProperties.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Value) == false) {
+            return false;
+        }
+        Value rhs = ((Value) other);
+        return ((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties)));
+    }
+
+}

--- a/specs/models/ContentObject.schema.json
+++ b/specs/models/ContentObject.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "http://marklogic.com/data-hub/ContentObject.schema.json",
+  "title": "ContentObject",
+  "description": "Defines the object that is passed, either by itself or within an array, to a step module for processing and is then used for writing documents",
+  "type": "object",
+  "properties": {
+    "uri": {
+      "type": "string",
+      "description": "The identifier for this content object. Will be a real URI value unless sourceQueryIsScript in the step, in which case it can be any value."
+    },
+    "value": {
+      "type": "object",
+      "description": "The document to be processed"
+    },
+    "context": {
+      "type": "object",
+      "description": "Defines properties that will affect how a document is written",
+      "properties" : {
+        "collections": {
+          "type": "array",
+          "description": "Defines the collections that the document will be written to. Currently not populated by default when passed to a step module.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "originalCollections": {
+          "type": "array",
+          "description": "Defines the collections that currently exist on the document",
+          "items": {
+            "type": "string"
+          }
+        },
+        "permissions": {
+          "type": "array",
+          "description": "Defines the permissions that will be included when this document is written",
+          "items": {
+            "type": "object",
+            "properties": {
+              "roleId": {
+                "type": "string",
+                "description": "MarkLogic-defined ID of the role associated with this permissions"
+              },
+              "capability": {
+                "type": "string",
+                "description": "Either read, update, insert, or execute"
+              }
+            }
+          }
+        },
+        "metadata": {
+          "type": "object",
+          "description": "Defines the metadata keys and values that will be included when the document is persisted"
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Defines changes to entity properties by a step",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^.*$": {
+          "type": "object",
+          "description": "The property name is the URI of the source document",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^.*$": {
+              "type": "object",
+              "description": "The property name is the property name or XPath expression in the source document containing the altered value",
+              "properties": {
+                "destination": {
+                  "type": "string",
+                  "description": "Property name or XPath expression for the altered value"
+                },
+                "value": {
+                  "type": "string",
+                  "description": "Value of the altered property"
+                }
+              }
+            }
+          }
+        } 
+      }
+    }
+  }
+}

--- a/specs/models/ContentObject.schema.json
+++ b/specs/models/ContentObject.schema.json
@@ -2,44 +2,48 @@
   "$schema": "http://json-schema.org/schema#",
   "$id": "http://marklogic.com/data-hub/ContentObject.schema.json",
   "title": "ContentObject",
-  "description": "Defines the object that is passed, either by itself or within an array, to a step module for processing and is then used for writing documents",
+  "description": "Defines the object that is passed, either by itself or within a sequence, to a step module for processing; the step module then outputs a content object that is used to insert a document",
   "type": "object",
   "properties": {
     "uri": {
       "type": "string",
-      "description": "The identifier for this content object. Will be a real URI value unless sourceQueryIsScript in the step, in which case it can be any value."
+      "description": "The identifier for this content object; will be a document URI unless sourceQueryIsScript=true in the step, in which case it can be any value"
     },
     "value": {
       "type": "object",
       "description": "The document to be processed"
     },
+    "$delete": {
+      "type": "boolean",
+      "description": "If true, then the documented identified by the 'uri' property will be deleted and no document will be inserted"
+    },
     "context": {
       "type": "object",
-      "description": "Defines properties that will affect how a document is written",
+      "description": "Defines properties that affect how a document is inserted",
       "properties" : {
         "collections": {
           "type": "array",
-          "description": "Defines the collections that the document will be written to. Currently not populated by default when passed to a step module.",
+          "description": "The collections to be included when the document is inserted; not populated when passed to a step module; intended to be populated by a step module",
           "items": {
             "type": "string"
           }
         },
         "originalCollections": {
           "type": "array",
-          "description": "Defines the collections that currently exist on the document",
+          "description": "The collections that exist on the document",
           "items": {
             "type": "string"
           }
         },
         "permissions": {
           "type": "array",
-          "description": "Defines the permissions that will be included when this document is written",
+          "description": "The permissions to be included when the document is inserted",
           "items": {
             "type": "object",
             "properties": {
               "roleId": {
                 "type": "string",
-                "description": "MarkLogic-defined ID of the role associated with this permissions"
+                "description": "MarkLogic-defined ID of the role associated with this permission"
               },
               "capability": {
                 "type": "string",
@@ -50,7 +54,7 @@
         },
         "metadata": {
           "type": "object",
-          "description": "Defines the metadata keys and values that will be included when the document is persisted"
+          "description": "The metadata keys and values to be included when the document is inserted"
         }
       }
     },


### PR DESCRIPTION
### Description

Excluding "previousUri" for now, as that's only used internally. If we want to expose it to users, we will likely use a more meaningful name like "derivedFrom". 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

