### PR TITLE
DHFPROD-6260: Enable Advanced Settings during step creation

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/mapping.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/mapping.spec.tsx
@@ -44,15 +44,21 @@ describe("Mapping", () => {
     loadPage.saveButton().should("be.enabled");
     loadPage.stepNameInput().type(loadStep);
     loadPage.stepDescriptionInput().type("load order with processors");
-    loadPage.confirmationOptions("Save").click();
+    //verify advanced setting modifications during creation
+    loadPage.switchEditAdvanced().click();
+    // add processor to load step
+    advancedSettingsDialog.setStepProcessor("loadTile/orderCategoryCodeProcessor");
+
+    loadPage.confirmationOptions("Save").click({force: true});
     cy.findByText(loadStep).should("be.visible");
 
     // Open step settings and switch to Advanced tab
     loadPage.editStepInCardView(loadStep).click({force: true});
     loadPage.switchEditAdvanced().click();
 
-    // add processor to load step
-    advancedSettingsDialog.setStepProcessor("loadTile/orderCategoryCodeProcessor");
+    //processor should already be set during creation
+    cy.findByLabelText("processors-expand").trigger("mouseover").click();
+    cy.get("#processors").should("not.be.empty");
 
     //add cutomHook to load step
     advancedSettingsDialog.setCustomHook("loadTile/addPrimaryKeyHook");
@@ -80,12 +86,17 @@ describe("Mapping", () => {
     cy.waitUntil(() => curatePage.getEntityTypePanel("Customer").should("be.visible"));
     curatePage.toggleEntityTypeId("Order");
     cy.waitUntil(() => curatePage.addNewStep().click());
-
     createEditMappingDialog.setMappingName(mapStep);
     createEditMappingDialog.setMappingDescription("An order mapping with custom processors");
     createEditMappingDialog.setSourceRadio("Query");
     createEditMappingDialog.setQueryInput(`cts.collectionQuery(['${loadStep}'])`);
-    createEditMappingDialog.saveButton().click();
+
+    //verify advanced setting modifications during creation
+    loadPage.switchEditAdvanced().click();
+    // add processor to map step
+    advancedSettingsDialog.setStepProcessor("curateTile/orderDateProcessor");
+
+    createEditMappingDialog.saveButton().click({force: true});
 
     //verify that step details automatically opens after step creation
     curatePage.verifyStepDetailsOpen(mapStep);
@@ -98,8 +109,9 @@ describe("Mapping", () => {
     cy.waitUntil(() => curatePage.editStep(mapStep).click({force: true}));
     curatePage.switchEditAdvanced().click();
 
-    // add processors
-    advancedSettingsDialog.setStepProcessor("curateTile/orderDateProcessor");
+    //processor should already be set during creation
+    cy.findByLabelText("processors-expand").trigger("mouseover").click();
+    cy.get("#processors").should("not.be.empty");
 
     // add customHook to mapping step
     advancedSettingsDialog.setCustomHook("curateTile/customUriHook");

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/curation/advanced-settings.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/curation/advanced-settings.data.ts
@@ -1,82 +1,7 @@
-// Passed as prop
-const advancedLoad = {
-  tabKey: "2",
-  tooltipsData: {},
-  openStepSettings: true,
-  setOpenStepSettings: jest.fn(),
-  stepData: {name: "AdvancedLoad"},
-  updateLoadArtifact: jest.fn(),
-  activityType: "ingestion",
-  canWrite: true,
-  currentTab: "2",
-  setIsValid: jest.fn(),
-  resetTabs: jest.fn(),
-  setHasChanged: jest.fn(),
-  setPayload: jest.fn(),
-  createStep: jest.fn(),
-};
-
-// Passed as prop
-const advancedMapping = {
-  tabKey: "2",
-  tooltipsData: {},
-  openStepSettings: true,
-  setOpenStepSettings: jest.fn(),
-  stepData: {name: "AdvancedMapping"},
-  updateLoadArtifact: jest.fn(),
-  activityType: "mapping",
-  canWrite: true,
-  currentTab: "2",
-  setIsValid: jest.fn(),
-  resetTabs: jest.fn(),
-  setHasChanged: jest.fn(),
-  setPayload: jest.fn(),
-  createStep: jest.fn(),
-};
-
-// Passed as prop
-const advancedMatching = {
-  tabKey: "2",
-  tooltipsData: {},
-  openStepSettings: true,
-  setOpenStepSettings: jest.fn(),
-  openAdvancedSettings: true,
-  setOpenAdvancedSettings: jest.fn(),
-  stepData: {name: "AdvancedMatching"},
-  updateLoadArtifact: jest.fn(),
-  activityType: "matching",
-  canWrite: true,
-  currentTab: "2",
-  setIsValid: true,
-  resetTabs: jest.fn(),
-  setHasChanged: jest.fn(),
-  setPayload: jest.fn(),
-  createStep: jest.fn(),
-};
-
-const advancedMerging = {
-  tabKey: "2",
-  tooltipsData: {},
-  openStepSettings: true,
-  setOpenStepSettings: jest.fn(),
-  openAdvancedSettings: true,
-  setOpenAdvancedSettings: jest.fn(),
-  stepData: {name: "AdvancedMerging"},
-  updateLoadArtifact: jest.fn(),
-  activityType: "merging",
-  canWrite: true,
-  currentTab: "2",
-  setIsValid: true,
-  resetTabs: jest.fn(),
-  setHasChanged: jest.fn(),
-  setPayload: jest.fn(),
-  createStep: jest.fn(),
-};
-
 // Returned from endpoint: /api/steps/ingestion/AdvancedLoad
 const stepLoad = {"data":
     {
-      "collections": ["testCollection"],
+      "collections": ["AdvancedLoad"],
       "additionalCollections": ["addedCollection"],
       "batchSize": 35,
       "permissions": "data-hub-common,read,data-hub-common,update",
@@ -109,7 +34,7 @@ const stepLoad = {"data":
 // Returned from endpoint: /api/steps/mapping/AdvancedMapping
 const stepMapping = {"data":
     {
-      "collections": ["testCollection"],
+      "collections": ["AdvancedMapping"],
       "additionalCollections": ["addedCollection"],
       "batchSize": 35,
       "permissions": "data-hub-common,read,data-hub-common,update",
@@ -142,7 +67,7 @@ const stepMapping = {"data":
 // Returned from endpoint: /api/steps/matching/AdvancedMatching
 const stepMatching = {"data":
         {
-          "collections": ["testCollection"],
+          "collections": ["AdvancedMatching"],
           "additionalCollections": ["addedCollection"],
           "batchSize": 35,
           "permissions": "data-hub-common,read,data-hub-common,update",
@@ -218,10 +143,118 @@ const defaultTargetCollections = {"data":
 "status": 200
 };
 
+// Passed as prop
+const advancedLoad = {
+  tabKey: "2",
+  tooltipsData: {},
+  isEditing: true,
+  openStepSettings: true,
+  setOpenStepSettings: jest.fn(),
+  stepData: stepLoad.data,
+  updateLoadArtifact: jest.fn(),
+  activityType: "ingestion",
+  canWrite: true,
+  currentTab: "2",
+  setIsValid: jest.fn(),
+  resetTabs: jest.fn(),
+  setHasChanged: jest.fn(),
+  setPayload: jest.fn(),
+  createStep: jest.fn(),
+  onCancel: jest.fn(),
+  defaultCollections: [stepLoad.data.name]
+};
+
+// Passed as prop
+const advancedLoadNew = {
+  ...advancedLoad,
+  stepData: {},
+  defaultCollections: []
+};
+
+// Passed as prop
+const advancedMapping = {
+  tabKey: "2",
+  tooltipsData: {},
+  isEditing: true,
+  openStepSettings: true,
+  setOpenStepSettings: jest.fn(),
+  stepData: stepMapping.data,
+  updateLoadArtifact: jest.fn(),
+  activityType: "mapping",
+  canWrite: true,
+  currentTab: "2",
+  setIsValid: jest.fn(),
+  resetTabs: jest.fn(),
+  setHasChanged: jest.fn(),
+  setPayload: jest.fn(),
+  createStep: jest.fn(),
+  onCancel: jest.fn(),
+  defaultCollections: [stepMapping.data.name, "EntityName"]
+};
+
+// Passed as prop
+const advancedMappingNew = {
+  ...advancedMapping,
+  stepData: {},
+  defaultCollections: []
+};
+
+// Passed as prop
+const advancedMatching = {
+  tabKey: "2",
+  tooltipsData: {},
+  isEditing: true,
+  openStepSettings: true,
+  setOpenStepSettings: jest.fn(),
+  openAdvancedSettings: true,
+  setOpenAdvancedSettings: jest.fn(),
+  stepData: stepMatching.data,
+  updateLoadArtifact: jest.fn(),
+  activityType: "matching",
+  canWrite: true,
+  currentTab: "2",
+  setIsValid: true,
+  resetTabs: jest.fn(),
+  setHasChanged: jest.fn(),
+  setPayload: jest.fn(),
+  createStep: jest.fn(),
+  onCancel: jest.fn(),
+  defaultCollections: [stepMatching.data.name]
+};
+
+const advancedMerging = {
+  tabKey: "2",
+  tooltipsData: {},
+  isEditing: true,
+  openStepSettings: true,
+  setOpenStepSettings: jest.fn(),
+  openAdvancedSettings: true,
+  setOpenAdvancedSettings: jest.fn(),
+  stepData: stepMerging.data,
+  updateLoadArtifact: jest.fn(),
+  activityType: "merging",
+  canWrite: true,
+  currentTab: "2",
+  setIsValid: true,
+  resetTabs: jest.fn(),
+  setHasChanged: jest.fn(),
+  setPayload: jest.fn(),
+  createStep: jest.fn(),
+  onCancel: jest.fn(),
+  defaultCollections: [stepMerging.data.name]
+};
+
 const data = {
   advancedLoad: advancedLoad,
-  customLoad: {...advancedLoad, stepData: {name: "CustomLoad"}},
+  advancedLoadNew: advancedLoadNew,
+  customLoad: {...advancedLoad, stepData: {
+    ...stepLoad.data,
+    name: "CustomLoad",
+    stepDefinitionType: "custom",
+    stepDefinitionName: "custom-step"
+  }},
   advancedMapping: advancedMapping,
+  advancedMappingNew: advancedMappingNew,
   advancedMatching: advancedMatching,
   advancedMerging: advancedMerging,
   stepLoad: stepLoad,

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/curation/common.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/curation/common.data.ts
@@ -74,6 +74,21 @@ const loadData = {
       targetFormat: "json",
       outputURIReplacement: "",
       inputFilePath: "/json-test/data-sets/testLoad",
+      provenanceGranularityLevel: "coarse",
+      batchSize: 35,
+      permissions: "data-hub-operator,read,data-hub-operator,update",
+      targetDatabase: "data-hub-STAGING",
+      collections: ["testLoad"],
+      additionalCollections: ["addedCollection"],
+      headers: {
+        "header": true
+      },
+      processors: {
+        "processor": true
+      },
+      customHook: {
+        "hook": true
+      },
       lastUpdated: "2000-01-01T12:00:00.000000-00:00"
     },
     {

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/curation/flows.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/curation/flows.data.ts
@@ -283,6 +283,14 @@ const mappings = {"data":
           "sourcedFrom": "PIN"
         }
       },
+      "provenanceGranularityLevel": "coarse",
+      "batchSize": 50,
+      "permissions": "data-hub-common,read,data-hub-common,update",
+      "sourceDatabase": "data-hub-STAGING",
+      "targetDatabase": "data-hub-FINAL",
+      "collections": ["Mapping1", "Customer"],
+      "additionalCollections": ["customerCollection"],
+      "validateEntity": false,
       "lastUpdated": "2020-04-24T13:21:00.169198-07:00"
     }
   ]
@@ -302,6 +310,14 @@ const mappings = {"data":
           "sourcedFrom": "PIN"
         }
       },
+      "provenanceGranularityLevel": "coarse",
+      "batchSize": 50,
+      "permissions": "data-hub-common,read,data-hub-common,update",
+      "sourceDatabase": "data-hub-STAGING",
+      "targetDatabase": "data-hub-FINAL",
+      "collections": ["Mapping1", "Customer"],
+      "additionalCollections": ["customerCollection"],
+      "validateEntity": false,
       "lastUpdated": "2020-10-01T02:38:00.169198-07:00"
     }
   ]

--- a/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.test.tsx
@@ -35,7 +35,7 @@ describe("Advanced step settings", () => {
     expect(getByText("Target Collections")).toBeInTheDocument();
     expect(getByText("Please add target collections")).toBeInTheDocument();
     expect(getByText("Default Collections")).toBeInTheDocument();
-    expect((await(waitForElement(() => getAllByText("testCollection")))).length > 0);
+    expect((await(waitForElement(() => getAllByText("AdvancedLoad")))).length > 0);
 
     expect(getByText("Target Permissions")).toBeInTheDocument();
 
@@ -60,8 +60,7 @@ describe("Advanced step settings", () => {
 
   });
 
-  /* Custom ingestion step should be same as default-ingestion except that for "step definition name"
-     field which should be present*/
+  /* Custom ingestion step should be same as default-ingestion except "step definition name" field should be present */
   test("Verify settings for Custom Load step", async () => {
     const {getByText, getAllByText, queryByText} = render(
       <AdvancedSettings {...data.customLoad} />
@@ -74,8 +73,8 @@ describe("Advanced step settings", () => {
     expect(getByText("Target Collections")).toBeInTheDocument();
     expect(getByText("Please add target collections")).toBeInTheDocument();
     expect(getByText("Default Collections")).toBeInTheDocument();
+    expect(getAllByText(data.customLoad.stepData.collections[0]).length > 0);
 
-    expect((await(waitForElement(() => getAllByText("custom-ingestion")))).length > 0);
     expect(getByText("Step Definition Name")).toBeInTheDocument();
 
     expect(getByText("Target Permissions")).toBeInTheDocument();
@@ -111,7 +110,7 @@ describe("Advanced step settings", () => {
     expect(getByText("Target Collections")).toBeInTheDocument();
     expect(getByText("Please add target collections")).toBeInTheDocument();
     expect(getByText("Default Collections")).toBeInTheDocument();
-    expect((await(waitForElement(() => getAllByText("testCollection")))).length > 0);
+    expect((await(waitForElement(() => getAllByText("AdvancedMapping")))).length > 0);
 
     expect(getByText("Target Permissions")).toBeInTheDocument();
 
@@ -138,14 +137,14 @@ describe("Advanced step settings", () => {
   });
 
   test("Verify settings for Matching", async () => {
-    const {getByText} = render(
+    const {getByText, getAllByText} = render(
       <AdvancedSettings {...data.advancedMatching} />
     );
 
     expect(getByText("Source Database")).toBeInTheDocument();
-    expect(getByText("data-hub-FINAL")).toBeInTheDocument();
+    expect(getAllByText("data-hub-FINAL")[0]).toBeInTheDocument();
     expect(getByText("Target Database")).toBeInTheDocument();
-    expect(getByText("data-hub-FINAL")).toBeInTheDocument();
+    expect(getAllByText("data-hub-FINAL")[1]).toBeInTheDocument();
 
     expect(getByText("Target Collections")).toBeInTheDocument();
     expect(getByText("Please add target collections")).toBeInTheDocument();
@@ -175,9 +174,9 @@ describe("Advanced step settings", () => {
     );
 
     expect(getByText("Source Database")).toBeInTheDocument();
-    expect(getByText("data-hub-FINAL")).toBeInTheDocument();
+    expect(getAllByText("data-hub-FINAL")[0]).toBeInTheDocument();
     expect(getByText("Target Database")).toBeInTheDocument();
-    expect(getByText("data-hub-FINAL")).toBeInTheDocument();
+    expect(getAllByText("data-hub-FINAL")[1]).toBeInTheDocument();
 
     expect(getByText("Target Collections:")).toBeInTheDocument();
     expect(getByText("Default Collections")).toBeInTheDocument();
@@ -189,7 +188,7 @@ describe("Advanced step settings", () => {
 
     // Can edit the additional collections
     fireEvent.click(getByTestId("onMerge-edit"));
-    let collectionInput = getByLabelText("additionalColl-select-onMerge").getElementsByTagName("input").item(0);
+    let collectionInput = getByLabelText("additionalColl-select-onMerge").getElementsByTagName("input").item(0)!;
     // test discarding a collection update
     fireEvent.input(collectionInput, {target: {value: "discardedMergeCollection"}});
     expect(collectionInput).toHaveValue("discardedMergeCollection");
@@ -200,7 +199,7 @@ describe("Advanced step settings", () => {
 
     // test keeping a collection update
     fireEvent.click(getByTestId("onMerge-edit"));
-    collectionInput = getByLabelText("additionalColl-select-onMerge").getElementsByTagName("input").item(0);
+    collectionInput = getByLabelText("additionalColl-select-onMerge").getElementsByTagName("input").item(0)!;
     fireEvent.input(collectionInput, {target: {value: "keptMergeCollection"}});
     expect(collectionInput).toHaveValue("keptMergeCollection");
     fireEvent.keyDown(collectionInput, {keyCode: 13, key: "Enter"});
@@ -314,8 +313,8 @@ describe("Advanced step settings", () => {
     expect(getByPlaceholderText("Please enter batch size")).toHaveValue("25");
 
     // Verify targetFormat options select field
-    expect(getByText("JSON")).toBeInTheDocument();
-    fireEvent.click(getByText("JSON"));
+    expect(getAllByText("JSON")[0]).toBeInTheDocument();
+    fireEvent.click(getAllByText("JSON")[0]);
     const testFormatOptions = getAllByTestId("targetFormatOptions").map(li => li);
     expect(testFormatOptions.map(li => li.textContent).toString()).toEqual("JSON,XML");
     fireEvent.select(testFormatOptions[1]);

--- a/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.tsx
+++ b/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.tsx
@@ -4,7 +4,7 @@ import {Form, Input, Icon, Select} from "antd";
 import styles from "./advanced-settings.module.scss";
 import {AdvancedSettingsTooltips} from "../../config/tooltips.config";
 import {AdvancedSettingsMessages} from "../../config/messages.config";
-import {getStep} from "../../api/steps";
+import StepsConfig from "../../config/steps.config";
 import {MLButton, MLTooltip} from "@marklogic/design-system";
 import "./advanced-settings.scss";
 import AdvancedTargetCollections from "./advanced-target-collections";
@@ -15,6 +15,7 @@ const {Option} = Select;
 type Props = {
   tabKey: string;
   tooltipsData: any;
+  isEditing: boolean;
   openStepSettings: boolean;
   setOpenStepSettings: any;
   stepData: any;
@@ -28,24 +29,24 @@ type Props = {
   setPayload: any;
   createStep: any;
   onCancel: any;
+  defaultCollections?: any;
 }
 
 const AdvancedSettings: React.FC<Props> = (props) => {
   const tooltips = Object.assign({}, AdvancedSettingsTooltips, props.tooltipsData);
   const stepType = props.activityType;
-  const invalidJSONMessage = "Invalid JSON";
-
-  const usesSourceDatabase = stepType !== "ingestion";
-  const defaultSourceDatabase = usesSourceDatabase ? "data-hub-STAGING" : "data-hub-FINAL";
+  const invalidJSONMessage = StepsConfig.invalidJSONMessage;
 
   const [isCustomIngestion, setIsCustomIngestion] = useState(false);
   const [stepDefinitionName, setStepDefinitionName] = useState("");
 
+  const usesSourceDatabase = stepType !== "ingestion";
+  const defaultSourceDatabase = usesSourceDatabase ? StepsConfig.stagingDb : StepsConfig.finalDb;
   const [sourceDatabase, setSourceDatabase] = useState(defaultSourceDatabase);
   const [sourceDatabaseTouched, setSourceDatabaseTouched] = useState(false);
 
-  const defaultTargetDatabase = !usesSourceDatabase ? "data-hub-STAGING" : "data-hub-FINAL";
-  const databaseOptions = ["data-hub-STAGING", "data-hub-FINAL"];
+  const defaultTargetDatabase = !usesSourceDatabase ? StepsConfig.stagingDb : StepsConfig.finalDb;
+  const databaseOptions = [StepsConfig.stagingDb, StepsConfig.finalDb];
   const [targetDatabase, setTargetDatabase] = useState(defaultTargetDatabase);
   const [targetDatabaseTouched, setTargetDatabaseTouched] = useState(false);
 
@@ -57,30 +58,31 @@ const AdvancedSettings: React.FC<Props> = (props) => {
   const [defaultTargetCollections, setDefaultTargetCollections] = useState<any>({});
   const [targetCollections, setTargetCollections] = useState<any>(null);
 
-  const [targetPermissions, setTargetPermissions] = useState("");
-  const validCapabilities = ["read", "update", "insert", "execute"];
+  const defaultTargetPermissions = StepsConfig.defaultTargetPerms;
+  const [targetPermissions, setTargetPermissions] = useState(defaultTargetPermissions);
+  const validCapabilities = StepsConfig.validCapabilities;
   const [targetPermissionsTouched, setTargetPermissionsTouched] = useState(false);
   const [permissionValidationError, setPermissionValidationError] = useState("");
   const [targetPermissionsValid, setTargetPermissionsValid] = useState(true);
 
   const usesTargetFormat = stepType === "mapping";
-  const defaultTargetFormat = "JSON";
+  const defaultTargetFormat = StepsConfig.defaultTargetFormat;
   const targetFormatOptions = ["JSON", "XML"].map(d => <Option data-testid="targetFormatOptions" key={d}>{d}</Option>);
-  const [targetFormat, setTargetFormat] = useState("JSON");
+  const [targetFormat, setTargetFormat] = useState(defaultTargetFormat);
   const [targetFormatTouched, setTargetFormatTouched] = useState(false);
 
-  const defaultprovGranularity = "coarse";
+  const defaultprovGranularity = StepsConfig.defaultProvGran;
   const fineGrainProvAvailable = stepType === "matching" || stepType === "merging";
   const provGranularityOptions = fineGrainProvAvailable ? {"Coarse-grained": "coarse", "Fine-grained": "fine", "Off": "off"} : {"Coarse-grained": "coarse", "Off": "off"};
   const [provGranularity, setProvGranularity] = useState(defaultprovGranularity);
   const [provGranularityTouched, setProvGranularityTouched] = useState(false);
 
-  const defaultValidateEntity = "doNotValidate";
+  const defaultValidateEntity = StepsConfig.defaultValidateEntity;
   const validateEntityOptions = {"Do not validate": "doNotValidate", "Store validation errors in entity headers": "accept", "Skip documents with validation  errors": "reject"};
-  const [validateEntity, setValidateEntity] = useState("doNotValidate");
+  const [validateEntity, setValidateEntity] = useState(defaultValidateEntity);
   const [validateEntityTouched, setValidateEntityTouched] = useState(false);
 
-  const defaultBatchSize = 100;
+  const defaultBatchSize = StepsConfig.defaultBatchSize;
   const [batchSize, setBatchSize] = useState(defaultBatchSize);
   const [batchSizeTouched, setBatchSizeTouched] = useState(false);
 
@@ -100,11 +102,11 @@ const AdvancedSettings: React.FC<Props> = (props) => {
   const [customHookValid, setCustomHookValid] = useState(true);
   const [additionalSettings, setAdditionalSettings] = useState("");
 
-  const [changed, setChanged] = useState(false);
-
   const canReadWrite = props.canWrite;
 
-  const initStep = () => {
+  useEffect(() => {
+    getSettings();
+
     setSourceDatabaseTouched(false);
     setTargetDatabaseTouched(false);
     setAddCollTouched(false);
@@ -117,39 +119,7 @@ const AdvancedSettings: React.FC<Props> = (props) => {
     setProcessorsTouched(false);
     setCustomHookTouched(false);
     setTargetPermissionsTouched(false);
-  };
 
-  useEffect(() => {
-    getSettings();
-    initStep();
-
-    return () => {
-      setStepDefinitionName("");
-      setIsCustomIngestion(false);
-
-      setSourceDatabase(defaultSourceDatabase);
-      setTargetDatabase(defaultTargetDatabase);
-      setAdditionalCollections([]);
-      setTargetCollections(null);
-      setTargetPermissions("");
-      setPermissionValidationError("");
-      setTargetFormat(defaultTargetFormat);
-      setProvGranularity(defaultprovGranularity);
-      setValidateEntity(defaultValidateEntity);
-      setBatchSize(defaultBatchSize);
-      setHeaders("{}");
-      setProcessors("[]");
-      setCustomHook("{}");
-      setAdditionalSettings("");
-
-      setProcessorsExpanded(false);
-      setCustomHookExpanded(false);
-
-      setHeadersValid(true);
-      setProcessorsValid(true);
-      setCustomHookValid(true);
-      setTargetPermissionsValid(true);
-    };
   }, [props.openStepSettings]);
 
   const isFormValid = () => {
@@ -178,76 +148,59 @@ const AdvancedSettings: React.FC<Props> = (props) => {
     }
   };
 
-  const createSettings = (settingsObj) => {
-    // Parent handles saving of all tabs
-    if (props.stepData.name) {
-      props.createStep(settingsObj);
-    }
-  };
-
   const getSettings = async () => {
-    if (props.stepData.name) {
-      try {
-        let response = await getStep(props.stepData.name, stepType);
-        if (response.status === 200) {
-          if (stepType === "ingestion" && response.data.stepDefinitionName !== "default-ingestion") {
-            setIsCustomIngestion(true);
-            setStepDefinitionName(response.data.stepDefinitionName);
-          }
-          if (response.data.sourceDatabase) {
-            setSourceDatabase(response.data.sourceDatabase);
-          }
-          if (response.data.collections) {
-            setDefaultCollections(response.data.collections);
-          }
-          setTargetDatabase(response.data.targetDatabase);
-          if (response.data.additionalCollections) {
-            setAdditionalCollections([...response.data.additionalCollections]);
-          }
-          setTargetPermissions(response.data.permissions);
-          setTargetFormat(response.data.targetFormat);
-          setProvGranularity(response.data.provenanceGranularityLevel);
-          setValidateEntity(response.data.validateEntity) ;
-          setBatchSize(response.data.batchSize);
-          if (response.data.headers) {
-            setHeaders(formatJSON(response.data.headers));
-          }
-          if (response.data.processors) {
-            setProcessors(formatJSON(response.data.processors));
-          }
-          if (response.data.customHook) {
-            setCustomHook(formatJSON(response.data.customHook));
-          }
-          if (response.data.additionalSettings) {
-            setAdditionalSettings(formatJSON(response.data.additionalSettings));
-          }
-          if (usesAdvancedTargetCollections) {
-            const targetEntityType = response.data.targetEntityType || response.data.targetEntity;
-            const defaultCollectionsURL = `/api/steps/${stepType}/defaultCollections/${encodeURI(targetEntityType)}`;
-            const defaultCollectionsResp = await Axios.get(defaultCollectionsURL);
-            if (defaultCollectionsResp.status === 200) {
-              setDefaultTargetCollections(defaultCollectionsResp.data);
-            }
-            setTargetCollections(response.data.targetCollections || {});
-          }
+    if (props.isEditing) {
+      if (stepType === "ingestion" && props.stepData.stepDefinitionName !== "default-ingestion") {
+        setIsCustomIngestion(true);
+        setStepDefinitionName(props.stepData.stepDefinitionName);
+      }
+      if (props.stepData.sourceDatabase) {
+        setSourceDatabase(props.stepData.sourceDatabase);
+      }
+      if (props.stepData.collections) {
+        setDefaultCollections(props.stepData.collections);
+      }
+      if (props.stepData.sourceDatabase) {
+        setTargetDatabase(props.stepData.targetDatabase);
+      }
+      if (props.stepData.additionalCollections) {
+        setAdditionalCollections([...props.stepData.additionalCollections]);
+      }
+      if (props.stepData.permissions) {
+        setTargetPermissions(props.stepData.permissions);
+      }
+      if (props.stepData.targetFormat) {
+        setTargetFormat(props.stepData.targetFormat);
+      }
+      if (props.stepData.provenanceGranularityLevel) {
+        setProvGranularity(props.stepData.provenanceGranularityLevel);
+      }
+      if (props.stepData.validateEntity) {
+        setValidateEntity(props.stepData.validateEntity);
+      }
+      if (props.stepData.batchSize) {
+        setBatchSize(props.stepData.batchSize);
+      }
+      if (props.stepData.headers) {
+        setHeaders(formatJSON(props.stepData.headers));
+      }
+      if (props.stepData.processors) {
+        setProcessors(formatJSON(props.stepData.processors));
+      }
+      if (props.stepData.customHook) {
+        setCustomHook(formatJSON(props.stepData.customHook));
+      }
+      if (props.stepData.additionalSettings) {
+        setAdditionalSettings(formatJSON(props.stepData.additionalSettings));
+      }
+      if (usesAdvancedTargetCollections) {
+        const targetEntityType = props.stepData.targetEntityType || props.stepData.targetEntity;
+        const defaultCollectionsURL = `/api/steps/${stepType}/defaultCollections/${encodeURI(targetEntityType)}`;
+        const defaultCollectionsResp = await Axios.get(defaultCollectionsURL);
+        if (defaultCollectionsResp.status === 200) {
+          setDefaultTargetCollections(defaultCollectionsResp.data);
         }
-      } catch (error) {
-        let message = error.response;
-        console.error("Error while fetching settings artifact", message || error);
-        setSourceDatabase(defaultSourceDatabase);
-        setTargetDatabase(defaultTargetDatabase);
-        setAdditionalCollections([]);
-        setTargetPermissions("");
-        setTargetFormat(defaultTargetFormat);
-        setProvGranularity(defaultprovGranularity);
-        setValidateEntity(defaultValidateEntity);
-        setBatchSize(defaultBatchSize);
-        setHeaders("{}");
-        setProcessors("[]");
-        setCustomHook("{}");
-        setStepDefinitionName("");
-        setIsCustomIngestion(false);
-        setAdditionalSettings("");
+        setTargetCollections(props.stepData.targetCollections || {});
       }
     }
   };
@@ -257,12 +210,18 @@ const AdvancedSettings: React.FC<Props> = (props) => {
     props.onCancel();
   };
 
-  // On change of any form field, update the changed flag for parent
+  // On change of any form field (or on init), update the changed flag for parent
   useEffect(() => {
     props.setHasChanged(hasFormChanged());
-    setChanged(false);
     props.setPayload(getPayload());
-  }, [changed]);
+  }, [batchSize, sourceDatabase, targetCollections, advancedTargetCollectionsTouched, defaultTargetCollections, targetPermissions, targetDatabase, validateEntity, provGranularity, headers, processors, customHook, additionalSettings, targetCollections, targetFormat, targetPermissions, isCustomIngestion, stepDefinitionName]);
+
+  // On change of default collections in parent, update default collections if not empty
+  useEffect(() => {
+    if (props.defaultCollections.length > 0) {
+      setDefaultCollections(props.defaultCollections);
+    }
+  }, [props.defaultCollections]);
 
   //Check if Delete Confirmation dialog should be opened or not.
   const hasFormChanged = () => {
@@ -306,8 +265,9 @@ const AdvancedSettings: React.FC<Props> = (props) => {
   const handleSubmit = async (event: { preventDefault: () => void; }) => {
     if (event) event.preventDefault();
 
-    let payload = getPayload();
-    createSettings(payload);
+    // Parent handles saving of all tabs
+    props.createStep(getPayload());
+
     props.setOpenStepSettings(false);
     props.resetTabs();
   };
@@ -395,7 +355,6 @@ const AdvancedSettings: React.FC<Props> = (props) => {
       setBatchSize(event.target.value);
       setBatchSizeTouched(true);
     }
-    setChanged(true);
   };
 
   const handleBlur = (event) => {
@@ -422,8 +381,6 @@ const AdvancedSettings: React.FC<Props> = (props) => {
     if (event.target.id === "targetPermissions") {
       setTargetPermissionsValid(isPermissionsValid());
     }
-
-    setChanged(true);
   };
 
   const handleSourceDatabase = (value) => {
@@ -433,7 +390,6 @@ const AdvancedSettings: React.FC<Props> = (props) => {
       setSourceDatabaseTouched(true);
       setSourceDatabase(value);
     }
-    setChanged(true);
   };
 
   const handleTargetDatabase = (value) => {
@@ -443,7 +399,6 @@ const AdvancedSettings: React.FC<Props> = (props) => {
       setTargetDatabaseTouched(true);
       setTargetDatabase(value);
     }
-    setChanged(true);
   };
 
   const handleAddColl = (value) => {
@@ -454,7 +409,6 @@ const AdvancedSettings: React.FC<Props> = (props) => {
       // default collections will come from default settings retrieved. Don't want them to be added to additionalCollections property
       setAdditionalCollections(value.filter((col) => !defaultCollections.includes(col)));
     }
-    setChanged(true);
   };
 
   const handleAdvancedTargetCollections = (value) => {
@@ -464,7 +418,6 @@ const AdvancedSettings: React.FC<Props> = (props) => {
       setAdvancedTargetCollectionsTouched(true);
       setTargetCollections(value);
     }
-    setChanged(true);
   };
 
   const handleTargetFormat = (value) => {
@@ -474,7 +427,6 @@ const AdvancedSettings: React.FC<Props> = (props) => {
       setTargetFormat(value);
       setTargetFormatTouched(true);
     }
-    setChanged(true);
   };
 
   const handleProvGranularity = (value) => {
@@ -484,7 +436,6 @@ const AdvancedSettings: React.FC<Props> = (props) => {
       setProvGranularityTouched(true);
       setProvGranularity(value);
     }
-    setChanged(true);
   };
 
   const handleValidateEntity = (value) => {

--- a/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.tsx
@@ -45,14 +45,16 @@ const srcTypeOptions = [
 const {TextArea} = Input;
 
 const CreateEditStep: React.FC<Props>  = (props) => {
+  // TODO use steps.config.ts for default values
   const {handleError} = useContext(UserContext);
   const [stepName, setStepName] = useState("");
   const [description, setDescription] = useState("");
 
   const [collections, setCollections] = useState("");
   const [collectionOptions, setCollectionOptions] = useState(["a", "b"]);
-  const [selectedSource, setSelectedSource] = useState("collection");
+  const [selectedSource, setSelectedSource] = useState(props.editStepArtifactObject.selectedSource ? props.editStepArtifactObject.selectedSource : "collection");
   const [srcQuery, setSrcQuery] = useState("");
+  const [timestamp, setTimestamp] = useState("");
 
   //To check submit validity
   const [isStepNameTouched, setStepNameTouched] = useState(false);
@@ -60,13 +62,11 @@ const CreateEditStep: React.FC<Props>  = (props) => {
   const [isCollectionsTouched, setCollectionsTouched] = useState(false);
   const [isSrcQueryTouched, setSrcQueryTouched] = useState(false);
   const [isSelectedSourceTouched, setSelectedSourceTouched] = useState(false);
-  const [timestamp, setTimestamp] = useState("");
   const [isTimestampTouched, setTimestampTouched] = useState(false);
 
   const [isValid, setIsValid] = useState(false); // eslint-disable-line @typescript-eslint/no-unused-vars
 
   const [tobeDisabled, setTobeDisabled] = useState(false);
-  const [changed, setChanged] = useState(false);
 
   const initStep = () => {
     setStepName(props.editStepArtifactObject.name);
@@ -86,18 +86,19 @@ const CreateEditStep: React.FC<Props>  = (props) => {
     resetTouchedValues();
     setIsValid(true);
     setTobeDisabled(true);
+
+    props.setIsValid(true);
   };
 
   useEffect(() => {
-    if (props.currentTab === props.tabKey) {
-      // Edit Step Artifact
-      if (props.isEditing) {
-        initStep();
-      } else { // New Step Artifact
-        reset();
-      }
+    // Edit Step Artifact
+    if (props.isEditing) {
+      initStep();
+    } else { // New Step Artifact
+      reset();
+      props.setIsValid(false);
     }
-  }, [props.currentTab]);
+  }, [props.openStepSettings]);
 
   const reset = () => {
     setStepName("");
@@ -132,8 +133,7 @@ const CreateEditStep: React.FC<Props>  = (props) => {
   useEffect(() => {
     props.setHasChanged(hasFormChanged());
     props.setPayload(getPayload());
-    setChanged(false);
-  }, [changed]);
+  }, [stepName, description, collections, selectedSource, srcQuery, timestamp]);
 
   const hasFormChanged = () => {
     if (!isStepNameTouched
@@ -150,9 +150,9 @@ const CreateEditStep: React.FC<Props>  = (props) => {
   };
 
   const getPayload = () => {
-    let result;
+    let result, sQuery;
     if (selectedSource === "collection") {
-      let sQuery = `cts.collectionQuery(['${collections}'])`;
+      sQuery = collections ? `cts.collectionQuery(['${collections}'])` : props.editStepArtifactObject.sourceQuery;
       result = {
         name: stepName,
         targetEntityType: props.targetEntityType,
@@ -161,12 +161,13 @@ const CreateEditStep: React.FC<Props>  = (props) => {
         sourceQuery: sQuery
       };
     } else {
+      sQuery = srcQuery ? srcQuery : props.editStepArtifactObject.sourceQuery;
       result = {
         name: stepName,
         targetEntityType: props.targetEntityType,
         description: description,
         selectedSource: selectedSource,
-        sourceQuery: srcQuery
+        sourceQuery: sQuery
       };
     }
     if (props.stepType === StepType.Merging) {
@@ -248,9 +249,11 @@ const CreateEditStep: React.FC<Props>  = (props) => {
       if (data.length > 0) {
         if (stepName) {
           setIsValid(true);
+          props.setIsValid(true);
         }
       } else {
         setIsValid(false);
+        props.setIsValid(false);
       }
     }
   };
@@ -265,9 +268,11 @@ const CreateEditStep: React.FC<Props>  = (props) => {
         if (event.target.value.length > 0) {
           if (collections || srcQuery) {
             setIsValid(true);
+            props.setIsValid(true);
           }
         } else {
           setIsValid(false);
+          props.setIsValid(false);
         }
       }
     }
@@ -295,9 +300,11 @@ const CreateEditStep: React.FC<Props>  = (props) => {
         if (event.target.value.length > 0) {
           if (stepName) {
             setIsValid(true);
+            props.setIsValid(true);
           }
         } else {
           setIsValid(false);
+          props.setIsValid(false);
         }
       }
     }
@@ -315,9 +322,11 @@ const CreateEditStep: React.FC<Props>  = (props) => {
         if (event.target.value.length > 0) {
           if (stepName) {
             setIsValid(true);
+            props.setIsValid(true);
           }
         } else {
           setIsValid(false);
+          props.setIsValid(false);
         }
       }
     }
@@ -335,7 +344,6 @@ const CreateEditStep: React.FC<Props>  = (props) => {
         }
       }
     }
-    setChanged(true);
   };
 
   const handleSelectedSource = (event) => {
@@ -350,18 +358,21 @@ const CreateEditStep: React.FC<Props>  = (props) => {
       if (event.target.value === "collection") {
         if (stepName && collections) {
           setIsValid(true);
+          props.setIsValid(true);
         } else {
           setIsValid(false);
+          props.setIsValid(false);
         }
       } else {
         if (stepName && srcQuery) {
           setIsValid(true);
+          props.setIsValid(true);
         } else {
           setIsValid(false);
+          props.setIsValid(false);
         }
       }
     }
-    setChanged(true);
   };
 
   return (

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/create-edit-mapping/create-edit-mapping.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/create-edit-mapping/create-edit-mapping.tsx
@@ -10,7 +10,6 @@ interface Props {
   tabKey: string;
   openStepSettings: boolean;
   setOpenStepSettings: any;
-  openStepDetails: any;
   isEditing: boolean;
   canReadWrite: boolean;
   canReadOnly: boolean;
@@ -27,7 +26,7 @@ interface Props {
 }
 
 const CreateEditMapping: React.FC<Props> = (props) => {
-
+  // TODO use steps.config.ts for default values
   const {handleError} = useContext(UserContext);
   const [mapName, setMapName] = useState("");
   const [description, setDescription] = useState(props.stepData && props.stepData !== {} ? props.stepData.description : "");
@@ -36,7 +35,6 @@ const CreateEditMapping: React.FC<Props> = (props) => {
   const [collectionOptions, setCollectionOptions] = useState(["a", "b"]);
   const [selectedSource, setSelectedSource] = useState(props.stepData && props.stepData.selectedSource ? props.stepData.selectedSource : "collection");
   const [srcQuery, setSrcQuery] = useState(props.stepData && props.stepData !== {} ? props.stepData.sourceQuery : "");
-  const [isQuerySelected, setIsQuerySelected] = useState(false);
 
   //To check submit validity
   const [isMapNameTouched, setMapNameTouched] = useState(false);
@@ -50,66 +48,52 @@ const CreateEditMapping: React.FC<Props> = (props) => {
   const [errorMessage, setErrorMessage] = useState(""); // eslint-disable-line @typescript-eslint/no-unused-vars
 
   const [tobeDisabled, setTobeDisabled] = useState(false);
-  const [changed, setChanged] = useState(false);
 
   const initStep = () => {
     setMapName(props.stepData.name);
     setDescription(props.stepData.description);
     setSrcQuery(props.stepData.sourceQuery);
     setSelectedSource(props.stepData.selectedSource);
-    if (isQuerySelected === true) setCollections("");
     if (props.stepData.selectedSource === "collection") {
-      if (props.stepData.sourceQuery.includes("[") && props.stepData.sourceQuery.includes("]")) {
-        let srcCollection = props.stepData.sourceQuery.substring(
-          props.stepData.sourceQuery.lastIndexOf("[") + 2,
-          props.stepData.sourceQuery.lastIndexOf("]") - 1
-        );
-        setCollections(srcCollection);
-      } else if ((props.stepData.sourceQuery.includes("(") && props.stepData.sourceQuery.includes(")"))) {
-        let srcCollection = props.stepData.sourceQuery.substring(
-          props.stepData.sourceQuery.lastIndexOf("(") + 2,
-          props.stepData.sourceQuery.lastIndexOf(")") - 1
-        );
-        setCollections(srcCollection);
-      } else {
-        setCollections(props.stepData.sourceQuery);
-      }
+      let srcCollection = props.stepData.sourceQuery.substring(
+        props.stepData.sourceQuery.lastIndexOf("[") + 2,
+        props.stepData.sourceQuery.lastIndexOf("]") - 1
+      );
+      setCollections(srcCollection);
     }
+    resetTouchedValues();
     setIsValid(true);
     setTobeDisabled(true);
 
-    setDescriptionTouched(false);
-    setCollectionsTouched(false);
-    setSrcQueryTouched(false);
-    setSelectedSourceTouched(false);
+    props.setIsValid(true);
   };
 
   useEffect(() => {
-    // Edit step
-    if (props.stepData && JSON.stringify(props.stepData) !== JSON.stringify({}) && props.isEditing) {
+    // Edit mapping
+    if (props.isEditing) {
       initStep();
-    } else {     // New step
-      setMapName("");
-      setMapNameTouched(false);
-      setCollections("");
-      setDescription("");
-      setSrcQuery("");
-      setIsNameDuplicate(false);
+    } else { // New mapping
+      reset();
+      props.setIsValid(false);
     }
-    // Reset
-    return (() => {
-      setMapName("");
-      setMapNameTouched(false);
-      setDescription("");
-      setDescriptionTouched(false);
-      setSelectedSource("collection");
-      setSelectedSourceTouched(false);
-      setCollectionsTouched(false);
-      setTobeDisabled(false);
-      setIsNameDuplicate(false);
-    });
+  }, [props.openStepSettings]);
 
-  }, [props.stepData]);
+  const reset = () => {
+    setMapName("");
+    setDescription("");
+    setSelectedSource("collection");
+    setTobeDisabled(false);
+    setCollections("");
+    setSrcQuery("");
+    resetTouchedValues();
+  };
+
+  const resetTouchedValues = () => {
+    setMapNameTouched(false);
+    setDescriptionTouched(false);
+    setSelectedSourceTouched(false);
+    setCollectionsTouched(false);
+  };
 
   const onCancel = () => {
     // Parent checks changes across tabs
@@ -120,8 +104,7 @@ const CreateEditMapping: React.FC<Props> = (props) => {
   useEffect(() => {
     props.setHasChanged(hasFormChanged());
     props.setPayload(getPayload());
-    setChanged(false);
-  }, [changed]);
+  }, [mapName, description, collections, selectedSource, srcQuery]);
 
   const hasFormChanged = () => {
     if (!isMapNameTouched
@@ -137,9 +120,9 @@ const CreateEditMapping: React.FC<Props> = (props) => {
   };
 
   const getPayload = () => {
-    let result;
+    let result, sQuery;
     if (selectedSource === "collection") {
-      let sQuery = `cts.collectionQuery(['${collections}'])`;
+      sQuery = collections ? `cts.collectionQuery(['${collections}'])` : props.stepData.sourceQuery;
       result = {
         name: mapName,
         targetEntityType: props.targetEntityType,
@@ -148,13 +131,13 @@ const CreateEditMapping: React.FC<Props> = (props) => {
         sourceQuery: sQuery
       };
     } else {
-      setIsQuerySelected(true); //to reset collection name
+      sQuery = srcQuery? srcQuery : props.stepData.sourceQuery;
       result = {
         name: mapName,
         targetEntityType: props.targetEntityType,
         description: description,
         selectedSource: selectedSource,
-        sourceQuery: srcQuery
+        sourceQuery: sQuery
       };
     }
     return result;
@@ -187,8 +170,6 @@ const CreateEditMapping: React.FC<Props> = (props) => {
     props.setOpenStepSettings(false);
     props.resetTabs();
     await props.createMappingArtifact(getPayload());
-    props.openStepDetails(mapName);
-
   };
 
   const handleSearch = async (value: any) => {
@@ -223,6 +204,7 @@ const CreateEditMapping: React.FC<Props> = (props) => {
   };
 
   const handleTypeaheadChange = (data: any) => {
+
     if (data === " ") {
       setCollectionsTouched(false);
     } else {
@@ -241,7 +223,6 @@ const CreateEditMapping: React.FC<Props> = (props) => {
         setIsValid(false);
       }
     }
-    setChanged(true);
   };
 
   const handleChange = (event) => {
@@ -254,10 +235,12 @@ const CreateEditMapping: React.FC<Props> = (props) => {
         if (event.target.value.length > 0) {
           if (collections|| srcQuery) {
             setIsValid(true);
+            props.setIsValid(true);
             setIsNameDuplicate(false);
           }
         } else {
           setIsValid(false);
+          props.setIsValid(false);
         }
       }
     }
@@ -290,9 +273,11 @@ const CreateEditMapping: React.FC<Props> = (props) => {
         if (event.target.value.length > 0) {
           if (mapName) {
             setIsValid(true);
+            props.setIsValid(true);
           }
         } else {
           setIsValid(false);
+          props.setIsValid(false);
         }
       }
     }
@@ -311,13 +296,14 @@ const CreateEditMapping: React.FC<Props> = (props) => {
         if (event.target.value.length > 0) {
           if (mapName) {
             setIsValid(true);
+            props.setIsValid(true);
           }
         } else {
           setIsValid(false);
+          props.setIsValid(false);
         }
       }
     }
-    setChanged(true);
   };
   /* // Handling multiple collections in a select tags list - Deprecated
   const handleCollList = (value) => {
@@ -356,26 +342,34 @@ const CreateEditMapping: React.FC<Props> = (props) => {
       if (event.target.value === "collection") {
         if (mapName && collections) {
           setIsValid(true);
+          props.setIsValid(true);
         } else {
           setIsValid(false);
+          props.setIsValid(false);
         }
       } else {
         if (mapName && srcQuery) {
           setIsValid(true);
+          props.setIsValid(true);
         } else {
           setIsValid(false);
+          props.setIsValid(false);
         }
       }
     }
-    setChanged(true);
   };
 
   const isSourceQueryValid = () => {
-    if ((collections && selectedSource === "collection") ||
-    (srcQuery && selectedSource !== "collection") ||
-    (!isSelectedSourceTouched && !isCollectionsTouched && !isSrcQueryTouched)) {
+    if ((collections && selectedSource === "collection") || (srcQuery && selectedSource !== "collection")) {
+      // Touched
       if (props.currentTab === props.tabKey) {
         props.setIsValid(true);
+      }
+      return true;
+    } else if ((!isSelectedSourceTouched && !isCollectionsTouched && !isSrcQueryTouched)) {
+      // Untouched
+      if (props.currentTab === props.tabKey) {
+        props.setIsValid(false);
       }
       return true;
     } else {

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
@@ -161,7 +161,7 @@ describe("Mapping Card component", () => {
   test("Open step settings", async () => {
     const authorityService = new AuthoritiesService();
     authorityService.setAuthorities(["writeMapping", "readMapping"]);
-    const {debug, getByText, getByLabelText, getByTestId, getByPlaceholderText} = render(
+    const {getByText, getByLabelText, getByTestId, getByPlaceholderText} = render(
       <Router><AuthoritiesContext.Provider value={authorityService}><MappingCard
         {...mappingProps}
         canReadWrite={true}
@@ -174,7 +174,6 @@ describe("Mapping Card component", () => {
       fireEvent.click(getByTestId("Mapping1-edit"));
     });
     expect(getByText("Mapping Step Settings")).toBeInTheDocument();
-    debug;
     expect(getByText("Basic").closest("div")).toHaveClass("ant-tabs-tab-active");
     expect(getByText("Advanced").closest("div")).not.toHaveClass("ant-tabs-tab-active");
 

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
@@ -796,6 +796,7 @@ const MappingCard: React.FC<Props> = (props) => {
         updateStep={updateMappingArtifact}
         activityType={activityType}
         targetEntityType={props.entityModel.entityTypeId}
+        targetEntityName={props.entityModel.entityName}
         openStepDetails={openStepDetails}
       />
     </div>

--- a/marklogic-data-hub-central/ui/src/components/load/create-edit-load/create-edit-load.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/create-edit-load/create-edit-load.tsx
@@ -2,6 +2,7 @@ import React, {useState, useEffect} from "react";
 import {Form, Input, Icon, Select} from "antd";
 import styles from "./create-edit-load.module.scss";
 import {srcOptions, tgtOptions, fieldSeparatorOptions} from "../../../config/formats.config";
+import StepsConfig from "../../../config/steps.config";
 import {NewLoadTooltips} from "../../../config/tooltips.config";
 import {MLButton, MLTooltip} from "@marklogic/design-system";
 
@@ -25,18 +26,27 @@ interface Props {
 const CreateEditLoad: React.FC<Props> = (props) => {
   const [stepName, setStepName] = useState(props.stepData && props.stepData !== {} ? props.stepData.name : "");
   const [description, setDescription] = useState(props.stepData && props.stepData !== {} ? props.stepData.description : "");
-  const [srcFormat, setSrcFormat] = useState(props.stepData && props.stepData !== {} ? props.stepData.sourceFormat : "json");
-  const [tgtFormat, setTgtFormat] = useState(props.stepData && props.stepData !== {} ? props.stepData.targetFormat : "json");
+  const [srcFormat, setSrcFormat] = useState(props.stepData && props.stepData !== {} ? props.stepData.sourceFormat : StepsConfig.defaultSourceFormat);
+  const [tgtFormat, setTgtFormat] = useState(props.stepData && props.stepData !== {} ? props.stepData.targetFormat : StepsConfig.defaultTargetFormat);
   const [sourceName, setSourceName] = useState(props.stepData && props.stepData !== {} ? props.stepData.sourceName : "");
   const [sourceType, setSourceType] = useState(props.stepData && props.stepData !== {} ? props.stepData.sourceType : "");
   const [outputUriPrefix, setOutputUriPrefix] = useState(props.stepData && props.stepData !== {} ? props.stepData.outputURIPrefix : "");
-  const [fieldSeparator, setFieldSeparator] = useState(props.stepData && props.stepData !== {} ? props.stepData.fieldSeparator : ",");
+  const [fieldSeparator, setFieldSeparator] = useState(props.stepData && props.stepData !== {} ? props.stepData.fieldSeparator : StepsConfig.defaultFieldSeparator);
   const [otherSeparator, setOtherSeparator] = useState("");
 
+  //To check submit validity
   const [isStepNameTouched, setStepNameTouched] = useState(false);
+  const [isDescriptionTouched, setDescriptionTouched] = useState(false);
+  const [isSrcFormatTouched, setSrcFormatTouched] = useState(false);
+  const [isTgtFormatTouched, setTgtFormatTouched] = useState(false);
+  const [isSourceNameTouched, setSourceNameTouched] = useState(false);
+  const [isSourceTypeTouched, setSourceTypeTouched] = useState(false);
+  const [isOutputUriPrefixTouched, setOutputUriPrefixTouched] = useState(false);
+  const [isFieldSeparatorTouched, setFieldSeparatorTouched] = useState(false);
+  const [isOtherSeparatorTouched, setOtherSeparatorTouched] = useState(false);
+
   const [isValid, setIsValid] = useState(false); // eslint-disable-line @typescript-eslint/no-unused-vars
   const [tobeDisabled, setTobeDisabled] = useState(false);
-  const [changed, setChanged] = useState(false);
 
   const initStep = () => {
     setStepName(props.stepData.name);
@@ -53,7 +63,15 @@ const CreateEditLoad: React.FC<Props> = (props) => {
     setTgtFormat(props.stepData.targetFormat);
     setOutputUriPrefix(props.stepData.outputURIPrefix);
     setIsValid(true);
+    props.setIsValid(true);
     setTobeDisabled(true);
+
+    setDescriptionTouched(false);
+    setSrcFormatTouched(false);
+    setTgtFormatTouched(false);
+    setSourceNameTouched(false);
+    setSourceTypeTouched(false);
+    setOutputUriPrefixTouched(false);
   };
 
   useEffect(() => {
@@ -64,27 +82,44 @@ const CreateEditLoad: React.FC<Props> = (props) => {
       setStepName("");
       setStepNameTouched(false);
       setDescription("");
-      setSrcFormat("json");
-      setFieldSeparator(",");
+      setDescriptionTouched(false);
+      setSrcFormat(StepsConfig.defaultSourceFormat);
+      setSrcFormatTouched(false);
+      setFieldSeparator(StepsConfig.defaultFieldSeparator);
+      setFieldSeparatorTouched(false);
       setOtherSeparator("");
-      setTgtFormat("json");
+      setOtherSeparatorTouched(false);
+      setTgtFormat(StepsConfig.defaultTargetFormat);
+      setTgtFormatTouched(false);
       setSourceName("");
+      setSourceNameTouched(false);
       setSourceType("");
+      setSourceTypeTouched(false);
       setOutputUriPrefix("");
+      setOutputUriPrefixTouched(false);
       setIsValid(false);
+      props.setIsValid(false);
     }
     // Reset
     return (() => {
       setStepName("");
       setStepNameTouched(false);
       setDescription("");
-      setSrcFormat("json");
-      setFieldSeparator(",");
+      setDescriptionTouched(false);
+      setSrcFormat(StepsConfig.defaultSourceFormat);
+      setSrcFormatTouched(false);
+      setFieldSeparator(StepsConfig.defaultFieldSeparator);
+      setFieldSeparatorTouched(false);
       setOtherSeparator("");
-      setTgtFormat("json");
+      setOtherSeparatorTouched(false);
+      setTgtFormat(StepsConfig.defaultTargetFormat);
+      setTgtFormatTouched(false);
       setSourceName("");
+      setSourceNameTouched(false);
       setSourceType("");
+      setSourceTypeTouched(false);
       setOutputUriPrefix("");
+      setOutputUriPrefixTouched(false);
       setTobeDisabled(false);
     });
 
@@ -99,36 +134,22 @@ const CreateEditLoad: React.FC<Props> = (props) => {
   useEffect(() => {
     props.setHasChanged(hasFormChanged());
     props.setPayload(getPayload());
-    setChanged(false);
-  }, [changed]);
+  }, [stepName, description, srcFormat, tgtFormat, sourceName, sourceType, outputUriPrefix, fieldSeparator, otherSeparator]);
 
-  // TODO update hasFormChanged() pattern to match other create-edit-* components
   const hasFormChanged = () => {
-    const step = props.stepData;
-    // Edit
-    if (step && JSON.stringify(step) !== JSON.stringify({}) && props.isEditing) {
-      // Any settings changed (excluding separator)?
-      if (
-        stepName === step.name && description === step.description && srcFormat === step.sourceFormat
-        && tgtFormat === step.targetFormat && sourceName === step.sourceName && sourceType === step.sourceType
-        && outputUriPrefix === step.outputURIPrefix
-      ) {
-        // Separator?
-        if ((step.separator && fieldSeparator === "Other" && otherSeparator === step.separator) ||
-          (step.separator && fieldSeparator !== "Other" && fieldSeparator === step.separator) ||
-          (!step.separator && (fieldSeparator === "," || !fieldSeparator) && otherSeparator === "")) {
-          return false;
-        } else return true;
-      } else return true;
-    } else {     // New
-      // Any settings changed (excluding separator)?
-      if (stepName === "" && description === "" && srcFormat === "json" && tgtFormat === "json"
-        && sourceName === "" && sourceType === "" && outputUriPrefix === "") {
-        // Separator?
-        if (fieldSeparator === "," && otherSeparator === "") {
-          return false;
-        } else return true;
-      } else return true;
+    if (!isStepNameTouched
+      && !isDescriptionTouched
+      && !isSrcFormatTouched
+      && !isTgtFormatTouched
+      && !isSourceNameTouched
+      && !isSourceTypeTouched
+      && !isOutputUriPrefixTouched
+      && !isFieldSeparatorTouched
+      && !isOtherSeparatorTouched
+    ) {
+      return false;
+    } else {
+      return true;
     }
   };
 
@@ -198,63 +219,170 @@ const CreateEditLoad: React.FC<Props> = (props) => {
         }
       }
     }
+
     if (event.target.id === "description") {
-      setDescription(event.target.value);
+      if (event.target.value === " ") {
+        setDescriptionTouched(false);
+      } else {
+        setDescriptionTouched(true);
+        setDescription(event.target.value);
+        if (props.stepData && props.stepData.description) {
+          if (event.target.value === props.stepData.description) {
+            setDescriptionTouched(false);
+          }
+        }
+        if (!props.isEditing) {
+          if (event.target.value === "") {
+            setDescriptionTouched(false);
+          }
+        }
+      }
     }
 
     if (event.target.id === "sourceName") {
-      setSourceName(event.target.value);
+      if (event.target.value === " ") {
+        setSourceNameTouched(false);
+      } else {
+        setSourceNameTouched(true);
+        setSourceName(event.target.value);
+        if (props.stepData && props.stepData.sourceName) {
+          if (event.target.value === props.stepData.sourceName) {
+            setSourceNameTouched(false);
+          }
+        }
+        if (!props.isEditing) {
+          if (event.target.value === "") {
+            setSourceNameTouched(false);
+          }
+        }
+      }
     }
 
     if (event.target.id === "sourceType") {
-      setSourceType(event.target.value);
+      if (event.target.value === " ") {
+        setSourceTypeTouched(false);
+      } else {
+        setSourceTypeTouched(true);
+        setSourceType(event.target.value);
+        if (props.stepData && props.stepData.sourceType) {
+          if (event.target.value === props.stepData.sourceType) {
+            setSourceTypeTouched(false);
+          }
+        }
+        if (!props.isEditing) {
+          if (event.target.value === "") {
+            setSourceTypeTouched(false);
+          }
+        }
+      }
     }
-    setChanged(true);
   };
 
   const handleOutputUriPrefix = (event) => {
     if (event.target.id === "outputUriPrefix") {
-      setOutputUriPrefix(event.target.value);
+      if (event.target.value === " ") {
+        setOutputUriPrefixTouched(false);
+      } else {
+        setOutputUriPrefixTouched(true);
+        setOutputUriPrefix(event.target.value);
+        if (props.stepData && props.stepData.outputURIPrefix) {
+          if (event.target.value === props.stepData.outputURIPrefix) {
+            setOutputUriPrefixTouched(false);
+          }
+        }
+        if (!props.isEditing) {
+          if (event.target.value === "") {
+            setOutputUriPrefixTouched(false);
+          }
+        }
+      }
     }
-    setChanged(true);
   };
 
   const handleSrcFormat = (value) => {
-    if (value !== " ") {
+    if (value === " ") {
+      setSrcFormatTouched(false);
+    } else {
+      setSrcFormatTouched(true);
       setSrcFormat(value);
+      if (props.stepData && props.stepData.srcFormat) {
+        if (value === props.stepData.srcFormat) {
+          setSrcFormatTouched(false);
+        }
+      }
+      if (!props.isEditing) {
+        if (value === "") {
+          setSrcFormatTouched(false);
+        }
+      }
       if (value === "csv") {
-        setFieldSeparator(",");
+        setFieldSeparator(StepsConfig.defaultFieldSeparator);
       }
     }
-    setChanged(true);
   };
 
   const handleFieldSeparator = (value) => {
-    if (value !== " ") {
+    if (value === " ") {
+      setFieldSeparatorTouched(false);
+    } else {
+      setFieldSeparatorTouched(true);
       setFieldSeparator(value);
       if (value === "Other") {
         setOtherSeparator("");
       }
+      if (props.stepData && props.stepData.fieldSeparator) {
+        if (value === props.stepData.fieldSeparator) {
+          setFieldSeparatorTouched(false);
+        }
+      }
+      if (!props.isEditing) {
+        if (value === StepsConfig.defaultFieldSeparator) {
+          setFieldSeparatorTouched(false);
+        }
+      }
     }
-    setChanged(true);
   };
 
   const handleOtherSeparator = (event) => {
-    if (event.target.id === "otherSeparator") {
+    if (event.target.value === " ") {
+      setOtherSeparatorTouched(false);
+    } else {
+      setOtherSeparatorTouched(true);
       setOtherSeparator(event.target.value);
+      if (props.stepData && props.stepData.fieldSeparator) {
+        if (event.target.value === props.stepData.fieldSeparator) {
+          setOtherSeparatorTouched(false);
+        }
+      }
+      if (!props.isEditing) {
+        if (event.target.value === "") {
+          setOtherSeparatorTouched(false);
+        }
+      }
     }
-    setChanged(true);
   };
 
   const handleTgtFormat = (value) => {
-    if (value !== " ") {
+    if (value === " ") {
+      setTgtFormatTouched(false);
+    } else {
+      setTgtFormatTouched(true);
       setTgtFormat(value);
+      if (props.stepData && props.stepData.tgtFormat) {
+        if (value === props.stepData.tgtFormat) {
+          setTgtFormatTouched(false);
+        }
+      }
+      if (!props.isEditing) {
+        if (value === "") {
+          setTgtFormatTouched(false);
+        }
+      }
       if (value !== "json" && value !== "xml") {
         setSourceName("");
         setSourceType("");
       }
     }
-    setChanged(true);
   };
 
   const formItemLayout = {
@@ -380,7 +508,7 @@ const CreateEditLoad: React.FC<Props> = (props) => {
             <Icon type="question-circle" className={styles.questionCircle} theme="filled" />
           </MLTooltip>
         </Form.Item>
-        {(tgtFormat === "json" || tgtFormat === "xml") && <Form.Item label={<span>
+        {(tgtFormat && (tgtFormat.toLowerCase() === "json" || tgtFormat.toLowerCase() === "xml")) && <Form.Item label={<span>
           Source Name:&nbsp;
         </span>} labelAlign="left">
           <Input
@@ -394,7 +522,7 @@ const CreateEditLoad: React.FC<Props> = (props) => {
             <Icon type="question-circle" className={styles.questionCircle} theme="filled" />
           </MLTooltip>
         </Form.Item>}
-        {(tgtFormat === "json" || tgtFormat === "xml") && <Form.Item label={<span>
+        {(tgtFormat && (tgtFormat.toLowerCase() === "json" || tgtFormat.toLowerCase() === "xml")) && <Form.Item label={<span>
           Source Type:&nbsp;
         </span>} labelAlign="left">
           <Input

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.test.tsx
@@ -145,7 +145,7 @@ describe("Load data component", () => {
     expect(getByText("Advanced").closest("div")).not.toHaveClass("ant-tabs-tab-active");
 
     // Basic settings values
-    expect(getByText("testLoad")).toBeInTheDocument();
+    expect(getAllByText("testLoad")[0]).toBeInTheDocument();
     expect(getByPlaceholderText("Enter description")).toBeInTheDocument();
     expect(getAllByText("JSON").length === 2);
     expect(getByPlaceholderText("Enter URI Prefix")).toBeInTheDocument();
@@ -155,7 +155,6 @@ describe("Load data component", () => {
     await wait(() => {
       fireEvent.click(getByText("Advanced"));
     });
-    expect(axiosMock.get).toBeCalledWith("/api/steps/ingestion/" + data.loadData.data[0].name);
     expect(getByText("Basic").closest("div")).not.toHaveClass("ant-tabs-tab-active");
     expect(getByText("Advanced").closest("div")).toHaveClass("ant-tabs-tab-active");
     let saveButton = getAllByText("Save"); // Each tab has a Save button

--- a/marklogic-data-hub-central/ui/src/config/steps.config.ts
+++ b/marklogic-data-hub-central/ui/src/config/steps.config.ts
@@ -1,0 +1,29 @@
+// Configuration information for steps (Load, Mapping, Matching, Merging, Custom)
+
+const invalidJSONMessage = "Invalid JSON";
+const stagingDb = "data-hub-STAGING";
+const finalDb = "data-hub-FINAL";
+const defaultTargetPerms = "data-hub-common,read,data-hub-common,update";
+const validCapabilities = ["read", "update", "insert", "execute"];
+const defaultSourceFormat = "json";
+const defaultTargetFormat = "JSON";
+const defaultProvGran = "coarse";
+const defaultValidateEntity = "doNotValidate";
+const defaultBatchSize = 100;
+const defaultSelectedSource = "collections";
+const defaultFieldSeparator = ",";
+
+export default {
+    invalidJSONMessage,
+    stagingDb,
+    finalDb,
+    defaultTargetPerms,
+    validCapabilities,
+    defaultSourceFormat,
+    defaultTargetFormat,
+    defaultProvGran,
+    defaultValidateEntity,
+    defaultBatchSize,
+    defaultSelectedSource,
+    defaultFieldSeparator,
+};


### PR DESCRIPTION
### Description

- User can now edit Advanced settings (under Advanced tab) during step creation.
- Advanced tab is disabled until all require fields are filled out under Basic tab.
- Default Collections under Advanced tab are dynamically generated based on the Name value under Basic tab (and also the entity name in the case of mapping steps).
- Most default step values have been moved to a new config/steps.config.ts file.
- Unit and e2e tests now test settings editing under both tabs for new steps.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

