### PR TITLE
DHFPROD-6441:Do not refresh metadata when fetching transform,resources

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/DataHubImpl.java
@@ -370,7 +370,7 @@ public class DataHubImpl implements DataHub, InitializingBean {
 
             // remove transforms using amped channel
             TransformExtensionsManager transformExtensionsManager = configMgr.newTransformExtensionsManager();
-            JsonNode transformsList = transformExtensionsManager.listTransforms(new JacksonHandle()).get();
+            JsonNode transformsList = transformExtensionsManager.listTransforms(new JacksonHandle(), false).get();
             transformsList.findValuesAsText("name").forEach(
                 x -> {
                     if (!(dataHubTransforms.contains(x) || x.startsWith("ml"))) {
@@ -381,7 +381,7 @@ public class DataHubImpl implements DataHub, InitializingBean {
 
             // remove resource extensions
             ResourceExtensionsManager resourceExtensionsManager = configMgr.newResourceExtensionsManager();
-            JsonNode resourceExtensions = resourceExtensionsManager.listServices(new JacksonHandle()).get();
+            JsonNode resourceExtensions = resourceExtensionsManager.listServices(new JacksonHandle(), false).get();
             if (resourceNamesToNotDelete == null) {
                 resourceNamesToNotDelete = new ArrayList<>(); // makes the boolean logic below simpler
             }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/installer/command/UpdateDhsRestExtensionPermissionsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/installer/command/UpdateDhsRestExtensionPermissionsTest.java
@@ -5,63 +5,78 @@ import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.hub.AbstractHubCoreTest;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.dhs.installer.deploy.UpdateDhsModulesPermissionsCommand;
+import com.marklogic.hub.impl.DataHubImpl;
 import com.marklogic.mgmt.resource.databases.DatabaseManager;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class UpdateDhsRestExtensionPermissionsTest extends AbstractHubCoreTest {
 
     /**
-     * Cannot run this test in DHS, as it depends on installHubModules, which messages up the DHS
+     * Cannot run this test in DHS, as it depends on installHubModules, which messes up the DHS
      * installation.
      */
+    @BeforeEach
+    void setup(){
+        runAsAdmin();
+        new UpdateDhsModulesPermissionsCommand(getHubConfig()).execute(newCommandContext());
+    }
+
+    @AfterEach
+    void reloadHubModulesAndArtifacts(){
+        runAsAdmin();
+        new DatabaseManager(getHubClient().getManageClient()).clearDatabase(HubConfig.DEFAULT_MODULES_DB_NAME);
+        installHubModules();
+        installHubArtifacts();
+    }
+
     @Test
     public void testUpdateDhsResourcePermissions() {
-        try {
-            runAsAdmin();
-            new UpdateDhsModulesPermissionsCommand(getHubConfig()).execute(newCommandContext());
+        GenericDocumentManager modMgr = getHubClient().getModulesClient().newDocumentManager();
 
-            GenericDocumentManager modMgr = getHubClient().getModulesClient().newDocumentManager();
+        DocumentMetadataHandle metadataHandle = new DocumentMetadataHandle();
+        modMgr.readMetadata("/marklogic.rest.resource/mlDbConfigs/assets/metadata.xml", metadataHandle);
+        DocumentMetadataHandle.DocumentPermissions perms = metadataHandle.getPermissions();
 
-            DocumentMetadataHandle metadataHandle = new DocumentMetadataHandle();
-            modMgr.readMetadata("/marklogic.rest.resource/mlDbConfigs/assets/metadata.xml", metadataHandle);
-            DocumentMetadataHandle.DocumentPermissions perms = metadataHandle.getPermissions();
+        Assertions.assertEquals(DocumentMetadataHandle.Capability.UPDATE, perms.get("data-hub-environment-manager").iterator().next());
+        Assertions.assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("rest-extension-user").iterator().next());
 
-            Assertions.assertEquals(DocumentMetadataHandle.Capability.UPDATE, perms.get("data-hub-environment-manager").iterator().next());
-            Assertions.assertEquals(DocumentMetadataHandle.Capability.READ, perms.get("rest-extension-user").iterator().next());
+        DocumentMetadataHandle moduleMetadataHandle = new DocumentMetadataHandle();
+        modMgr.readMetadata("/marklogic.rest.resource/mlBatches/assets/resource.sjs", moduleMetadataHandle);
+        DocumentMetadataHandle.DocumentPermissions modulePerms = moduleMetadataHandle.getPermissions();
 
-            DocumentMetadataHandle moduleMetadataHandle = new DocumentMetadataHandle();
-            modMgr.readMetadata("/marklogic.rest.resource/mlBatches/assets/resource.sjs", moduleMetadataHandle);
-            DocumentMetadataHandle.DocumentPermissions modulePerms = moduleMetadataHandle.getPermissions();
+        Assertions.assertEquals(DocumentMetadataHandle.Capability.UPDATE, modulePerms.get("data-hub-environment-manager").iterator().next());
+        Assertions.assertNull(modulePerms.get("rest-admin-internal"));
 
-            Assertions.assertEquals(DocumentMetadataHandle.Capability.UPDATE, modulePerms.get("data-hub-environment-manager").iterator().next());
-            Assertions.assertNull(modulePerms.get("rest-admin-internal"));
+        moduleMetadataHandle = new DocumentMetadataHandle();
+        modMgr.readMetadata("/marklogic.rest.resource/mlBatches/assets/resource.xqy", moduleMetadataHandle);
+        modulePerms = moduleMetadataHandle.getPermissions();
 
-            moduleMetadataHandle = new DocumentMetadataHandle();
-            modMgr.readMetadata("/marklogic.rest.resource/mlBatches/assets/resource.xqy", moduleMetadataHandle);
-            modulePerms = moduleMetadataHandle.getPermissions();
+        Assertions.assertEquals(DocumentMetadataHandle.Capability.UPDATE, modulePerms.get("data-hub-environment-manager").iterator().next());
+        Assertions.assertNull(modulePerms.get("rest-admin-internal"));
 
-            Assertions.assertEquals(DocumentMetadataHandle.Capability.UPDATE, modulePerms.get("data-hub-environment-manager").iterator().next());
-            Assertions.assertNull(modulePerms.get("rest-admin-internal"));
+        moduleMetadataHandle = new DocumentMetadataHandle();
+        modMgr.readMetadata("/marklogic.rest.transform/mlGenerateFunctionMetadata/assets/transform.sjs", moduleMetadataHandle);
+        modulePerms = moduleMetadataHandle.getPermissions();
 
-            moduleMetadataHandle = new DocumentMetadataHandle();
-            modMgr.readMetadata("/marklogic.rest.transform/mlGenerateFunctionMetadata/assets/transform.sjs", moduleMetadataHandle);
-            modulePerms = moduleMetadataHandle.getPermissions();
+        Assertions.assertEquals(DocumentMetadataHandle.Capability.UPDATE, modulePerms.get("data-hub-environment-manager").iterator().next());
+        Assertions.assertNull(modulePerms.get("rest-admin-internal"));
 
-            Assertions.assertEquals(DocumentMetadataHandle.Capability.UPDATE, modulePerms.get("data-hub-environment-manager").iterator().next());
-            Assertions.assertNull(modulePerms.get("rest-admin-internal"));
+        moduleMetadataHandle = new DocumentMetadataHandle();
+        modMgr.readMetadata("/marklogic.rest.transform/mlGenerateFunctionMetadata/assets/transform.xqy", moduleMetadataHandle);
+        modulePerms = moduleMetadataHandle.getPermissions();
 
-            moduleMetadataHandle = new DocumentMetadataHandle();
-            modMgr.readMetadata("/marklogic.rest.transform/mlGenerateFunctionMetadata/assets/transform.xqy", moduleMetadataHandle);
-            modulePerms = moduleMetadataHandle.getPermissions();
+        Assertions.assertEquals(DocumentMetadataHandle.Capability.UPDATE, modulePerms.get("data-hub-environment-manager").iterator().next());
+        Assertions.assertNull(modulePerms.get("rest-admin-internal"));
+    }
 
-            Assertions.assertEquals(DocumentMetadataHandle.Capability.UPDATE, modulePerms.get("data-hub-environment-manager").iterator().next());
-            Assertions.assertNull(modulePerms.get("rest-admin-internal"));
-        } finally {
-            new DatabaseManager(getHubClient().getManageClient()).clearDatabase(HubConfig.DEFAULT_MODULES_DB_NAME);
-            installHubModules();
-            installHubArtifacts();
-        }
+    //The clearUserModules() should run successfully without errors after the module permissions are updated.
+    @Test
+    void runClearUserModulesWithUpdatedPermissions(){
+        runAsDataHubDeveloper();
+        new DataHubImpl(getHubConfig()).clearUserModules();
     }
 
 }


### PR DESCRIPTION
### Description
Do not refresh metadata when fetching transform,resources
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

