### PR TITLE
DHFPROD-6476: Step processor failure now reports correct job counts

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/impl/FlowRunnerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/impl/FlowRunnerImpl.java
@@ -256,11 +256,8 @@ public class FlowRunnerImpl implements FlowRunner {
             stepsMap.remove(jobId);
             isJobCancelled.set(true);
         }
-        else {
-            throw new RuntimeException("Job not running");
-        }
 
-        if (jobId.equals(runningJobId)) {
+        if (jobId != null && jobId.equals(runningJobId)) {
             if (stepRunner != null) {
                 stepRunner.stop();
             }


### PR DESCRIPTION
### Description

Had to remove the throwing of an exception from stopJob - I couldn't find any reason why that would be good. With it there, the test was failing because 4 failed items were being reported instead of 2. Specifically, a stepItemFailureListener was throwing this exception, after the 2 failed items had already been captured. So it seems unnecessary to throw an exception when stopJob is called but the jobId cannot be found. Also ran all of the flow tests and none of them failed with this change. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

