### PR TITLE
DHFPROD-6482: Step creation in HC doesn't set the "collections" to step name

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestion.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestion.spec.tsx
@@ -2,6 +2,7 @@ import {Application} from "../../../support/application.config";
 import {tiles, toolbar} from "../../../support/components/common";
 import loadPage from "../../../support/pages/load";
 import runPage from "../../../support/pages/run";
+import browsePage from "../../../support/pages/browse";
 
 describe("Default ingestion ", () => {
 
@@ -426,7 +427,15 @@ describe("Default ingestion ", () => {
     runPage.runStep(stepName).click();
     cy.uploadFile("input/test-1.xml");
     cy.verifyStepRunResult("success", "Ingestion", stepName);
-    tiles.closeRunMessage();
+
+    //Verify step name appears as a collection facet in explorer
+    runPage.explorerLink().click();
+    browsePage.waitForSpinnerToDisappear();
+    cy.waitForAsyncRequest();
+
+    browsePage.getTotalDocuments().should("be", 1);
+    browsePage.getFacet("collection").should("exist");
+    browsePage.getFacetItemCheckbox("collection", stepName).should("be.visible");
   });
 
 });

--- a/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.tsx
+++ b/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.tsx
@@ -214,7 +214,7 @@ const AdvancedSettings: React.FC<Props> = (props) => {
   useEffect(() => {
     props.setHasChanged(hasFormChanged());
     props.setPayload(getPayload());
-  }, [batchSize, sourceDatabase, targetCollections, advancedTargetCollectionsTouched, defaultTargetCollections, targetPermissions, targetDatabase, validateEntity, provGranularity, headers, processors, customHook, additionalSettings, targetCollections, targetFormat, targetPermissions, isCustomIngestion, stepDefinitionName]);
+  }, [batchSize, sourceDatabase, targetCollections, advancedTargetCollectionsTouched, defaultTargetCollections, targetPermissions, targetDatabase, validateEntity, provGranularity, headers, processors, customHook, additionalSettings, targetCollections, targetFormat, targetPermissions, isCustomIngestion, stepDefinitionName, defaultCollections]);
 
   // On change of default collections in parent, update default collections if not empty
   useEffect(() => {


### PR DESCRIPTION
### Description
Quick fix to update defaultCollection value when user provides the step name in UI.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

