### PR TITLE
DHFPROD-6429: Info icons in Add Strategy modal are not properly aligned in Win4

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merge-strategy-dialog/merge-strategy-dialog.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merge-strategy-dialog/merge-strategy-dialog.module.scss
@@ -26,7 +26,7 @@
 .questionCircle {
     font-size: 12px;
     color: #7F86B5;
-    margin-left: 20px;
+    margin-left: 12px;
 }
 
 .addButtonContainer {

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merge-strategy-dialog/merge-strategy-dialog.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merge-strategy-dialog/merge-strategy-dialog.tsx
@@ -328,11 +328,12 @@ const MergeStrategyDialog: React.FC<Props> = (props) => {
         >
           <Radio.Group  value={radioValuesOptionClicked} onChange={handleChange}  name={"maxValues"}>
             <Radio value={1} > All</Radio>
-            <Radio value={2} ><Input id="maxValuesStrategyInput" value={maxValues} placeholder={"Enter max values"} onChange={handleChange} ></Input></Radio>
+            <Radio value={2} ><Input id="maxValuesStrategyInput" value={maxValues} placeholder={"Enter max values"} onChange={handleChange} ></Input>
+              <MLTooltip title={MergeRuleTooltips.maxValues}>
+                <Icon type="question-circle" className={styles.questionCircle} theme="filled" />
+              </MLTooltip>
+            </Radio>
           </Radio.Group>
-          <MLTooltip title={MergeRuleTooltips.maxValues}>
-            <Icon type="question-circle" className={styles.questionCircle} theme="filled" />
-          </MLTooltip>
         </Form.Item>
         <Form.Item
           colon={false}
@@ -341,11 +342,12 @@ const MergeStrategyDialog: React.FC<Props> = (props) => {
         >
           <Radio.Group  value={radioSourcesOptionClicked} onChange={handleChange}  name={"maxSources"}>
             <Radio value={1} > All</Radio>
-            <Radio value={2} ><Input id="maxSourcesStrategyInput" value={maxSources} onChange={handleChange} placeholder={"Enter max sources"}></Input></Radio>
+            <Radio value={2} ><Input id="maxSourcesStrategyInput" value={maxSources} onChange={handleChange} placeholder={"Enter max sources"}></Input>
+              <MLTooltip title={MergeRuleTooltips.maxSources}>
+                <Icon type="question-circle" className={styles.questionCircle} theme="filled" />
+              </MLTooltip>
+            </Radio>
           </Radio.Group>
-          <MLTooltip title={MergeRuleTooltips.maxSources}>
-            <Icon type="question-circle" className={styles.questionCircle} theme="filled" />
-          </MLTooltip>
         </Form.Item>
         {!isCustomStrategy && <div className={styles.priorityOrderContainer} data-testid={"prioritySlider"}>
           <div><p className={styles.priorityText}>Priority Order<MLTooltip title={multiSliderTooltips.priorityOrder} placement="right">


### PR DESCRIPTION
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

