### PR TITLE
DHFPROD-6515: Adding new privileges

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/CreateGranularPrivilegesCommand.java
@@ -10,6 +10,7 @@ import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.MarkLogicVersion;
 import com.marklogic.mgmt.ManageClient;
+import com.marklogic.mgmt.ManageConfig;
 import com.marklogic.mgmt.api.API;
 import com.marklogic.mgmt.api.configuration.Configuration;
 import com.marklogic.mgmt.api.configuration.Configurations;
@@ -81,12 +82,22 @@ public class CreateGranularPrivilegesCommand extends LoggingObject implements Co
         "data-hub-module-writer",
         "data-hub-odbc-user",
         "data-hub-saved-query-user",
+        "data-hub-spawn-user",
         "data-hub-step-definition-reader",
         "data-hub-step-definition-writer",
         "data-hub-temporal-user",
         "data-hub-user-reader",
         "pii-reader",
-        "redaction-user"
+        "redaction-user",
+
+        // Added in 5.4.0 to allow for pre-5.2 customers to create custom roles that can access documents that have
+        // permissions with these roles
+        "rest-reader",
+        "rest-writer",
+
+        // Added in 5.4.0 to allow for custom roles to use DLS
+        "dls-user",
+        "dls-admin"
     );
 
 
@@ -121,8 +132,7 @@ public class CreateGranularPrivilegesCommand extends LoggingObject implements Co
         if (new MarkLogicVersion(hubConfig.getManageClient()).isVersionCompatibleWith520Roles()) {
             Map<String, Privilege> granularPrivileges = buildGranularPrivileges(context.getManageClient());
             saveGranularPrivileges(context.getManageClient(), granularPrivileges);
-        }
-        else {
+        } else {
             logger.info("Not running, as version of MarkLogic does not support the granular privileges in Data Hub roles");
         }
     }
@@ -140,8 +150,7 @@ public class CreateGranularPrivilegesCommand extends LoggingObject implements Co
             granularPrivileges.values().forEach(privilege -> {
                 mgr.deleteAtPath("/manage/v2/privileges/" + privilege.getPrivilegeName() + "?kind=execute");
             });
-        }
-        else {
+        } else {
             logger.info("Not running, as version of MarkLogic does not support the granular privileges in Data Hub roles");
         }
     }

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-common-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-common-writer.json
@@ -6,8 +6,18 @@
   ],
   "privilege": [
     {
-      "privilege-name": "xdmp:document-load",
-      "action": "http://marklogic.com/xdmp/privileges/xdmp-document-load",
+      "privilege-name": "ps-user",
+      "action": "http://marklogic.com/xdmp/privileges/ps-user",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "rest-writer",
+      "action": "http://marklogic.com/xdmp/privileges/rest-writer",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "sem:sparql-update",
+      "action": "http://marklogic.com/xdmp/privileges/sem-sparql-update",
       "kind": "execute"
     },
     {
@@ -21,21 +31,6 @@
       "kind": "execute"
     },
     {
-      "privilege-name": "ps-user",
-      "action": "http://marklogic.com/xdmp/privileges/ps-user",
-      "kind": "execute"
-    },
-    {
-      "privilege-name": "rest-writer",
-      "action": "http://marklogic.com/xdmp/privileges/rest-writer",
-      "kind": "execute"
-    },
-    {
-      "privilege-name": "xdmp:xslt-invoke",
-      "action": "http://marklogic.com/xdmp/privileges/xslt-invoke",
-      "kind": "execute"
-    },
-    {
       "privilege-name": "xdbc:insert",
       "action": "http://marklogic.com/xdmp/privileges/xdbc-insert",
       "kind": "execute"
@@ -43,6 +38,11 @@
     {
       "privilege-name": "xdbc:insert-in",
       "action": "http://marklogic.com/xdmp/privileges/xdbc-insert-in",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:document-load",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-document-load",
       "kind": "execute"
     }
   ]

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-common.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-common.json
@@ -8,6 +8,51 @@
   ],
   "privilege": [
     {
+      "privilege-name": "debug-any-requests",
+      "action": "http://marklogic.com/xdmp/privileges/debug-any-requests",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "debug-my-requests",
+      "action": "http://marklogic.com/xdmp/privileges/debug-my-requests",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "my-transaction-locks",
+      "action": "http://marklogic.com/xdmp/privileges/my-transaction-locks",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "profile-my-requests",
+      "action": "http://marklogic.com/xdmp/privileges/profile-my-requests",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "sem:sparql",
+      "action": "http://marklogic.com/xdmp/privileges/sem-sparql",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "set-my-transaction-name",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-set-transaction-name-my",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "term-query",
+      "action": "http://marklogic.com/xdmp/privileges/term-query",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdbc:eval",
+      "action": "http://marklogic.com/xdmp/privileges/xdbc-eval",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdbc:eval-in",
+      "action": "http://marklogic.com/xdmp/privileges/xdbc-eval-in",
+      "kind": "execute"
+    },
+    {
       "privilege-name": "xdmp:eval-in",
       "action": "http://marklogic.com/xdmp/privileges/xdmp-eval-in",
       "kind": "execute"
@@ -23,13 +68,18 @@
       "kind": "execute"
     },
     {
-      "privilege-name": "xdbc:eval",
-      "action": "http://marklogic.com/xdmp/privileges/xdbc-eval",
+      "privilege-name": "xdmp:plan",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-plan",
       "kind": "execute"
     },
     {
-      "privilege-name": "xdbc:eval-in",
-      "action": "http://marklogic.com/xdmp/privileges/xdbc-eval-in",
+      "privilege-name": "xdmp:sql",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-sql",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:timestamp",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-timestamp",
       "kind": "execute"
     },
     {
@@ -38,13 +88,13 @@
       "kind": "execute"
     },
     {
-      "privilege-name": "sem:sparql",
-      "action": "http://marklogic.com/xdmp/privileges/sem-sparql",
+      "privilege-name": "xdmp:with-namespaces",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-with-namespaces",
       "kind": "execute"
     },
     {
-      "privilege-name": "xdmp:with-namespaces",
-      "action": "http://marklogic.com/xdmp/privileges/xdmp-with-namespaces",
+      "privilege-name": "xdmp:xslt-invoke",
+      "action": "http://marklogic.com/xdmp/privileges/xslt-invoke",
       "kind": "execute"
     }
   ]

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-spawn-user.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-spawn-user.json
@@ -1,0 +1,11 @@
+{
+  "role-name": "data-hub-spawn-user",
+  "description": "Permits using xdmp.spawn",
+  "privilege": [
+    {
+      "privilege-name": "xdmp:spawn",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-spawn",
+      "kind": "execute"
+    }
+  ]
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubCommonTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubCommonTest.java
@@ -1,0 +1,37 @@
+package com.marklogic.hub.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DataHubCommonTest extends AbstractSecurityTest {
+
+    @Override
+    protected String getRoleName() {
+        return "data-hub-common";
+    }
+
+    @Test
+    void documentPrivilegeInclusions() {
+        List<String> privilegeNames = roleBeingTested.getPrivilege().stream()
+            .map(rolePrivilege -> rolePrivilege.getPrivilegeName())
+            .collect(Collectors.toList());
+
+        assertTrue(privilegeNames.contains("debug-any-requests"), "Added in 5.4.0 to support debugging, particularly by Support");
+        assertTrue(privilegeNames.contains("debug-my-requests"), "Added in 5.4.0 to support debugging, particularly by Support");
+        assertTrue(privilegeNames.contains("my-transaction-locks"), "Added in 5.4.0 to support debugging");
+        assertTrue(privilegeNames.contains("profile-my-requests"), "Added in 5.4.0 to support debugging performance");
+        assertTrue(privilegeNames.contains("set-my-transaction-name"), "Added in 5.4.0 to support custom code");
+        assertTrue(privilegeNames.contains("term-query"), "Added in 5.4.0 to allow for cts.termQuery usage, which is needed " +
+            "for 'expert' queries like finding all documents with a particular permission");
+        assertTrue(privilegeNames.contains("xdmp:plan"), "Added in 5.4.0 to support debugging");
+        assertTrue(privilegeNames.contains("xdmp:sql"), "Added in 5.4.0 to allow for SQL queries in custom code");
+        assertTrue(privilegeNames.contains("xdmp:timestamp"), "Added in 5.4.0 to allow for point-in-time queries in custom code");
+        assertTrue(privilegeNames.contains("xdmp:xslt-invoke"), "In 5.4.0, moved from data-hub-common-writer to data-hub-common " +
+            "since it does not involve writing data");
+    }
+
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubSecurityAdminTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubSecurityAdminTest.java
@@ -97,7 +97,7 @@ public class DataHubSecurityAdminTest extends AbstractSecurityTest {
         Role customRole = new Role(userWithRoleBeingTestedApi, roleName);
         customRole.setRole(CreateGranularPrivilegesCommand.ROLES_THAT_CAN_BE_INHERITED);
 
-        assertEquals(45, customRole.getRole().size(), "As of DHFPROD-6450 in 5.4.0, 45 roles are expected to be " +
+        assertEquals(50, customRole.getRole().size(), "As of DHFPROD-6515 in 5.4.0, 50 roles are expected to be " +
             "inheritable in custom roles created by a user with the data-hub-security-admin role. When new roles must " +
             "be inheritable, they should be added to the list in CreateGranularPrivilegesCommand, and this count " +
             "should be updated to match the new total.");

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubSpawnUserTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubSpawnUserTest.java
@@ -1,0 +1,31 @@
+package com.marklogic.hub.security;
+
+import com.marklogic.client.FailedRequestException;
+import com.marklogic.hub.AbstractHubCoreTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DataHubSpawnUserTest extends AbstractHubCoreTest {
+
+    @Test
+    void useSpawn() {
+        runAsTestUserWithRoles("data-hub-spawn-user", "data-hub-common");
+        useXdmpSpawn(); // lack of error means success
+
+        runAsDataHubDeveloper();
+        FailedRequestException ex = assertThrows(FailedRequestException.class, () -> useXdmpSpawn(),
+            "No DHF role inherits data-hub-spawn-user by default; if Pari wants to use xdmp.spawn, she'll need to do " +
+                "so via a custom role that inherits data-hub-spawn-user. This is done to not encourage xdmp.spawn " +
+                "usage and instead require users to opt into its usage.");
+        assertTrue(ex.getMessage().contains("Need privilege: http://marklogic.com/xdmp/privileges/xdmp-spawn"));
+    }
+
+    private void useXdmpSpawn() {
+        // We don't care about the response, just whether an error is thrown or not
+        getHubClient().getFinalClient().newServerEval()
+            .javascript("xdmp.spawn('/data-hub/5/data-services/models/getPrimaryEntityTypes.sjs')")
+            .evalAs(String.class);
+    }
+}


### PR DESCRIPTION
### Description

Alphabetized privs in data-hub-common and data-hub-common-writer.

Also moved xdmp:xslt-eval from common-writer to common. This seems reasonable as it doesn't involve writing data, and Pari may want to use it in custom code with a read-only user. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [ ] JIRA_ID included in all the commit messages
- [ ] PR title is in the format JIRA_ID:Title
- [ ] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [ ] Code passes ESLint tests
- [ ] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests

