### PR TITLE
DHFPROD-6427: users with insufficient permission can no longer see curate page

### DIFF
--- a/marklogic-data-hub-central/ui/src/assets/mock-data/authorities.testutils.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/authorities.testutils.ts
@@ -58,6 +58,18 @@ class DeveloperRolesService implements IAuthoritiesContextInterface {
     public canClearUserData:() => boolean = () => {
       return true;
     };
+    public canAccessLoad: () => boolean = () => {
+      return true;
+    };
+    public canAccessModel: () => boolean = () => {
+      return true;
+    };
+    public canAccessCurate: () => boolean = () => {
+      return true;
+    };
+    public canAccessRun: () => boolean = () => {
+      return true;
+    };
 }
 
 // Roles service for data-hub-operator
@@ -118,6 +130,18 @@ class OperatorRolesService implements IAuthoritiesContextInterface {
     public canClearUserData:() => boolean = () => {
       return false;
     };
+    public canAccessLoad: () => boolean = () => {
+      return true;
+    };
+    public canAccessModel: () => boolean = () => {
+      return true;
+    };
+    public canAccessCurate: () => boolean = () => {
+      return true;
+    };
+    public canAccessRun: () => boolean = () => {
+      return true;
+    };
 }
 
 class HCUserRolesService implements IAuthoritiesContextInterface {
@@ -175,6 +199,18 @@ class HCUserRolesService implements IAuthoritiesContextInterface {
       return false;
     };
     public canClearUserData:() => boolean = () => {
+      return false;
+    };
+    public canAccessLoad: () => boolean = () => {
+      return false;
+    };
+    public canAccessModel: () => boolean = () => {
+      return false;
+    };
+    public canAccessCurate: () => boolean = () => {
+      return false;
+    };
+    public canAccessRun: () => boolean = () => {
       return false;
     };
 }

--- a/marklogic-data-hub-central/ui/src/config/messages.config.tsx
+++ b/marklogic-data-hub-central/ui/src/config/messages.config.tsx
@@ -17,11 +17,14 @@ const AdvancedSettingsMessages = {
 };
 
 const ConfirmYesNoMessages = {
-        'discardChanges' : 'Discard changes?',
-        'saveChanges' : 'Save changes?'
+    'discardChanges' : 'Discard changes?',
+    'saveChanges' : 'Save changes?'
 };
+
+const MissingPagePermission = "You do not have permission to view this page.";
 
 export {
     AdvancedSettingsMessages,
-    ConfirmYesNoMessages
+    ConfirmYesNoMessages,
+    MissingPagePermission
 };

--- a/marklogic-data-hub-central/ui/src/pages/Curate.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Curate.test.tsx
@@ -7,6 +7,7 @@ import mocks from "../api/__mocks__/mocks.data";
 import Curate from "./Curate";
 import {MemoryRouter} from "react-router-dom";
 import tiles from "../config/tiles.config";
+import {MissingPagePermission} from "../config/messages.config";
 
 jest.mock("axios");
 
@@ -83,5 +84,15 @@ describe("Curate component", () => {
     fireEvent.click(getByTestId("Mapping1-delete"));
     fireEvent.click(getByText("Yes"));
     expect(axiosMock.delete).toHaveBeenNthCalledWith(1, "/api/steps/mapping/Mapping1");
+  });
+
+  test("Verify user with no authorities cannot access page", async () => {
+    const authorityService = new AuthoritiesService();
+    const {getByText, queryByText} = await render(<MemoryRouter><AuthoritiesContext.Provider value={authorityService}><Curate/></AuthoritiesContext.Provider></MemoryRouter>);
+
+    expect(await(waitForElement(() => getByText(MissingPagePermission)))).toBeInTheDocument();
+
+    // entities should not be visible
+    expect(queryByText("Customer")).not.toBeInTheDocument();
   });
 });

--- a/marklogic-data-hub-central/ui/src/pages/Curate.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Curate.tsx
@@ -6,6 +6,7 @@ import {UserContext} from "../util/user-context";
 import axios from "axios";
 import EntityTiles from "../components/entities/entity-tiles";
 import tiles from "../config/tiles.config";
+import {MissingPagePermission} from "../config/messages.config";
 
 const Curate: React.FC = () => {
 
@@ -27,6 +28,7 @@ const Curate: React.FC = () => {
   const canWriteMatchMerge = authorityService.canWriteMatchMerge();
   const canWriteFlow = authorityService.canWriteFlow();
   const canReadCustom = authorityService.canReadCustom();
+  const canAccessCurate = authorityService.canAccessCurate();
 
   const getEntityModels = async () => {
     try {
@@ -100,26 +102,32 @@ const Curate: React.FC = () => {
     }
   };
 
-
   return (
     <div className={styles.curateContainer}>
-      <div className={styles.intro}>
-        <p>{tiles.curate.intro}</p>
-      </div>
-      <EntityTiles
-        flows={flows}
-        canReadMatchMerge={canReadMatchMerge}
-        canWriteMatchMerge={canWriteMatchMerge}
-        canWriteMapping={canWriteMapping}
-        canReadMapping={canReadMapping}
-        canReadCustom={canReadCustom}
-        canWriteCustom={false}
-        entityModels={entityModels}
-        getEntityModels={getEntityModels}
-        canWriteFlow={canWriteFlow}
-        addStepToFlow={addStepToFlow}
-        addStepToNew={addStepToNew}
-      />
+      {
+        canAccessCurate ?
+          [
+            <div className={styles.intro}>
+              <p>{tiles.curate.intro}</p>
+            </div>,
+            <EntityTiles
+              flows={flows}
+              canReadMatchMerge={canReadMatchMerge}
+              canWriteMatchMerge={canWriteMatchMerge}
+              canWriteMapping={canWriteMapping}
+              canReadMapping={canReadMapping}
+              canReadCustom={canReadCustom}
+              canWriteCustom={false}
+              entityModels={entityModels}
+              getEntityModels={getEntityModels}
+              canWriteFlow={canWriteFlow}
+              addStepToFlow={addStepToFlow}
+              addStepToNew={addStepToNew}
+            />
+          ]
+          :
+          <p>{MissingPagePermission}</p>
+      }
     </div>
   );
 

--- a/marklogic-data-hub-central/ui/src/pages/Load.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Load.tsx
@@ -11,6 +11,7 @@ import {createStep, updateStep, getSteps, deleteStep} from "../api/steps";
 import {AuthoritiesContext} from "../util/authorities";
 import tiles from "../config/tiles.config";
 import {LoadingContext} from "../util/loading-context";
+import {MissingPagePermission} from "../config/messages.config";
 
 export type ViewType =  "card" | "list";
 
@@ -36,6 +37,7 @@ const Load: React.FC = () => {
   const canReadOnly = authorityService.canReadLoad();
   const canReadWrite = authorityService.canWriteLoad();
   const canWriteFlow = authorityService.canWriteFlow();
+  const canAccessLoad = authorityService.canAccessLoad();
 
   // Set context for switching views
   const handleViewSelection = (view) => {
@@ -218,7 +220,7 @@ const Load: React.FC = () => {
 
   return (
     <div>
-      {canReadWrite || canReadOnly ?
+      {canAccessLoad ?
         <div className={styles.loadContainer}>
           <div className={styles.intro}>
             <p>{tiles.load.intro}</p>
@@ -227,7 +229,11 @@ const Load: React.FC = () => {
             </div>
           </div>
           {output}
-        </div> : ""
+        </div>
+        :
+        <div className={styles.loadContainer}>
+          <p>{MissingPagePermission}</p>
+        </div>
       }
     </div>
   );

--- a/marklogic-data-hub-central/ui/src/pages/Modeling.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Modeling.tsx
@@ -16,6 +16,7 @@ import {AuthoritiesContext} from "../util/authorities";
 import {EntityModified} from "../types/modeling-types";
 import {ConfirmationType} from "../types/common-types";
 import tiles from "../config/tiles.config";
+import {MissingPagePermission} from "../config/messages.config";
 
 const Modeling: React.FC = () => {
   const {handleError} = useContext(UserContext);
@@ -36,6 +37,7 @@ const Modeling: React.FC = () => {
   const authorityService = useContext(AuthoritiesContext);
   const canReadEntityModel = authorityService.canReadEntityModel();
   const canWriteEntityModel = authorityService.canWriteEntityModel();
+  const canAccessModel = authorityService.canAccessModel();
 
   useEffect(() => {
     if (canReadEntityModel) {
@@ -159,7 +161,7 @@ const Modeling: React.FC = () => {
     Revert All
   </MLButton>;
 
-  if (canReadEntityModel) {
+  if (canAccessModel) {
     return (
       <div className={styles.modelContainer}>
         <div className={styles.intro}>
@@ -229,7 +231,13 @@ const Modeling: React.FC = () => {
         />
       </div>
     );
-  } else return null;
+  } else {
+    return (
+      <div className={styles.modelContainer}>
+        <p>{MissingPagePermission}</p>
+      </div>
+    );
+  }
 };
 
 export default Modeling;

--- a/marklogic-data-hub-central/ui/src/pages/Run.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Run.tsx
@@ -8,6 +8,7 @@ import {UserContext} from "../util/user-context";
 import {useHistory} from "react-router-dom";
 import tiles from "../config/tiles.config";
 import {getFromPath} from "../util/json-utils";
+import {MissingPagePermission} from "../config/messages.config";
 
 const {Panel} = Collapse;
 
@@ -41,6 +42,7 @@ const Run = (props) => {
   const canReadFlow = authorityService.canReadFlow();
   const canWriteFlow = authorityService.canWriteFlow();
   const hasOperatorRole = authorityService.canRunStep();
+  const canAccessRun = authorityService.canAccessRun();
 
   //For handling flows expand and collapse within Run tile
   const [newFlowName, setNewFlowName] = useState("");
@@ -427,28 +429,35 @@ const Run = (props) => {
   return (
     <div>
       <div className={styles.runContainer}>
-        <div className={styles.intro}>
-          <p>{tiles.run.intro}</p>
-        </div>
-        <Flows
-          flows={flows}
-          steps={steps}
-          deleteFlow={deleteFlow}
-          createFlow={createFlow}
-          updateFlow={updateFlow}
-          runStep={runStep}
-          deleteStep={deleteStep}
-          canReadFlow={canReadFlow}
-          canWriteFlow={canWriteFlow}
-          hasOperatorRole={hasOperatorRole}
-          running={running}
-          uploadError={uploadError}
-          newStepToFlowOptions={props.newStepToFlowOptions}
-          addStepToFlow={addStepToFlow}
-          flowsDefaultActiveKey={flowsDefaultActiveKey}
-          showStepRunResponse={showStepRunResponse}
-          runEnded={runEnded}
-        />
+        {
+          canAccessRun ?
+            [
+              <div className={styles.intro}>
+                <p>{tiles.run.intro}</p>
+              </div>,
+              <Flows
+                flows={flows}
+                steps={steps}
+                deleteFlow={deleteFlow}
+                createFlow={createFlow}
+                updateFlow={updateFlow}
+                runStep={runStep}
+                deleteStep={deleteStep}
+                canReadFlow={canReadFlow}
+                canWriteFlow={canWriteFlow}
+                hasOperatorRole={hasOperatorRole}
+                running={running}
+                uploadError={uploadError}
+                newStepToFlowOptions={props.newStepToFlowOptions}
+                addStepToFlow={addStepToFlow}
+                flowsDefaultActiveKey={flowsDefaultActiveKey}
+                showStepRunResponse={showStepRunResponse}
+                runEnded={runEnded}
+              />
+            ]
+            :
+            <p>{MissingPagePermission}</p>
+        }
       </div>
     </div>
   );

--- a/marklogic-data-hub-central/ui/src/util/authorities.tsx
+++ b/marklogic-data-hub-central/ui/src/util/authorities.tsx
@@ -20,6 +20,12 @@ export interface IAuthoritiesContextInterface {
     isSavedQueryUser: () => boolean;
     canRunStep: () => boolean;
     canClearUserData: () => boolean;
+
+    // for accessing tiles
+    canAccessLoad: () => boolean;
+    canAccessModel: () => boolean;
+    canAccessCurate: () => boolean;
+    canAccessRun: () => boolean;
 }
 
 /**
@@ -86,6 +92,23 @@ export class AuthoritiesService implements IAuthoritiesContextInterface {
     };
     public canClearUserData:() => boolean = () => {
       return this.authorities.includes("clearUserData");
+    };
+
+    /* can see Load tile */
+    public canAccessLoad: () => boolean = () => {
+      return this.canReadLoad() || this.canWriteLoad();
+    };
+    /* can see Model tile */
+    public canAccessModel: () => boolean = () => {
+      return this.canReadEntityModel();
+    };
+    /* can see Curate tile */
+    public canAccessCurate: () => boolean = () => {
+      return this.canReadMapping() || this.canReadMatchMerge() || this.canReadCustom();
+    };
+    /* can see Run tile */
+    public canAccessRun: () => boolean = () => {
+      return this.canReadFlow();
     };
 }
 


### PR DESCRIPTION
### Description
Note to reviewers: I also took the liberty of adding a missing permissions message to other tiles.  Please also check those pages by directly manipulating the URL (to /tiles/run, etc.).
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

