### PR TITLE
DHFPROD-6522: totalEvents is now calculated correctly

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/impl/RunFlowOnOverFiveThousandItemsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/impl/RunFlowOnOverFiveThousandItemsTest.java
@@ -1,0 +1,42 @@
+package com.marklogic.hub.flow.impl;
+
+import com.marklogic.client.io.Format;
+import com.marklogic.hub.AbstractHubCoreTest;
+import com.marklogic.hub.flow.FlowInputs;
+import com.marklogic.hub.flow.RunFlowResponse;
+import com.marklogic.hub.step.RunStepResponse;
+import com.marklogic.hub.test.Customer;
+import com.marklogic.hub.test.ReferenceModelProject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RunFlowOnOverFiveThousandItemsTest extends AbstractHubCoreTest {
+
+    @Test
+    void test() {
+        installProjectInFolder("test-projects/simple-custom-step");
+
+        final int customerCount = 5001;
+        writeManyCustomers(customerCount);
+        RunFlowResponse response = runFlow(new FlowInputs("simpleCustomStepFlow"));
+        RunStepResponse stepResponse = response.getStepResponses().get("1");
+
+        assertEquals(customerCount, stepResponse.getTotalEvents(),
+            "CollectorImpl is expected to have a size of 5000; this ensures that the correct total size is returned");
+        assertEquals(customerCount, stepResponse.getSuccessfulEvents());
+        assertEquals(0, stepResponse.getFailedEvents());
+        assertEquals(51, stepResponse.getSuccessfulBatches(), "Assumes a default batch size of 100, so we have " +
+            "51 batches with the last batch having 1 doc in it");
+        assertEquals(0, stepResponse.getFailedBatches());
+    }
+
+    private void writeManyCustomers(int count) {
+        ReferenceModelProject project = new ReferenceModelProject(getHubClient());
+        doWithWriteBatcher(getHubClient().getStagingClient(), writeBatcher -> {
+            for (int i = 1; i <= count; i++) {
+                writeBatcher.add(project.buildCustomerInstanceToWrite(new Customer(i, "Jane" + i), Format.JSON, null));
+            }
+        });
+    }
+}

--- a/marklogic-data-hub/src/test/resources/test-projects/simple-custom-step/flows/simpleCustomStepFlow.flow.json
+++ b/marklogic-data-hub/src/test/resources/test-projects/simple-custom-step/flows/simpleCustomStepFlow.flow.json
@@ -1,0 +1,16 @@
+{
+  "name": "simpleCustomStepFlow",
+  "steps": {
+    "1": {
+      "name": "simpleCustomStep",
+      "stepDefinitionName": "simpleCustomStep-step",
+      "stepDefinitionType": "CUSTOM",
+      "options": {
+        "sourceQuery": "cts.collectionQuery('Customer')",
+        "sourceDatabase": "data-hub-STAGING",
+        "targetDatabase": "data-hub-FINAL",
+        "permissions": "data-hub-common,read,data-hub-common,update"
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/resources/test-projects/simple-custom-step/modules/root/custom-modules/custom/simpleCustomStep/simpleCustomStep.sjs
+++ b/marklogic-data-hub/src/test/resources/test-projects/simple-custom-step/modules/root/custom-modules/custom/simpleCustomStep/simpleCustomStep.sjs
@@ -1,0 +1,7 @@
+function main(contentItem, options) {
+  return contentItem;
+}
+
+module.exports = {
+  main: main
+};

--- a/marklogic-data-hub/src/test/resources/test-projects/simple-custom-step/step-definitions/custom/simpleCustomStep/simpleCustomStep.step.json
+++ b/marklogic-data-hub/src/test/resources/test-projects/simple-custom-step/step-definitions/custom/simpleCustomStep/simpleCustomStep.step.json
@@ -1,0 +1,9 @@
+{
+  "lang": "zxx",
+  "name": "simpleCustomStep-step",
+  "type": "CUSTOM",
+  "options": {
+    "outputFormat": "json"
+  },
+  "modulePath": "/custom-modules/custom/simpleCustomStep/simpleCustomStep.sjs"
+}


### PR DESCRIPTION
### Description

uris.size() was being called after uris.close(), which resulted in an incorrect count.

Did some cleanup in QueryStepRunner as well - e.g. removing try/catch blocks that weren't doing anything. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

