### PR TITLE
DHFPROD-6369: Fix error handling in Run when a flow is missing a step

### DIFF
--- a/marklogic-data-hub-central/ui/src/api/__mocks__/mocks.data.ts
+++ b/marklogic-data-hub-central/ui/src/api/__mocks__/mocks.data.ts
@@ -196,6 +196,27 @@ const runAddStepAPI = (axiosMock) => {
   });
 };
 
+// For testing display of a flow missing a step (DHFPROD-6369)
+const runMissingStep = (axiosMock) => {
+  axiosMock.get["mockImplementation"]((url) => {
+    switch (url) {
+    case "/api/flows":
+      return Promise.reject({
+        "response": {
+          "data": {
+            "code": 400,
+            "message": "Error message"
+          }
+        }
+      });
+    case "/api/steps":
+      return Promise.resolve(curateData.steps);
+    default:
+      return Promise.reject(new Error("not found"));
+    }
+  });
+};
+
 const runErrorsAPI = (axiosMock) => {
   return axiosMock.get["mockImplementation"]((url) => {
     switch (url) {
@@ -321,6 +342,7 @@ const mocks = {
   curateAPI: curateAPI,
   runAPI: runAPI,
   runAddStepAPI: runAddStepAPI,
+  runMissingStep: runMissingStep,
   runCrudAPI: runCrudAPI,
   runErrorsAPI: runErrorsAPI,
   runFailedAPI: runFailedAPI,

--- a/marklogic-data-hub-central/ui/src/pages/Run.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Run.test.tsx
@@ -858,4 +858,12 @@ describe("Verify Add Step function", () => {
 
   });
 
+  test("Verify a missing step error is handled with a modal displaying error message", async () => {
+    mocks.runMissingStep(axiosMock);
+    const {getByText} = await render(<MemoryRouter>
+      <AuthoritiesContext.Provider value={ mockOpRolesService }><Run/></AuthoritiesContext.Provider>
+    </MemoryRouter>);
+    await(waitForElement(() => getByText("Error message")));
+  });
+
 });

--- a/marklogic-data-hub-central/ui/src/pages/Run.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Run.tsx
@@ -85,8 +85,12 @@ const Run = (props) => {
         setFlows(response.data);
       }
     } catch (error) {
-      console.error("Error getting flows", error);
-      handleError(error);
+      console.error("Error getting flows", error.response);
+      if (error.response.data && error.response.data.message) {
+        Modal.error({
+          content: error.response.data.message
+        });
+      }
     }
   };
 
@@ -97,9 +101,7 @@ const Run = (props) => {
         setSteps(response.data);
       }
     } catch (error) {
-      console.error("********* ERROR", error);
-      let message = error.response.data.message;
-      console.error("Error getting steps", message);
+      console.error("Error getting steps", error);
     }
   };
 


### PR DESCRIPTION
- Display modal with message from error object when calling api/flows fails
- Add test of api/flows error case

To test manually:

1. Create a flow and add a step to that flow.
2. Remove that added step via some external manner (e.g., remove the step file in QConsole). 
3. Go to the Run tile. An error modal should be displayed and the browser should no longer go into an infinite flows-retrieving loop.

Note that the resulting page displays no flows whatsoever (since the api/flows endpoint sends back and error and no flows).

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

