### PR TITLE
DHFPROD-6454: Add validation to steps and flow names in Hub Central

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.test.tsx
@@ -59,8 +59,8 @@ describe("Create Edit Step Dialog component", () => {
     expect(getByLabelText("Collection")).toBeChecked();
   });
 
-  test("Verify save button is always enabled", () => {
-    const {getByText, getByPlaceholderText} = render(<CreateEditStep {...data.newMerging} />);
+  test("Verify save button is always enabled and error messaging appears as needed", async () => {
+    const {getByText, getByPlaceholderText, queryByText} = render(<CreateEditStep {...data.newMerging} />);
     const nameInput = getByPlaceholderText("Enter name");
     const saveButton = getByText("Save");
 
@@ -70,8 +70,36 @@ describe("Create Edit Step Dialog component", () => {
     expect(nameInput).toHaveValue("testCreateMerging");
     expect(saveButton).toBeEnabled();
 
+    //verify validation on name field
+
+    //proper error message shows when field is empty
     fireEvent.change(nameInput, {target: {value: ""}});
     expect(getByText("Name is required")).toBeInTheDocument();
+
+    //proper error message shows when field does not lead with a letter
+    fireEvent.change(nameInput, {target: {value: "123testCreateStep"}});
+    expect(getByText("Names must start with a letter and can contain letters, numbers, hyphens, and underscores only.")).toBeInTheDocument();
+
+    //reset name field
+    fireEvent.change(nameInput, {target: {value: ""}});
+    expect(getByText("Name is required")).toBeInTheDocument();
+
+    //proper error message shows when field contains special characters
+    fireEvent.change(nameInput, {target: {value: "testCreateStep@#~"}});
+    expect(getByText("Names must start with a letter and can contain letters, numbers, hyphens, and underscores only.")).toBeInTheDocument();
+
+    //reset name field
+    fireEvent.change(nameInput, {target: {value: ""}});
+    expect(getByText("Name is required")).toBeInTheDocument();
+
+    //enter in a valid name and verify error message disappears (test hyphen and underscores are allowed)
+    fireEvent.change(nameInput, {target: {value: "test-Create-Step__"}});
+
+    await wait(() => {
+      expect(queryByText("Name is required")).toBeNull();
+      expect(queryByText("Names must start with a letter and can contain letters, numbers, hyphens, and underscores only.")).toBeNull();
+    });
+
     expect(saveButton).toBeEnabled();
   });
 

--- a/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.tsx
@@ -65,6 +65,7 @@ const CreateEditStep: React.FC<Props>  = (props) => {
   const [isSelectedSourceTouched, setSelectedSourceTouched] = useState(false);
   const [isTimestampTouched, setTimestampTouched] = useState(false);
 
+  const [invalidChars, setInvalidChars] = useState(false);
   const [isValid, setIsValid] = useState(false); // eslint-disable-line @typescript-eslint/no-unused-vars
 
   const [tobeDisabled, setTobeDisabled] = useState(false);
@@ -271,6 +272,14 @@ const CreateEditStep: React.FC<Props>  = (props) => {
       } else {
         setStepNameTouched(true);
         setStepName(event.target.value);
+
+        //check value does not contain special chars and leads with a letter
+        if (event.target.value !== "" && (/[~`!#$%^&*+=\\[\]\\';,/{}@()|\\":<>?]/g.test(event.target.value) || !event.target.value[0].match(/[a-z]/i))) {
+          setInvalidChars(true);
+        } else {
+          setInvalidChars(false);
+        }
+
         if (event.target.value.length > 0) {
           if (collections || srcQuery) {
             setIsValid(true);
@@ -388,8 +397,8 @@ const CreateEditStep: React.FC<Props>  = (props) => {
             Name:&nbsp;<span className={styles.asterisk}>*</span>
             &nbsp;
         </span>} labelAlign="left"
-        validateStatus={(stepName || !isStepNameTouched) ? "" : "error"}
-        help={(stepName || !isStepNameTouched) ? "" : "Name is required"}
+        validateStatus={(stepName || !isStepNameTouched) ? (invalidChars ? "error" : "") : "error"}
+        help={invalidChars ? "Names must start with a letter and can contain letters, numbers, hyphens, and underscores only." : (stepName || !isStepNameTouched) ? "" : "Name is required"}
         >
           { tobeDisabled?<MLTooltip title={NewMatchTooltips.nameField} placement={"bottom"}> <Input
             id="name"

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/create-edit-mapping/create-edit-mapping.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/create-edit-mapping/create-edit-mapping.test.tsx
@@ -154,8 +154,8 @@ describe("Create/Edit Mapping Step artifact component", () => {
 
   });
 
-  test("Verify Save button requires all mandatory fields", async () => {
-    const {getByText, getByPlaceholderText} = render(<CreateEditMapping {...data.newMap} />);
+  test("Verify Save button requires all mandatory fields and error messaging appears as needed", async () => {
+    const {getByText, queryByText, getByPlaceholderText} = render(<CreateEditMapping {...data.newMap} />);
     const nameInput = getByPlaceholderText("Enter name");
     const collInput = document.querySelector(("#collList .ant-input"));
 
@@ -166,9 +166,31 @@ describe("Create/Edit Mapping Step artifact component", () => {
     expect(getByText("Name is required")).toBeInTheDocument();
     expect(getByText("Collection or Query is required")).toBeInTheDocument();
 
-    // enter name only
-    fireEvent.change(nameInput, {target: {value: "testCreateMap"}});
-    expect(nameInput).toHaveValue("testCreateMap");
+    //verify validation on name field
+
+    //proper error message shows when field does not lead with a letter
+    fireEvent.change(nameInput, {target: {value: "123testCreateMap"}});
+    expect(getByText("Names must start with a letter and can contain letters, numbers, hyphens, and underscores only.")).toBeInTheDocument();
+
+    //reset name field
+    fireEvent.change(nameInput, {target: {value: ""}});
+    expect(getByText("Name is required")).toBeInTheDocument();
+
+    //proper error message shows when field contains special characters
+    fireEvent.change(nameInput, {target: {value: "testCreateStep^()+="}});
+    expect(getByText("Names must start with a letter and can contain letters, numbers, hyphens, and underscores only.")).toBeInTheDocument();
+
+    //reset name field
+    fireEvent.change(nameInput, {target: {value: ""}});
+    expect(getByText("Name is required")).toBeInTheDocument();
+
+    //enter in a valid name and verify error message disappears (test hyphen and underscores are allowed)
+    fireEvent.change(nameInput, {target: {value: "test_Create-Step-"}});
+
+    await wait(() => {
+      expect(queryByText("Name is required")).toBeNull();
+      expect(queryByText("Names must start with a letter and can contain letters, numbers, hyphens, and underscores only.")).toBeNull();
+    });
 
     fireEvent.click(getByText("Save"));
 

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/create-edit-mapping/create-edit-mapping.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/create-edit-mapping/create-edit-mapping.tsx
@@ -45,7 +45,7 @@ const CreateEditMapping: React.FC<Props> = (props) => {
   const [isSelectedSourceTouched, setSelectedSourceTouched] = useState(false);
 
   const [isValid, setIsValid] = useState(false); // eslint-disable-line @typescript-eslint/no-unused-vars
-  const [isNameDuplicate, setIsNameDuplicate] = useState(false);
+  const [invalidChars, setInvalidChars] = useState(false);
   const [errorMessage, setErrorMessage] = useState(""); // eslint-disable-line @typescript-eslint/no-unused-vars
 
   const [tobeDisabled, setTobeDisabled] = useState(false);
@@ -237,11 +237,17 @@ const CreateEditMapping: React.FC<Props> = (props) => {
       } else {
         setMapNameTouched(true);
         setMapName(event.target.value);
+
+        //check value does not contain special chars and leads with a letter
+        if (event.target.value !== "" && (/[~`!#$%^&*+=\\[\]\\';,/{}@()|\\":<>?]/g.test(event.target.value) || !event.target.value[0].match(/[a-z]/i))) {
+          setInvalidChars(true);
+        } else {
+          setInvalidChars(false);
+        }
         if (event.target.value.length > 0) {
           if (collections|| srcQuery) {
             setIsValid(true);
             props.setIsValid(true);
-            setIsNameDuplicate(false);
           }
         } else {
           setIsValid(false);
@@ -409,8 +415,8 @@ const CreateEditMapping: React.FC<Props> = (props) => {
           Name:&nbsp;<span className={styles.asterisk}>*</span>
           &nbsp;
         </span>} labelAlign="left"
-        validateStatus={(mapName || !isMapNameTouched) ? (!isNameDuplicate ? "" : "error") : "error"}
-        help={(mapName || !isMapNameTouched) ? (isNameDuplicate ? errorMessage :"") : "Name is required"}
+        validateStatus={(mapName || !isMapNameTouched) ? (invalidChars ? "error" : "") : "error"}
+        help={invalidChars ? "Names must start with a letter and can contain letters, numbers, hyphens, and underscores only." : (mapName || !isMapNameTouched) ? "" : "Name is required"}
         >
           { tobeDisabled?<MLTooltip title={NewMapTooltips.nameField} placement={"bottom"}> <Input
             id="name"

--- a/marklogic-data-hub-central/ui/src/components/flows/new-flow-dialog/new-flow-dialog.tsx
+++ b/marklogic-data-hub-central/ui/src/components/flows/new-flow-dialog/new-flow-dialog.tsx
@@ -15,6 +15,7 @@ const NewFlowDialog = (props) => {
 
   const [, setIsLoading] = useState(false);
   const [tobeDisabled, setTobeDisabled] = useState(false);
+  const [invalidChars, setInvalidChars] = useState(false);
 
   let history = useHistory();
   useEffect(() => {
@@ -99,6 +100,14 @@ const NewFlowDialog = (props) => {
       } else {
         setFlowNameTouched(true);
         setFlowName(event.target.value);
+
+        //check value does not contain special chars and leads with a letter
+        if (event.target.value !== "" && (/[~`!#$%^&*+=\\[\]\\';,/{}@()|\\":<>?]/g.test(event.target.value) || !event.target.value[0].match(/[a-z]/i))) {
+          setInvalidChars(true);
+        } else {
+          setInvalidChars(false);
+        }
+
       }
     }
     if (event.target.id === "name" && event.target.value.length === 0) {
@@ -137,9 +146,10 @@ const NewFlowDialog = (props) => {
         <Form.Item label={<span>
           Name:&nbsp;<span className={styles.asterisk}>*</span>&nbsp;
         </span>} labelAlign="left"
-        validateStatus={(flowName || !isFlowNameTouched) ? "" : "error"}
-        help={(flowName || !isFlowNameTouched) ? "" : "Name is required"}>
-          { tobeDisabled?<MLTooltip title={NewFlowTooltips.nameField} placement={"bottom"}> <Input
+        validateStatus={(flowName || !isFlowNameTouched) ? (invalidChars ? "error" : "") : "error"}
+        help={invalidChars ? "Names must start with a letter and can contain letters, numbers, hyphens, and underscores only." : (flowName || !isFlowNameTouched) ? "" : "Name is required"}
+        >
+          { tobeDisabled?<MLTooltip title={NewFlowTooltips.nameField} placement={"bottom"} > <Input
             id="name"
             placeholder="Enter name"
             value={flowName}

--- a/marklogic-data-hub-central/ui/src/components/load/create-edit-load/create-edit-load.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/create-edit-load/create-edit-load.test.tsx
@@ -102,7 +102,7 @@ describe("New/edit load step configuration", () => {
     expect(queryByText("Source Type")).not.toBeInTheDocument();
   });
 
-  test("Verify name is required for form submission and error messaging appears", async () => {
+  test("Verify name is required for form submission and error messaging appears as needed", async () => {
     const {queryByText, getByText, getByPlaceholderText} =
     render(<BrowserRouter><CreateEditLoad {...loadProps} isEditing={false} /></BrowserRouter>);
     const nameInput = getByPlaceholderText("Enter name");
@@ -116,13 +116,25 @@ describe("New/edit load step configuration", () => {
     // message should appear when save button is clicked
     expect(queryByText("Name is required")).toBeInTheDocument();
 
-    // enter in a name and verify message disappears
-    fireEvent.change(nameInput, {target: {value: "testLoadStep"}});
-    await wait(() => {
-      expect(nameInput).toHaveValue("testLoadStep");
-    });
+    //error message should appear when name field does not lead with a letter
+    fireEvent.change(nameInput, {target: {value: "123testLoadStep"}});
+    expect(getByText("Names must start with a letter and can contain letters, numbers, hyphens, and underscores only.")).toBeInTheDocument();
 
-    expect(queryByText("Name is required")).toBeNull();
+    //reset name field
+    fireEvent.change(nameInput, {target: {value: ""}});
+    expect(getByText("Name is required")).toBeInTheDocument();
+
+    //error message should appear when name field contains special characters
+    fireEvent.change(nameInput, {target: {value: "testLoadStep$&*"}});
+    expect(getByText("Names must start with a letter and can contain letters, numbers, hyphens, and underscores only.")).toBeInTheDocument();
+
+    //enter in a valid name and verify error message disappears (test hyphen and underscores are allowed)
+    fireEvent.change(nameInput, {target: {value: "test_Load_Step--"}});
+
+    await wait(() => {
+      expect(queryByText("Name is required")).toBeNull();
+      expect(queryByText("Names must start with a letter and can contain letters, numbers, hyphens, and underscores only.")).toBeNull();
+    });
   });
 
 });

--- a/marklogic-data-hub-central/ui/src/components/load/create-edit-load/create-edit-load.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/create-edit-load/create-edit-load.tsx
@@ -47,6 +47,7 @@ const CreateEditLoad: React.FC<Props> = (props) => {
   const [isOtherSeparatorTouched, setOtherSeparatorTouched] = useState(false);
 
   const [isValid, setIsValid] = useState(false); // eslint-disable-line @typescript-eslint/no-unused-vars
+  const [invalidChars, setInvalidChars] = useState(false);
   const [tobeDisabled, setTobeDisabled] = useState(false);
 
   const initStep = () => {
@@ -215,6 +216,12 @@ const CreateEditLoad: React.FC<Props> = (props) => {
         setStepNameTouched(true);
         setStepName(event.target.value);
 
+        //check value does not contain special chars and leads with a letter
+        if (event.target.value !== "" && (/[~`!#$%^&*+=\\[\]\\';,/{}@()|\\":<>?]/g.test(event.target.value) || !event.target.value[0].match(/[a-z]/i))) {
+          setInvalidChars(true);
+        } else {
+          setInvalidChars(false);
+        }
         if (event.target.value.length === 0) {
           setIsValid(false);
           props.setIsValid(false);
@@ -414,8 +421,8 @@ const CreateEditLoad: React.FC<Props> = (props) => {
 
           &nbsp;
         </span>} labelAlign="left"
-        validateStatus={(stepName || !isStepNameTouched) ? "" : "error"}
-        help={(stepName || !isStepNameTouched) ? "" : "Name is required"}
+        validateStatus={(stepName || !isStepNameTouched) ? (invalidChars ? "error" : "") : "error"}
+        help={invalidChars ? "Names must start with a letter and can contain letters, numbers, hyphens, and underscores only." : (stepName || !isStepNameTouched) ? "" : "Name is required"}
         >
           { tobeDisabled?<MLTooltip title={NewLoadTooltips.nameField} placement={"bottom"}> <Input
             id="name"

--- a/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
+++ b/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
@@ -428,7 +428,7 @@ const multiSliderTooltips = {
 
 /* TO BE DEPRECATED. Please use FlowTooltips. */
 const NewFlowTooltips = {
-  name: 'The name of this flow configuration. This cannot be changed after the flow is created.',
+  name: 'The name of this flow configuration. This cannot be changed after the flow is created. Names must start with a letter and contain letters, numbers, hyphens, and underscores only.',
   nameField: 'The flow name is used as part of filenames, as a collection name, and as metadata in logs. It cannot be changed after the flow is created.',
   description: 'A description of this flow configuration.'
 };
@@ -465,7 +465,7 @@ const AdvancedSettingsTooltips = {
 
 /* TO BE DEPRECATED. Please use LoadingStepTooltips. */
 const NewLoadTooltips = {
-  name: 'The name of this loading step configuration. This cannot be changed after the step is created.',
+  name: 'The name of this loading step configuration. This cannot be changed after the step is created. Names must start with a letter and contain letters, numbers, hyphens, and underscores only.',
   nameField: 'The step name is used as part of filenames, as a collection name, and as metadata in logs. It cannot be changed after the step is created.',
   description: 'A description of this loading step configuration.',
   files: 'Click *Upload* to select the source files. The total size of the files must be 100MB or less.',
@@ -488,7 +488,7 @@ const AdvLoadTooltips = {
 
 /* TO BE DEPRECATED. Please use MappingStepTooltips. */
 const NewMapTooltips = {
-  name: 'The name of this mapping step configuration. This cannot be changed after the step is created.',
+  name: 'The name of this mapping step configuration. This cannot be changed after the step is created. Names must start with a letter and contain letters, numbers, hyphens, and underscores only.',
   nameField: 'The step name is used as part of filenames, as a collection name, and as metadata in logs. It cannot be changed after the step is created.',
   description: 'A description of this mapping step configuration.',
   sourceQuery: 'The collection or CTS query that selects the source data to process in this configuration.',
@@ -517,7 +517,7 @@ const NewMatchTooltips = {
   collation: 'The URI for a collation, which specifies the order for sorting strings.',
   namespace: 'The namespace of the module that contains the function.',  /* intended dupe: match-merge */
   function: 'The function to run if this action definition is selected.',
-  name: 'The name of this matching step configuration. This cannot be changed after the step is created.',
+  name: 'The name of this matching step configuration. This cannot be changed after the step is created. Names must start with a letter and contain letters, numbers, hyphens, and underscores only.',
   nameField: 'The step name is used as part of filenames, as a collection name, and as metadata in logs. It cannot be changed after the step is created.',
   uri: 'The path to the module that contains the function.',  /* intended dupe: match-merge */
   distanceThreshold: 'The threshold below which the phonetic difference (distance) between two strings is considered insignificant; i.e., the strings are similar to each other.',
@@ -540,7 +540,7 @@ const MatchingStepDetailText = {
 /* TO BE DEPRECATED. Please use MergingStepTooltips. */
 const NewMergeTooltips = {
   timestampPath: 'The path to a timestamp field within the record. This field is used to determine which values to include in the merged property, based on their recency.',
-  name: 'The name of this merging step configuration. This cannot be changed after the step is created.',
+  name: 'The name of this merging step configuration. This cannot be changed after the step is created. Names must start with a letter and contain letters, numbers, hyphens, and underscores only.',
   description: 'A description of this merging step configuration.',
 
   /* TO BE DEPRECATED. Please use SecurityTooltips.missingPermission. */
@@ -576,7 +576,7 @@ const MergeStrategyTooltips = {
 
 /* TO BE DEPRECATED. Please use CustomStepTooltips. */
 const NewCustomTooltips = {
-  name: 'The name of this custom step configuration. This cannot be changed after the step is created.',
+  name: 'The name of this custom step configuration. This cannot be changed after the step is created. Names must start with a letter and contain letters, numbers, hyphens, and underscores only.',
   nameField: 'The step name is used as part of filenames, as a collection name, and as metadata in logs. It cannot be changed after the step is created.',
   description: 'A description of this custom step configuration.',
   sourceQuery: 'The collection or CTS query that selects the source data to process in this configuration.'


### PR DESCRIPTION
### Description

- Validation for step names and flow names (no special characters besides hyphens and underscores allowed, leading character must be a letter)

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

