### PR TITLE
DHFPROD-6527: No longer generating empty range-element-index array

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-entities.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-entities.xqy
@@ -456,8 +456,8 @@ duplicates are considered to have the same local name, namespace URI, and collat
 declare private function hent:remove-duplicate-range-indexes($database-config as item())
 {
   let $indexes := map:get($database-config, "range-element-index")
-  return
-    if (fn:exists($indexes)) then
+  where (fn:exists($indexes))
+  return 
       let $index-map := map:map()
       let $_ :=
         for $index in json:array-values($indexes)
@@ -474,9 +474,6 @@ declare private function hent:remove-duplicate-range-indexes($database-config as
       let $deduplicated-indexes := json:array()
       let $_ := map:keys($index-map) ! json:array-push($deduplicated-indexes, map:get($index-map, .))
       let $_ := map:put($database-config, "range-element-index", $deduplicated-indexes)
-      return ()
-    else
-      let $_ := map:put($database-config, "range-element-index", json:array())
       return ()
 };
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/GenerateIndexesTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/GenerateIndexesTest.java
@@ -36,7 +36,14 @@ public class GenerateIndexesTest extends AbstractHubCoreTest {
         final String namespace = null;
         givenAnEntityWithTitleProperty("Book", namespace, false);
         whenTheIndexesAreBuilt();
-        thenAnEmptyRangeIndexArrayExists();
+        assertFalse(indexes.has("range-element-index"), "DHFPROD-2615 added logic for an empty array to be included " +
+            "when no element range indexes existed; however, this was and is inconsistent with how rangeIndex and " +
+            "pathRangeIndex work, where no empty array is created if those properties are not specified. To be " +
+            "consistent and to avoid indexes from being surprisingly removed, an empty array should not be added to " +
+            "the file; range-element-index should not exist, just like range-path-index does not exist. How the OBE " +
+            "indexes are removed is up to the developer; given that indexes are often added in a development " +
+            "environment, a common technique is to reset the entire ML instance to remove OBE resources and then " +
+            "redeploy the application");
     }
 
     private void givenAnEntityWithTitleProperty(String entityName, String namespace, boolean includeRangeIndex) {
@@ -83,12 +90,5 @@ public class GenerateIndexesTest extends AbstractHubCoreTest {
         } else {
             assertEquals(namespace, index.get("namespace-uri").asText());
         }
-    }
-
-    private void thenAnEmptyRangeIndexArrayExists() {
-        ArrayNode rangeIndexes = (ArrayNode) indexes.get("range-element-index");
-        assertEquals(0, rangeIndexes.size(),
-            "An empty array is needed here so that if indexes were previously defined for entity properties, and then" +
-                "they are removed, the empty array ensures that they are removed from the database. ");
     }
 }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/generateIndexes.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/generateIndexes.sjs
@@ -145,7 +145,7 @@ function differentPropertyNames() {
 }
 
 function generateIndexConfigForFacetableProperties() {
-  const indexes = generateRangeIndexConfig([
+  const indexes = hent.dumpIndexes([
     {
       "info": {
         "title": "Book"
@@ -170,13 +170,16 @@ function generateIndexConfigForFacetableProperties() {
         }
       }
     }
-  ]);
+  ]).toObject();
 
+  const pathIndexes = indexes["range-path-index"];
   return [
-    test.assertEqual(3, indexes.length),
-    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/title", indexes[0]["path-expression"]),
-    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/authors", indexes[1]["path-expression"]),
-    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/rating", indexes[2]["path-expression"])
+    test.assertFalse(indexes.hasOwnProperty("range-element-index"), "Since no range element indexes were generated, " + 
+      ", there should not be a range-element-index property, as an empty array can remove existing indexes"),
+    test.assertEqual(3, pathIndexes.length),
+    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/title", pathIndexes[0]["path-expression"]),
+    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/authors", pathIndexes[1]["path-expression"]),
+    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/rating", pathIndexes[2]["path-expression"])
   ];
 }
 


### PR DESCRIPTION
### Description

I looked into the history of this change, and I think when it was made for DHFPROD-6215, the intent was good - try to remove indexes that previously existed - but it wasn't being done consistently for path range indexes as well. Nor is removal being done anywhere else - e.g. for protected paths based on PII properties. But we know that an empty array can be a dangerous thing, as that can remove all indexes from a database. And in the context of the entity-config database files, there's no way to know if all indexes should be removed or not. So an empty array is no longer being generated. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

