### PR TITLE
DHFPROD-5000: Add Documentation and Video Tutorial links to Overview

### DIFF
--- a/marklogic-data-hub-central/ui/src/config/overview.config.ts
+++ b/marklogic-data-hub-central/ui/src/config/overview.config.ts
@@ -1,0 +1,24 @@
+const VERSION = "5.4";
+
+const documentationLinkRoot = "https://docs.marklogic.com/datahub/" + VERSION + "/";
+const documentationLinks = {
+    load: documentationLinkRoot + "flows/loading-with-hubcentral.html",
+    model: documentationLinkRoot + "entities/modeling-with-hubcentral.html",
+    curate: documentationLinkRoot + "flows/curating-with-hubcentral.html",
+    run: documentationLinkRoot + "flows/running-steps-with-hubcentral.html",
+    explore: documentationLinkRoot + "tools/hubcentral/exploring-with-hubcentral.html",
+}
+
+const videoLinkRoot = "https://developer.marklogic.com/video/datahub/" + VERSION + "/";
+const videoLinks = {
+    load: videoLinkRoot + "data-hub-central-load",
+    model: videoLinkRoot + "data-hub-central-model",
+    curate: videoLinkRoot + "data-hub-central-curate",
+    run: videoLinkRoot + "data-hub-central-run",
+    explore: videoLinkRoot + "data-hub-central-explore",
+}
+
+export default {
+    documentationLinks,
+    videoLinks
+};

--- a/marklogic-data-hub-central/ui/src/pages/Overview.module.scss
+++ b/marklogic-data-hub-central/ui/src/pages/Overview.module.scss
@@ -40,7 +40,25 @@
                 font-size: 16pt;
             }
             .body {
-                padding: 0px 20px 10px 44px;
+                padding: 0px 20px 15px 44px;
+                .docLink, .vidLink {
+                    font-size: 13px;
+                    span {
+                        color: #5B69AF;
+                        cursor: pointer;
+                    }
+                    :before {
+                        content:"•";
+                        color: #333;
+                        padding-right: 5px;
+                    }
+                }
+                .docLink {
+                    padding-top: 10px;
+                }
+                .vidLink {
+                    padding-top: 3px;
+                }
             }
             i {
                 position: relative;
@@ -107,10 +125,10 @@
                 font-weight: 600;
             }
             .permissionsRun {
-                padding-top: 98px;
+                padding-top: 28px;
             }
             .permissionsExplore {
-                padding-top: 110px;
+                padding-top: 40px;
             }
 
             .cardLoad {

--- a/marklogic-data-hub-central/ui/src/pages/Overview.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Overview.test.tsx
@@ -4,6 +4,7 @@ import {createMemoryHistory} from "history";
 import userEvent from "@testing-library/user-event";
 import {render, fireEvent} from "@testing-library/react";
 import Overview from "./Overview";
+import overviewConfig from "../config/overview.config";
 
 describe("Overview component", () => {
 
@@ -43,7 +44,6 @@ describe("Overview component", () => {
     });
     // NO cards have permissions warning
     expect(queryAllByText("*additional permissions required")).toHaveLength(0);
-
   });
 
   it("Verify disabled cards are not clickable and have appropriate styling/content", async () => {
@@ -144,6 +144,39 @@ describe("Overview component", () => {
       });
     });
 
+  });
+
+  it("Verify Documentation and Video Tutorial links", async () => {
+
+    const history = createMemoryHistory();
+    history.push("/tiles"); // initial state
+
+    let enabled = ["load", "model", "curate", "run", "explore"];
+    const {getAllByText} = render(<Router history={history}><Overview enabled={enabled}/></Router>);
+
+    // Mock method for opening links
+    const mockedWindowOpen = jest.fn();
+    const originalOpen = window.open;
+    window.open = mockedWindowOpen;
+
+    // Check Documentation links
+    const documentationLinks = getAllByText("Documentation");
+    expect(documentationLinks.length === enabled.length); // All cards should have Documentation links
+    documentationLinks.forEach((docLink, i) => {
+      fireEvent.click(docLink);
+      expect(mockedWindowOpen).toBeCalledWith(overviewConfig.documentationLinks[enabled[i]], "_blank");
+    });
+
+    // Check Video Tutorial links
+    const videoLinks = getAllByText("Video Tutorial");
+    expect(videoLinks.length === enabled.length); // All cards should have Video Tutorial links
+    videoLinks.forEach((vidLink, i) => {
+      fireEvent.click(vidLink);
+      expect(mockedWindowOpen).toBeCalledWith(overviewConfig.videoLinks[enabled[i]], "_blank");
+    });
+
+    // Reset mocked method
+    window.open = originalOpen;
   });
 
 });

--- a/marklogic-data-hub-central/ui/src/pages/Overview.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Overview.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styles from "./Overview.module.scss";
 import {useHistory} from "react-router-dom";
+import overviewConfig from "../config/overview.config";
 
 interface Props {
     enabled: any;
@@ -19,6 +20,16 @@ const Overview: React.FC<Props> = (props) => {
         }
       });
     }
+  };
+
+  const openDocumentation = (e, type) => {
+    if (e) e.stopPropagation(); // Stop click from also opening tile
+    window.open(overviewConfig.documentationLinks[type], "_blank");
+  };
+
+  const openVideo = (e, type) => {
+    if (e) e.stopPropagation(); // Stop click from also opening tile
+    window.open(overviewConfig.videoLinks[type], "_blank");
   };
 
   const getClassNames = (id) => {
@@ -130,6 +141,12 @@ const Overview: React.FC<Props> = (props) => {
               <span className={styles.icon} aria-label="load-icon"></span>Load
             </div>
             <div className={styles.body}>Create and configure steps that define how data should be loaded.
+              <div className={styles.docLink}>
+                <span onClick={(e) => { openDocumentation(e, "load"); }}>Documentation</span>
+              </div>
+              <div className={styles.vidLink}>
+                <span onClick={(e) => { openVideo(e, "load"); }}>Video Tutorial</span>
+              </div>
               { props.enabled && !props.enabled.includes("load") &&
                             <div className={styles.permissions}>*additional permissions required</div> }
             </div>
@@ -145,6 +162,12 @@ const Overview: React.FC<Props> = (props) => {
               <span className={styles.icon} aria-label="model-icon"></span>Model
             </div>
             <div className={styles.body}>Define the entity models that describe and standardize your data.
+              <div className={styles.docLink}>
+                <span onClick={(e) => { openDocumentation(e, "model"); }}>Documentation</span>
+              </div>
+              <div className={styles.vidLink}>
+                <span onClick={(e) => { openVideo(e, "model"); }}>Video Tutorial</span>
+              </div>
               { props.enabled && !props.enabled.includes("model") &&
                             <div className={styles.permissions}>*additional permissions required</div> }
             </div>
@@ -160,6 +183,12 @@ const Overview: React.FC<Props> = (props) => {
               <span className={styles.icon} aria-label="curate-icon"></span>Curate
             </div>
             <div className={styles.body}>Create and configure steps that curate and refine your data.
+              <div className={styles.docLink}>
+                <span onClick={(e) => { openDocumentation(e, "curate"); }}>Documentation</span>
+              </div>
+              <div className={styles.vidLink}>
+                <span onClick={(e) => { openVideo(e, "curate"); }}>Video Tutorial</span>
+              </div>
               { props.enabled && !props.enabled.includes("curate") &&
                             <div className={styles.permissions}>*additional permissions required</div> }
             </div>
@@ -175,6 +204,12 @@ const Overview: React.FC<Props> = (props) => {
                 <span className={styles.icon} aria-label="run-icon"></span>Run
               </div>
               <div className={styles.body}>Add your step to a flow and run it.
+                <div className={styles.docLink}>
+                  <span onClick={(e) => { openDocumentation(e, "run"); }}>Documentation</span>
+                </div>
+                <div className={styles.vidLink}>
+                  <span onClick={(e) => { openVideo(e, "run"); }}>Video Tutorial</span>
+                </div>
                 { props.enabled && !props.enabled.includes("run") &&
                                 <div className={styles.permissionsRun}>*additional permissions required</div> }
               </div>
@@ -190,6 +225,12 @@ const Overview: React.FC<Props> = (props) => {
               <span className={styles.icon} aria-label="explore-icon"></span>
               <div className={styles.subtitle}>Explore</div>
               <div className={styles.body}>Search, filter, and export your curated data.
+                <div className={styles.docLink}>
+                  <span onClick={(e) => { openDocumentation(e, "explore"); }}>Documentation</span>
+                </div>
+                <div className={styles.vidLink}>
+                  <span onClick={(e) => { openVideo(e, "explore"); }}>Video Tutorial</span>
+                </div>
                 { props.enabled && !props.enabled.includes("explore") &&
                                 <div className={styles.permissionsExplore}>*additional permissions required</div> }
               </div>


### PR DESCRIPTION
### Description

Screencast of the link functionality is here: https://drive.google.com/file/d/1GfPNCikMGP1_pdIrv_bKRpqNnWHhySaC/view

URL information is stored in a new `overview.config.ts` file for easy updating by Docs or whomever.

New unit test in Overview.test that checks the links for all five cards.

**Note that none of the link destinations are live yet!** They will become functional prior to the release, see details in the Jira ticket: https://project.marklogic.com/jira/browse/DHFPROD-5000

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

