### PR TITLE
DHFPROD-6560: mlWatch now generates function metadata

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/util/ModuleWatchingConsumer.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/util/ModuleWatchingConsumer.java
@@ -24,12 +24,17 @@ public class ModuleWatchingConsumer extends LoggingObject implements Consumer<Se
 
     @Override
     public void accept(Set<Resource> resources) {
-        if (generateFunctionMetadataCommand != null && commandContext != null && shouldFunctionMetadataBeGenerated(resources)) {
-            try {
-                logger.info("Generating function metadata for modules containing mapping functions");
-                generateFunctionMetadataCommand.execute(commandContext);
-            } catch (Exception ex) {
-                logger.error("Unable to generate function metadata, cause: " + ex.getMessage());
+        if (shouldFunctionMetadataBeGenerated(resources)) {
+            if (generateFunctionMetadataCommand == null || commandContext == null) {
+                logger.warn("Unable to generate function metadata for modules containing mapping functions; no command or command context found");
+            } else {
+                try {
+                    logger.info("Generating function metadata for modules containing mapping functions");
+                    generateFunctionMetadataCommand.execute(commandContext);
+                } catch (Exception ex) {
+                    logger.error("Unable to generate function metadata, cause: " + ex.getMessage());
+                }
+
             }
         }
     }

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -265,6 +265,7 @@ class DataHubPlugin implements Plugin<Project> {
         loadHubArtifactsCommand = ctx.getBean(LoadHubArtifactsCommand.class)
         loadUserModulesCommand = ctx.getBean(LoadUserModulesCommand.class)
         loadUserArtifactsCommand = ctx.getBean(LoadUserArtifactsCommand.class)
+        generateFunctionMetadataCommand = ctx.getBean(GenerateFunctionMetadataCommand.class)
         mappingManager = ctx.getBean(MappingManagerImpl.class)
         masteringManager = ctx.getBean(MasteringManagerImpl.class)
         stepManager = ctx.getBean(StepDefinitionManagerImpl.class)


### PR DESCRIPTION
### Description

I tried to get a test in place for this, but I don't know how to test mlWatch in a test (which enters an infinite loop). Instead, I added some logging to at least indicate when there's a misconfiguration -  i.e. the command or context are null. 

The actual bug fix is just to populate generateFunctionMetadataCommand when the other beans are populated in DataHubPlugin. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

