### PR TITLE
DHFPROD-6492: Fix regression in QuickStart mastering related test

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/impl/collections.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/impl/collections.xqy
@@ -12,13 +12,19 @@ declare function coll:get-collections($spec as item()*, $default as xs:string?)
   as xs:string*
 {
   let $coll-names := $spec ! fn:string()[. ne '']
-  return
+  let $collections :=
     if ($spec instance of element()* and fn:exists($spec/@none)) then
       ()
     else if (fn:exists($coll-names)) then
       $coll-names
     else
       $default
+  return (
+    $collections,
+    if (xdmp:trace-enabled($const:TRACE-MERGE-RESULTS)) then
+      xdmp:trace($const:TRACE-MERGE-RESULTS, $default || " set collections: " || xdmp:to-json-string($collections))
+    else ()
+  )
 };
 
 declare function coll:content-collections($options as node()?)

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/impl/process.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/impl/process.xqy
@@ -363,7 +363,7 @@ declare function proc-impl:build-match-summary(
   tel:increment(),
   let $start-elapsed := xdmp:elapsed-time()
   let $compiled-matching-options := match-opt-impl:compile-match-options($match-options, ())
-  let $match-options-node := $compiled-matching-options => map:get("matchOptionsNode")
+  let $match-options-node := $compiled-matching-options => map:get("normalizedOptions")
   let $archived-collection := coll:archived-collections($match-options-node)
   let $normalized-input :=
     if ($input instance of xs:string*) then
@@ -633,6 +633,8 @@ declare function proc-impl:process-match-and-merge-with-options(
   (: increment usage count :)
   tel:increment(),
   let $start-elapsed := xdmp:elapsed-time()
+  let $compiled-match-options := match-opt-impl:compile-match-options($matching-options, ())
+  let $matching-options := $compiled-match-options => map:get("normalizedOptions")
   let $archived-collection := coll:archived-collections($matching-options)
   let $normalized-input :=
     if ($input instance of xs:string*) then

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/impl/util.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/impl/util.xqy
@@ -123,7 +123,7 @@ declare function util-impl:properties-to-values-functions(
       map:map()
   let $distinct-properties :=
     fn:distinct-values((
-      $property-definitions/*:property/(@name|name) ! fn:string(.),
+      $property-definitions/(*:property|*:properties)/(@name|name) ! fn:string(.),
       if ($return-all-properties) then
         map:keys($entity-property-info)
       else (
@@ -135,7 +135,7 @@ declare function util-impl:properties-to-values-functions(
   return map:new(
     for $property-name in $distinct-properties
     let $entity-property-info := $entity-property-info => map:get($property-name)
-    let $property-definition := $property-definitions/*:property[(@name|name) = $property-name]
+    let $property-definition := $property-definitions/(*:property|properties)[(@name|name) = $property-name]
     let $document-xpath-rule := fn:head(($property-definition[@path|path], $rules[documentXPath eq $property-name]))
     let $function :=
       if (fn:exists($entity-property-info)) then

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/matcher-impl/matcher-impl.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/matcher-impl/matcher-impl.xqy
@@ -220,6 +220,11 @@ declare function match-impl:find-document-matches-by-options(
       $document-uri,
       blocks-impl:get-blocks(fn:base-uri($document))/node()
     )
+    let $_trace :=
+      if ($match-trace-is-enabled) then
+        xdmp:trace($const:TRACE-MATCH-RESULTS, "Excluding the following URIs from matching with cts.doc('"|| $document-uri ||"'): " || xdmp:to-json-string($excluded-uris))
+      else
+        ()
     let $match-base-query := cts:and-query((
           $compiled-options => map:get("baseContentQuery"),
           $minimum-threshold-combinations-query

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/collections.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/collections.xqy
@@ -115,7 +115,7 @@ declare function collection-impl:execute-algorithm(
       )
     )
   let $algorithm := $algorithm-map => map:get($event-name)
-  return
+  let $results :=
     if (fn:ends-with(xdmp:function-module($algorithm), "sjs")) then
       let $collections-by-uri := xdmp:to-json($collections-by-uri)/object-node()
       let $event-options := merge-impl:collection-event-to-json($event-options)
@@ -132,6 +132,13 @@ declare function collection-impl:execute-algorithm(
             ()
     else
       xdmp:apply($algorithm, $event-name, $collections-by-uri, $event-options)
+  return (
+    $results,
+    if (xdmp:trace-enabled($const:TRACE-MERGE-RESULTS)) then
+      xdmp:trace($const:TRACE-MERGE-RESULTS, "Collections for event '" || $event-name || "': " || xdmp:to-json-string($results))
+    else ()
+  )
+
 };
 
 declare function collection-impl:on-merge($collections-by-uri as map:map, $event-options as node()?) {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/options.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/options.xqy
@@ -184,7 +184,8 @@ declare function merge-impl:options-to-json($options-xml as element(merging:opti
                       object-node {
                         "name": $alg/@name/fn:string(),
                         "function": $alg/@function/fn:string(),
-                        "at": let $at := $alg/@at/fn:string() return if (fn:exists($at)) then $at else ""
+                        "at": let $at := $alg/@at/fn:string() return if (fn:exists($at)) then $at else "",
+                        "namespace": let $ns := $alg/@namespace/fn:string() return if (fn:exists($ns)) then $ns else ""
                       }
                   }),
                 if (fn:exists($options-xml/merging:algorithms/merging:std-algorithm)) then
@@ -628,7 +629,7 @@ declare function merge-impl:compile-merge-options(
       map:get($_cached-compiled-merge-options, $cache-id)
     else
       let $_trace := if (xdmp:trace-enabled($const:TRACE-MERGE-RESULTS)) then
-          xdmp:trace($const:TRACE-MERGE-RESULTS, "compiling merge options: " || xdmp:describe($merge-options, (), ()))
+          xdmp:trace($const:TRACE-MERGE-RESULTS, "compiling merge options: " || xdmp:to-json-string($merge-options))
         else
           ()
     let $message-output :=
@@ -810,7 +811,7 @@ declare function merge-impl:build-merge-rules-info(
     for $merge-rule in $merge-rules
     let $merge-rule := merge-impl:expand-merge-rule($merge-options, $merge-rule)
     let $property-name := fn:string(fn:head($merge-rule/(@property-name|propertyName|entityPropertyPath|documentXPath)))
-    let $property-def := $property-defs/(*:property|properties)[(@name|name) = $property-name]
+    let $property-def := $property-defs/(*:property|*:properties)[(@name|name) = $property-name]
     let $path := fn:head((
         $merge-rule/documentXPath,
         $property-def/(@path|path),
@@ -826,7 +827,7 @@ declare function merge-impl:build-merge-rules-info(
     let $algorithm-name := if (fn:exists($merge-rule/mergeModuleFunction[fn:normalize-space(.)])) then
                               fn:string($merge-rule/mergeModulePath) || ":" || fn:string($merge-rule/mergeModuleFunction)
                           else
-                              fn:string(fn:head($merge-rule/(@algorithm-ref|algorithmRef)))
+                              fn:string(fn:head(($merge-rule/(@algorithm-ref|algorithmRef),"standard")))
     let $merge-algorithm := $merge-algorithms => map:get($algorithm-name)
     return (
       xdmp:trace($const:TRACE-MERGE-RESULTS, "Explicit merge for property: " || $property-name),

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mastering/default/matching.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mastering/default/matching.sjs
@@ -35,7 +35,7 @@ function filterContentAlreadyProcessed(content, summaryCollection, collectionInf
   const jobIdQuery = cts.fieldWordQuery('datahubCreatedByJob', jobID);
   let auditingNotificationsInSourceQuery = false;
   for (let item of content) {
-    const collections = item.context ? item.context.collections || [] : [];
+    const collections = item.context ? item.context.originalCollections || [] : [];
     const auditingOrNotificationDoc = collections.includes(collectionInfo.notificationCollection) || collections.includes(collectionInfo.auditingCollection);
     if (!(cts.exists(cts.andQuery([collectionQuery,jobIdQuery,cts.jsonPropertyValueQuery('uris', item.uri, 'exact')])) ||
         auditingOrNotificationDoc

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mastering/default/checkOptions.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mastering/default/checkOptions.sjs
@@ -39,6 +39,20 @@ xdmp.invokeFunction(
       Sequence.from(currentDocs[0].context.originalCollections),
       Sequence.from(filteredDocs[0].context.collections),
       'Original collections should be carried forward.'));
+    let optionsWithTargetEntity = { targetEntity: "TestTargetEntityCarryOver", mergeOptions: {}, matchOptions: {} };
+    lib.checkOptions(null, optionsWithTargetEntity, null);
+    assertions.push(test.assertEqual(
+        "TestTargetEntityCarryOver",
+        optionsWithTargetEntity.targetEntityType,
+        "targetEntity should be moved to the new standard targetEntityType."));
+      assertions.push(test.assertEqual(
+          "TestTargetEntityCarryOver",
+          optionsWithTargetEntity.matchOptions.targetEntityType,
+          "Child matchOptions should now have targetEntityType set since that gets passed to the lower-level matching function."));
+      assertions.push(test.assertEqual(
+          "TestTargetEntityCarryOver",
+          optionsWithTargetEntity.mergeOptions.targetEntityType,
+          "Child mergeOptions should now have targetEntityType set since that gets passed to the lower-level merging function."));
   },
   {update: 'true', commit: 'auto'}
 );

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mastering/default/filterMatchingContent.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mastering/default/filterMatchingContent.sjs
@@ -5,9 +5,9 @@ const test = require("/test/test-helper.xqy");
 
 const collectionInfo = lib.checkOptions(null, { targetEntity: 'Customer', mergeOptions: {}, matchOptions: {} });
 const content = Sequence.from([
-    { uri: 'doc1', context: {collections: [collectionInfo.auditingCollection, collectionInfo.contentCollection]}},
-    { uri: 'doc2', context: {collections: [collectionInfo.contentCollection, collectionInfo.notificationCollection]}},
-    { uri: 'doc3', context: {collections: [collectionInfo.contentCollection, collectionInfo.archivedCollection]}}
+    { uri: 'doc1', context: {originalCollections: [collectionInfo.auditingCollection, collectionInfo.contentCollection]}},
+    { uri: 'doc2', context: {originalCollections: [collectionInfo.contentCollection, collectionInfo.notificationCollection]}},
+    { uri: 'doc3', context: {originalCollections: [collectionInfo.contentCollection, collectionInfo.archivedCollection]}}
 ]);
 const filteredContent = matching.filterContentAlreadyProcessed(content, 'summaryCollection', collectionInfo).toArray();
 

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mastering/default/suite-setup.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mastering/default/suite-setup.xqy
@@ -1,0 +1,8 @@
+xquery version "1.0-ml";
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+hub-test:reset-hub();
+
+xquery version "1.0-ml";
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+import module namespace test = "http://marklogic.com/test" at "/test/test-helper.xqy";
+hub-test:load-entities($test:__CALLER_FILE__);

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mastering/default/test-data/entities/TestTargetEntityCarryOver.entity.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/builtins/steps/mastering/default/test-data/entities/TestTargetEntityCarryOver.entity.json
@@ -1,0 +1,11 @@
+{
+  "info": {
+    "title": "TestTargetEntityCarryOver",
+    "version": "0.0.1",
+    "baseUri": "http://marklogic.com/example/",
+    "description": "This is a very simple entity to test that the targetEntity in QuickStart options are passed to matchOptions and mergeOptions."
+  },
+  "definitions": {
+    "TestTargetEntityCarryOver": {}
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/get-options-as-json.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/get-options-as-json.sjs
@@ -49,13 +49,14 @@ for (let prop of actual.options.propertyDefs.properties) {
 for (let alg of actual.options.algorithms.custom) {
   if (alg.name === 'name') {
     assertions.push(
-      test.assertEqual('name', alg.function),
-      test.assertEqual('', alg.at)
+      test.assertEqual('quickStartMergeProperties', alg.function),
+      test.assertEqual('/test/suites/data-hub/5/smart-mastering/merging/test-data/javascriptMergingFunctions.sjs', alg.at)
     );
   } else if (alg.name === 'customThing') {
     assertions.push(
       test.assertEqual('customThing', alg.function),
-      test.assertEqual('/custom-merge-xqy.xqy', alg.at)
+      test.assertEqual('/test/suites/data-hub/5/smart-mastering/merging-json/test-data/custom-merge-xqy.xqy', alg.at),
+      test.assertEqual('http://marklogic.com/smart-mastering/merging', alg.namespace)
     );
   } else {
     test.fail('Unexpected algorithm: ' + alg.name)

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/json-options-round-trip.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/json-options-round-trip.xqy
@@ -38,18 +38,18 @@ declare variable $strategy-options := test:get-test-file("merge-options-with-str
  : JSON.
  :)
 let $actual := merging:get-options("json-options", $const:FORMAT-JSON)
-return test:assert-true(fn:deep-equal($options, $actual)),
+return test:assert-true(fn:deep-equal($options, $actual), "Expected: " || xdmp:to-json-string($options)  || ", Got: " || xdmp:to-json-string($actual)),
 
 let $expected := test:get-test-file("merge-options.json")/node()
 let $actual := merging:get-options($lib:OPTIONS-NAME-COMPLETE, $const:FORMAT-JSON)
-return test:assert-true(fn:deep-equal($options, $actual)),
+return test:assert-true(fn:deep-equal($options, $actual), "Expected: " || xdmp:to-json-string($options)  || ", Got: " || xdmp:to-json-string($actual)),
 
 (: For some reason, the below test needed to convert the JSON to string to determine
  : that they are equal. See https://github.com/marklogic-community/marklogic-unit-test/issues/44
  :)
 let $expected := test:get-test-file("merge-options-with-strategies.json")/node()
 let $actual := merging:get-options($lib:OPTIONS-NAME-STRATEGIES, $const:FORMAT-JSON)
-return test:assert-true(fn:deep-equal($expected, $actual)),
+return test:assert-true(fn:deep-equal($expected, $actual), "Expected: " || xdmp:to-json-string($options)  || ", Got: " || xdmp:to-json-string($actual)),
 
 xdmp:document-delete('/com.marklogic.smart-mastering/options/merging/json-options.xml'),
 xdmp:document-delete('/com.marklogic.smart-mastering/options/merging/json-options-with-strategy.xml')

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/min-json-options-round-trip.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/min-json-options-round-trip.sjs
@@ -39,7 +39,8 @@ const small =
               {
                 "name": "customThing",
                 "function": "customThing",
-                "at": "/custom-merge-xqy.xqy"
+                "at": "/test/suites/data-hub/5/smart-mastering/merging-json/test-data/custom-merge-xqy.xqy",
+                "namespace": ""
               }
             ],
             "collections": {

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/suite-setup.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/suite-setup.xqy
@@ -33,8 +33,4 @@ merging:save-options($lib:OPTIONS-NAME-COMPLETE, test:get-test-file("merge-optio
 merging:save-options($lib:OPTIONS-NAME-CUST-XQY, test:get-test-file("custom-xqy-merge-options.xml")),
 merging:save-options($lib:OPTIONS-NAME-CUST-SJS, test:get-test-file("custom-sjs-merge-options.xml")),
 merging:save-options($lib:OPTIONS-NAME-PATH, test:get-test-file("path-merge-options.xml")),
-merging:save-options($lib:NESTED-OPTIONS, test:get-test-file("nested-merge-options.json")),
-
-test:load-test-file("custom-merge-xqy.xqy", xdmp:modules-database(), "/custom-merge-xqy.xqy", $module-permissions),
-test:load-test-file("custom-merge-sjs.sjs", xdmp:modules-database(), "/custom-merge-sjs.sjs", $module-permissions),
-test:load-test-file("combine-json.xqy", xdmp:modules-database(), "/combine-json.xqy", $module-permissions)
+merging:save-options($lib:NESTED-OPTIONS, test:get-test-file("nested-merge-options.json"))

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/suite-teardown.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/suite-teardown.xqy
@@ -6,15 +6,4 @@ import module namespace const = "http://marklogic.com/smart-mastering/constants"
 (: Currently, there isn't a function to delete options. :)
 xdmp:collection-delete($const:OPTIONS-COLL),
 
-xdmp:collection-delete($const:ALGORITHM-COLL),
-
-xdmp:invoke-function(function() {
-  xdmp:document-delete("/custom-merge-xqy.xqy"),
-  xdmp:document-delete("/custom-merge-sjs.sjs"),
-  xdmp:document-delete("/combine-json.xqy")
-},
-  map:new((
-    map:entry('database', xdmp:modules-database()),
-    map:entry('update','true')
-  ))
-)
+xdmp:collection-delete($const:ALGORITHM-COLL)

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/test-data/custom-sjs-merge-options.xml
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/test-data/custom-sjs-merge-options.xml
@@ -7,7 +7,7 @@
     <property namespace="" localname="CustomThing" name="customThing"/>
   </property-defs>
   <algorithms>
-    <algorithm name="customThing" function="customThing" namespace="" at="/custom-merge-sjs.sjs" />
+    <algorithm name="customThing" function="customThing" namespace="" at="/test/suites/data-hub/5/smart-mastering/merging-json/test-data/custom-merge-sjs.sjs" />
   </algorithms>
   <merging>
     <merge property-name="ssn">

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/test-data/custom-xqy-merge-options.xml
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/test-data/custom-xqy-merge-options.xml
@@ -7,7 +7,7 @@
     <property namespace="" localname="CustomThing" name="customThing"/>
   </property-defs>
   <algorithms>
-    <algorithm name="customThing" function="customThing" namespace="http://marklogic.com/smart-mastering/merging" at="/custom-merge-xqy.xqy" />
+    <algorithm name="customThing" function="customThing" namespace="http://marklogic.com/smart-mastering/merging" at="/test/suites/data-hub/5/smart-mastering/merging-json/test-data/custom-merge-xqy.xqy" />
   </algorithms>
   <merging>
     <merge property-name="ssn">

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/test-data/merge-options-complete.xml
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/test-data/merge-options-complete.xml
@@ -10,8 +10,8 @@
     <property path="/es:envelope/es:headers/custom/this/has:a/deep/path" name="deep"/>
   </property-defs>
   <algorithms>
-    <algorithm name="name" function="name" namespace="" at="" />
-    <algorithm name="customThing" function="customThing" namespace="http://marklogic.com/smart-mastering/merging" at="/custom-merge-xqy.xqy" />
+    <algorithm name="name" function="quickStartMergeProperties" namespace="" at="/test/suites/data-hub/5/smart-mastering/merging/test-data/javascriptMergingFunctions.sjs" />
+    <algorithm name="customThing" function="customThing" namespace="http://marklogic.com/smart-mastering/merging" at="/test/suites/data-hub/5/smart-mastering/merging-json/test-data/custom-merge-xqy.xqy" />
     <std-algorithm xmlns:es="http://marklogic.com/entity-services" xmlns:sm="http://marklogic.com/smart-mastering">
       <!-- provide the path to the timestamp element to use for sorting -->
       <!-- when merging the values are sorted in recency order from newest
@@ -42,7 +42,7 @@
   <triple-merge
     function="custom-trips"
     namespace="http://marklogic.com/smart-mastering/merging"
-    at="/custom-triple-merge-xqy.xqy">
+    at="/test/suites/data-hub/5/smart-mastering/merging-json/test-data/custom-triple-merge-xqy.xqy">
     <some-param>3</some-param>
   </triple-merge>
 </options>

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/test-data/merge-options-with-array-limit.xml
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/test-data/merge-options-with-array-limit.xml
@@ -10,7 +10,7 @@
   </property-defs>
   <algorithms>
     <algorithm name="name" function="name" namespace="" at="" />
-    <algorithm name="customThing" function="customThing" namespace="http://marklogic.com/smart-mastering/merging" at="/custom-merge-xqy.xqy" />
+    <algorithm name="customThing" function="customThing" namespace="http://marklogic.com/smart-mastering/merging" at="/test/suites/data-hub/5/smart-mastering/merging-json/test-data/custom-merge-xqy.xqy" />
     <std-algorithm xmlns:es="http://marklogic.com/entity-services" xmlns:sm="http://marklogic.com/smart-mastering">
       <!-- provide the path to the timestamp element to use for sorting -->
       <!-- when merging the values are sorted in recency order from newest

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/test-data/merge-options.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/test-data/merge-options.json
@@ -33,13 +33,15 @@
       "custom": [
         {
           "name": "name",
-          "function": "name",
-          "at": ""
+          "function": "quickStartMergeProperties",
+          "at": "/test/suites/data-hub/5/smart-mastering/merging/test-data/javascriptMergingFunctions.sjs",
+          "namespace": ""
         },
         {
           "name": "customThing",
           "function": "customThing",
-          "at": "/custom-merge-xqy.xqy"
+          "namespace": "http://marklogic.com/smart-mastering/merging",
+          "at": "/test/suites/data-hub/5/smart-mastering/merging-json/test-data/custom-merge-xqy.xqy"
         }
       ],
       "stdAlgorithm": {
@@ -98,7 +100,7 @@
     "tripleMerge": {
       "function": "custom-trips",
       "namespace": "http://marklogic.com/smart-mastering/merging",
-      "at": "/custom-triple-merge-xqy.xqy",
+      "at": "/test/suites/data-hub/5/smart-mastering/merging-json/test-data/custom-triple-merge-xqy.xqy",
       "someParam": "3"
     }
   }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/test-data/merge-options.xml
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/test-data/merge-options.xml
@@ -10,8 +10,8 @@
     <property path="/es:envelope/es:headers/custom/this/has:a/deep/path" name="deep"/>
   </property-defs>
   <algorithms>
-    <algorithm name="name" function="name" namespace="" at="" />
-    <algorithm name="customThing" function="customThing" namespace="http://marklogic.com/smart-mastering/merging" at="/custom-merge-xqy.xqy" />
+    <algorithm name="name" function="quickStartMergeProperties" namespace="" at="/test/suites/data-hub/5/smart-mastering/merging/test-data/javascriptMergingFunctions.sjs" />
+    <algorithm name="customThing" function="customThing" namespace="http://marklogic.com/smart-mastering/merging" at="/test/suites/data-hub/5/smart-mastering/merging-json/test-data/custom-merge-xqy.xqy" />
     <std-algorithm xmlns:es="http://marklogic.com/entity-services" xmlns:sm="http://marklogic.com/smart-mastering">
       <!-- provide the path to the timestamp element to use for sorting -->
       <!-- when merging the values are sorted in recency order from newest
@@ -21,7 +21,7 @@
     </std-algorithm>
   </algorithms>
   <merging>
-    <merge property-name="ssn" algorithm-ref="user-defined">
+    <merge property-name="ssn" algorithm-ref="customThing">
       <source-ref document-uri="docA" />
     </merge>
     <merge property-name="name"  max-values="1">

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/test-data/path-merge-options.xml
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/merging-json/test-data/path-merge-options.xml
@@ -10,7 +10,7 @@
     <m:property path="/envelope/headers/custom/this/has/a/deep/path" name="deep"/>
   </m:property-defs>
   <algorithms>
-    <algorithm name="combine" function="combine" namespace="http://marklogic.com/smart-mastering/merging" at="/combine-json.xqy" />
+    <algorithm name="combine" function="combine" namespace="http://marklogic.com/smart-mastering/merging" at="/test/suites/data-hub/5/smart-mastering/merging-json/test-data/combine-json.xqy" />
   </algorithms>
   <merging>
     <merge property-name="ssn">

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/ManualMergeUnmergeTaskTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/ManualMergeUnmergeTaskTest.groovy
@@ -95,7 +95,7 @@ class ManualMergeUnmergeTaskTest extends BaseTest{
         result.task(':hubRunFlow').outcome == TaskOutcome.SUCCESS
         //4 auditing docs are created after manualMergeUnmerge() is called. Blocked merges causes it to not add auditing document
         getDocCount(HubConfig.DEFAULT_FINAL_NAME, "sm-person-auditing") == 4
-        //1 The merged document is achived since the merges were blocked by the unmerge
+        //1 The merged document is archived since the merges were blocked by the unmerge
         getDocCount(HubConfig.DEFAULT_FINAL_NAME, "sm-person-archived") == 1
         runInDatabase(mergedANDMastered, HubConfig.DEFAULT_FINAL_NAME).next().getNumber() == 0
     }

--- a/ml-data-hub-plugin/src/test/resources/master-test/myNewFlow.flow.json
+++ b/ml-data-hub-plugin/src/test/resources/master-test/myNewFlow.flow.json
@@ -25,7 +25,7 @@
       "stepDefinitionName": "default-mapping",
       "stepDefinitionType": "MAPPING",
       "options": {
-        "collections" : [ "mapping", "mdm-content" ],
+        "collections" : [ "mapping" ],
         "sourceDatabase": "data-hub-STAGING",
         "targetDatabase": "data-hub-FINAL",
         "mapping": {

--- a/web/e2e/specs/browse/browse-data.ts
+++ b/web/e2e/specs/browse/browse-data.ts
@@ -69,7 +69,7 @@ export default function (qaProjectDir) {
       await browsePage.closeCollection();
 
       await browsePage.clickFacetName('http://marklogic.com/data-hub/step-definition');
-      await expect(await browsePage.resultsUriCount()).toBe(8);
+      await expect(await browsePage.resultsUriCount()).toBe(9);
       await browsePage.closeCollection();
     });
 


### PR DESCRIPTION
### Description
Items Covered:

- The number step definitions increased by 1
- targetEntityType was no longer picked up when the mastering step was run causing the wrong collections to be applied
- The targetTypeEntity not being found hid an issue with blocking future merges. Once the mastering step was fixed, the step wasn't finding the merged record that was archived.
- Using the compiled merge options as a standard way to apply collections caused some merge options related tests to be updated to ensure they call valid functions. This didn't matter before because those tests covered translating between JSON and XML formats.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

