### PR TITLE
DHFPROD-6491: Update how Button to Explore looks in success and error modals in all steps

### DIFF
--- a/marklogic-data-hub-central/ui/src/pages/Run.module.scss
+++ b/marklogic-data-hub-central/ui/src/pages/Run.module.scss
@@ -21,6 +21,7 @@
 
 .errorSummary {
     font-weight: normal;
+    padding-top: 40px;
 }
 
 .errorVal {
@@ -33,7 +34,7 @@
     font-size: 24px;
     padding-right: 6px;
     vertical-align: middle;
-    color: #5B69AF;
+    color: #ffffff;
 }
 
 @font-face {
@@ -42,22 +43,22 @@
     format('truetype');
 }
 
+.exploreDataContainer {
+    margin: auto;
+    width: 50%;
+    padding-top: 10px;
+    margin-bottom: -10px;
+}
+
 .exploreCuratedData, .exploreLoadedData {
-    margin-top: -96px;
-    float: right;
     cursor: pointer;
-    box-shadow: 0 3px 3px 3px #cccccc;
-    border-color: #cccccc;
-    border-style: solid;
-    border-width: 0px 1px 1px 1px;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-radius: 4px;
     padding: 0px 7px;
     margin-right: -3px;
 }
 
 .exploreText{
-    font-size: 15px;
-    color: #5B69AF;
+    font-size: 17px;
+    padding-right: 5px;
 }
 

--- a/marklogic-data-hub-central/ui/src/pages/Run.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Run.tsx
@@ -9,6 +9,7 @@ import {useHistory} from "react-router-dom";
 import tiles from "../config/tiles.config";
 import {getFromPath} from "../util/json-utils";
 import {MissingPagePermission} from "../config/messages.config";
+import {MLButton} from "@marklogic/design-system";
 
 const {Panel} = Collapse;
 
@@ -242,16 +243,21 @@ const Run = (props) => {
       title: <div><p style={{fontWeight: 400}}>The {stepType.toLowerCase()} step <strong>{stepName}</strong> completed successfully</p></div>,
       icon: <Icon type="check-circle" theme="filled"/>,
       okText: "Close",
+      okType: (stepType.toLowerCase() === "mapping" || stepType.toLowerCase() === "merging") && entityName ? "default" : stepType.toLowerCase() === "ingestion" ? "default" : "primary",
       mask: false,
       width: 650,
       content: (stepType.toLowerCase() === "mapping" || stepType.toLowerCase() === "merging") && entityName ?
-        <div data-testid="explorer-link" onClick={() => goToExplorer(entityName, targetDatabase, jobId, stepType)} className={styles.exploreCuratedData}>
-          <span className={styles.exploreIcon}></span>
-          <span className={styles.exploreText}>Explore Curated Data</span>
-        </div> : stepType.toLowerCase() === "ingestion" ?
-          <div data-testid="explorer-link" onClick={() => goToExplorer(entityName, targetDatabase, jobId, stepType)} className={styles.exploreLoadedData}>
+        <div className={styles.exploreDataContainer}>
+          <MLButton data-testid="explorer-link" size="large" type="primary" onClick={() => goToExplorer(entityName, targetDatabase, jobId, stepType)} className={styles.exploreCuratedData}>
             <span className={styles.exploreIcon}></span>
-            <span className={styles.exploreText}>Explore Loaded Data</span>
+            <span className={styles.exploreText}>Explore Curated Data</span>
+          </MLButton>
+        </div> : stepType.toLowerCase() === "ingestion" ?
+          <div className={styles.exploreDataContainer}>
+            <MLButton data-testid="explorer-link" size="large" type="primary" onClick={() => goToExplorer(entityName, targetDatabase, jobId, stepType)} className={styles.exploreLoadedData}>
+              <span className={styles.exploreIcon}></span>
+              <span className={styles.exploreText}>Explore Loaded Data</span>
+            </MLButton>
           </div> : ""
     });
   }
@@ -291,14 +297,16 @@ const Run = (props) => {
       content: (
         <div id="error-list">
           {((stepType.toLowerCase() === "mapping" || stepType.toLowerCase() === "merging") && entityName) ?
-            <div onClick={() => goToExplorer(entityName, targetDatabase, jobId, stepType)} className={styles.exploreCuratedData}>
-              <span className={styles.exploreIcon}></span>
-              <span className={styles.exploreText}>Explore Curated Data</span>
-            </div> : stepType.toLowerCase() === "ingestion" ?
-              <div onClick={() => goToExplorer(entityName, targetDatabase, jobId, stepType)} className={styles.exploreLoadedData}>
+            <div className={styles.exploreDataContainer}>
+              <MLButton size="large" type="primary" onClick={() => goToExplorer(entityName, targetDatabase, jobId, stepType)} className={styles.exploreCuratedData}>
                 <span className={styles.exploreIcon}></span>
-                <span className={styles.exploreText}>Explore Loaded Data</span>
-              </div> : ""}
+                <span className={styles.exploreText}>Explore Curated Data</span>
+              </MLButton></div> : stepType.toLowerCase() === "ingestion" ?
+              <div className={styles.exploreDataContainer}>
+                <MLButton size="large" type="primary" onClick={() => goToExplorer(entityName, targetDatabase, jobId, stepType)} className={styles.exploreLoadedData}>
+                  <span className={styles.exploreIcon}></span>
+                  <span className={styles.exploreText}>Explore Loaded Data</span>
+                </MLButton></div> : ""}
           <p className={styles.errorSummary}>{getErrorsSummary(response)}</p>
           <Collapse defaultActiveKey={["0"]} bordered={false}>
             {errors.map((e, i) => {
@@ -310,6 +318,7 @@ const Run = (props) => {
         </div>
       ),
       okText: "Close",
+      okType: (stepType.toLowerCase() === "mapping" || stepType.toLowerCase() === "merging") && entityName ? "default" : stepType.toLowerCase() === "ingestion" ? "default" : "primary",
       mask: false,
       width: 800
     });


### PR DESCRIPTION
### Description
Just the simple change to update layout of the  confirmation modal. The relevant test scenarios already exist.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [N/A] Added Tests
  

- ##### Reviewer:

- [N/A] Reviewed Tests

