### PR TITLE
DHFPROD-6599: hubDhs=true now also enables simple SSL

### DIFF
--- a/marklogic-data-hub-api/src/main/java/com/marklogic/hub/HubClientConfig.java
+++ b/marklogic-data-hub-api/src/main/java/com/marklogic/hub/HubClientConfig.java
@@ -268,19 +268,37 @@ public class HubClientConfig {
         modulePermissions = "data-hub-module-reader,read,data-hub-module-reader,execute,data-hub-module-writer,update,rest-extension-user,execute";
     }
 
+    /**
+     * Configures properties for DHS, and also configures properties for SSL.
+     */
     public void configureForDhs() {
         isHostLoadBalancer = true;
         finalAuthMethod = "basic";
         stagingAuthMethod = "basic";
         jobAuthMethod = "basic";
+        enableSimpleSsl();
     }
 
-    public void configureSimpleSsl() {
+    /**
+     * Configures properties for making SSL connections to the staging, final, job, and Manage app servers.
+     */
+    public void enableSimpleSsl() {
         finalSimpleSsl = true;
         stagingSimpleSsl = true;
         jobSimpleSsl = true;
         manageConfig.setScheme("https");
         manageConfig.setConfigureSimpleSsl(true);
+    }
+
+    /**
+     * Reverts back to the default property values, undoing what enableSimpleSsl() does.
+     */
+    public void disableSimpleSsl() {
+        finalSimpleSsl = false;
+        stagingSimpleSsl = false;
+        jobSimpleSsl = false;
+        manageConfig.setScheme("http");
+        manageConfig.setConfigureSimpleSsl(false);
     }
 
     /**
@@ -342,7 +360,9 @@ public class HubClientConfig {
 
         propertyConsumerMap.put("hubSsl", prop -> {
             if (Boolean.parseBoolean(prop)) {
-                configureSimpleSsl();
+                enableSimpleSsl();
+            } else if (!Boolean.parseBoolean(prop)) {
+                disableSimpleSsl();
             }
         });
     }

--- a/marklogic-data-hub-central/src/main/resources/application.properties
+++ b/marklogic-data-hub-central/src/main/resources/application.properties
@@ -12,7 +12,8 @@ spring.thymeleaf.prefix=classpath:/static/
 server.tomcat.remote_ip_header=x-forwarded-for
 server.tomcat.protocol_header=x-forwarded-proto
 
-# Data Hub connection properties. These default to the expected values for DHS.
+# Data Hub connection properties. These default to the expected values for DHS. Both properties are defined in case HC
+# needs to run behind a load balancer at some point, in which case hubDhs=true and hubSsl=false would be used.
 mlHost=localhost
 hubDhs=true
 hubSsl=true

--- a/marklogic-data-hub-spark-connector/spark-test-project/src/main/java/org/example/ReadCustomersFromFinal.java
+++ b/marklogic-data-hub-spark-connector/spark-test-project/src/main/java/org/example/ReadCustomersFromFinal.java
@@ -25,7 +25,6 @@ public class ReadCustomersFromFinal extends ExampleSupport {
             .option("mlUsername", username)
             .option("mlPassword", password)
             .option("hubDhs", "false")
-            .option("hubSsl", "false")
 
             // Query properties
             .option("view", "Customer")

--- a/marklogic-data-hub-spark-connector/spark-test-project/src/main/java/org/example/StreamingWriteCustomersToStaging.java
+++ b/marklogic-data-hub-spark-connector/spark-test-project/src/main/java/org/example/StreamingWriteCustomersToStaging.java
@@ -56,7 +56,6 @@ public class StreamingWriteCustomersToStaging extends ExampleSupport {
             .option("collections", "sparkCustomer,streamingTest")
             .option("permissions", "data-hub-common,read,data-hub-common,update")
             .option("hubDhs", "false")
-            .option("hubSsl", "false")
             .option("batchSize", "3")
             .option("checkpointLocation", "build/checkpoints/" + System.currentTimeMillis())
             .start();

--- a/marklogic-data-hub-spark-connector/spark-test-project/src/main/java/org/example/WriteCustomersToStaging.java
+++ b/marklogic-data-hub-spark-connector/spark-test-project/src/main/java/org/example/WriteCustomersToStaging.java
@@ -50,7 +50,6 @@ public class WriteCustomersToStaging extends ExampleSupport {
             .option("collections", "sparkCustomer,sparkData")
             .option("permissions", "data-hub-common,read,data-hub-common,update")
             .option("hubDhs", "false")
-            .option("hubSsl", "false")
             .save();
     }
 }

--- a/marklogic-data-hub-spark-connector/src/main/java/com/marklogic/hub/spark/sql/sources/v2/Util.java
+++ b/marklogic-data-hub-spark-connector/src/main/java/com/marklogic/hub/spark/sql/sources/v2/Util.java
@@ -11,7 +11,6 @@ public abstract class Util {
         Properties props = new Properties();
         // Assume DHS usage by default; the options map can override these
         props.setProperty("hubdhs", "true");
-        props.setProperty("hubssl", "true");
         options.keySet().forEach(key -> props.setProperty(key, options.get(key)));
 
         HubClientConfig hubClientConfig = new HubClientConfig();
@@ -19,5 +18,5 @@ public abstract class Util {
         hubClientConfig.applyProperties(props);
         return hubClientConfig;
     }
-    
+
 }

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/AbstractSparkConnectorTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/AbstractSparkConnectorTest.java
@@ -78,7 +78,6 @@ public abstract class AbstractSparkConnectorTest extends AbstractHubClientTest {
         testProperties = new Properties();
         String mlHost = "localhost";
         String hubDhs = "false";
-        String hubSsl = "false";
         boolean isDhs = false;
         //Can override if we want to run tests on DHS
         if (System.getProperty("mlHost") != null) {
@@ -89,13 +88,11 @@ public abstract class AbstractSparkConnectorTest extends AbstractHubClientTest {
         }
         if (isDhs) {
             hubDhs = "true";
-            hubSsl = "true";
         }
         testProperties.setProperty("mlHost", mlHost);
         testProperties.setProperty("mlUsername", username);
         testProperties.setProperty("mlPassword", password);
-        testProperties.setProperty("hubDHS", hubDhs);
-        testProperties.setProperty("hubSsl", hubSsl);
+        testProperties.setProperty("hubDhs", hubDhs);
         hubClient = new HubClientImpl(new HubClientConfig(testProperties));
         return hubClient;
     }


### PR DESCRIPTION
### Description

Updated the Spark connector to only set hubDhs=true, which means the user only needs to set hubDhs=false instead of both hubDhs/hubSsl. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

