### PR TITLE
DHFPROD-6591: Entity snippet results use 'uri' instead of 'URI'

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/run/runFlow.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/run/runFlow.spec.tsx
@@ -73,7 +73,7 @@ describe("Run Tile tests", () => {
     cy.waitForAsyncRequest();
     browsePage.waitForSpinnerToDisappear();
 
-    cy.contains("uri: /com.marklogic.smart-mastering/merged/").should("be.visible");
+    cy.contains("URI: /com.marklogic.smart-mastering/merged/").should("be.visible");
     cy.contains("123 Wilson St").scrollIntoView().should("be.visible");
     cy.contains("123 Wilson Rd").should("be.visible");
   });

--- a/marklogic-data-hub-central/ui/src/components/detail-header/detail-header.tsx
+++ b/marklogic-data-hub-central/ui/src/components/detail-header/detail-header.tsx
@@ -124,7 +124,7 @@ const DetailHeader: React.FC<Props> = (props) => {
               </>
             ) : (
               <>
-                <Text type="secondary"> uri: </Text>
+                <Text type="secondary"> URI: </Text>
                 <Text data-cy="document-uri">{id}</Text>
               </>
             )}


### PR DESCRIPTION
### Description

- Follow-up PR to #5186 from comment in QA, capitalizing URI in instance and record view as well.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- N/A Added Tests
  

- ##### Reviewer:

- N/A Reviewed Tests

