### PR TITLE
DHFPROD-6590:Entity model property names should be an NCName

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/entity-lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/entity-lib.sjs
@@ -370,8 +370,11 @@ function validateModelDefinitions(definitions) {
     }
     if (definitions[entityName].properties) {
       Object.keys(definitions[entityName].properties).forEach(propertyName => {
-        if (!pattern.test(propertyName)) {
-          throw new Error(`Invalid property name: ${propertyName}; must start with a letter and can only contain letters, numbers, hyphens, and underscores.`);
+        try{
+          fn.QName('',propertyName)
+        }
+        catch(ex){
+          throw new Error(`Invalid property name: ${propertyName} in entity model ${entityName}; it must be a valid NCName as defined at http://www.datypic.com/sc/xsd/t-xsd_Name.html.`);
         }
       });
     }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/models/CreateAndUpdateModelTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dataservices/models/CreateAndUpdateModelTest.java
@@ -176,7 +176,7 @@ public class CreateAndUpdateModelTest extends AbstractHubCoreTest {
             fail("Expected an error because of an invalid property name");
         } catch (Exception ex) {
             logger.info("Caught expected error: " + ex.getMessage());
-            assertTrue(ex.getMessage().contains("must start with a letter"));
+            assertTrue(ex.getMessage().contains("it must be a valid NCName"));
         }
     }
 }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/models/validateModelDefinitions.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/models/validateModelDefinitions.sjs
@@ -17,7 +17,7 @@ function assertThrowsPropertyNameError(model, badPropertyName) {
     entityLib.validateModelDefinitions(model);
     throw new Error("Expected model to fail validation: " + xdmp.toJsonString(model));
   } catch (e) {
-    assertions.push(test.assertEqual("Invalid property name: " + badPropertyName + "; must start with a letter and can only contain letters, numbers, hyphens, and underscores.", e.message));
+    assertions.push(test.assertEqual("Invalid property name: " + badPropertyName + " in entity model ThisIsFine; it must be a valid NCName as defined at http://www.datypic.com/sc/xsd/t-xsd_Name.html.", e.message));
   }
 }
 
@@ -57,4 +57,17 @@ assertions.push(
   }, "Cannot have spaces")
 );
 
+entityLib.validateModelDefinitions({
+  "PropsWithGermanCharacters": {
+    "properties": {
+      "prop1ä": {},
+      "prop2ö":{},
+      "prop3ü":{},
+      "prop4ß":{},
+      "prop5Ä":{},
+      "prop6Ö":{},
+      "prop7Ü":{}
+    }
+  }
+});
 assertions;


### PR DESCRIPTION
### Description
Entity model property names should be an NCName
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

