### PR TITLE
DHFPROD-6607: New Mapping step form can switch to Advanced tab withou…

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/create-edit-mapping/create-edit-mapping.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/create-edit-mapping/create-edit-mapping.tsx
@@ -231,6 +231,9 @@ const CreateEditMapping: React.FC<Props> = (props) => {
         if (mapName) {
           setIsValid(true);
           props.setIsValid(true);
+        } else {
+          setIsValid(false);
+          props.setIsValid(false);
         }
       } else {
         setIsValid(false);
@@ -358,7 +361,7 @@ const CreateEditMapping: React.FC<Props> = (props) => {
   };
 
   const propagateSrcValidity = () => {
-    if ((collections && selectedSource === "collection") || (srcQuery && selectedSource !== "collection")) {
+    if (mapName && ((collections && selectedSource === "collection") || (srcQuery && selectedSource !== "collection"))) {
       // Touched
       if (props.currentTab === props.tabKey) {
         props.setIsValid(true);


### PR DESCRIPTION
…t name input

### Description

- Fixed bug on a new mapping step where user could only fill out collections with no name and switch to advanced tab.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- N/A Added Tests
  

- ##### Reviewer:

- N/A Reviewed Tests

