### PR TITLE
DHFPROD-6541: fixed incompatible children type in multi-slider

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/matching/multi-slider/multi-slider.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/multi-slider/multi-slider.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from "react";
 import {Icon} from "antd";
-import {Slider, Handles, Ticks} from "@marklogic/react-compound-slider";
+import {Slider, Handles, Ticks, Rail, GetRailProps} from "@marklogic/react-compound-slider";
 import "./multi-slider.scss";
 import {MLTooltip} from "@marklogic/design-system";
 import {multiSliderTooltips} from "../../../../config/tooltips.config";
@@ -13,8 +13,18 @@ const MultiSlider = (props) => {
   const [activeHandleIdOptions, setActiveHandleIdOptions] = useState<object>({});
   const [tickValue, setTickValue] = useState<any>(0);
 
-
-
+  // props for slider rail
+  interface SliderRailProps {
+    getRailProps: GetRailProps;
+  }
+  const SliderRail: React.FC<SliderRailProps> = ({getRailProps}) => {
+    return (
+      <>
+        <div className={"sliderRail"} data-testid={`${props.type}-slider-rail`} {...getRailProps()} />
+        <div className={"sliderRail"} />
+      </>
+    );
+  };
 
   function Handle({handle: {id, value, percent},
     options: options,
@@ -190,7 +200,9 @@ const MultiSlider = (props) => {
             );
           }}
         </Handles>
-        <div className={"sliderRail"} data-testid={`${props.type}-slider-rail`}/>
+        <Rail>
+          {({getRailProps}) => <SliderRail getRailProps={getRailProps} />}
+        </Rail>
         <Ticks count={100}>
           {({ticks}) => (
             <div data-testid={`${props.type}-slider-ticks`} >

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.tsx
@@ -381,7 +381,7 @@ const MergingStepDetail: React.FC = () => {
           </div>
           <div>
             <Table
-              rowKey="strategy"
+              rowKey="strategyName"
               className={styles.table}
               columns={mergeStrategyColumns}
               dataSource={mergeStrategiesData}
@@ -418,7 +418,7 @@ const MergingStepDetail: React.FC = () => {
             </div>
           </div>
           <MLTable
-            rowKey="rule"
+            rowKey="property"
             className={styles.table}
             columns={mergeRuleColumns}
             dataSource={mergeRulesData}


### PR DESCRIPTION
### Description
Reviews should verify that there are no red console warnings when adjusting sliders in **Step Details** for any **Matching** step.  (Warnings are from React, and will only show up when running UI with `npm start`.)

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- N/A Added Tests
  

- ##### Reviewer:

- N/A Reviewed Tests

