### PR TITLE
DHFPROD-6410: Construct HC reduce rules appropriately

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mastering/updateMatchOptionsLib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/mastering/updateMatchOptionsLib.sjs
@@ -249,7 +249,11 @@ function adjustWeight(weight, maxWeight) {
 function getEntityPropertyPath(propName, propertyDefinitions = {})
 {
   let propertyDefinition = propertyDefinitions[propName];
-  return propertyDefinition ? propertyDefinition.localname : propName;
+  let propPath = propertyDefinition ? propertyDefinition.localname : propName;
+  if (Array.isArray(propPath) && propPath.length === 1) {
+    propPath = propPath[0];
+  }
+  return propPath;
 }
 
 module.exports = {

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mastering/updateMatchOptions.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/mastering/updateMatchOptions.sjs
@@ -238,6 +238,42 @@ const reduceAllMatchExpected =
   };
 
 // -----------------------------------------------
+// reduce/allMatch scenario 2, "address" property localname and name as arrays.
+// This might not be considered a valid pre-HC input, but the smart-mastering-complete
+// example project in 5.2 had one property with the localname and name as arrays containing
+// a single string. Different input but expecting same output.
+// -----------------------------------------------
+const reduceAllMatchInputWithArrayProperties =
+  {
+    "propertyDefs": {
+      "property": [
+        {
+          "namespace": "",
+          "localname": "lastName",
+          "name": "lastName"
+        },
+        {
+          "namespace": "",
+          "localname": ["address"],
+          "name": ["address"]
+        }
+      ]
+    },
+    "scoring": {
+      "reduce": [
+        {
+          "allMatch": {
+            "property": [ "address", "lastName" ]
+          },
+          "algorithmRef": "standard-reduction",
+          "weight": "5"
+        }
+      ]
+    }
+  };
+
+
+// -----------------------------------------------
 // large options, tests most cases
 // -----------------------------------------------
 const largeInput =
@@ -433,5 +469,8 @@ const largeExpected =
   test.assertEqualJson(normExpected, invokeService(normNegInput), "normalize weights, negative reduce"),
   test.assertEqualJson(normExpected, invokeService(normPosInput), "normalize weights, positive reduce"),
   test.assertEqualJson(reduceAllMatchExpected, invokeService(reduceAllMatchInput), "reduce allMatch"),
+  test.assertEqualJson(reduceAllMatchExpected, invokeService(reduceAllMatchInputWithArrayProperties), "reduce allMatch, property localname and name as arrays"),
   test.assertEqualJson(largeExpected, invokeService(largeInput), "large options, most cases")
 ];
+
+


### PR DESCRIPTION
Fixing bug in match options conversion noticed by Rob in reviewing PR 5192

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

