### PR TITLE
DHFPROD-6646: Reverting DHF to Java 8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,12 +119,12 @@ def dhfWinTests(String mlVersion, String type){
         	        ''').trim().split();
         def bldPath=bldOutput[bldOutput.size()-1]
         setupMLWinCluster bldPath,pkgLoc
-        bat 'set PATH=C:\\Program Files\\Java\\jdk-11.0.2\\bin;$PATH & cd data-hub & gradlew.bat clean'
-        bat 'set PATH=C:\\Program Files\\Java\\jdk-11.0.2\\bin;$PATH & cd data-hub & gradlew.bat marklogic-data-hub:bootstrapAndTest  || exit /b 0'
-        bat 'set PATH=C:\\Program Files\\Java\\jdk-11.0.2\\bin;$PATH & cd data-hub & gradlew.bat marklogic-data-hub-central:test  || exit /b 0'
-        bat 'set PATH=C:\\Program Files\\Java\\jdk-11.0.2\\bin;$PATH & cd data-hub & gradlew.bat ml-data-hub:test  || exit /b 0'
-        bat 'set PATH=C:\\Program Files\\Java\\jdk-11.0.2\\bin;$PATH & cd data-hub & gradlew.bat web:test || exit /b 0'
-        bat 'set PATH=C:\\Program Files\\Java\\jdk-11.0.2\\bin;$PATH & cd data-hub & gradlew.bat marklogic-data-hub-spark-connector:test  || exit /b 0'
+        bat 'set PATH=C:\\Program Files\\Java\\jdk1.8.0_72\\bin;$PATH & cd data-hub & gradlew.bat clean'
+        bat 'set PATH=C:\\Program Files\\Java\\jdk1.8.0_72\\bin;$PATH & cd data-hub & gradlew.bat marklogic-data-hub:bootstrapAndTest  || exit /b 0'
+        bat 'set PATH=C:\\Program Files\\Java\\jdk1.8.0_72\\bin;$PATH & cd data-hub & gradlew.bat marklogic-data-hub-central:test  || exit /b 0'
+        bat 'set PATH=C:\\Program Files\\Java\\jdk1.8.0_72\\bin;$PATH & cd data-hub & gradlew.bat ml-data-hub:test  || exit /b 0'
+        bat 'set PATH=C:\\Program Files\\Java\\jdk1.8.0_72\\bin;$PATH & cd data-hub & gradlew.bat web:test || exit /b 0'
+        bat 'set PATH=C:\\Program Files\\Java\\jdk1.8.0_72\\bin;$PATH & cd data-hub & gradlew.bat marklogic-data-hub-spark-connector:test  || exit /b 0'
         junit '**/TEST-*.xml'
     }
 }
@@ -144,12 +144,12 @@ script{
                                 	        ''').trim().split();
                                 def bldPath=bldOutput[bldOutput.size()-1]
                                 setupMLWinCluster bldPath,pkgLoc,"w2k16-10-dhf-2,w2k16-10-dhf-3"
-                                bat 'set PATH=C:\\Program Files\\Java\\jdk-11.0.2\\bin;$PATH & cd data-hub & gradlew.bat clean'
-                                bat 'set PATH=C:\\Program Files\\Java\\jdk-11.0.2\\bin;$PATH & cd data-hub & gradlew.bat marklogic-data-hub:bootstrapAndTest  || exit /b 0'
-                                bat 'set PATH=C:\\Program Files\\Java\\jdk-11.0.2\\bin;$PATH & cd data-hub & gradlew.bat marklogic-data-hub-central:test  || exit /b 0'
-                                bat 'set PATH=C:\\Program Files\\Java\\jdk-11.0.2\\bin;$PATH & cd data-hub & gradlew.bat ml-data-hub:test  || exit /b 0'
-                                bat 'set PATH=C:\\Program Files\\Java\\jdk-11.0.2\bin;$PATH & cd data-hub & gradlew.bat web:test || exit /b 0'
-                                bat 'set PATH=C:\\Program Files\\Java\\jdk-11.0.2\\bin;$PATH & cd data-hub & gradlew.bat marklogic-data-hub-spark-connector:test  || exit /b 0'
+                                bat 'set PATH=C:\\Program Files\\Java\\jdk1.8.0_72\\bin;$PATH & cd data-hub & gradlew.bat clean'
+                                bat 'set PATH=C:\\Program Files\\Java\\jdk1.8.0_72\\bin;$PATH & cd data-hub & gradlew.bat marklogic-data-hub:bootstrapAndTest  || exit /b 0'
+                                bat 'set PATH=C:\\Program Files\\Java\\jdk1.8.0_72\\bin;$PATH & cd data-hub & gradlew.bat marklogic-data-hub-central:test  || exit /b 0'
+                                bat 'set PATH=C:\\Program Files\\Java\\jdk1.8.0_72\\bin;$PATH & cd data-hub & gradlew.bat ml-data-hub:test  || exit /b 0'
+                                bat 'set PATH=C:\\Program Files\\Java\\jdk1.8.0_72\bin;$PATH & cd data-hub & gradlew.bat web:test || exit /b 0'
+                                bat 'set PATH=C:\\Program Files\\Java\\jdk1.8.0_72\\bin;$PATH & cd data-hub & gradlew.bat marklogic-data-hub-spark-connector:test  || exit /b 0'
                                 junit '**/TEST-*.xml'
                             }
 }
@@ -188,14 +188,14 @@ def runCypressE2e(){
         sh 'rm -rf *central*.rpm || true'
         copyArtifacts filter: '**/*.rpm', fingerprintArtifacts: true, flatten: true, projectName: '${JOB_NAME}', selector: specific('${BUILD_NUMBER}')
         sh(script:'''#!/bin/bash
-            export JAVA_HOME=~/java/jdk-11.0.2
+            export JAVA_HOME=`eval echo "$JAVA_HOME_DIR"`;
             sudo mladmin install-hubcentral $WORKSPACE/*central*.rpm;
             sudo mladmin add-javahome-hubcentral $JAVA_HOME
             sudo mladmin add-hubcentral-property hubUseLocalDefaults=true
             sudo mladmin start-hubcentral
         ''')
         sh(script:'''#!/bin/bash
-            export JAVA_HOME=~/java/jdk-11.0.2
+            export JAVA_HOME=`eval echo "$JAVA_HOME_DIR"`;
             export M2_LOCAL_REPO=$WORKSPACE/$M2_HOME_REPO
             export GRADLE_USER_HOME=$WORKSPACE$GRADLE_DIR;
             export PATH=$M2_LOCAL_REPO:$JAVA_HOME/bin:$GRADLE_USER_HOME:$PATH;
@@ -453,7 +453,7 @@ pipeline{
   	buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '30', numToKeepStr: '')
 	}
 	environment{
-	JAVA_HOME_DIR="~/java/jdk-11.0.2"
+	JAVA_HOME_DIR="~/java/jdk1.8.0_72"
 	GRADLE_DIR="/.gradle"
 	MAVEN_HOME="/usr/local/maven"
 	M2_HOME_REPO="/repository"

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ allprojects {
 subprojects {
     apply plugin: 'java'
     apply plugin: 'jacoco'
-    sourceCompatibility = "9"
-    targetCompatibility = "9"
+    sourceCompatibility = "8"
+    targetCompatibility = "8"
 
     repositories {
         mavenCentral()

--- a/marklogic-data-hub-central/build.gradle
+++ b/marklogic-data-hub-central/build.gradle
@@ -25,8 +25,8 @@ apply plugin: "com.github.node-gradle.node"
 apply plugin: "jsonschema2pojo"
 apply from: 'build-rpm.gradle'
 
-sourceCompatibility = "9"
-targetCompatibility = "9"
+sourceCompatibility = "8"
+targetCompatibility = "8"
 
 // See https://github.com/snyk/gradle-plugin for docs
 snyk {

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/auth/SessionMonitorInterceptor.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/auth/SessionMonitorInterceptor.java
@@ -14,7 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class SessionMonitorInterceptor implements HandlerInterceptor {
-    static final Map<String, Object> stompHeaders = new HashMap<>() {{
+    static final Map<String, Object> stompHeaders = new HashMap<String, Object>() {{
         put("content-type","application/json");
     }};
 

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/impl/CreatedOnFacetHandlerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/impl/CreatedOnFacetHandlerTest.java
@@ -88,7 +88,7 @@ public class CreatedOnFacetHandlerTest extends AbstractFacetHandlerTest {
 
         assertEquals(startDateTime.getOffset().getTotalSeconds()/60, Integer.parseInt(stringValues.get(1)));
         assertEquals(endDateTime.getOffset().getTotalSeconds()/60, Integer.parseInt(stringValues.get(1)));
-        assertEquals(Duration.between(startDateTime, endDateTime).dividedBy(Duration.ofDays(1)), 1);
+        assertEquals(1, getDurationInSeconds(startDateTime, endDateTime));
     }
 
     @Test
@@ -100,14 +100,13 @@ public class CreatedOnFacetHandlerTest extends AbstractFacetHandlerTest {
         dateRange = createdOnFacetHandler.computeDateRange(facetData, facetInputs);
         startDateTime = ZonedDateTime.parse(dateRange.get("startDateTime"), CreatedOnFacetHandler.DATE_TIME_FORMAT);
         endDateTime = ZonedDateTime.parse(dateRange.get("endDateTime"), CreatedOnFacetHandler.DATE_TIME_FORMAT);
-        ZonedDateTime currentDateTime = LocalDate.now().atStartOfDay().atZone(zoneId);
+        currentDateTime = LocalDate.now().atStartOfDay().atZone(zoneId);
 
         assertEquals(startDateTime.getOffset().getTotalSeconds()/60, Integer.parseInt(stringValues.get(1)));
         assertEquals(endDateTime.getOffset().getTotalSeconds()/60, Integer.parseInt(stringValues.get(1)));
-        assertEquals(Duration.between(startDateTime, endDateTime).dividedBy(Duration.ofDays(1)),
-                Duration.between(startDateTime, currentDateTime).dividedBy(Duration.ofDays(1)) + 1);
-
+        assertEquals(getDurationInSeconds(startDateTime, endDateTime), getDurationInSeconds(startDateTime, currentDateTime) + 1);
     }
+
     @Test
     public void testThisMonthDateRange() {
         stringValues = Arrays.asList("This Month", zoneOffset);
@@ -121,9 +120,8 @@ public class CreatedOnFacetHandlerTest extends AbstractFacetHandlerTest {
 
         assertEquals(startDateTime.getOffset().getTotalSeconds()/60, Integer.parseInt(stringValues.get(1)));
         assertEquals(endDateTime.getOffset().getTotalSeconds()/60, Integer.parseInt(stringValues.get(1)));
-        assertEquals(Duration.between(startDateTime, endDateTime).dividedBy(Duration.ofDays(1)),
-                Duration.between(startDateTime, currentDateTime).dividedBy(Duration.ofDays(1)) + 1);
-        assertEquals(Duration.between(startDateTime, endDateTime).dividedBy(Duration.ofDays(1)), currentDateTime.getDayOfMonth());
+        assertEquals(getDurationInSeconds(startDateTime, endDateTime), getDurationInSeconds(startDateTime, currentDateTime) + 1);
+        assertEquals(getDurationInSeconds(startDateTime, endDateTime), currentDateTime.getDayOfMonth());
     }
 
     // try block test
@@ -171,5 +169,9 @@ public class CreatedOnFacetHandlerTest extends AbstractFacetHandlerTest {
         facetData.setRangeValues(rangeValues);
 
         assertThrows(DataHubException.class, () -> createdOnFacetHandler.computeDateRange(facetData, facetInputs));
+    }
+
+    private long getDurationInSeconds(ZonedDateTime start, ZonedDateTime end) {
+        return Duration.between(start, end).dividedBy(Duration.ofDays(1).getSeconds()).getSeconds();
     }
 }

--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -38,8 +38,8 @@ repositories {
 
 group = 'com.marklogic'
 
-sourceCompatibility = "9"
-targetCompatibility = "9"
+sourceCompatibility = "8"
+targetCompatibility = "8"
 
 ext {
     // Something changed with 5.5.0 such that "test --tests" doesn't work with Gradle 6.2 or 6.5

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/EntityManager.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/EntityManager.java
@@ -68,7 +68,7 @@ public interface EntityManager {
 
     List<HubEntity> getEntities(Boolean extendSubEntities);
 
-    @Deprecated(since = "DHF 5.3.0; use ModelsService instead")
+    @Deprecated // since DHF 5.3.0; use ModelsService instead
     HubEntity saveEntity(HubEntity entity, Boolean rename) throws IOException;
 
     void deleteEntity(String entity) throws IOException;

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/impl/FlowRunnerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/flow/impl/FlowRunnerImpl.java
@@ -110,8 +110,7 @@ public class FlowRunnerImpl implements FlowRunner {
         this.flowManager = new FlowManagerImpl(hubClient);
     }
 
-    @Deprecated(since = "5.3.0-beta; must be retained because the 5.2 dh-5-example project used it in an example. " +
-        "Should use FlowRunnerImpl(HubClient) instead.")
+    @Deprecated // since 5.3.0-beta; must be retained because the 5.2 dh-5-example project used it in an example. Should use FlowRunnerImpl(HubClient) instead.
     public FlowRunnerImpl(HubConfig hubConfig) {
         this(hubConfig.newHubClient());
     }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/hubcentral/conversion/FlowConverter.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/hubcentral/conversion/FlowConverter.java
@@ -45,6 +45,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -361,7 +362,9 @@ public class FlowConverter extends LoggingObject {
         stepArtifact.remove("options");
         JsonNode options = inlineStep.get("options");
         if (options != null) {
-            Set<String> fieldsNotToBeCopied = Set.of("mapping", "sourceCollection");
+            Set<String> fieldsNotToBeCopied = new HashSet<>();
+            fieldsNotToBeCopied.add("mapping");
+            fieldsNotToBeCopied.add("sourceCollection");
             //Don't remove any properties from 'options' for custom steps and convert them as is
             options.fields().forEachRemaining(kv -> {
                 if (!fieldsNotToBeCopied.contains(kv.getKey()) || inlineStep.get("stepDefinitionType").asText().equals(StepDefinitionType.CUSTOM.toString())) {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/EntityManagerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/EntityManagerImpl.java
@@ -395,7 +395,7 @@ public class EntityManagerImpl extends LoggingObject implements EntityManager {
         return entities;
     }
 
-    @Deprecated(since = "DHF 5.3.0; use ModelsService instead")
+    @Deprecated // since DHF 5.3.0; use ModelsService instead
     public HubEntity saveEntity(HubEntity entity, Boolean rename) throws IOException {
         JsonNode node = entity.toJson();
         ObjectMapper objectMapper = new ObjectMapper();

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -148,8 +148,7 @@ public class HubConfigImpl extends HubClientConfig implements HubConfig
      *
      * @return
      */
-    @Deprecated(since = "5.3.0-beta; must be retained because the 5.2 dh-5-example project used it in an example. " +
-        "Should use new HubConfigImpl() instead.")
+    @Deprecated // since 5.3.0-beta; must be retained because the 5.2 dh-5-example project used it in an example. Should use new HubConfigImpl() instead.
     public static HubConfigImpl withDefaultProperties() {
         return new HubConfigImpl();
     }
@@ -1306,7 +1305,9 @@ public class HubConfigImpl extends HubClientConfig implements HubConfig
         if (hubProject != null) {
             initializeConfigDirs(config);
             initializeModulePaths(config);
-            config.setSchemaPaths(List.of(getUserSchemasDir().toString()));
+            List<String> paths = new ArrayList<>();
+            paths.add(getUserSchemasDir().toString());
+            config.setSchemaPaths(paths);
         }
 
         addDhfPropertiesToCustomTokens(config);

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -148,7 +148,7 @@ public class HubTestBase extends AbstractHubTest {
         LegacyTracing.create(getHubClient().getStagingClient()).disable();
     }
 
-    @Deprecated(since = "Deprecated in DHF 5.4.0; using this may not work when the test is run against DHS; use runAsDataHubOperator instead")
+    @Deprecated // since DHF 5.4.0; using this may not work when the test is run against DHS; use runAsDataHubOperator instead
     protected HubConfigImpl runAsFlowOperator() {
         runAsUser("flow-operator", "password");
         return getHubConfig();
@@ -160,7 +160,7 @@ public class HubTestBase extends AbstractHubTest {
      *
      * @return
      */
-    @Deprecated(since = "Deprecated in DHF 5.4.0; using this may not work when the test is run against DHS; use runAsAdmin or runAsDataHubDeveloper instead")
+    @Deprecated // since DHF 5.4.0; using this may not work when the test is run against DHS; use runAsAdmin or runAsDataHubDeveloper instead
     protected HubConfigImpl runAsFlowDeveloper() {
         runAsUser("flow-developer", "password");
         return getHubConfig();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/MarkLogicVersionTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/MarkLogicVersionTest.java
@@ -17,6 +17,7 @@ package com.marklogic.hub;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,58 +43,54 @@ public class MarkLogicVersionTest {
 
     @Test
     void isVersionCompatibleWith520Roles() {
-        Map<String, Boolean> versionMap = Map.of(
-                "9.0-20200909", false,
-                "9.0-10.2", false,
-                "10.0-20200909", true,
-                "10.0-2.1", false,
-                "10.0-3", true,
-                "10.0-3.1", true,
-                "11.0-10.2", true
-        );
+        Map<String, Boolean> versionMap = new HashMap<>();
+        versionMap.put("9.0-20200909", false);
+        versionMap.put("9.0-10.2", false);
+        versionMap.put("10.0-20200909", true);
+        versionMap.put("10.0-2.1", false);
+        versionMap.put("10.0-3", true);
+        versionMap.put("10.0-3.1", true);
+        versionMap.put("11.0-10.2", true);
         versionMap.forEach((version, aBoolean) -> assertEquals(new MarkLogicVersion(version).isVersionCompatibleWith520Roles(), aBoolean, "Expected " + aBoolean + " for " + version));
     }
 
     @Test
     void supportsRangeIndexConstraints() {
-        Map<String, Boolean> versionMap = Map.of(
-                "9.0-20200909", false,
-                "9.0-10.2", false,
-                "10.0-20200909", true,
-                "10.0-3.1", false,
-                "10.0-4", true,
-                "10.0-4.1", true,
-                "11.0-10.2", true
-        );
+        Map<String, Boolean> versionMap = new HashMap<>();
+        versionMap.put("9.0-20200909", false);
+        versionMap.put("9.0-10.2", false);
+        versionMap.put("10.0-20200909", true);
+        versionMap.put("10.0-3.1", false);
+        versionMap.put("10.0-4", true);
+        versionMap.put("10.0-4.1", true);
+        versionMap.put("11.0-10.2", true);
         versionMap.forEach((version, aBoolean) -> assertEquals(new MarkLogicVersion(version).supportsRangeIndexConstraints(), aBoolean, "Expected " + aBoolean + " for " + version));
     }
 
     @Test
     void supportsDataHubFramework() {
-        Map<String, Boolean> versionMap = Map.of(
-                "9.0-20200909", true,
-                "9.0-10.2", false,
-                "9.0-11", true,
-                "9.0-11.1", true,
-                "10.0-20200909", true,
-                "10.0-2", false,
-                "10.0-2.1", true,
-                "10.0-4.1", true,
-                "11.0-10.2", true
-        );
+        Map<String, Boolean> versionMap = new HashMap<>();
+        versionMap.put("9.0-20200909", true);
+        versionMap.put("9.0-10.2", false);
+        versionMap.put("9.0-11", true);
+        versionMap.put("9.0-11.1", true);
+        versionMap.put("10.0-20200909", true);
+        versionMap.put("10.0-2", false);
+        versionMap.put("10.0-2.1", true);
+        versionMap.put("10.0-4.1", true);
+        versionMap.put("11.0-10.2", true);
         versionMap.forEach((version, aBoolean) -> assertEquals(new MarkLogicVersion(version).supportsDataHubFramework(), aBoolean, "Expected " + aBoolean + " for " + version));
     }
 
     @Test
     void cannotUpdateAmps() {
-        Map<String, Boolean> versionMap = Map.of(
-                "9.0-20200909", false,
-                "9.0-10.2", false,
-                "10.0-20200909", false,
-                "10.0-2.1", false,
-                "10.0-4.4", true,
-                "11.0-10.2", false
-        );
+        Map<String, Boolean> versionMap = new HashMap<>();
+        versionMap.put("9.0-20200909", false);
+        versionMap.put("9.0-10.2", false);
+        versionMap.put("10.0-20200909", false);
+        versionMap.put("10.0-2.1", false);
+        versionMap.put("10.0-4.4", true);
+        versionMap.put("11.0-10.2", false);
         versionMap.forEach((version, aBoolean) -> assertEquals(new MarkLogicVersion(version).cannotUpdateAmps(), aBoolean, "Expected " + aBoolean + " for " + version));
     }
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/DeployDatabaseFieldCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/DeployDatabaseFieldCommandTest.java
@@ -14,9 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DeployDatabaseFieldCommandTest extends AbstractHubCoreTest {
 
@@ -145,7 +143,9 @@ public class DeployDatabaseFieldCommandTest extends AbstractHubCoreTest {
         ObjectNode db = getDatabaseProperties(getHubClient().getDbName(DatabaseKind.FINAL));
 
         ArrayNode array = (ArrayNode) db.get("field");
-        List fieldsToBeRemoved = new ArrayList(List.of("myField", "fieldWithNamespace"));
+        List fieldsToBeRemoved = new ArrayList();
+        fieldsToBeRemoved.add("myField");
+        fieldsToBeRemoved.add("fieldWithNamespace");
         for (int i = 0; i < array.size(); i++) {
             JsonNode field = array.get(i);
             if ("myField".equals(field.get("field-name").asText()) || "fieldWithNamespace".equals(field.get("field-name").asText())) {
@@ -156,7 +156,9 @@ public class DeployDatabaseFieldCommandTest extends AbstractHubCoreTest {
         }
 
         array = (ArrayNode) db.get("range-field-index");
-        fieldsToBeRemoved = new ArrayList(List.of("myField", "fieldWithNamespace"));
+        fieldsToBeRemoved = new ArrayList();
+        fieldsToBeRemoved.add("myField");
+        fieldsToBeRemoved.add("fieldWithNamespace");
         for (int i = 0; i < array.size(); i++) {
             JsonNode field = array.get(i);
             if ("myField".equals(field.get("field-name").asText()) || "fieldWithNamespace".equals(field.get("field-name").asText())) {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommandTest.java
@@ -228,7 +228,8 @@ public class LoadUserArtifactsCommandTest extends AbstractHubCoreTest {
         props1.forEach((key, val) -> assertEquals(val, props2.getProperty((String) key)));
         assertEquals(props1.size(), props2.size());
 
-        //modify flow files
+        // Wait a second, and then modify each flow file to ensure it has a timestamp more recent than what was recorded before
+        sleep(1000);
         Files.list(hubConfig.getFlowsDir()).forEach(path -> path.toFile().setLastModified(new Date().getTime()));
 
         loadUserArtifactsCommand.execute(new CommandContext(hubConfig.getAppConfig(), hubConfig.getManageClient(), null));
@@ -236,11 +237,12 @@ public class LoadUserArtifactsCommandTest extends AbstractHubCoreTest {
         props3.load(FileUtils.openInputStream(new File(timestampFile)));
         assertEquals(props2.size(), props3.size());
         props2.forEach((key, val) -> {
+            String timestamp = props3.getProperty((String)key);
             if(key.toString().contains("flow.json")){
-                assertNotEquals(val, props3.getProperty((String) key));
+                assertNotEquals(val, timestamp, "Expected values to not be equal: " + val + "; " + timestamp + "; key: " + key);
             }
             else{
-                assertEquals(val, props3.getProperty((String) key));
+                assertEquals(val, timestamp, "Expected equal values for key: " + key);
             }
         });
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/hubcentral/conversion/FlowConverterTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/hubcentral/conversion/FlowConverterTest.java
@@ -127,9 +127,9 @@ class FlowConverterTest extends AbstractHubCoreTest {
         JsonNode customStep2 = readJsonObject(customSteps.resolve("generate-dictionary.step.json").toFile());
         JsonNode customStep3 = readJsonObject(customSteps.resolve("custom-mapping-step.step.json").toFile());
 
-        assertEquals(List.of("master-customer", "Customer", "custom-mastering" ), getCollectionsAsList(customStep1));
-        assertEquals(List.of("generate-dictionary", "Customer"), getCollectionsAsList(customStep2));
-        assertEquals(List.of("custom-mapping-step" ), getCollectionsAsList(customStep3));
+        assertEquals(Arrays.asList("master-customer", "Customer", "custom-mastering" ), getCollectionsAsList(customStep1));
+        assertEquals(Arrays.asList("generate-dictionary", "Customer"), getCollectionsAsList(customStep2));
+        assertEquals(Arrays.asList("custom-mapping-step" ), getCollectionsAsList(customStep3));
 
         verifyOptions(customStep1, mapper.valueToTree(customMasterFlow.getStep("3").getOptions()));
         verifyOptions(customStep2, mapper.valueToTree(customMasterFlow.getStep("1").getOptions()));
@@ -283,17 +283,17 @@ class FlowConverterTest extends AbstractHubCoreTest {
     }
 
     private void verifyOptions(JsonNode step, JsonNode options){
-        Set fieldNotExpected ;
+        List<String> fieldNotExpected ;
         if ("mapping".equalsIgnoreCase(step.get("stepDefinitionType").asText())){
-            fieldNotExpected = Set.of("outputFormat", "mapping");
+            fieldNotExpected = Arrays.asList("outputFormat", "mapping");
         }
         else if ("ingestion".equalsIgnoreCase(step.get("stepDefinitionType").asText())){
-            fieldNotExpected = Set.of("outputFormat");
+            fieldNotExpected = Arrays.asList("outputFormat");
         }
         // in case of custom steps, "collections" have been tested separately,"outputFormat", "targetEntity" properties
         // are removed from converted steps
         else {
-            fieldNotExpected = Set.of("outputFormat", "targetEntity", "collections");
+            fieldNotExpected = Arrays.asList("outputFormat", "targetEntity", "collections");
         }
 
         options.fields().forEachRemaining(kv -> {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/ClearUserModulesTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/ClearUserModulesTest.java
@@ -11,10 +11,7 @@ import com.marklogic.client.io.QueryOptionsListHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.hub.AbstractHubCoreTest;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.HubConfig;
@@ -130,7 +127,7 @@ class ClearUserModulesTest extends AbstractHubCoreTest {
             JsonNode resourceExtensionsList = resourceExtensionsManager.listServices(new JacksonHandle()).get();
             List<String> resourceExtensions = resourceExtensionsList.findValuesAsText("name");
 
-            return List.of(optionsMap.keySet(), transforms, resourceExtensions);
+            return Arrays.asList(optionsMap.keySet(), transforms, resourceExtensions);
         }
 
         private void setModuleCounts(){

--- a/ml-data-hub-plugin/build.gradle
+++ b/ml-data-hub-plugin/build.gradle
@@ -39,8 +39,8 @@ plugins {
 
 apply plugin: "com.gradle.plugin-publish"
 
-sourceCompatibility = "9"
-targetCompatibility = "9"
+sourceCompatibility = "8"
+targetCompatibility = "8"
 
 bootJar.enabled = false
 jar.enabled = true

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -47,8 +47,8 @@ repositories {
     maven {url 'http://developer.marklogic.com/maven2/'}
 }
 
-sourceCompatibility = "1.9"
-targetCompatibility = "1.9"
+sourceCompatibility = "8"
+targetCompatibility = "8"
 
 // While 5.4.2 works in core DHF, gradle test --tests doesn't work unless 5.3.2 is used for QS
 ext.junitPlatformVersion = '1.3.2'

--- a/web/src/main/java/com/marklogic/hub/web/service/EntityManagerService.java
+++ b/web/src/main/java/com/marklogic/hub/web/service/EntityManagerService.java
@@ -111,7 +111,7 @@ public class EntityManagerService {
         return getEntity(newEntity.getName());
     }
 
-    @Deprecated(since = "DHF 5.3.0; use ModelsService instead")
+    @Deprecated // since DHF 5.3.0; use ModelsService instead
     public EntityModel saveEntity(EntityModel entity) throws IOException {
         JsonNode node = entity.toJson();
         String fullpath = entity.getFilename();


### PR DESCRIPTION
### Description

Code changes are mostly changing how @Deprecated is used and not using some collections APIs that were added in Java 9 (but are easily replaced). 

Commented out CreatedOnFacetHandlerTest, will figure out how to fix those lines before this is merged. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

