### PR TITLE
DHFPROD-6632: Advanced tab is enabled in a new step with invalid name field

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.tsx
@@ -274,6 +274,7 @@ const CreateEditStep: React.FC<Props>  = (props) => {
 
   const handleChange = (event) => {
     if (event.target.id === "name") {
+      let isSpecialChars = false;
       if (event.target.value === " ") {
         setStepNameTouched(false);
       } else {
@@ -283,11 +284,12 @@ const CreateEditStep: React.FC<Props>  = (props) => {
         //check value does not contain special chars and leads with a letter
         if (event.target.value !== "" && !(/^[a-zA-Z][a-zA-Z0-9\-_]*$/g.test(event.target.value))) {
           setInvalidChars(true);
+          isSpecialChars = true;
         } else {
           setInvalidChars(false);
         }
 
-        if (event.target.value.length > 0) {
+        if (event.target.value.length > 0 && !isSpecialChars) {
           if (collections || srcQuery) {
             setIsValid(true);
             props.setIsValid(true);

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/create-edit-mapping/create-edit-mapping.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/create-edit-mapping/create-edit-mapping.tsx
@@ -244,6 +244,7 @@ const CreateEditMapping: React.FC<Props> = (props) => {
 
   const handleChange = (event) => {
     if (event.target.id === "name") {
+      let isSpecialChars = false;
       if (event.target.value === " ") {
         setMapNameTouched(false);
       } else {
@@ -253,10 +254,11 @@ const CreateEditMapping: React.FC<Props> = (props) => {
         //check value does not contain special chars and leads with a letter
         if (event.target.value !== "" && !(/^[a-zA-Z][a-zA-Z0-9\-_]*$/g.test(event.target.value))) {
           setInvalidChars(true);
+          isSpecialChars = true;
         } else {
           setInvalidChars(false);
         }
-        if (event.target.value.length > 0) {
+        if (event.target.value.length > 0 && !isSpecialChars) {
           if (collections|| srcQuery) {
             setIsValid(true);
             props.setIsValid(true);

--- a/marklogic-data-hub-central/ui/src/components/load/create-edit-load/create-edit-load.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/create-edit-load/create-edit-load.tsx
@@ -210,6 +210,7 @@ const CreateEditLoad: React.FC<Props> = (props) => {
 
   const handleChange = (event) => {
     if (event.target.id === "name") {
+      let isSpecialChars = false;
       if (event.target.value === " ") {
         setStepNameTouched(false);
       } else {
@@ -219,10 +220,11 @@ const CreateEditLoad: React.FC<Props> = (props) => {
         //check value does not contain special chars and leads with a letter
         if (event.target.value !== "" && !(/^[a-zA-Z][a-zA-Z0-9\-_]*$/g.test(event.target.value))) {
           setInvalidChars(true);
+          isSpecialChars = true;
         } else {
           setInvalidChars(false);
         }
-        if (event.target.value.length === 0) {
+        if (event.target.value.length === 0 || isSpecialChars) {
           setIsValid(false);
           props.setIsValid(false);
         } else if (srcFormat && tgtFormat) {


### PR DESCRIPTION
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- N/A Added Tests
  

- ##### Reviewer:

- N/A Reviewed Tests

