### PR TITLE
DHFPROD-6111:Tooltip for source doc should only appear for truncated values

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
@@ -431,7 +431,15 @@ describe("RTL Source-to-entity map tests", () => {
 
   test("Verify evaluation of valid expression for mapping writer user", async () => {
     axiosMock.post["mockImplementation"](jest.fn(() => Promise.resolve({status: 200, data: data.testJSONResponse})));
-    const {getByText, getByTestId, queryByTestId} = render(<SourceToEntityMap {...data.mapProps} mappingVisible={true} />);
+    const {getByText, getByTestId, queryByTestId, queryAllByText} = render(<SourceToEntityMap {...data.mapProps} mappingVisible={true} />);
+
+    await(waitForElement(() => getByTestId("proteinId-srcValue")));
+    expect(getByTestId("proteinId-srcValue")).toHaveTextContent("123EAC");
+
+    fireEvent.mouseOver(getByText("123EAC"));
+    //Verify there is no tooltip.
+    expect(queryAllByText("123EAC")).toHaveLength(1);
+
     let propNameExpression = getByText("testNameInExp");
     let propAttributeExpression = getByText("placeholderAttribute");
 

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
@@ -565,7 +565,7 @@ const SourceToEntityMap = (props) => {
       ellipsis: true,
       sorter: (a: any, b: any) => a.val?.localeCompare(b.val),
       width: "40%",
-      render: (text, row) => (<div data-testid = {row.key +"-srcValue"} className = {styles.sourceValue}>{(text || text === "") ? <MLTooltip title={text}>{getTextforSourceValue(text, row)}</MLTooltip> : ""}</div>)
+      render: (text, row) => (<div data-testid = {row.key +"-srcValue"} className = {styles.sourceValue}>{(text || text === "") ?  getTextforSourceValue(text, row) : ""}</div>)
     }
   ];
 
@@ -652,24 +652,32 @@ const SourceToEntityMap = (props) => {
 
   const getTextforSourceValue = (text, row) => {
     let arr = typeof(text) === "string" ? text.split(", ") : text;
+    let stringLenWithoutEllipsis = 14;
+    let requiresToolTip = false;
+    let response;
     if (Array.isArray(arr)) {
+      requiresToolTip = (arr[0] ? arr[0].length > stringLenWithoutEllipsis : false) || (arr[1] ? arr[1].length > stringLenWithoutEllipsis : false);
       if (arr.length >= 2) {
         let xMore = <span className="moreVal">{"(" + (arr.length - 2) + " more)"}</span>;
-        let itemOne = <span className={getClassNames(srcFormat, row.datatype)}>{getInitialChars(arr[0], 14, "...")}</span>;
-        let itemTwo = <span className={getClassNames(srcFormat, row.datatype)}>{getInitialChars(arr[1], 14, "...")}</span>;
+        let itemOne = <span className={getClassNames(srcFormat, row.datatype)}>{getInitialChars(arr[0], stringLenWithoutEllipsis, "...")}</span>;
+        let itemTwo = <span className={getClassNames(srcFormat, row.datatype)}>{getInitialChars(arr[1], stringLenWithoutEllipsis, "...")}</span>;
         let fullItem = <span>{itemOne}{"\n"}{itemTwo}</span>;
         if (arr.length === 2) {
-          return <p>{fullItem}</p>;
+          response =  <p>{fullItem}</p>;
         } else {
-          return <p>{fullItem}{"\n"}{xMore}</p>;
+          //If there are more than 2 elements in array, tooltip is required.
+          requiresToolTip = true;
+          response =  <p>{fullItem}{"\n"}{xMore}</p>;
         }
       } else {
-        return <span className={getClassNames(srcFormat, row.datatype)}>{getInitialChars(arr[0], 14, "...")}</span>;
+        response = <span className={getClassNames(srcFormat, row.datatype)}>{getInitialChars(arr[0], stringLenWithoutEllipsis, "...")}</span>;
       }
 
     } else {
-      return <span className={getClassNames(srcFormat, row.datatype)}>{getInitialChars(text, 14, "...")}</span>;
+      requiresToolTip = text.length > stringLenWithoutEllipsis;
+      response = <span className={getClassNames(srcFormat, row.datatype)}>{getInitialChars(text, stringLenWithoutEllipsis, "...")}</span>;
     }
+    return requiresToolTip ?  <MLTooltip placement="bottom" title={text}>{response}</MLTooltip> : response;
   };
 
   //Response from server already is an array for multiple values, string for single value


### PR DESCRIPTION
### Description
Tooltip for source doc should only appear for truncated values
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

