### PR TITLE
DHFPROD-6637: Fix for Explorer UI breaks when record contains source object instead of array

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/entities/entity-search-lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/entities/entity-search-lib.sjs
@@ -285,7 +285,8 @@ function getEntitySources(docUri) {
   }
 
   if (doc.toObject() && doc.toObject().envelope && doc.toObject().envelope.headers && doc.toObject().envelope.headers.sources) {
-    sourcesArr = doc.toObject().envelope.headers.sources;
+    const sources = doc.toObject().envelope.headers.sources;
+    sourcesArr = Array.isArray(sources) ? sources : [sources];
   }
   return sourcesArr.length ? handleDuplicateSources("datahubSourceName",sourcesArr) : sourcesArr;
 }
@@ -489,11 +490,15 @@ function addDocumentMetadataToSearchResults(searchResponse) {
     let hubMetadata = {};
     const docUri = result.uri;
     const documentMetadata = xdmp.documentGetMetadata(docUri);
+    const sources = getEntitySources(docUri);
     if(documentMetadata) {
       hubMetadata["lastProcessedByFlow"] = documentMetadata.datahubCreatedInFlow;
       hubMetadata["lastProcessedByStep"] = documentMetadata.datahubCreatedByStep;
       hubMetadata["lastProcessedDateTime"] = documentMetadata.datahubCreatedOn;
-      hubMetadata["sources"] = getEntitySources(docUri);
+    }
+
+    if(sources.length) {
+      hubMetadata["sources"] = sources;
     }
     result["documentSize"] = getDocumentSize(cts.doc(docUri));
     result["hubMetadata"] = hubMetadata;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/addDocumentMetadataToSearchResults.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/addDocumentMetadataToSearchResults.sjs
@@ -91,7 +91,7 @@ function verifyMetadataForDocumentWithPartialMetadata() {
     test.assertEqual(null, response.results[0].hubMetadata.lastProcessedByFlow),
     test.assertEqual("map-step", response.results[0].hubMetadata.lastProcessedByStep),
     test.assertEqual(null, response.results[0].hubMetadata.lastProcessedDateTime),
-    test.assertEqual(0, response.results[0].hubMetadata.sources.length)
+    test.assertEqual(null, response.results[0].hubMetadata.sources)
   ];
 }
 
@@ -125,8 +125,32 @@ function verifyDocumentSizes() {
   ]
 }
 
+function verifySourcesIsArray() {
+  let response = {
+    "snippet-format": "snippet",
+    "total": 2,
+    "results": [
+      {
+        "index": 1,
+        "uri": "/content/sally.json"
+      },
+      {
+        "index": 2,
+        "uri": "/content/recordWithSourcesObject.json"
+      }
+    ]
+  };
+
+  entitySearchLib.addDocumentMetadataToSearchResults(response);
+  return[
+    test.assertTrue(Array.isArray(response.results[0].hubMetadata.sources)),
+    test.assertTrue(Array.isArray(response.results[1].hubMetadata.sources))
+  ];
+}
+
 []
     .concat(verifyMetadataForDocumentWithAllMetadata())
     .concat(verifyMetadataForDocumentWithoutMetadata())
     .concat(verifyMetadataForDocumentWithPartialMetadata())
-    .concat(verifyDocumentSizes());
+    .concat(verifyDocumentSizes())
+    .concat(verifySourcesIsArray());

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/test-data/content/recordWithSourcesObject.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/test-data/content/recordWithSourcesObject.json
@@ -1,0 +1,24 @@
+{
+  "envelope": {
+    "headers": {
+      "sources": {
+        "datahubSourceName": "loadData"
+      }
+    },
+    "instance": {
+      "info": {
+        "title": "Customer",
+        "version": "0.0.1",
+        "baseUri": "http://example.org/"
+      },
+      "Customer": {
+        "customerId": 101,
+        "name": "Jane Foster",
+        "nicknames": [
+          "jane",
+          "foster"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

