### PR TITLE
DHFPROD-6660: Fix Advanced Target Collections change checking

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/merging.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/merging.spec.tsx
@@ -79,11 +79,9 @@ describe("Merging", () => {
     cy.waitUntil(() => cy.findAllByText("keptMerged").should("have.length.gt", 0));
     cy.findAllByText("keptMerged").should("exist");
   });
-  it("Validate when clicking on cancel with changes should display confirmation modal ", () => {
+  it("Validate when canceling with Target Collection changes should not display confirmation modal (DHFPROD-6660)", () => {
     advancedSettings.cancelSettingsButton(mergeStep).click();
-    confirmYesNo.getDiscardText().should("be.visible");
-    confirmYesNo.getNoButton().click();
-    advancedSettings.saveSettingsButton(mergeStep).click();
+    confirmYesNo.getDiscardText().should("not.be.visible");
     cy.waitForAsyncRequest();
   });
   it("Validate when clicking on cancel without changes should not display confirmation modal ", () => {

--- a/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.tsx
+++ b/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.tsx
@@ -217,9 +217,11 @@ const AdvancedSettings: React.FC<Props> = (props) => {
     props.setPayload(getPayload());
   };
 
-  // On change of any form field (or on init), update the changed flag for parent
   useEffect(() => {
-    props.setHasChanged(hasFormChanged());
+    // Advanced Target Collections saves independently so don't check here on change (DHFPROD-6660)
+    if (!usesAdvancedTargetCollections) {
+      props.setHasChanged(hasFormChanged());
+    }
     props.setPayload(getPayload());
   }, [targetCollections, advancedTargetCollectionsTouched, defaultTargetCollections, defaultCollections]);
 

--- a/marklogic-data-hub-central/ui/src/components/steps/steps.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/steps/steps.test.tsx
@@ -158,12 +158,29 @@ describe("Steps settings component", () => {
   });
 
   test("Verify rendering of edit Merging step", async () => {
-    const {getByText, getByLabelText} = render(
+    const {getByText, getByLabelText, getByTestId, queryByText} = render(
       <Steps {...data.editMerging} />
     );
 
     expect(getByText("Merging Step Settings")).toBeInTheDocument();
     expect(getByLabelText("Close")).toBeInTheDocument();
+
+    // Additional collection change doesn't trigger Discard Changes alert (DHFPROD-6660)
+    await wait(() => {
+      fireEvent.click(getByText("Advanced"));
+    });
+    fireEvent.click(getByTestId("onMerge-edit"));
+    await wait(() => {
+      expect(getByLabelText("additionalColl-select-onMerge")).toBeInTheDocument();
+    });
+    let collectionInput = getByLabelText("additionalColl-select-onMerge").getElementsByTagName("input").item(0)!;
+    fireEvent.input(collectionInput, {target: {value: "newCollection"}});
+    fireEvent.keyDown(collectionInput, {keyCode: 13, key: "Enter"});
+    fireEvent.click(getByTestId("onMerge-keep"));
+    expect(getByText("newCollection")).toBeInTheDocument();
+    fireEvent.click(getByTestId("AdvancedMatching-cancel-settings"));
+    expect(queryByText("Discard changes?")).not.toBeInTheDocument();
+
   });
 
   test("Verify rendering of Custom step", async () => {


### PR DESCRIPTION
### Description

Changes to Advanced Target Collections values in Merge settings should not trigger the Discard Changes alert (since such values are saved independently). Here's the problem: https://drive.google.com/file/d/1BUQj9FRMM_mIji2wGxAqTiahLhYH_GHt/view

Test added in steps-test.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

