### PR TITLE
DHFPROD-6668:Add "eval-search-string" privilege to Datahub

### DIFF
--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-operator.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-operator.json
@@ -47,6 +47,11 @@
       "kind": "execute"
     },
     {
+      "privilege-name": "eval-search-string",
+      "action": "http://marklogic.com/xdmp/privileges/eval-search-string",
+      "kind": "execute"
+    },
+    {
       "privilege-name": "xdmp:xslt-eval",
       "action": "http://marklogic.com/xdmp/privileges/xslt-eval",
       "kind": "execute"


### PR DESCRIPTION
### Description
Add "eval-search-string" privilege to Datahub
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

