### PR TITLE
DHFPROD-6673:HC returns "Internal Server Error" when logged in with a user with "data-hub-developer"

### DIFF
--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/auth/AuthenticationFilter.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/auth/AuthenticationFilter.java
@@ -96,7 +96,7 @@ public class AuthenticationFilter extends AbstractAuthenticationProcessingFilter
                     throw new BadCredentialsException("Unauthorized");
                 }
                 //In case user can't read the getAuthorities.sjs module, return an empty 'authorities' object
-                if(fre.getServerStatusCode() == 404){
+                if(fre.getServerStatusCode() == 404 || fre.getServerStatusCode() == 403){
                     return new AuthenticationToken(username, password, authorities);
                 }
             }

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/auth/AuthTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/auth/AuthTest.java
@@ -50,6 +50,16 @@ class AuthTest extends AbstractMvcTest {
     }
 
     @Test
+    void loginWithDataHubDeveloper() throws Exception {
+        setTestUserRoles("data-hub-developer");
+        String payload = buildLoginPayload(testConstants.TEST_USER_USERNAME);
+        mockMvc
+            .perform(post(LOGIN_URL).contentType(MediaType.APPLICATION_JSON).content(payload))
+            .andExpect(status().isForbidden());
+
+    }
+
+    @Test
     void loginWithDataHubManagerAndLogout() throws Exception {
         loginAsUser(testConstants.ENVIRONMENT_MANAGER_USERNAME).andDo(
             result -> {


### PR DESCRIPTION

### Description
HC returns "Internal Server Error" when logged in with a user with "data-hub-developer"
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

