### PR TITLE
DHFPROD-6664: Permissions field in advanced tab shows incorrect values after editing

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.tsx
+++ b/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.tsx
@@ -286,7 +286,7 @@ const AdvancedSettings: React.FC<Props> = (props) => {
   };
 
   const isPermissionsValid = () => {
-    if (targetPermissions && targetPermissions.trim().length === 0) {
+    if (targetPermissions.trim().length === 0) {
       setPermissionValidationError(AdvancedSettingsMessages.targetPermissions.incorrectFormat);
       props.setIsValid(false);
       return false;


### PR DESCRIPTION
### Description
This PR fixes the issue where a user was allowed to save without at least one target permission.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- N/A Added Tests
  

- ##### Reviewer:

- N/A Reviewed Tests

