### PR TITLE
DHFPROD-6625: Run button should start running the step without dropdo…

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/AddMatchStepToFlow.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/AddMatchStepToFlow.spec.tsx
@@ -104,13 +104,18 @@ describe("Add Matching step to a flow", () => {
     cy.verifyStepRunResult("success", "Matching", matchStep);
     tiles.closeRunMessage();
   });
+  it("Delete the match step", () => {
+    runPage.deleteStep(matchStep).click();
+    loadPage.confirmationOptions("Yes").click();
+    cy.waitForAsyncRequest();
+  });
   it("Navigating to match tab", () => {
     cy.waitUntil(() => toolbar.getCurateToolbarIcon()).click();
     cy.waitUntil(() => curatePage.getEntityTypePanel("Customer").should("be.visible"));
     curatePage.toggleEntityTypeId("Customer");
     curatePage.selectMatchTab("Customer");
   });
-  it("Add the Match step to new flow from run tile and should automatically run", () => {
+  it("Add the Match step to new flow from card run button and should automatically run", () => {
     curatePage.runStepInCardView(matchStep).click();
     curatePage.runInNewFlow(matchStep).click();
     cy.findByText("New Flow").should("be.visible");
@@ -134,14 +139,59 @@ describe("Add Matching step to a flow", () => {
     curatePage.toggleEntityTypeId("Customer");
     curatePage.selectMatchTab("Customer");
   });
-  it("Add the Match step to an existing flow from run tile and should automatically run", () => {
+  it("Add the Match step to an existing flow from card run button and should automatically run", () => {
     curatePage.runStepInCardView(matchStep).click();
-    curatePage.runStepInExistingFlow(matchStep, flowName2);
-    curatePage.addStepToFlowRunConfirmationMessage();
-    curatePage.confirmAddStepToFlow(matchStep, flowName2);
+    curatePage.runStepSelectFlowConfirmation().should("be.visible");
+    curatePage.selectFlowToRunIn(flowName2);
     cy.waitForAsyncRequest();
     cy.verifyStepAddedToFlow("Match", matchStep);
     cy.waitUntil(() => runPage.getFlowName(flowName2).should("be.visible"));
+    cy.verifyStepRunResult("success", "Matching", matchStep);
+    tiles.closeRunMessage();
+  });
+  it("Navigating to match tab", () => {
+    cy.waitUntil(() => toolbar.getCurateToolbarIcon()).click();
+    cy.waitUntil(() => curatePage.getEntityTypePanel("Customer").should("be.visible"));
+    curatePage.toggleEntityTypeId("Customer");
+    curatePage.selectMatchTab("Customer");
+  });
+  it("Run the Match step from card run button and should automatically run in the flow where step exists", () => {
+    curatePage.runStepInCardView(matchStep).click();
+    curatePage.runStepExistsOneFlowConfirmation().should("be.visible");
+    curatePage.confirmContinueRun();
+    cy.waitForAsyncRequest();
+    cy.verifyStepAddedToFlow("Match", matchStep);
+    cy.waitUntil(() => runPage.getFlowName(flowName2).should("be.visible"));
+    cy.verifyStepRunResult("success", "Matching", matchStep);
+    tiles.closeRunMessage();
+  });
+  it("Navigating to match tab", () => {
+    cy.waitUntil(() => toolbar.getCurateToolbarIcon()).click();
+    cy.waitUntil(() => curatePage.getEntityTypePanel("Customer").should("be.visible"));
+    curatePage.toggleEntityTypeId("Customer");
+    curatePage.selectMatchTab("Customer");
+  });
+  it("Add the match step to a second flow and verify it was added", () => {
+    curatePage.openExistingFlowDropdown("Customer", matchStep);
+    curatePage.getExistingFlowFromDropdown(flowName1).click();
+    curatePage.addStepToFlowConfirmationMessage();
+    curatePage.confirmAddStepToFlow(matchStep, flowName1);
+    cy.waitForAsyncRequest();
+    cy.verifyStepAddedToFlow("Match", matchStep);
+  });
+  it("Navigating to match tab", () => {
+    cy.waitUntil(() => toolbar.getCurateToolbarIcon()).click();
+    cy.waitUntil(() => curatePage.getEntityTypePanel("Customer").should("be.visible"));
+    curatePage.toggleEntityTypeId("Customer");
+    curatePage.selectMatchTab("Customer");
+  });
+  it("Run the Match step from card run button and should display all flows where step exists, choose one to automatically run in", () => {
+    curatePage.runStepInCardView(matchStep).click();
+    curatePage.runStepExistsMultFlowsConfirmation().should("be.visible");
+    curatePage.selectFlowToRunIn(flowName1);
+    cy.waitForAsyncRequest();
+    cy.verifyStepAddedToFlow("Match", matchStep);
+    cy.waitUntil(() => runPage.getFlowName(flowName1).should("be.visible"));
     cy.verifyStepRunResult("success", "Matching", matchStep);
     tiles.closeRunMessage();
   });

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/AddMergeStepToFlow.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/AddMergeStepToFlow.spec.tsx
@@ -106,13 +106,18 @@ describe("Add Merge step to a flow", () => {
     cy.verifyStepRunResult("success", "Merging", mergeStep);
     tiles.closeRunMessage();
   });
+  it("Delete the merge step", () => {
+    runPage.deleteStep(mergeStep).click();
+    loadPage.confirmationOptions("Yes").click();
+    cy.waitForAsyncRequest();
+  });
   it("Navigating to merge tab", () => {
     cy.waitUntil(() => toolbar.getCurateToolbarIcon()).click();
     cy.waitUntil(() => curatePage.getEntityTypePanel("Customer").should("be.visible"));
     curatePage.toggleEntityTypeId("Customer");
     curatePage.selectMergeTab("Customer");
   });
-  it("Add the Merge step to new flow from run tile and should automatically run", () => {
+  it("Add the Merge step to new flow from card run button and should automatically run", () => {
     curatePage.runStepInCardView(mergeStep).click();
     curatePage.runInNewFlow(mergeStep).click();
     cy.findByText("New Flow").should("be.visible");
@@ -136,14 +141,59 @@ describe("Add Merge step to a flow", () => {
     curatePage.toggleEntityTypeId("Customer");
     curatePage.selectMergeTab("Customer");
   });
-  it("Add the Merge step to an existing flow from run tile and should automatically run", () => {
+  it("Add the Merge step to an existing flow from card run button and should automatically run", () => {
     curatePage.runStepInCardView(mergeStep).click();
-    curatePage.runStepInExistingFlow(mergeStep, flowName2);
-    curatePage.addStepToFlowRunConfirmationMessage();
-    curatePage.confirmAddStepToFlow(mergeStep, flowName2);
+    curatePage.runStepSelectFlowConfirmation().should("be.visible");
+    curatePage.selectFlowToRunIn(flowName2);
     cy.waitForAsyncRequest();
     cy.verifyStepAddedToFlow("Merge", mergeStep);
     cy.waitUntil(() => runPage.getFlowName(flowName2).should("be.visible"));
+    cy.verifyStepRunResult("success", "Merging", mergeStep);
+    tiles.closeRunMessage();
+  });
+  it("Navigating to merge tab", () => {
+    cy.waitUntil(() => toolbar.getCurateToolbarIcon()).click();
+    cy.waitUntil(() => curatePage.getEntityTypePanel("Customer").should("be.visible"));
+    curatePage.toggleEntityTypeId("Customer");
+    curatePage.selectMergeTab("Customer");
+  });
+  it("Run the Merge step from card run button and should automatically run in the flow where step exists", () => {
+    curatePage.runStepInCardView(mergeStep).click();
+    curatePage.runStepExistsOneFlowConfirmation().should("be.visible");
+    curatePage.confirmContinueRun();
+    cy.waitForAsyncRequest();
+    cy.verifyStepAddedToFlow("Merge", mergeStep);
+    cy.waitUntil(() => runPage.getFlowName(flowName2).should("be.visible"));
+    cy.verifyStepRunResult("success", "Merging", mergeStep);
+    tiles.closeRunMessage();
+  });
+  it("Navigating to merge tab", () => {
+    cy.waitUntil(() => toolbar.getCurateToolbarIcon()).click();
+    cy.waitUntil(() => curatePage.getEntityTypePanel("Customer").should("be.visible"));
+    curatePage.toggleEntityTypeId("Customer");
+    curatePage.selectMergeTab("Customer");
+  });
+  it("Add the merge step to a second flow and verify it was added", () => {
+    curatePage.openExistingFlowDropdown("Customer", mergeStep);
+    curatePage.getExistingFlowFromDropdown(flowName1).click();
+    curatePage.addStepToFlowConfirmationMessage();
+    curatePage.confirmAddStepToFlow(mergeStep, flowName1);
+    cy.waitForAsyncRequest();
+    cy.verifyStepAddedToFlow("Merge", mergeStep);
+  });
+  it("Navigating to merge tab", () => {
+    cy.waitUntil(() => toolbar.getCurateToolbarIcon()).click();
+    cy.waitUntil(() => curatePage.getEntityTypePanel("Customer").should("be.visible"));
+    curatePage.toggleEntityTypeId("Customer");
+    curatePage.selectMergeTab("Customer");
+  });
+  it("Run the Merge step from card run button and should display all flows where step exists, choose one to automatically run in", () => {
+    curatePage.runStepInCardView(mergeStep).click();
+    curatePage.runStepExistsMultFlowsConfirmation().should("be.visible");
+    curatePage.selectFlowToRunIn(flowName1);
+    cy.waitForAsyncRequest();
+    cy.verifyStepAddedToFlow("Merge", mergeStep);
+    cy.waitUntil(() => runPage.getFlowName(flowName1).should("be.visible"));
     cy.verifyStepRunResult("success", "Merging", mergeStep);
     tiles.closeRunMessage();
   });

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/commands.js
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/commands.js
@@ -111,7 +111,6 @@ Cypress.Commands.add("logout", () => {
 });
 
 Cypress.Commands.add("verifyStepAddedToFlow", (stepType, stepName) => {
-  cy.waitForModalToDisappear();
   cy.findAllByText(stepType).last().should("be.visible");
   cy.findAllByText(stepName).last().should("be.visible");
 });

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/curate.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/curate.tsx
@@ -118,9 +118,8 @@ class CuratePage {
     return cy.findByTestId(`${stepName}-run-flowsList`);
   }
 
-  runStepInExistingFlow(stepName: string, flowName: string) {
-    this.runExistingFlowsList(stepName).click({force: true});
-    cy.findByLabelText(`${flowName}-run-option`).click({force: true});
+  selectFlowToRunIn(flowName: string) {
+    cy.findByTestId(`${flowName}-run-step`).click();
   }
 
   verifyStepNameIsVisible(stepName: string) {
@@ -169,8 +168,20 @@ class CuratePage {
     return cy.findByLabelText("step-in-flow");
   }
 
-  addStepExistingToFlowRunConfirmationMessage() {
-    return cy.findByLabelText("step-in-flow-run");
+  runStepSelectFlowConfirmation() {
+    return cy.findByLabelText("step-in-no-flows-confirmation");
+  }
+
+  runStepExistsOneFlowConfirmation() {
+    return cy.findByLabelText("run-step-one-flow-confirmation");
+  }
+
+  runStepExistsMultFlowsConfirmation() {
+    return cy.findByLabelText("run-step-mult-flows-confirmation");
+  }
+
+  confirmContinueRun() {
+    cy.findByLabelText("continue-confirm").click();
   }
 
   confirmAddStepToFlow(stepName: string, flowName: string) {

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/load.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/load.tsx
@@ -82,11 +82,6 @@ class LoadPage {
   addStepToFlowConfirmationMessage() {
     return cy.findByLabelText("step-not-in-flow");
   }
-
-  addStepToFlowRunConfirmationMessage() {
-    return cy.findByLabelText("step-not-in-flow-run");
-  }
-
   addStepExistingToFlowConfirmationMessage() {
     return cy.findByLabelText("step-in-flow");
   }
@@ -95,6 +90,25 @@ class LoadPage {
     return cy.findByLabelText("step-in-flow-run");
   }
 
+  runStepSelectFlowConfirmation() {
+    return cy.findByLabelText("step-in-no-flows-confirmation");
+  }
+
+  selectFlowToRunIn(flowName: string) {
+    cy.findByTestId(`${flowName}-run-step`).click();
+  }
+
+  runStepExistsOneFlowConfirmation() {
+    return cy.findByLabelText("run-step-one-flow-confirmation");
+  }
+
+  runStepExistsMultFlowsConfirmation() {
+    return cy.findByLabelText("run-step-mult-flows-confirmation");
+  }
+
+  confirmContinueRun() {
+    cy.findByLabelText("continue-confirm").click();
+  }
   pagination() {
 
   }
@@ -256,21 +270,12 @@ class LoadPage {
     return cy.findByTestId(`${stepName}-edit`);
   }
 
-  runStepInCardView(stepName: string) {
+  runStep(stepName: string) {
     return cy.findByTestId(`${stepName}-run`);
   }
 
   runInNewFlow(stepName: string) {
     return cy.findByTestId(`${stepName}-run-toNewFlow`);
-  }
-
-  runExistingFlowsList(stepName: string) {
-    return cy.findByTestId(`${stepName}-run-flowsList`);
-  }
-
-  runStepInExistingFlow(stepName: string, flowName: string) {
-    this.runExistingFlowsList(stepName).click({force: true});
-    cy.findByLabelText(`${flowName}-run-option`).click({force: true});
   }
 
   addToNewFlow(stepName: string) {

--- a/marklogic-data-hub-central/ui/src/App.tsx
+++ b/marklogic-data-hub-central/ui/src/App.tsx
@@ -57,7 +57,7 @@ const App: React.FC<Props> = ({history, location}) => {
     if (user.authenticated) {
       if (location.pathname === "/") {
         history.push(user.pageRoute);
-      } else if (location.pathname === "/tiles/run/add" || location.pathname === "/tiles/run/add-run") {
+      } else if (location.pathname === "/tiles/run/add" || location.pathname === "/tiles/run/add-run" || location.pathname === "/tiles/run/run-step") {
         history.push("/tiles/run");
       } else {
         history.push(location.pathname);
@@ -127,10 +127,13 @@ const App: React.FC<Props> = ({history, location}) => {
                       <TilesView id="run"/>
                     </PrivateRoute>
                     <PrivateRoute path="/tiles/run/add" exact>
-                      <TilesView id="run" addingStepToFlow="true" startRunStep={false}/>
+                      <TilesView id="run" routeToFlow={true} addingStepToFlow={true} startRunStep={false}/>
                     </PrivateRoute>
                     <PrivateRoute path="/tiles/run/add-run" exact>
-                      <TilesView id="run" addingStepToFlow="true" startRunStep={true}/>
+                      <TilesView id="run" routeToFlow={true} addingStepToFlow={true} startRunStep={true}/>
+                    </PrivateRoute>
+                    <PrivateRoute path="/tiles/run/run-step" exact>
+                      <TilesView id="run" routeToFlow={true} addingStepToFlow={false} startRunStep={true}/>
                     </PrivateRoute>
                     <PrivateRoute path="/tiles/explore" exact>
                       <TilesView id="explore"/>

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/curation/common.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/curation/common.data.ts
@@ -43,7 +43,7 @@ const flowsAdd = [
     name: "FlowStepNoExist",
     steps: [
       {
-        stepNume: "1",
+        stepNum: "1",
         stepName: "testLoad456", // has step NOT IN loadData
         stepDefinitionType: "Load Data",
         stepId: "testLoad456-ingestion",
@@ -55,14 +55,33 @@ const flowsAdd = [
     name: "FlowStepExist",
     steps: [
       {
-        stepNume: "2",
+        stepNum: "1",
         stepName: "testLoadXML", // has step IN loadData
         stepDefinitionType: "Load Data",
         stepId: "testLoadXML-ingestion",
         format: "xml"
       },
+      {
+        stepNum: "2",
+        stepName: "testLoad", // step exists in more than one flow
+        stepDefinitionType: "Load Data",
+        stepId: "testLoad-ingestion",
+        format: "json"
+      }
     ]
   },
+  {
+    name: "FlowStepMultExist",
+    steps: [
+      {
+        stepNum: "1",
+        stepName: "testLoad", // step exists in more than one flow
+        stepDefinitionType: "Load Data",
+        stepId: "testLoad-ingestion",
+        format: "json",
+      }
+    ]
+  }
 ];
 
 const loadData = {

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/curation/flows.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/curation/flows.data.ts
@@ -315,13 +315,39 @@ const mappings = {"data":
       "permissions": "data-hub-common,read,data-hub-common,update",
       "sourceDatabase": "data-hub-STAGING",
       "targetDatabase": "data-hub-FINAL",
-      "collections": ["Mapping1", "Customer"],
+      "collections": ["Mapping2", "Customer"],
       "additionalCollections": ["customerCollection"],
       "validateEntity": false,
       "lastUpdated": "2020-10-01T02:38:00.169198-07:00"
     }
   ]
-}
+},
+{
+  "entityType": "Customer",
+  "entityTypeId": "Customer",
+  "artifacts": [
+    {
+      "name": "Mapping3",
+      "targetEntityType": "Customer",
+      "description": "",
+      "selectedSource": "collection",
+      "sourceQuery": "cts.collectionQuery(['default-ingestion'])",
+      "properties": {
+        "customerId": {
+          "sourcedFrom": "PIN"
+        }
+      },
+      "provenanceGranularityLevel": "coarse",
+      "batchSize": 50,
+      "permissions": "data-hub-common,read,data-hub-common,update",
+      "sourceDatabase": "data-hub-STAGING",
+      "targetDatabase": "data-hub-FINAL",
+      "collections": ["Mapping3", "Customer"],
+      "additionalCollections": ["customerCollection"],
+      "validateEntity": false,
+      "lastUpdated": "2020-01-12T13:21:00.169198-07:00"
+    }
+  ]}
 ],
 "status": 200
 };

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/curation/matching.data.js
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/curation/matching.data.js
@@ -117,6 +117,28 @@ export const matchingStep = {
       "customHook": {},
       "matchRulesets": [],
       "thresholds": []
+    },
+    {
+      "name": "matchCustomers123",
+      "stepDefinitionName": "default-matching",
+      "stepDefinitionType": "matching",
+      "stepId": "matchCustomersEmpty-matching",
+      "targetEntityType": "http://example.org/Customer-0.0.1/Customer",
+      "description": "",
+      "lastUpdated": "2020-09-25T09:40:08.300673-07:00",
+      "selectedSource": "collection",
+      "sourceQuery": "cts.collectionQuery(['Customer'])",
+      "collections": ["matchCustomers"],
+      "additionalCollections": [],
+      "sourceDatabase": "data-hub-FINAL",
+      "targetDatabase": "data-hub-FINAL",
+      "targetFormat": "JSON",
+      "permissions": "data-hub-common,read,data-hub-common-writer,update",
+      "provenanceGranularityLevel": "fine",
+      "interceptors": [],
+      "customHook": {},
+      "matchRulesets": [],
+      "thresholds": []
     }
   ]
 };

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/curation/merging.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/curation/merging.data.ts
@@ -151,6 +151,31 @@ export const mergingStep = {
       },
       mergeStrategies: [],
       mergeRules: [],
+    },
+    {
+      name: "mergeCustomers123",
+      stepDefinitionName: "default-merging",
+      stepDefinitionType: "merging",
+      stepId: "mergeCustomers-merging",
+      lastUpdated: "2020-09-25T09:40:08.300673-07:00",
+      targetEntityType: "http://example.org/Customer-0.0.1/Customer",
+      description: "",
+      selectedSource: "collection",
+      sourceQuery: "cts.collectionQuery(['matchCustomers'])",
+      collections: ["mergeCustomers"],
+      additionalCollections: [],
+      sourceDatabase: "data-hub-FINAL",
+      targetDatabase: "data-hub-FINAL",
+      targetFormat: "JSON",
+      permissions: "data-hub-common,read,data-hub-common-writer,update",
+      timestamp: "/envelope/headers/createdOn",
+      provenanceGranularityLevel: "fine",
+      lastUpdatedLocation: {
+        namespaces: {es: "http://marklogic.com/entity-services"},
+        documentXPath: "/es:envelope/es:headers/timestamp"
+      },
+      mergeStrategies: [],
+      mergeRules: [],
     }
   ]
 };

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.module.scss
@@ -76,6 +76,14 @@
     }
 
 }
+
+.plusIconNewFlow {
+  font-size: 15px;
+  color: #44499C;
+  margin-right: 10px;
+  cursor: pointer;
+}
+
 .addNewContent {
     font-size: 20px;
     color: #67749c;
@@ -102,6 +110,20 @@
         color: var(--hoverColor);
     }
 
+}
+
+.flowSelectGrid {
+    font-size: 16px;
+    padding-top: 30px;
+}
+
+.runNewFlow {
+    display: flex;
+}
+
+.verticalDiv {
+    margin-left: 15px;
+    height: 55vh;
 }
 
 .cardLinks {
@@ -167,6 +189,18 @@
     &:hover{
         color: var(--hoverColor);
     }
+}
+
+.stepLink:hover {
+  cursor: pointer;
+  .plusIconNewFlow {
+    color: var(--hoverColor);
+  }
+}
+
+.newFlowStepLink {
+  margin-left: 5px;
+  color: var(--hoverColor);
 }
 
 .stepLinkExisting {

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
@@ -267,13 +267,11 @@ describe("Mapping Card component", () => {
     //Click play button 'Run' icon
     fireEvent.click(getByTestId("Mapping2-run"));
 
-    //'Run in an existing Flow'
-    fireEvent.click(getByTestId("Mapping2-run-flowsList"));
-    fireEvent.click(getByLabelText("testFlow-run-option"));
+    //Modal with options to run in an existing or new flow should appear
+    expect(getByLabelText("step-in-no-flows-confirmation")).toBeInTheDocument();
 
-    //Dialog appears, click 'Yes' button
-    expect(getByLabelText("step-not-in-flow-run")).toBeInTheDocument();
-    fireEvent.click(getByTestId("Mapping2-to-testFlow-Confirm"));
+    //Select flow to add and run step in
+    fireEvent.click(getByTestId("testFlow-run-step"));
 
     //Check if the /tiles/run/add-run route has been called
     wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/add-run"); });
@@ -315,27 +313,63 @@ describe("Mapping Card component", () => {
     //Click play button 'Run' icon
     fireEvent.click(getByTestId("Mapping1-run"));
 
-    //'Run in an existing Flow'
-    fireEvent.click(getByTestId("Mapping1-run-flowsList"));
-    fireEvent.click(getByLabelText("testFlow-run-option"));
+    //Confirmation modal for directly running the step in its flow should appear
+    expect(getByLabelText("run-step-one-flow-confirmation")).toBeInTheDocument();
 
-    //Dialog appears, click 'Yes' button
-    expect(getByLabelText("step-in-flow-run")).toBeInTheDocument();
-    fireEvent.click(getByTestId("Mapping1-to-testFlow-Confirm"));
+    //Click Continue to confirm
+    fireEvent.click(getByLabelText("continue-confirm"));
+
+    //Check if the /tiles/run/run-step route has been called
+    wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/run-step"); });
+
+  });
+
+
+  test("Run step in an existing flow where step exists in MORE THAN ONE flow", async () => {
+    const authorityService = new AuthoritiesService();
+    authorityService.setAuthorities(["readMapping", "writeMapping", "writeFlow"]);
+    const mapping = data.mappings.data[2].artifacts;
+    const flows = [{name: "testStepInMultFlow", steps: [{stepName: "Mapping3"}]}, {name: "mappingFlow", steps: [{stepName: "Mapping3"}]}];
+    let getByLabelText, getByTestId;
+    await act(async () => {
+      const renderResults = render(
+        <MemoryRouter><AuthoritiesContext.Provider value={authorityService}><MappingCard
+          {...mappingProps}
+          data={mapping}
+          flows={flows}
+          canReadWrite={true}
+          canWriteFlow={true}
+        /></AuthoritiesContext.Provider></MemoryRouter>
+      );
+      getByLabelText = renderResults.getByLabelText;
+      getByTestId = renderResults.getByTestId;
+    });
+
+    //Verify run step in an existing flow where step exists in more than one flow
+
+    //Click play button 'Run' icon
+    fireEvent.click(getByTestId("Mapping3-run"));
+
+    //Modal with list of flows where step exists to select one to run in
+    expect(getByLabelText("run-step-mult-flows-confirmation")).toBeInTheDocument();
+
+    //Select flow to run step in
+    fireEvent.click(getByTestId("testStepInMultFlow-run-step"));
 
     //Check if the /tiles/run/add-run route has been called
     wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/add-run"); });
-
   });
 
   test("Adding the step to a new flow", async () => {
     const authorityService = new AuthoritiesService();
     authorityService.setAuthorities(["readMapping", "writeMapping", "writeFlow"]);
+    const mapping = data.mappings.data[0].artifacts;
     let getByText, getByTestId;
     await act(async () => {
       const renderResults = render(
         <MemoryRouter><AuthoritiesContext.Provider value={authorityService}><MappingCard
           {...mappingProps}
+          data={mapping}
           canReadWrite={true}
           canWriteFlow={true}
         /></AuthoritiesContext.Provider></MemoryRouter>
@@ -362,13 +396,36 @@ describe("Mapping Card component", () => {
       expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/add");
     });
 
-    //Verify run step in an new flow
+  });
+
+  test("Running the step in a new flow", async () => {
+    const authorityService = new AuthoritiesService();
+    authorityService.setAuthorities(["readMapping", "writeMapping", "writeFlow"]);
+    const mapping = data.mappings.data[1].artifacts;
+    let getByTestId, getByLabelText;
+    await act(async () => {
+      const renderResults = render(
+        <MemoryRouter><AuthoritiesContext.Provider value={authorityService}><MappingCard
+          {...mappingProps}
+          data={mapping}
+          canReadWrite={true}
+          canWriteFlow={true}
+        /></AuthoritiesContext.Provider></MemoryRouter>
+      );
+      getByTestId = renderResults.getByTestId;
+      getByLabelText = renderResults.getByLabelText;
+    });
+
+    //Verify run step in a new flow
 
     //Click play button 'Run' icon
-    fireEvent.click(getByTestId("Mapping1-run"));
+    fireEvent.click(getByTestId("Mapping2-run"));
 
-    //'Run in a new Flow'
-    fireEvent.click(getByTestId("Mapping1-run-toNewFlow"));
+    //Modal with option to add and run in a new flow should appear
+    expect(getByLabelText("step-in-no-flows-confirmation")).toBeInTheDocument();
+
+    //Select "New Flow" option to add and run in a new flow
+    fireEvent.click(getByTestId("Mapping2-run-toNewFlow"));
 
     //Check if the /tiles/run/add-run route has been called
     wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/add-run"); });

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/matching-card.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/matching-card.module.scss
@@ -83,6 +83,12 @@ cursor: pointer;
     color: var(--hoverColor);
   }
 }
+.plusIconNewFlow {
+  font-size: 15px;
+  color: #44499C;
+  margin-right: 10px;
+  cursor: pointer;
+}
 .addNewContent {
 font-size: 20px;
 color: #67749c;
@@ -166,6 +172,32 @@ margin-bottom: 10px;
     &:hover{
         color: var(--hoverColor);
     }
+}
+
+.flowSelectGrid {
+  font-size: 16px;
+  padding-top: 30px;
+}
+
+.runNewFlow {
+  display: flex;
+}
+
+.verticalDiv {
+  margin-left: 15px;
+  height: 55vh;
+}
+
+.stepLink:hover {
+  cursor: pointer;
+  .plusIconNewFlow {
+    color: var(--hoverColor);
+  }
+}
+
+.newFlowStepLink {
+  margin-left: 5px;
+  color: var(--hoverColor);
 }
 
 .disabledRunIcon {

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merging-card.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merging-card.module.scss
@@ -86,6 +86,12 @@
       color: var(--hoverColor);
   }
 }
+.plusIconNewFlow {
+  font-size: 15px;
+  color: #44499C;
+  margin-right: 10px;
+  cursor: pointer;
+}
 .addNewContent {
   font-size: 20px;
   color: #67749c;
@@ -169,6 +175,32 @@
   &:hover{
       color: var(--hoverColor);
     }
+}
+
+.flowSelectGrid {
+  font-size: 16px;
+  padding-top: 30px;
+}
+
+.runNewFlow {
+  display: flex;
+}
+
+.verticalDiv {
+  margin-left: 15px;
+  height: 55vh;
+}
+
+.stepLink:hover {
+  cursor: pointer;
+  .plusIconNewFlow {
+    color: var(--hoverColor);
+  }
+}
+
+.newFlowStepLink {
+  margin-left: 5px;
+  color: var(--hoverColor);
 }
 
 .disabledRunIcon {

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merging-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merging-card.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useContext} from "react";
 import {Link, useHistory} from "react-router-dom";
-import {Card, Icon, Row, Col, Select, Dropdown, Menu, Modal} from "antd";
+import {Card, Icon, Row, Col, Select, Divider, Modal} from "antd";
 import {MLTooltip} from "@marklogic/design-system";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faPencilAlt, faCog} from "@fortawesome/free-solid-svg-icons";
@@ -50,7 +50,11 @@ const MergingCard: React.FC<Props> = (props) => {
   const [addToFlowVisible, setAddToFlowVisible] = useState(false);
   const [mergingArtifactName, setMergingArtifactName] = useState("");
   const [flowName, setFlowName] = useState("");
-  const [addRun, setAddRun] = useState(false);
+
+  const [runNoFlowsDialogVisible, setRunNoFlowsDialogVisible] = useState(false);
+  const [runOneFlowDialogVisible, setRunOneFlowDialogVisible] = useState(false);
+  const [runMultFlowsDialogVisible, setRunMultFlowsDialogVisible] = useState(false);
+  const [flowsWithStep, setFlowsWithStep] = useState<any[]>([]);
 
   const [openStepSettings, setOpenStepSettings] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
@@ -110,18 +114,16 @@ const MergingCard: React.FC<Props> = (props) => {
     setTooltipVisible(false);
   }
 
+  const countStepInFlow = (mergingName) => {
+    let result : string[] = [];
+    if (props.flows) props.flows.forEach(f => f["steps"].findIndex(s => s.stepName === mergingName) > -1 ? result.push(f.name) : "");
+    return result;
+  };
+
   function handleSelect(obj) {
     let selectedNew = {...selected};
     selectedNew[obj.loadName] = obj.flowName;
     setSelected(selectedNew);
-    handleStepAdd(obj.mergingName, obj.flowName);
-  }
-
-  function handleSelectAddRun(obj) {
-    let selectedNew = {...selected};
-    selectedNew[obj.loadName] = obj.flowName;
-    setSelected(selectedNew);
-    setAddRun(true);
     handleStepAdd(obj.mergingName, obj.flowName);
   }
 
@@ -131,37 +133,68 @@ const MergingCard: React.FC<Props> = (props) => {
     setAddToFlowVisible(true);
   };
 
+  const handleStepRun = (mergingName) => {
+    setMergingArtifactName(mergingName);
+    let stepInFlows = countStepInFlow(mergingName);
+    setFlowsWithStep(stepInFlows);
+    if (stepInFlows.length > 1) {
+      setRunMultFlowsDialogVisible(true);
+    } else if (stepInFlows.length === 1) {
+      setRunOneFlowDialogVisible(true);
+    } else {
+      setRunNoFlowsDialogVisible(true);
+    }
+  };
+
+  const handleAddRun = async (flowName) => {
+    await props.addStepToFlow(mergingArtifactName, flowName, "merging");
+    setRunNoFlowsDialogVisible(false);
+
+    history.push({
+      pathname: "/tiles/run/add-run",
+      state: {
+        flowName: flowName,
+        flowsDefaultKey: [props.flows.findIndex(el => el.name === flowName)],
+        existingFlow: true,
+        addFlowDirty: true,
+        stepToAdd: mergingArtifactName,
+        stepDefinitionType: "merging"
+      }
+    });
+  };
+
+  const onContinueRun = () => {
+    history.push({
+      pathname: "/tiles/run/run-step",
+      state: {
+        flowName: flowsWithStep[0],
+        stepToAdd: mergingArtifactName,
+        stepDefinitionType: "merging",
+        existingFlow: false,
+        flowsDefaultKey: [props.flows.findIndex(el => el.name === flowsWithStep[0])],
+      }
+    });
+  };
+
   const onAddOk = async (lName, fName) => {
     await props.addStepToFlow(lName, fName, "merging");
     setAddToFlowVisible(false);
-
-    if (addRun) {
-      history.push({
-        pathname: "/tiles/run/add-run",
-        state: {
-          flowName: fName,
-          flowsDefaultKey: [props.flows.findIndex(el => el.name === fName)],
-          existingFlow: true,
-          addFlowDirty: true,
-          stepToAdd: mergingArtifactName,
-          stepDefinitionType: "merging"
-        }
-      });
-    } else {
-      history.push({
-        pathname: "/tiles/run/add",
-        state: {
-          flowName: fName,
-          addFlowDirty: true,
-          flowsDefaultKey: [props.flows.findIndex(el => el.name === fName)],
-          existingFlow: true
-        }
-      });
-    }
+    history.push({
+      pathname: "/tiles/run/add",
+      state: {
+        flowName: fName,
+        addFlowDirty: true,
+        flowsDefaultKey: [props.flows.findIndex(el => el.name === fName)],
+        existingFlow: true
+      }
+    });
   };
 
   const onAddCancel = () => {
     setAddToFlowVisible(false);
+    setRunNoFlowsDialogVisible(false);
+    setRunOneFlowDialogVisible(false);
+    setRunMultFlowsDialogVisible(false);
     setSelected({});
   };
 
@@ -193,45 +226,88 @@ const MergingCard: React.FC<Props> = (props) => {
     >
       <div aria-label="add-step-confirmation" style={{fontSize: "16px", padding: "10px"}}>
         { isStepInFlow(mergingArtifactName, flowName) ?
-          !addRun ? <p aria-label="step-in-flow">The step <strong>{mergingArtifactName}</strong> is already in the flow <strong>{flowName}</strong>. Would you like to add another instance?</p> : <p aria-label="step-in-flow-run">The step <strong>{mergingArtifactName}</strong> is already in the flow <strong>{flowName}</strong>. Would you like to add another instance and run it?</p>
-          : !addRun ? <p aria-label="step-not-in-flow">Are you sure you want to add the step <strong>{mergingArtifactName}</strong> to the flow <strong>{flowName}</strong>?</p> : <p aria-label="step-not-in-flow-run">Are you sure you want to add the step <strong>{mergingArtifactName}</strong> to the flow <strong>{flowName}</strong> and run it?</p>
+          <p aria-label="step-in-flow">The step <strong>{mergingArtifactName}</strong> is already in the flow <strong>{flowName}</strong>. Would you like to add another instance?</p> :
+          <p aria-label="step-not-in-flow">Are you sure you want to add the step <strong>{mergingArtifactName}</strong> to the flow <strong>{flowName}</strong>?</p>
         }
       </div>
     </Modal>
   );
 
-  const renderRunFlowMenu = (name) => (
-    <Menu style={{right: "80px"}}>
-      <Menu.Item key="0">
-        { <Link data-testid="link" id="tiles-add-run" to={
-          {pathname: "/tiles/run/add-run",
-            state: {
-              stepToAdd: name,
-              stepDefinitionType: "merging",
-              targetEntityType: props.entityModel.entityTypeId,
-              existingFlow: false
-            }}}><div className={styles.stepLink} data-testid={`${name}-run-toNewFlow`}>Run step in a new flow</div></Link>}
-      </Menu.Item>
-      <Menu.Item key="1">
-        <div className={styles.stepLinkExisting} data-testid={`${name}-run-toExistingFlow`}>Run step in an existing flow
-          <div className={styles.stepLinkSelect} onClick={(event) => { event.stopPropagation(); event.preventDefault(); }}>
-            <Select
-              style={{width: "100%"}}
-              value={selected[name] ? selected[name] : undefined}
-              onChange={(flowName) => handleSelectAddRun({flowName: flowName, mergingName: name})}
-              placeholder="Select Flow"
-              defaultActiveFirstOption={false}
-              disabled={!props.canWriteFlow}
-              data-testid={`${name}-run-flowsList`}
-            >
-              { props.flows && props.flows.length > 0 ? props.flows.map((f, i) => (
-                <Option aria-label={`${f.name}-run-option`} value={f.name} key={i}>{f.name}</Option>
-              )) : null}
-            </Select>
-          </div>
+  const runNoFlowsConfirmation = (
+    <Modal
+      visible={runNoFlowsDialogVisible}
+      cancelText="Cancel"
+      okButtonProps={{style: {display: "none"}}}
+      onCancel={() => onAddCancel()}
+      width={650}
+      maskClosable={false}
+    >
+      <div aria-label="step-in-no-flows-confirmation" style={{fontSize: "16px"}}>Choose the flow in which to add and run the step <strong>{mergingArtifactName}</strong>.</div>
+      <Row className={styles.flowSelectGrid}>
+        <Col span={11}>
+          <div>{props.flows.map((flow, i) => (
+            <p className={styles.stepLink} data-testid={`${flow.name}-run-step`} key={i} onClick={() => handleAddRun(flow.name)}>{flow.name}</p>
+          ))}</div>
+        </Col>
+        <Col span={2}>
+          <Divider type="vertical" className={styles.verticalDiv}></Divider>
+        </Col>
+        <Col span={11}>
+          <Link data-testid="link" id="tiles-add-run-new-flow" to={
+            {pathname: "/tiles/run/add-run",
+              state: {
+                stepToAdd: mergingArtifactName,
+                stepDefinitionType: "merging",
+                existingFlow: false
+              }}}><div className={styles.stepLink} data-testid={`${mergingArtifactName}-run-toNewFlow`}><Icon type="plus-circle" className={styles.plusIconNewFlow} theme="filled"/>New flow</div></Link>
+        </Col>
+      </Row>
+    </Modal>
+  );
+
+  const runOneFlowConfirmation = (
+    <Modal
+      visible={runOneFlowDialogVisible}
+      okText={<div aria-label="continue-confirm">Continue</div>}
+      onOk={() => onContinueRun()}
+      cancelText="Cancel"
+      onCancel={() => onAddCancel()}
+      width={650}
+      maskClosable={false}
+    >
+      <div aria-label="run-step-one-flow-confirmation" style={{fontSize: "16px", padding: "10px"}}>
+        <div>
+          <div aria-label="step-in-one-flow">Running the step <strong>{mergingArtifactName}</strong> in the flow <strong>{flowsWithStep}</strong></div>
         </div>
-      </Menu.Item>
-    </Menu>
+      </div>
+    </Modal>
+  );
+
+  const runMultFlowsConfirmation = (
+    <Modal
+      visible={runMultFlowsDialogVisible}
+      cancelText="Cancel"
+      okButtonProps={{style: {display: "none"}}}
+      onCancel={() => onAddCancel()}
+      width={650}
+      maskClosable={false}
+    >
+      <div aria-label="run-step-mult-flows-confirmation" style={{fontSize: "16px", padding: "10px"}}>
+        <div aria-label="step-in-mult-flows">Choose the flow in which to run the step <strong>{mergingArtifactName}</strong>.</div>
+        <div className = {styles.flowSelectGrid}>{flowsWithStep.map((flowName, i) => (
+          <Link data-testid="link" id="tiles-run-step" key={i} to={
+            {pathname: "/tiles/run/run-step",
+              state: {
+                flowName: flowName,
+                stepToAdd: mergingArtifactName,
+                stepDefinitionType: "merging",
+                existingFlow: false,
+                flowsDefaultKey: [props.flows.findIndex(el => el.name === flowName)],
+              }}}><p className={styles.stepLink} data-testid={`${flowName}-run-step`}>{flowName}</p></Link>
+        ))}
+        </div>
+      </div>
+    </Modal>
   );
 
   const renderCardActions = (step, index) => {
@@ -247,24 +323,17 @@ const MergingCard: React.FC<Props> = (props) => {
         </i>
       </MLTooltip>,
 
-      <Dropdown
-        data-testid={`${step.name}-dropdown`}
-        overlay={renderRunFlowMenu(step.name)}
-        trigger={["click"]}
-        disabled = {!props.canWriteFlow}
-      >
-        {props.canWriteMatchMerge ? (
-          <MLTooltip title={"Run"} placement="bottom">
-            <i aria-label="icon: run">
-              <Icon type="play-circle" theme="filled" className={styles.runIcon} data-testid={step.name+"-run"}/></i>
-          </MLTooltip>
-        ) : (
-          <MLTooltip title={"Run: " + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: "200px"}}>
-            <i role="disabled-run-matching button" data-testid={step.name+"-disabled-run"}>
-              <Icon type="play-circle" theme="filled" onClick={(event) => event.preventDefault()} className={styles.disabledRunIcon}/></i>
-          </MLTooltip>
-        )}
-      </Dropdown>,
+      props.canWriteMatchMerge ? (
+        <MLTooltip title={"Run"} placement="bottom">
+          <i aria-label="icon: run">
+            <Icon type="play-circle" theme="filled" className={styles.runIcon} data-testid={step.name+"-run"} onClick={() => handleStepRun(step.name)}/></i>
+        </MLTooltip>
+      ) : (
+        <MLTooltip title={"Run: " + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: "200px"}}>
+          <i role="disabled-run-merging button" data-testid={step.name+"-disabled-run"}>
+            <Icon type="play-circle" theme="filled" onClick={(event) => event.preventDefault()} className={styles.disabledRunIcon}/></i>
+        </MLTooltip>
+      ),
 
       props.canWriteMatchMerge ? (
         <MLTooltip title={"Delete"} placement="bottom">
@@ -395,6 +464,9 @@ const MergingCard: React.FC<Props> = (props) => {
         targetEntityName={props.entityModel.entityName}
       />
       {renderAddConfirmation}
+      {runNoFlowsConfirmation}
+      {runOneFlowConfirmation}
+      {runMultFlowsConfirmation}
     </div>
   );
 };

--- a/marklogic-data-hub-central/ui/src/components/load/load-card.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/load/load-card.module.scss
@@ -61,6 +61,12 @@
         color: var(--hoverColor);
     }
 }
+.plusIconNewFlow {
+  font-size: 15px;
+  color: #44499C;
+  margin-right: 10px;
+  cursor: pointer;
+}
 .plusIconDisabled{
     font-size: 80px;
     margin-top: 16px;
@@ -106,6 +112,20 @@
     &:hover{
         color: var(--hoverColor);
     }
+}
+
+.flowSelectGrid {
+  font-size: 16px;
+  padding-top: 30px;
+}
+
+.runNewFlow {
+  display: flex;
+}
+
+.verticalDiv {
+  margin-left: 15px;
+  height: 55vh;
 }
 
 .cardLinks {
@@ -165,6 +185,18 @@
     &:hover{
         color: var(--hoverColor);
     }
+}
+
+.stepLink:hover {
+  cursor: pointer;
+  .plusIconNewFlow {
+    color: var(--hoverColor);
+  }
+}
+
+.newFlowStepLink {
+  margin-left: 5px;
+  color: var(--hoverColor);
 }
 
 .stepLinkExisting {

--- a/marklogic-data-hub-central/ui/src/components/load/load-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-card.test.tsx
@@ -95,15 +95,13 @@ describe("Load Card component", () => {
     //Verify run step in an existing flow where step does not exist yet
 
     //Click play button 'Run' icon
-    fireEvent.click(getByTestId("testLoadXML-run"));
+    fireEvent.click(getByTestId("testLoad123-run"));
 
-    //'Run in an existing Flow'
-    fireEvent.click(getByTestId("testLoadXML-run-flowsList"));
-    fireEvent.click(getByLabelText("FlowStepNoExist-run-option"));
+    //Modal with options to run in an existing or new flow should appear
+    expect(getByLabelText("step-in-no-flows-confirmation")).toBeInTheDocument();
 
-    //Dialog appears, click 'Yes' button
-    expect(getByLabelText("step-not-in-flow-run")).toBeInTheDocument();
-    fireEvent.click(getByTestId("testLoadXML-to-FlowStepNoExist-Confirm"));
+    //Select flow to add and run step in
+    fireEvent.click(getByTestId("FlowStepNoExist-run-step"));
 
     //Check if the /tiles/run/add-run route has been called
     wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/add-run"); });
@@ -158,21 +156,49 @@ describe("Load Card component", () => {
     //Click play button 'Run' icon
     fireEvent.click(getByTestId("testLoadXML-run"));
 
-    //'Run in an existing Flow'
-    fireEvent.click(getByTestId("testLoadXML-run-flowsList"));
-    fireEvent.click(getByLabelText("FlowStepExist-run-option"));
+    //Confirmation modal for directly running the step in its flow should appear
+    expect(getByLabelText("run-step-one-flow-confirmation")).toBeInTheDocument();
 
-    //Dialog appears, click 'Yes' button
-    expect(getByLabelText("step-in-flow-run")).toBeInTheDocument();
-    fireEvent.click(getByTestId("testLoadXML-to-FlowStepExist-Confirm"));
+    //Click Continue to confirm
+    fireEvent.click(getByLabelText("continue-confirm"));
 
-    //Check if the /tiles/run/add-run route has been called
-    wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/add-run"); });
-
+    //Check if the /tiles/run/run-step route has been called
+    wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/run-step"); });
 
   });
 
-  test("Load Card - Verify card sort order and Add step to a new Flow", async () => {
+  test("Load Card - Run step in an existing flow where step exists in MORE THAN ONE flow", async () => {
+    const authorityService = new AuthoritiesService();
+    authorityService.setAuthorities(["readIngestion", "writeIngestion", "writeFlow"]);
+    const {getByLabelText, getByTestId} = render(
+      <MemoryRouter>
+        <AuthoritiesContext.Provider value={authorityService}>
+          <LoadCard
+            {...data.loadData}
+            flows={data.flowsAdd}
+            canWriteFlow={true}
+            addStepToFlow={jest.fn()}
+            addStepToNew={jest.fn()} />
+        </AuthoritiesContext.Provider>
+      </MemoryRouter>
+    );
+
+    //Verify run step in an existing flow where step exists in more than one flow
+
+    //Click play button 'Run' icon
+    fireEvent.click(getByTestId("testLoad-run"));
+
+    //Modal with list of flows where step exists to select one to run in
+    expect(getByLabelText("run-step-mult-flows-confirmation")).toBeInTheDocument();
+
+    //Select flow to run step in
+    fireEvent.click(getByTestId("FlowStepMultExist-run-step"));
+
+    //Check if the /tiles/run/add-run route has been called
+    wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/add-run"); });
+  });
+
+  test("Load Card - Verify card sort order, Add step to a new Flow, and Run step in a new Flow", async () => {
     const authorityService = new AuthoritiesService();
     authorityService.setAuthorities(["readIngestion", "writeIngestion", "writeFlow"]);
     const {getByText, getByLabelText, getByTestId} = render(
@@ -219,7 +245,10 @@ describe("Load Card component", () => {
     //Click play button 'Run' icon
     fireEvent.click(getByTestId("testLoadXML-run"));
 
-    //'Run in a new Flow'
+    //Modal with option to add and run in a new flow should appear
+    expect(getByLabelText("step-in-no-flows-confirmation")).toBeInTheDocument();
+
+    //Select "New Flow" option to add and run in a new flow
     fireEvent.click(getByTestId("testLoadXML-run-toNewFlow"));
 
     //Check if the /tiles/run/add-run route has been called
@@ -265,7 +294,7 @@ describe("Load Card component", () => {
   test("Verify Load card does not allow a step to be added to flow and run in a flow with readFlow authority only", async () => {
     const authorityService = new AuthoritiesService();
     authorityService.setAuthorities(["readIngestion", "readFlow"]);
-    const {getByText, queryByTestId, getByTestId, queryByText} = render(<MemoryRouter><AuthoritiesContext.Provider value={authorityService}><LoadCard
+    const {getByText, queryByTestId, getByTestId, queryByText, queryByLabelText} = render(<MemoryRouter><AuthoritiesContext.Provider value={authorityService}><LoadCard
       {...ingestionData.loadCardProps}
       data={data.loadData.data}
       flows={data.flows}/>
@@ -292,7 +321,7 @@ describe("Load Card component", () => {
     await wait(() => expect(getByText("Run: " + SecurityTooltips.missingPermission)).toBeInTheDocument());
 
     await fireEvent.click(getByTestId(`${loadStepName}-disabled-run`));
-    expect(queryByTestId(`${loadStepName}-run-flowsList`)).not.toBeInTheDocument();
+    expect(queryByLabelText("step-in-no-flows-confirmation")).not.toBeInTheDocument();
 
     // adding to new flow
     fireEvent.mouseOver(getByText(loadStepName));

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.module.scss
@@ -43,6 +43,13 @@
     border: none;
 }
 
+.plusIconNewFlow {
+  font-size: 15px;
+  color: #44499C;
+  margin-right: 10px;
+  cursor: pointer;
+}
+
 .settingsIcon {
     color: #44499C;
     font-size: 19px;
@@ -50,6 +57,9 @@
 
 .stepLink {
     color: #44499C;
+    &:hover{
+        color: var(--hoverColor);
+    }
 }
 
 .stepLinkExisting {
@@ -109,6 +119,32 @@
     &:hover{
         color: var(--hoverColor);
     }
+}
+
+.flowSelectGrid {
+  font-size: 16px;
+  padding-top: 30px;
+}
+
+.runNewFlow {
+  display: flex;
+}
+
+.verticalDiv {
+  margin-left: 15px;
+  height: 55vh;
+}
+
+.stepLink:hover {
+  cursor: pointer;
+  .plusIconNewFlow {
+    color: var(--hoverColor);
+  }
+}
+
+.newFlowStepLink {
+  margin-left: 5px;
+  color: var(--hoverColor);
 }
 
 .sourceFormatFS{

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.test.tsx
@@ -298,15 +298,13 @@ describe("Load data component", () => {
     //Verify run step in an existing flow where step does not exist yet
 
     //Click play button 'Run' icon
-    fireEvent.click(getByTestId("testLoadXML-run"));
+    fireEvent.click(getByTestId("testLoad123-run"));
 
-    //'Run in an existing Flow'
-    fireEvent.click(getByTestId("testLoadXML-run-flowsList"));
-    fireEvent.click(getByLabelText("FlowStepNoExist-run-option"));
+    //Modal with options to run in an existing or new flow should appear
+    expect(getByLabelText("step-in-no-flows-confirmation")).toBeInTheDocument();
 
-    //Dialog appears, click 'Yes' button
-    expect(getByLabelText("step-not-in-flow-run")).toBeInTheDocument();
-    fireEvent.click(getByTestId("testLoadXML-to-FlowStepNoExist-Confirm"));
+    //Select flow to add and run step in
+    fireEvent.click(getByTestId("FlowStepNoExist-run-step"));
 
     //Check if the /tiles/run/add-run route has been called
     wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/add-run"); });
@@ -332,13 +330,42 @@ describe("Load data component", () => {
     //Click play button 'Run' icon
     fireEvent.click(getByTestId("testLoadXML-run"));
 
-    //'Run in an existing Flow'
-    fireEvent.click(getByTestId("testLoadXML-run-flowsList"));
-    fireEvent.click(getByLabelText("FlowStepExist-run-option"));
+    //Confirmation modal for directly running the step in its flow should appear
+    expect(getByLabelText("run-step-one-flow-confirmation")).toBeInTheDocument();
 
-    //Dialog appears, click 'Yes' button
-    expect(getByLabelText("step-in-flow-run")).toBeInTheDocument();
-    fireEvent.click(getByTestId("testLoadXML-to-FlowStepExist-Confirm"));
+    //Click Continue to confirm
+    fireEvent.click(getByLabelText("continue-confirm"));
+
+    //Check if the /tiles/run/run-step route has been called
+    wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/run-step"); });
+  });
+
+  test("Load List - Run step in an existing flow where step exists in MORE THAN ONE flow", async () => {
+    const authorityService = new AuthoritiesService();
+    authorityService.setAuthorities(["readIngestion", "writeIngestion", "writeFlow"]);
+    const {getByLabelText, getByTestId} = render(
+      <MemoryRouter>
+        <AuthoritiesContext.Provider value={authorityService}>
+          <LoadList
+            {...data.loadData}
+            flows={data.flowsAdd}
+            canWriteFlow={true}
+            addStepToFlow={jest.fn()}
+            addStepToNew={jest.fn()} />
+        </AuthoritiesContext.Provider>
+      </MemoryRouter>
+    );
+
+    //Verify run step in an existing flow where step exists in more than one flow
+
+    //Click play button 'Run' icon
+    fireEvent.click(getByTestId("testLoad-run"));
+
+    //Modal with list of flows where step exists to select one to run in
+    expect(getByLabelText("run-step-mult-flows-confirmation")).toBeInTheDocument();
+
+    //Select flow to run step in
+    fireEvent.click(getByTestId("FlowStepMultExist-run-step"));
 
     //Check if the /tiles/run/add-run route has been called
     wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/add-run"); });
@@ -377,6 +404,21 @@ describe("Load data component", () => {
       expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/add");
     });
     //TODO- E2E test to check if the Run tile is loaded or not.
+
+
+    //Verify run step in a new flow
+
+    //Click play button 'Run' icon
+    fireEvent.click(getByTestId("testLoadXML-run"));
+
+    //Modal with option to add and run in a new flow should appear
+    expect(getByLabelText("step-in-no-flows-confirmation")).toBeInTheDocument();
+
+    //Select "New Flow" option to add and run in a new flow
+    fireEvent.click(getByTestId("testLoadXML-run-toNewFlow"));
+
+    //Check if the /tiles/run/add-run route has been called
+    wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/add-run"); });
 
   });
 

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.tsx
@@ -2,7 +2,7 @@ import React, {useState, useEffect, useContext} from "react";
 import {Link, useLocation, useHistory} from "react-router-dom";
 import styles from "./load-list.module.scss";
 import "./load-list.scss";
-import {Table, Icon, Modal, Menu, Select, Dropdown} from "antd";
+import {Table, Icon, Modal, Menu, Select, Row, Col, Divider, Dropdown} from "antd";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faTrashAlt} from "@fortawesome/free-regular-svg-icons";
 import {MLButton} from "@marklogic/design-system";
@@ -42,13 +42,16 @@ const LoadList: React.FC<Props> = (props) => {
   const [sortedInfo, setSortedInfo] = useState(props.sortOrderInfo);
   const [dialogVisible, setDialogVisible] = useState(false);
   const [addDialogVisible, setAddDialogVisible] = useState(false);
+  const [runNoFlowsDialogVisible, setRunNoFlowsDialogVisible] = useState(false);
+  const [runOneFlowDialogVisible, setRunOneFlowDialogVisible] = useState(false);
+  const [runMultFlowsDialogVisible, setRunMultFlowsDialogVisible] = useState(false);
+  const [flowsWithStep, setFlowsWithStep] = useState<any[]>([]);
   const [flowName, setFlowName] = useState("");
   const [loadArtifactName, setLoadArtifactName] = useState("");
   const [stepData, setStepData] = useState({});
   const [openStepSettings, setOpenStepSettings] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [selected, setSelected] = useState({}); // track Add Step selections so we can reset on cancel
-  const [addRun, setAddRun] = useState(false);
 
   const pageSizeOptions = props.data.length > 40 ? ["10", "20", "30", "40", props.data.length] : ["10", "20", "30", "40"];
 
@@ -99,6 +102,9 @@ const LoadList: React.FC<Props> = (props) => {
   const onCancel = () => {
     setDialogVisible(false);
     setAddDialogVisible(false);
+    setRunNoFlowsDialogVisible(false);
+    setRunOneFlowDialogVisible(false);
+    setRunMultFlowsDialogVisible(false);
     setSelected({}); // reset menus on cancel
   };
 
@@ -106,14 +112,6 @@ const LoadList: React.FC<Props> = (props) => {
     let selectedNew = {...selected};
     selectedNew[obj.loadName] = obj.flowName;
     setSelected(selectedNew);
-    handleStepAdd(obj.loadName, obj.flowName);
-  }
-
-  function handleSelectAddRun(obj) {
-    let selectedNew = {...selected};
-    selectedNew[obj.loadName] = obj.flowName;
-    setSelected(selectedNew);
-    setAddRun(true);
     handleStepAdd(obj.loadName, obj.flowName);
   }
 
@@ -130,38 +128,73 @@ const LoadList: React.FC<Props> = (props) => {
     return result;
   };
 
+  const countStepInFlow = (loadName) => {
+    let result : string[] = [];
+    if (props.flows) props.flows.forEach(f => f["steps"].findIndex(s => s.stepName === loadName) > -1 ? result.push(f.name) : "");
+    return result;
+  };
+
   const handleStepAdd = (loadName, flowName) => {
     setLoadArtifactName(loadName);
     setFlowName(flowName);
     setAddDialogVisible(true);
   };
 
+  const handleStepRun = (loadName) => {
+    setLoadArtifactName(loadName);
+    let stepInFlows = countStepInFlow(loadName);
+    setFlowsWithStep(stepInFlows);
+    if (stepInFlows.length > 1) {
+      setRunMultFlowsDialogVisible(true);
+    } else if (stepInFlows.length === 1) {
+      setRunOneFlowDialogVisible(true);
+    } else {
+      setRunNoFlowsDialogVisible(true);
+    }
+  };
+
+  const handleAddRun = async (flowName) => {
+    await props.addStepToFlow(loadArtifactName, flowName, "ingestion");
+    setRunNoFlowsDialogVisible(false);
+
+    history.push({
+      pathname: "/tiles/run/add-run",
+      state: {
+        flowName: flowName,
+        flowsDefaultKey: [props.flows.findIndex(el => el.name === flowName)],
+        existingFlow: true,
+        addFlowDirty: true,
+        stepToAdd: loadArtifactName,
+        stepDefinitionType: "ingestion"
+      }
+    });
+  };
+
+  const onContinueRun = () => {
+    history.push({
+      pathname: "/tiles/run/run-step",
+      state: {
+        flowName: flowsWithStep[0],
+        stepToAdd: loadArtifactName,
+        stepDefinitionType: "ingestion",
+        existingFlow: false,
+        flowsDefaultKey: [props.flows.findIndex(el => el.name === flowsWithStep[0])],
+      }
+    });
+  };
+
   const onAddOk = async (lName, fName) => {
     await props.addStepToFlow(lName, fName);
     setAddDialogVisible(false);
-    if (addRun) {
-      history.push({
-        pathname: "/tiles/run/add-run",
-        state: {
-          flowName: fName,
-          addFlowDirty: true,
-          flowsDefaultKey: [props.flows.findIndex(el => el.name === fName)],
-          existingFlow: true,
-          stepToAdd: loadArtifactName,
-          stepDefinitionType: "ingestion"
-        }
-      });
-    } else {
-      history.push({
-        pathname: "/tiles/run/add",
-        state: {
-          flowName: fName,
-          addFlowDirty: true,
-          flowsDefaultKey: [props.flows.findIndex(el => el.name === fName)],
-          existingFlow: true
-        }
-      });
-    }
+    history.push({
+      pathname: "/tiles/run/add",
+      state: {
+        flowName: fName,
+        addFlowDirty: true,
+        flowsDefaultKey: [props.flows.findIndex(el => el.name === fName)],
+        existingFlow: true
+      }
+    });
   };
 
   const addConfirmation = (
@@ -176,50 +209,88 @@ const LoadList: React.FC<Props> = (props) => {
     >
       <div aria-label="add-step-confirmation" style={{fontSize: "16px", padding: "10px"}}>
         {isStepInFlow(loadArtifactName, flowName) ?
-          !addRun ? <p aria-label="step-in-flow">The step <strong>{loadArtifactName}</strong> is already in the flow <strong>{flowName}</strong>. Would you like to add another instance?</p> : <p aria-label="step-in-flow-run">The step <strong>{loadArtifactName}</strong> is already in the flow <strong>{flowName}</strong>. Would you like to add another instance and run it?</p>
-          : !addRun ? <p aria-label="step-not-in-flow">Are you sure you want to add the step <strong>{loadArtifactName}</strong> to the flow <strong>{flowName}</strong>?</p> : <p aria-label="step-not-in-flow-run">Are you sure you want to add the step <strong>{loadArtifactName}</strong> to the flow <strong>{flowName}</strong> and run it?</p>
+          <p aria-label="step-in-flow">The step <strong>{loadArtifactName}</strong> is already in the flow <strong>{flowName}</strong>. Would you like to add another instance?</p> :
+          <p aria-label="step-not-in-flow">Are you sure you want to add the step <strong>{loadArtifactName}</strong> to the flow <strong>{flowName}</strong>?</p>
         }
       </div>
     </Modal>
   );
 
-  const runMenu = (name) => (
-    <Menu className={styles.dropdownMenu}>
-      <Menu.Item key="0">
-        {<Link data-testid="link" id="tiles-run-add" to={
-          {
-            pathname: "/tiles/run/add-run",
-            state: {
-              stepToAdd: name,
-              stepDefinitionType: "ingestion",
-              viewMode: "list",
-              pageSize: loadingOptions.pageSize,
-              page: loadingOptions.pageNumber,
-              sortOrderInfo: sortedInfo,
-              existingFlow: false
-            }
-          }}><div className={styles.stepLink} data-testid={`${name}-run-toNewFlow`}>Run step in a new flow</div></Link>}
-      </Menu.Item>
-      <Menu.Item key="1">
-        <div className={styles.stepLinkExisting} data-testid={`${name}-run-toExistingFlow`}>Run step in an existing flow
-          <div className={styles.stepLinkSelect} onClick={(event) => { event.stopPropagation(); event.preventDefault(); }}>
-            <Select
-              className={styles.flowSelect}
-              value={selected[name] ? selected[name] : undefined}
-              onChange={(flowName) => handleSelectAddRun({flowName: flowName, loadName: name})}
-              placeholder="Select Flow"
-              defaultActiveFirstOption={false}
-              disabled={!props.canWriteFlow}
-              data-testid={`${name}-run-flowsList`}
-            >
-              {props.flows && props.flows.length > 0 ? props.flows.map((f, i) => (
-                <Option aria-label={`${f.name}-run-option`} value={f.name} key={i}>{f.name}</Option>
-              )) : null}
-            </Select>
-          </div>
+  const runNoFlowsConfirmation = (
+    <Modal
+      visible={runNoFlowsDialogVisible}
+      cancelText="Cancel"
+      okButtonProps={{style: {display: "none"}}}
+      onCancel={() => onCancel()}
+      width={650}
+      maskClosable={false}
+    >
+      <div aria-label="step-in-no-flows-confirmation" style={{fontSize: "16px"}}>Choose the flow in which to add and run the step <strong>{loadArtifactName}</strong>.</div>
+      <Row className={styles.flowSelectGrid}>
+        <Col span={11}>
+          <div>{props.flows?.map((flow, i) => (
+            <p className={styles.stepLink} data-testid={`${flow.name}-run-step`} key={i} onClick={() => handleAddRun(flow.name)}>{flow.name}</p>
+          ))}</div>
+        </Col>
+        <Col span={2}>
+          <Divider type="vertical" className={styles.verticalDiv}></Divider>
+        </Col>
+        <Col span={11}>
+          <Link data-testid="link" id="tiles-add-run-new-flow" to={
+            {pathname: "/tiles/run/add-run",
+              state: {
+                stepToAdd: loadArtifactName,
+                stepDefinitionType: "ingestion",
+                existingFlow: false
+              }}}><div className={styles.stepLink} data-testid={`${loadArtifactName}-run-toNewFlow`}><Icon type="plus-circle" className={styles.plusIconNewFlow} theme="filled"/>New flow</div></Link>
+        </Col>
+      </Row>
+    </Modal>
+  );
+
+  const runOneFlowConfirmation = (
+    <Modal
+      visible={runOneFlowDialogVisible}
+      okText={<div aria-label="continue-confirm">Continue</div>}
+      onOk={() => onContinueRun()}
+      cancelText="Cancel"
+      onCancel={() => onCancel()}
+      width={650}
+      maskClosable={false}
+    >
+      <div aria-label="run-step-one-flow-confirmation" style={{fontSize: "16px", padding: "10px"}}>
+        <div>
+          <div aria-label="step-in-one-flow">Running the step <strong>{loadArtifactName}</strong> in the flow <strong>{flowsWithStep}</strong></div>
         </div>
-      </Menu.Item>
-    </Menu>
+      </div>
+    </Modal>
+  );
+
+  const runMultFlowsConfirmation = (
+    <Modal
+      visible={runMultFlowsDialogVisible}
+      cancelText="Cancel"
+      okButtonProps={{style: {display: "none"}}}
+      onCancel={() => onCancel()}
+      width={650}
+      maskClosable={false}
+    >
+      <div aria-label="run-step-mult-flows-confirmation" style={{fontSize: "16px", padding: "10px"}}>
+        <div aria-label="step-in-mult-flows">Choose the flow in which to run the step <strong>{loadArtifactName}</strong>.</div>
+        <div className = {styles.flowSelectGrid}>{flowsWithStep.map((flowName, i) => (
+          <Link data-testid="link" id="tiles-run-step" key={i} to={
+            {pathname: "/tiles/run/run-step",
+              state: {
+                flowName: flowName,
+                stepToAdd: loadArtifactName,
+                stepDefinitionType: "ingestion",
+                existingFlow: false,
+                flowsDefaultKey: [props.flows.findIndex(el => el.name === flowName)],
+              }}}><p className={styles.stepLink} data-testid={`${flowName}-run-step`}>{flowName}</p></Link>
+        ))}
+        </div>
+      </div>
+    </Modal>
   );
 
   const menu = (name) => (
@@ -335,9 +406,7 @@ const LoadList: React.FC<Props> = (props) => {
       key: "actions",
       render: (text, row) => (
         <span>
-          <Dropdown data-testid={`${row.name}-run-dropdown`} overlay={runMenu(row.name)} trigger={["click"]} disabled={!props.canWriteFlow} placement="bottomCenter">
-            {props.canReadWrite ? <MLTooltip title={"Run"} placement="bottom"><i aria-label="icon: run"><Icon type="play-circle" theme="filled" className={styles.runIcon} data-testid={row.name + "-run"} /></i></MLTooltip> : <MLTooltip title={"Run: " + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: "200px"}}><i role="disabled-run-load button" data-testid={row.name + "-disabled-run"}><Icon type="play-circle" theme="filled" onClick={(event) => event.preventDefault()} className={styles.disabledRunIcon} /></i></MLTooltip>}
-          </Dropdown>
+          {props.canReadWrite ? <MLTooltip title={"Run"} placement="bottom"><i aria-label="icon: run"><Icon type="play-circle" theme="filled" className={styles.runIcon} data-testid={row.name+"-run"} onClick={() => handleStepRun(row.name)}/></i></MLTooltip> : <MLTooltip title={"Run: " + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: "200px"}}><i role="disabled-run-load-list button" data-testid={row.name+"-disabled-run"}><Icon type="play-circle" theme="filled" onClick={(event) => event.preventDefault()} className={styles.disabledRunIcon}/></i></MLTooltip>}
           <Dropdown data-testid={`${row.name}-dropdown`} overlay={menu(row.name)} trigger={["click"]} disabled={!props.canWriteFlow} placement="bottomCenter">
             {props.canWriteFlow ? <MLTooltip title={"Add to Flow"} placement="bottom"><span className={"AddToFlowIcon"} aria-label={row.name + "-add-icon"}></span></MLTooltip> : <MLTooltip title={"Add to Flow: " + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: "225px"}}><span aria-label={row.name + "-disabled-add-icon"} className={"disabledAddToFlowIcon"}></span></MLTooltip>}
           </Dropdown>
@@ -377,6 +446,9 @@ const LoadList: React.FC<Props> = (props) => {
       />
       {deleteConfirmation}
       {addConfirmation}
+      {runNoFlowsConfirmation}
+      {runOneFlowConfirmation}
+      {runMultFlowsConfirmation}
       <Steps
         // Basic Settings
         isEditing={isEditing}

--- a/marklogic-data-hub-central/ui/src/components/tiles/tiles.tsx
+++ b/marklogic-data-hub-central/ui/src/components/tiles/tiles.tsx
@@ -159,7 +159,7 @@ const Tiles: React.FC<Props> = (props) => {
             title={options["title"]}
             renderToolbar={renderHeader}
           >
-            {!props.newStepToFlowOptions?.addingStepToFlow ? props.view : <Run newStepToFlowOptions={props.newStepToFlowOptions}/>}
+            {!props.newStepToFlowOptions?.routeToFlow ? props.view : <Run newStepToFlowOptions={props.newStepToFlowOptions}/>}
           </MosaicWindow>
         );
       }}

--- a/marklogic-data-hub-central/ui/src/pages/Curate.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Curate.test.tsx
@@ -40,16 +40,16 @@ describe("Curate component", () => {
     expect(queryByText("Match")).not.toBeInTheDocument();
     expect(queryByText("Merge")).not.toBeInTheDocument();
 
-    expect(getByText("Mapping2")).toBeInTheDocument();
+    expect(getByText("Mapping3")).toBeInTheDocument();
 
     // test edit
-    fireEvent.click(getByTestId("Mapping2-edit"));
+    fireEvent.click(getByTestId("Mapping3-edit"));
     expect(await(waitForElement(() => getByText("Mapping Step Settings")))).toBeInTheDocument();
     expect(getAllByText("Save")[0]).toBeDisabled();
     fireEvent.click(getAllByText("Cancel")[0]);
 
     // test delete
-    expect(queryByTestId("Mapping2-delete")).not.toBeInTheDocument();
+    expect(queryByTestId("Mapping3-delete")).not.toBeInTheDocument();
   });
 
   test("Verify writeMapping authority can edit mapping configs and settings", async () => {

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.test.tsx
@@ -104,7 +104,7 @@ describe("Tiles View component tests for Developer user", () => {
 
     fireEvent.click(getByText("Customer"));
 
-    fireEvent.mouseOver(getByText("Mapping2"));
+    fireEvent.mouseOver(getByText("Mapping3"));
 
     expect(getByText("Add step to a new flow"));
     expect(getByText("Add step to an existing flow"));

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.tsx
@@ -104,8 +104,9 @@ const TilesView = (props) => {
   }, []);
 
   const getNewStepToFlowOptions = () => {
-    return !props.addingStepToFlow ? {addingStepToFlow: false} : {
-      addingStepToFlow: true,
+    return {
+      routeToFlow: props.routeToFlow,
+      addingStepToFlow: props.addingStepToFlow,
       startRunStep: props.startRunStep,
       flowName: location.state?.flowName,
       newStepName: location.state?.stepToAdd,


### PR DESCRIPTION
…wn flow selection

### Description
- Changed Run button functionality to ALL steps: load card, load list, match, merge, and mapping steps.
- Remove need for dropdown menu when running step via run button
- Running now displays 3 different kinds of modals depending on the step's existence in a flow
    1. If step does not exist in any flow, show all flows to select one to add and run in, or select New Flow
    2. If step exists in one flow, show confirmation if user wants to run step in that flow
    3. If step exists in more than one flow, show the flows where step exists to select and run in.
- Functionality example for mapping step: https://drive.google.com/file/d/1626ePV3yt_y5GaRGtfVWRt2ZLAVn-fwH/view
- Reviewers please test every step type
- Added RTL and e2e tests in every step component for all scenarios. Tests passing locally.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

