### PR TITLE
DHFPROD-6397: Retrieve Pendo key from cloud service

### DIFF
--- a/marklogic-data-hub-central/build.gradle
+++ b/marklogic-data-hub-central/build.gradle
@@ -78,10 +78,8 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:4.7.2"
     implementation "com.squareup.okhttp3:logging-interceptor:4.7.2"
 
-    // Excluding okhttp3 dependency as it bumps down the dependency from 4.4.0 to 3.x
-    implementation ('com.microsoft.azure:azure-keyvault-secrets-spring-boot-starter:2.2.4') {
-        exclude group: "com.squareup.okhttp3", module: "okhttp"
-    }
+    implementation 'com.azure:azure-identity:1.2.0'
+    implementation 'com.azure:azure-security-keyvault-secrets:4.2.3'
     implementation 'com.azure:azure-storage-blob:12.8.0'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.11.847'
     implementation 'com.amazonaws:aws-java-sdk-ssm:1.11.847'

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/cloud/Constants.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/cloud/Constants.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2012-2021 MarkLogic Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.marklogic.hub.central.cloud;
+
+public class Constants {
+
+    public static final String CERTIFICATE_KEY_STORE_PASSWORD = "key-store-password";
+    public static final String PENDO_API_KEY = "pendo-api-key";
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/cloud/ParameterSource.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/cloud/ParameterSource.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2012-2021 MarkLogic Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.marklogic.hub.central.cloud;
+
+/**
+ * Abstracts how a parameter's value is obtained from the respective cloud service.(AWS/Azure)
+ * The implementation of this is expected to be injected by Spring based on the Spring profile.
+ */
+public interface ParameterSource {
+
+    String getParameter(String key);
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/cloud/aws/AWSConfiguration.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/cloud/aws/AWSConfiguration.java
@@ -17,20 +17,23 @@
 package com.marklogic.hub.central.cloud.aws;
 
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
-import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
 import com.marklogic.hub.central.web.SslUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 
 import java.io.InputStream;
+
+import static com.marklogic.hub.central.cloud.Constants.CERTIFICATE_KEY_STORE_PASSWORD;
 
 @Configuration
 @Profile("aws")
@@ -38,42 +41,30 @@ public class AWSConfiguration {
 
     private static final Logger logger = LoggerFactory.getLogger(AWSConfiguration.class);
 
-    @Value("${aws.s3.bucketName}")
+    @Autowired
+    AWSParameterStore awsParameterStore;
+
+    @Value("${aws.s3.bucketName:}")
     private String bucketName;
 
-    @Value("${aws.s3.keyName}")
+    @Value("${aws.s3.keyName:}")
     private String keyName;
 
-    private String keyStorePassword;
-
     @Bean
+    @Primary
+    @ConditionalOnProperty(name = "hubRetrieveCertificate", havingValue = "true")
     public ServerProperties serverProperties() {
         return SslUtil.buildServerProperties(retrieveKeyStorePassword());
     }
 
     @Bean
+    @ConditionalOnProperty(name = "hubRetrieveCertificate", havingValue = "true")
     public WebServerFactoryCustomizer<TomcatServletWebServerFactory> tomcatSslStoreCustomizer() {
         return SslUtil.configureSslStoreProvider(retrieveKeyStorePassword(), retrieveKeyStoreFile());
     }
 
     private String retrieveKeyStorePassword() {
-        if (keyStorePassword != null) {
-            return keyStorePassword;
-        }
-
-        logger.info("Retrieving keystore password");
-        GetParameterRequest parameterRequest = new GetParameterRequest()
-                .withName("key-store-password")
-                .withWithDecryption(true);
-
-        keyStorePassword = AWSSimpleSystemsManagementClientBuilder
-                .defaultClient()
-                .getParameter(parameterRequest)
-                .getParameter()
-                .getValue();
-        logger.info("Retrieved keystore password");
-
-        return keyStorePassword;
+        return awsParameterStore.getParameter(CERTIFICATE_KEY_STORE_PASSWORD);
     }
 
     private InputStream retrieveKeyStoreFile() {

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/cloud/aws/AWSParameterStore.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/cloud/aws/AWSParameterStore.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2012-2021 MarkLogic Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.marklogic.hub.central.cloud.aws;
+
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
+import com.marklogic.hub.central.cloud.ParameterSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@Profile("aws")
+public class AWSParameterStore implements ParameterSource {
+
+    private static final Logger logger = LoggerFactory.getLogger(AWSParameterStore.class);
+
+    private final Map<String, String> parameterValueMap;
+
+    AWSParameterStore() {
+        parameterValueMap = new HashMap<>();
+    }
+
+    @Override
+    public String getParameter(String key) {
+        if (parameterValueMap.containsKey(key)) {
+            return parameterValueMap.get(key);
+        }
+
+        String value = null;
+        try {
+            logger.info("Retrieving value for key: " + key);
+            GetParameterRequest parameterRequest = new GetParameterRequest()
+                    .withName(key)
+                    .withWithDecryption(true);
+
+            value = AWSSimpleSystemsManagementClientBuilder
+                    .defaultClient()
+                    .getParameter(parameterRequest)
+                    .getParameter()
+                    .getValue();
+            logger.info("Retrieved value for key: " + key);
+        }
+        catch (Exception e) {
+            logger.error("Error in retrieving value for key: " + key + "; cause: " + e.getMessage(), e);
+        }
+
+        // since we dont want to call the cloud service again, we will insert `null` if there's an error in retrieving the value for the key
+        parameterValueMap.put(key, value);
+
+        return value;
+    }
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/cloud/azure/AzureKeyVaultSecret.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/cloud/azure/AzureKeyVaultSecret.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2012-2021 MarkLogic Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.marklogic.hub.central.cloud.azure;
+
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.security.keyvault.secrets.SecretClient;
+import com.azure.security.keyvault.secrets.SecretClientBuilder;
+import com.marklogic.hub.central.cloud.ParameterSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@Profile("azure")
+public class AzureKeyVaultSecret implements ParameterSource {
+    private static final Logger logger = LoggerFactory.getLogger(AzureKeyVaultSecret.class);
+
+    private final Map<String, String> parameterValueMap;
+
+    @Value("${azure.keyvault.uri:}")
+    private String keyVaultUri;
+
+    AzureKeyVaultSecret() {
+        parameterValueMap = new HashMap<>();
+    }
+
+    @Override
+    public String getParameter(String key) {
+        if (parameterValueMap.containsKey(key)) {
+            return parameterValueMap.get(key);
+        }
+
+        String value = null;
+        try {
+            logger.info("Retrieving value for key: " + key);
+            SecretClient secretClient = new SecretClientBuilder()
+                    .vaultUrl(keyVaultUri)
+                    .credential(new DefaultAzureCredentialBuilder().build())
+                    .buildClient();
+
+            value = secretClient.getSecret(key).getValue();
+            logger.info("Retrieved value for key: " + key);
+        }
+        catch (Exception e) {
+            logger.error("Error in retrieving value for key: " + key + "; cause: " + e.getMessage(), e);
+        }
+
+        // since we dont want to call the cloud service again, we will insert `null` if there's an error in retrieving the value for the key
+        parameterValueMap.put(key, value);
+
+        return value;
+    }
+}

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/EnvironmentController.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/EnvironmentController.java
@@ -16,6 +16,7 @@
 package com.marklogic.hub.central.controllers;
 
 import com.marklogic.hub.central.HubCentral;
+import com.marklogic.hub.central.pendo.PendoKeyProvider;
 import com.marklogic.hub.hubcentral.HubCentralManager;
 import com.marklogic.hub.impl.DataHubImpl;
 import com.marklogic.hub.impl.VersionInfo;
@@ -43,6 +44,9 @@ public class EnvironmentController extends BaseController {
 
     @Autowired
     Environment environment;
+
+    @Autowired
+    PendoKeyProvider pendoKeyProvider;
 
     @RequestMapping(value = "/api/environment/downloadHubCentralFiles", produces = "application/zip", method = RequestMethod.GET)
     @Secured("ROLE_downloadProjectFiles")
@@ -86,7 +90,7 @@ public class EnvironmentController extends BaseController {
         info.dataHubVersion = versionInfo.getHubVersion();
         info.marklogicVersion = versionInfo.getMarkLogicVersion();
         info.host = hubCentral.getHost();
-        info.pendoKey = "dummy-key-f7d836d7-2afa-40a6-44e4-f32f58cb35a";
+        info.pendoKey = pendoKeyProvider.getPendoKey();
         info.sessionTimeout = environment.getProperty("server.servlet.session.timeout");
         Object hubCentralSessionToken = session.getAttribute("hubCentralSessionToken");
         if (hubCentralSessionToken != null) {

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/pendo/PendoKeyProvider.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/pendo/PendoKeyProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2021 MarkLogic Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.marklogic.hub.central.pendo;
+
+
+import com.marklogic.hub.central.cloud.ParameterSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import static com.marklogic.hub.central.cloud.Constants.PENDO_API_KEY;
+
+@Component
+public class PendoKeyProvider {
+
+    @Autowired(required = false)
+    private ParameterSource parameterSource;
+
+    private final Environment environment;
+
+    @Autowired
+    PendoKeyProvider(Environment environment) {
+        this.environment = environment;
+    }
+
+    public String getPendoKey() {
+        if (!isPendoEnabled() || parameterSource == null) {
+            return null;
+        }
+
+        return parameterSource.getParameter(PENDO_API_KEY);
+    }
+
+    protected boolean isPendoEnabled() {
+        return Boolean.parseBoolean(environment.getProperty("hubPendoEnabled", "false"));
+    }
+}

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/pendo/PendoKeyProviderTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/pendo/PendoKeyProviderTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012-2021 MarkLogic Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.marklogic.hub.central.pendo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class PendoKeyProviderTest {
+
+    @Test
+    void testIsPendoEnabled() {
+        Stream.of("true", "TRUE")
+                .forEach(s -> assertTrue(new PendoKeyProvider(getEnvironmentWithValue("hubPendoEnabled", s))
+                        .isPendoEnabled(), "Pendo should be enabled for property: hubPendoEnabled with value: " + s));
+
+        Stream.of("false", null, "", "foo")
+                .forEach(s -> assertFalse(new PendoKeyProvider(getEnvironmentWithValue("hubPendoEnabled", s))
+                        .isPendoEnabled(), "Pendo should be disabled for property: hubPendoEnabled with value: " + s));
+
+        Stream.of("false", "true", "", "foo")
+                .forEach(s -> assertFalse(new PendoKeyProvider(getEnvironmentWithValue("foo", s))
+                        .isPendoEnabled(), "Pendo should be disabled when property: hubPendoEnabled is not present"));
+    }
+
+    private Environment getEnvironmentWithValue(String property, String value) {
+        ConfigurableEnvironment environment = new StandardEnvironment();
+        MutablePropertySources propertySources = environment.getPropertySources();
+        Map<String, Object> pendoMap = new HashMap<>();
+        pendoMap.put(property, value);
+        propertySources.addFirst(new MapPropertySource("PENDO_MAP", pendoMap));
+
+        return environment;
+    }
+}


### PR DESCRIPTION
### Description
- Introduced two new properties:
```
hubPendoEnabled = true/false <If true HC will try to retireve the pendo api key>
hubRetrieveCertificate = true/false <if true HC will try to retrieve the certificates keystore and password>
```
- Earlier the certificates keystore and password retrieval was based on just the spring profile but now it depends on `hubRetrieveCertificate` property as we need to support the following service combinations:
1. Services with no certificate and no Pendo
2. Services with a certificate but no Pendo
3. Services with no certificate but with Pendo
4. Services with both certificate and Pendo

- DHS now always needs to apply the appropriate spring profile using `spring.profiles.active=aws/azure` and then can use the `hubPendoEnabled/hubRetrieveCertificate` properties to configure Pendo and certificate retrieval. This change will also help us to align with the on-prem HC release where cloud env will use aws/azure profiles and on-prem will use production profile.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [N/A] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

