### PR TITLE
DHFPROD-4854: Removing Spring Boot dependency from DHF core

### DIFF
--- a/marklogic-data-hub/.gitignore
+++ b/marklogic-data-hub/.gitignore
@@ -1,1 +1,2 @@
 src/main/resources/ml-modules/root/data-hub/third-party
+src/trace-ui/package-lock.json

--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -6,8 +6,6 @@ plugins {
     id 'com.jfrog.bintray' version '1.7.2'
     id 'com.marklogic.ml-gradle' version '4.1.1'
     id "com.github.node-gradle.node" version "2.2.4"
-    id 'org.springframework.boot' version '2.1.15.RELEASE'
-    id "io.spring.dependency-management" version "1.0.7.RELEASE"
     id 'com.marklogic.ml-development-tools' version '5.3.0'
 
     // Declaring this at each subproject level, as declaring it at root level resulted in an error about the plugin
@@ -71,9 +69,6 @@ dependencies {
         exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-common'
     }
 
-    compile group: 'org.springframework.boot', name: 'spring-boot', version: '2.1.15.RELEASE'
-    compile group: 'org.springframework.boot', name: 'spring-boot-autoconfigure', version: '2.1.15.RELEASE'
-
     compile 'com.marklogic:mlcp-util:0.9.0'
     compile 'com.marklogic:marklogic-data-movement-components:2.2.1'
 
@@ -115,13 +110,22 @@ dependencies {
     mlBundle "com.marklogic:marklogic-unit-test-modules:1.0.0"
 }
 
-import com.marklogic.mgmt.ManageClient
-import com.marklogic.mgmt.resource.hosts.HostManager
-
-
 configurations.all {
     exclude group: "org.slf4j", module: "slf4j-log4j12"
     exclude group: "log4j", module: "log4j"
+}
+
+ext {
+    uberJarLoggingClasses = configurations.datahubLogging.collect { it.isDirectory() ? it : zipTree(it) }
+
+    // Because this is evaluated eagerly, the project dependency classes directory main not yet exist. 
+    // But if it ends in "main", we know it's a directory and should not be zipped, which causes an error.
+    // The path likely ends in "build/classes/java/main", but we only need to check for "main" (and could 
+    // likely only check that it doesn't end in ".jar", but checking for "main" suffices for now).
+    uberJarClasses = configurations.compileClasspath.collect({
+        def isProjectDependencyClassesPath = "main".equals(it.getName())
+        return it.isDirectory() || isProjectDependencyClassesPath ? it : zipTree(it)
+    })
 }
 
 task extractFastXmlParserZip(type: Copy) {
@@ -136,21 +140,28 @@ task extractFastXmlParserZip(type: Copy) {
 // Ensure that the fast-xml-parser files are available before any DHF jars are built
 processResources.dependsOn extractFastXmlParserZip
 
-
-// The Spring Boot bootJar task produces an executable jar with all dependencies that runs the DHF installer
-// This jar is only meant to be used by the DHS team for installing DHF into DHS
-bootJar {
-    archiveClassifier = "installer"
-    mainClassName = "com.marklogic.hub.dhs.installer.Main"
-    from("src/main/installer") {
-        include "logback.xml"
+task installerJar(type: Jar) {
+    description = "Build an executable jar for installing DHF into DHS"
+    manifest {
+        attributes "Main-Class": "com.marklogic.hub.dhs.installer.Main"
     }
-    from(configurations.datahubLogging.collect { it.isDirectory() ? it : zipTree(it) }) {
+    archiveClassifier = "installer"
+    from(uberJarLoggingClasses) {
         exclude "META-INF/*.SF"
         exclude "META-INF/*.DSA"
         exclude "META-INF/*.RSA"
     }
+    from(uberJarClasses) {
+        exclude "META-INF/*.SF"
+        exclude "META-INF/*.DSA"
+        exclude "META-INF/*.RSA"
+    }
+    from("src/main/installer") {
+        include "logback.xml"
+    }
+    with jar
 }
+build.dependsOn installerJar
 
 task installDhfIntoDhs(type: Exec) {
     description = "Builds and runs the DHF installer for DHS"
@@ -165,7 +176,7 @@ task installDhfIntoDhs(type: Exec) {
         "dhsInstall"
     ]
 }
-installDhfIntoDhs.dependsOn bootJar
+installDhfIntoDhs.dependsOn installerJar
 
 task clientJar(type: Jar) {
     description = "Build an executable jar to be used by DHF clients; as of 5.2.0, this is just for running flows"
@@ -173,17 +184,16 @@ task clientJar(type: Jar) {
         attributes "Main-Class": "com.marklogic.hub.cli.client.Main"
     }
     archiveClassifier = "client"
-    from(configurations.datahubLogging.collect { it.isDirectory() ? it : zipTree(it) }) {
+    from(uberJarLoggingClasses) {
         exclude "META-INF/*.SF"
         exclude "META-INF/*.DSA"
         exclude "META-INF/*.RSA"
     }
-    from(configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }) {
+    from(uberJarClasses) {
         exclude "META-INF/*.SF"
         exclude "META-INF/*.DSA"
         exclude "META-INF/*.RSA"
     }
-    exclude "spring-boot*.jar"
     from("src/main/clientJar") {
         include "logback.xml"
     }
@@ -291,10 +301,6 @@ jar{
     enabled = true
 }
 
-bootRun {
-    enabled = false
-}
-
 javadoc {
    options.overview = 'src/main/resources/overview.html'
 }
@@ -340,7 +346,7 @@ publishing {
             from components.java
             artifact sourcesJar
             artifact javadocJar
-            artifact bootJar
+            artifact installerJar
             artifact clientJar
 
             pom.withXml {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/ApplicationConfig.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/ApplicationConfig.java
@@ -2,9 +2,6 @@ package com.marklogic.hub;
 
 import com.marklogic.hub.impl.HubConfigImpl;
 import com.marklogic.hub.impl.HubProjectImpl;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -16,7 +13,6 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ComponentScan(basePackages = {"com.marklogic.hub.impl", "com.marklogic.hub.legacy.impl", "com.marklogic.hub.deploy.commands",
     "com.marklogic.hub.job.impl", "com.marklogic.hub.flow.impl", "com.marklogic.hub.step", "com.marklogic.hub.util"})
-@EnableAutoConfiguration
 public class ApplicationConfig {
 
     /**
@@ -30,10 +26,6 @@ public class ApplicationConfig {
         return new HubConfigImpl(new HubProjectImpl());
     }
 
-    public static void main(String[] args) {
-        LoggerFactory.getLogger(ApplicationConfig.class).info("Starting Data Hub Application Context");
-        SpringApplication.run(ApplicationConfig.class);
-    }
 
 }
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dhs/installer/Main.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dhs/installer/Main.java
@@ -6,9 +6,8 @@ import com.marklogic.hub.ApplicationConfig;
 import com.marklogic.hub.dhs.installer.command.CanInstallDhsCommand;
 import com.marklogic.hub.dhs.installer.command.InstallIntoDhsCommand;
 import com.marklogic.hub.dhs.installer.command.VerifyDhfInDhsCommand;
-import org.springframework.boot.Banner;
-import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 /**
  * Intended for installing and upgrading DHF via a command-line interface. It is expected to be run as the main class
@@ -35,10 +34,7 @@ public class Main {
         } else {
             InstallerCommand command = (InstallerCommand) commander.getCommands().get(parsedCommand).getObjects().get(0);
 
-            SpringApplication app = new SpringApplication(ApplicationConfig.class);
-            app.setBannerMode(Banner.Mode.OFF);
-
-            ConfigurableApplicationContext context = app.run();
+            ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(ApplicationConfig.class);
             try {
                 command.run(context, options);
             } finally {

--- a/ml-data-hub-plugin/build.gradle
+++ b/ml-data-hub-plugin/build.gradle
@@ -31,8 +31,6 @@ plugins {
     id "java-gradle-plugin"
     id "maven-publish"
     id "com.jfrog.bintray" version "1.7.3"
-    id 'org.springframework.boot' version '2.1.3.RELEASE'
-    id "io.spring.dependency-management" version "1.0.7.RELEASE"
 
     id "io.snyk.gradle.plugin.snykplugin" version "0.4"
 }
@@ -42,7 +40,6 @@ apply plugin: "com.gradle.plugin-publish"
 sourceCompatibility = "8"
 targetCompatibility = "8"
 
-bootJar.enabled = false
 jar.enabled = true
 
 // See https://github.com/snyk/gradle-plugin for docs
@@ -75,9 +72,7 @@ dependencies {
     testCompile('org.spockframework:spock-core:1.2-groovy-2.5') {
         exclude module: 'groovy-all'
     }
-    testCompile ('org.springframework.boot:spring-boot-starter-test:2.1.3.RELEASE')  {
-        exclude module: "logback-classic"
-    }
+    testCompile 'org.springframework:spring-test:5.2.9.RELEASE'
 }
 
 test {
@@ -105,10 +100,6 @@ task sourcesJar(type: Jar, dependsOn: classes) {
     classifier 'sources'
     from sourceSets.main.allJava
     from sourceSets.main.allGroovy
-}
-
-bootRun {
-    enabled = false
 }
 
 publishing {

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -51,10 +51,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 
-@EnableAutoConfiguration
 class DataHubPlugin implements Plugin<Project> {
 
     private DataHubImpl dataHub

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/BaseTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/BaseTest.groovy
@@ -42,9 +42,7 @@ import org.custommonkey.xmlunit.XMLUnit
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.rules.TemporaryFolder
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
-import org.springframework.util.ReflectionUtils
 import org.w3c.dom.Document
 import org.xml.sax.SAXException
 import spock.lang.Specification
@@ -52,14 +50,10 @@ import spock.lang.Specification
 import javax.xml.parsers.DocumentBuilder
 import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.parsers.ParserConfigurationException
-import java.lang.reflect.Field
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
-import java.util.stream.Collectors
-import java.util.stream.Stream
 
-@EnableAutoConfiguration
 class BaseTest extends Specification {
 
     // this value is for legacy purposes.  on dev should always be 5


### PR DESCRIPTION
### Description

Figured out the build issue; see uberJarClasses in marklogic-data-hub/build.gradle. May want to include this now in 5.4. 

Spring Boot was never needed; Spring is still being used heavily. And Spring Boot is still used by the QS and HC projects. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

