### PR TITLE
Proposed additions to Batch schema in 5.5

### DIFF
--- a/specs/models/Batch.schema.json
+++ b/specs/models/Batch.schema.json
@@ -55,10 +55,33 @@
       "type": "string"
     },
     "writeTimeStamp": {
-      "type": "string"
+      "type": "string",
+      "description": "Captures date and time of the first write that occurs ('first' is only relevant when multiple steps are run)"
     },
     "writeTrnxID": {
-      "type": "string"
+      "type": "string",
+      "description": "Captures transaction ID of the first write that occurs ('first' is only relevant when multiple steps are run)"
+    },
+    "writeTransactions": {
+      "type": "object",
+      "description": "Captures information about each transaction that writes documents outputted by a step",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[0-9]+$": {
+          "type": "object",
+          "description": "Name of the database to which the transaction wrote",
+          "properties": {
+            "transactionId": {
+              "type": "string",
+              "description": "ID of the transaction, as returned by xdmp.transaction"
+            },
+            "transactionDateTime": {
+              "type": "string",
+              "description": "Date and time at which the transaction was written"
+            }  
+          }
+        }
+      }
     },
     "uris": {
       "type": "array",
@@ -106,6 +129,27 @@
         "uri": {
           "type": "string",
           "description": "Will be populated when the step configuration does not have 'acceptsBatch' set to 'true'"
+        }
+      }
+    },
+    "stepResults": {
+      "description": "When steps are connected, an object will exist for each step that was run on the batch",
+      "type": "array",
+      "items": {
+        "description": "In addition to below properties, contains each of the following top-level properties: stepId, step, stepNumber, uris, processedItemHashes, fileName, lineNumber, errorStack, error, completeError",
+        "type": "object",
+          "stepStartedDateTime": {
+            "type": "string",
+            "description": "dateTime at which processing of the step started"
+          },
+          "stepEndedDateTime": {
+            "type": "string",
+            "description": "dateTime at which processing of the step ended"
+          },
+          "stepDuration": {
+            "type": "string",
+            "description": "Difference, as a duration, between stepStartedDateTime and stepEndedDateTime"
+          }
         }
       }
     }


### PR DESCRIPTION
This is just a proposal, using a PR for feedback. These changes are being proposed to support execution of multiple steps in 5.5, which includes writing to multiple databases.

Couple things I'm not proposing changes for, interested in feedback on these:

- We'll still capture a single error at the batch level. The thought is that once an error occurs, we won't run any more steps. So we'll know the step that caused the error because it'll be the last step that was run. 
- We don't have a "step status", still just a batch status. Same concept as above - once an error occurs, we won't run any more steps, and the batch will have a failure status. 

In the future, we may allow e.g. step 2 to run even though step 1 had an error. And that would impact the schema. But we won't support that yet. 