### PR TITLE
DHFPROD-6965: One more rename of trace events for 5.4.0

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/lib.sjs
@@ -8,7 +8,7 @@ const inst = require('/MarkLogic/entity-services/entity-services-instance');
 const mappingLib = require('/data-hub/5/builtins/steps/mapping/default/lib.sjs');
 const sem = require("/MarkLogic/semantics.xqy");
 const semPrefixes = {es: 'http://marklogic.com/entity-services#'};
-const dhMappingTrace = 'DH-MAPPING';
+const dhMappingTrace = 'hub-mapping';
 const dhMappingTraceIsEnabled = xdmp.traceEnabled(dhMappingTrace);
 let xqueryLib = null;
 

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/consts.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/consts.sjs
@@ -82,6 +82,6 @@ module.exports = {
   ],
 
   // Define all DH trace events here
-  TRACE_STEP: "data-hub-step",
-  TRACE_FLOW_RUNNER: "data-hub-flow-runner"
+  TRACE_STEP: "hub-step",
+  TRACE_FLOW_RUNNER: "hub-flow-runner"
 };


### PR DESCRIPTION
### Description

This is just to slightly shorten them with "hub-" instead of "data-hub-". 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

