### PR TITLE
DHFPROD-6682: Can run ingest and map steps via connected steps endpoint

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/customStep.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/customStep.sjs
@@ -15,12 +15,12 @@
  */
 'use strict';
 
-const DataHubSingleton = require('/data-hub/5/datahub-singleton.sjs');
-const dataHub = DataHubSingleton.instance();
+const config = require("/com.marklogic.hub/config.sjs");
+const consts = require("/data-hub/5/impl/consts.sjs");
 
 const collections = ['http://marklogic.com/data-hub/steps/custom', 'http://marklogic.com/data-hub/steps'];
-const databases = [dataHub.config.STAGINGDATABASE, dataHub.config.FINALDATABASE];
-const permissions = [xdmp.permission(dataHub.consts.DATA_HUB_CUSTOM_WRITE_ROLE, 'update'), xdmp.permission(dataHub.consts.DATA_HUB_CUSTOM_READ_ROLE, 'read')];
+const databases = [config.STAGINGDATABASE, config.FINALDATABASE];
+const permissions = [xdmp.permission(consts.DATA_HUB_CUSTOM_WRITE_ROLE, 'update'), xdmp.permission(consts.DATA_HUB_CUSTOM_READ_ROLE, 'read')];
 const requiredProperties = ['name', 'selectedSource'];
 
 function getNameProperty() {
@@ -76,8 +76,8 @@ function defaultArtifact(artifactName, entityTypeId) {
     collections: defaultCollections,
     permissions: defaultPermissions,
     batchSize: 100,
-    sourceDatabase: dataHub.config.STAGINGDATABASE,
-    targetDatabase: dataHub.config.FINALDATABASE,
+    sourceDatabase: config.STAGINGDATABASE,
+    targetDatabase: config.FINALDATABASE,
     provenanceGranularityLevel: 'coarse',
   };
 }

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/loadData.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/loadData.sjs
@@ -15,14 +15,12 @@
  */
 'use strict';
 
-const DataHubSingleton = require('/data-hub/5/datahub-singleton.sjs');
-
-// define constants for caching expensive operations
-const dataHub = DataHubSingleton.instance();
+const config = require("/com.marklogic.hub/config.sjs");
+const consts = require("/data-hub/5/impl/consts.sjs");
 
 const collections = ['http://marklogic.com/data-hub/steps/ingestion', 'http://marklogic.com/data-hub/steps'];
-const databases = [dataHub.config.STAGINGDATABASE, dataHub.config.FINALDATABASE];
-const permissions = [xdmp.permission(dataHub.consts.DATA_HUB_LOAD_DATA_WRITE_ROLE, 'update'), xdmp.permission(dataHub.consts.DATA_HUB_LOAD_DATA_READ_ROLE, 'read')];
+const databases = [config.STAGINGDATABASE, config.FINALDATABASE];
+const permissions = [xdmp.permission(consts.DATA_HUB_LOAD_DATA_WRITE_ROLE, 'update'), xdmp.permission(consts.DATA_HUB_LOAD_DATA_READ_ROLE, 'read')];
 const requiredProperties = ['name', 'sourceFormat', 'targetFormat'];
 
 function getNameProperty() {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/mapping.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/mapping.sjs
@@ -15,15 +15,13 @@
  */
 'use strict';
 
-const DataHubSingleton = require('/data-hub/5/datahub-singleton.sjs');
-
-// define constants for caching expensive operations
-const dataHub = DataHubSingleton.instance();
+const config = require("/com.marklogic.hub/config.sjs");
+const consts = require("/data-hub/5/impl/consts.sjs");
 const hubEs = require("/data-hub/5/impl/hub-es.sjs");
 
 const collections = ['http://marklogic.com/data-hub/steps/mapping', 'http://marklogic.com/data-hub/steps', 'http://marklogic.com/data-hub/mappings'];
-const databases = [dataHub.config.STAGINGDATABASE, dataHub.config.FINALDATABASE];
-const permissions = [xdmp.permission(dataHub.consts.DATA_HUB_MAPPING_WRITE_ROLE, 'update'), xdmp.permission(dataHub.consts.DATA_HUB_MAPPING_READ_ROLE, 'read')];
+const databases = [config.STAGINGDATABASE, config.FINALDATABASE];
+const permissions = [xdmp.permission(consts.DATA_HUB_MAPPING_WRITE_ROLE, 'update'), xdmp.permission(consts.DATA_HUB_MAPPING_READ_ROLE, 'read')];
 const requiredProperties = ['name', 'targetEntityType', 'selectedSource'];
 
 function getNameProperty() {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/mastering.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/mastering.sjs
@@ -15,17 +15,15 @@
  */
 'use strict';
 
-const DataHubSingleton = require('/data-hub/5/datahub-singleton.sjs');
-
-// define constants for caching expensive operations
-const dataHub = DataHubSingleton.instance();
+const config = require("/com.marklogic.hub/config.sjs");
+const consts = require("/data-hub/5/impl/consts.sjs");
 
 const collections = ['http://marklogic.com/data-hub/steps/mastering', 'http://marklogic.com/data-hub/steps'];
-const databases = [dataHub.config.STAGINGDATABASE, dataHub.config.FINALDATABASE];
+const databases = [config.STAGINGDATABASE, config.FINALDATABASE];
 const permissions =
   [
-    xdmp.permission(dataHub.consts.DATA_HUB_MATCHING_WRITE_ROLE, 'update'),
-    xdmp.permission(dataHub.consts.DATA_HUB_MATCHING_READ_ROLE, 'read')
+    xdmp.permission(consts.DATA_HUB_MATCHING_WRITE_ROLE, 'update'),
+    xdmp.permission(consts.DATA_HUB_MATCHING_READ_ROLE, 'read')
   ];
 const requiredProperties = ['name'];
 
@@ -72,8 +70,8 @@ function defaultArtifact(artifactName) {
     artifactName,
     collections: ['default-mastering'],
     additionalCollections: [],
-    sourceDatabase: dataHub.config.FINALDATABASE,
-    targetDatabase: dataHub.config.FINALDATABASE,
+    sourceDatabase: config.FINALDATABASE,
+    targetDatabase: config.FINALDATABASE,
     provenanceGranularityLevel: 'coarse',
     permissions: defaultPermissions,
     batchSize: 100

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/matching.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/matching.sjs
@@ -15,17 +15,15 @@
  */
 'use strict';
 
-const DataHubSingleton = require('/data-hub/5/datahub-singleton.sjs');
-
-// define constants for caching expensive operations
-const dataHub = DataHubSingleton.instance();
+const config = require("/com.marklogic.hub/config.sjs");
+const consts = require("/data-hub/5/impl/consts.sjs");
 
 const collections = ['http://marklogic.com/data-hub/steps/matching', 'http://marklogic.com/data-hub/steps'];
-const databases = [dataHub.config.STAGINGDATABASE, dataHub.config.FINALDATABASE];
+const databases = [config.STAGINGDATABASE, config.FINALDATABASE];
 const permissions =
   [
-    xdmp.permission(dataHub.consts.DATA_HUB_MATCHING_WRITE_ROLE, 'update'),
-    xdmp.permission(dataHub.consts.DATA_HUB_MATCHING_READ_ROLE, 'read')
+    xdmp.permission(consts.DATA_HUB_MATCHING_WRITE_ROLE, 'update'),
+    xdmp.permission(consts.DATA_HUB_MATCHING_READ_ROLE, 'read')
   ];
 const requiredProperties = ['name'];
 
@@ -70,8 +68,8 @@ function defaultArtifact(artifactName) {
   const defaultPermissions = 'data-hub-common,read,data-hub-common,update';
   let artifact = {
     batchSize: 100,
-    sourceDatabase: dataHub.config.FINALDATABASE,
-    targetDatabase: dataHub.config.FINALDATABASE,
+    sourceDatabase: config.FINALDATABASE,
+    targetDatabase: config.FINALDATABASE,
     targetEntity: "Change this to a valid entity type name; e.g. Customer",
     sourceQuery: "cts.collectionQuery('Change this to a valid collection name; e.g. Customer')",
     collections: [

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/merging.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/merging.sjs
@@ -15,17 +15,15 @@
  */
 'use strict';
 
-const DataHubSingleton = require('/data-hub/5/datahub-singleton.sjs');
-
-// define constants for caching expensive operations
-const dataHub = DataHubSingleton.instance();
+const config = require("/com.marklogic.hub/config.sjs");
+const consts = require("/data-hub/5/impl/consts.sjs");
 
 const collections = ['http://marklogic.com/data-hub/steps/merging', 'http://marklogic.com/data-hub/steps'];
-const databases = [dataHub.config.STAGINGDATABASE, dataHub.config.FINALDATABASE];
+const databases = [config.STAGINGDATABASE, config.FINALDATABASE];
 const permissions =
   [
-    xdmp.permission(dataHub.consts.DATA_HUB_MATCHING_WRITE_ROLE, 'update'),
-    xdmp.permission(dataHub.consts.DATA_HUB_MATCHING_READ_ROLE, 'read')
+    xdmp.permission(consts.DATA_HUB_MATCHING_WRITE_ROLE, 'update'),
+    xdmp.permission(consts.DATA_HUB_MATCHING_READ_ROLE, 'read')
   ];
 const requiredProperties = ['name'];
 
@@ -71,8 +69,8 @@ function defaultArtifact(artifactName) {
   let artifact = {
     // defaulting to batch size one, since a single match summary document updates multiple other documents
     batchSize: 1,
-    sourceDatabase: dataHub.config.FINALDATABASE,
-    targetDatabase: dataHub.config.FINALDATABASE,
+    sourceDatabase: config.FINALDATABASE,
+    targetDatabase: config.FINALDATABASE,
     permissions: defaultPermissions,
     targetEntity: "Change this to a valid entity type name; e.g. Customer",
     sourceQuery: "cts.collectionQuery('mastering-summary')",

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/flowRunner.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/flowRunner.sjs
@@ -1,0 +1,295 @@
+/**
+ Copyright (c) 2021 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+const Artifacts = require('/data-hub/5/artifacts/core.sjs');
+const StepExecutionContext = require('stepExecutionContext.sjs');
+const consts = require("/data-hub/5/impl/consts.sjs");
+const flowUtils = require("/data-hub/5/impl/flow-utils.sjs");
+const httpUtils = require("/data-hub/5/impl/http-utils.sjs");
+const hubUtils = require("/data-hub/5/impl/hub-utils.sjs");
+const StepDefinition = require("/data-hub/5/impl/stepDefinition.sjs");
+
+/**
+ * Processes the given contentArray - a batch of content - against each step in the given flow. Each step
+ * is run in-memory, with the output of one step becoming the input of the next step.
+ *
+ * @param flowName
+ * @param contentArray
+ * @param jobId
+ * @param runtimeOptions
+ */
+function processContentWithFlow(flowName, contentArray, jobId, runtimeOptions) {
+  if (!flowName) {
+    httpUtils.throwBadRequest(`Unable to process content; no flow name provided`);
+  }
+  if (!Array.isArray(contentArray)) {
+    contentArray = [contentArray];
+  }
+
+  const traceEvent = consts.TRACE_FLOW_RUNNER;
+  hubUtils.hubTrace(traceEvent, `Processing content with flow ${flowName}; content array length: ${contentArray.length}`);
+
+  const theFlow = Artifacts.getFullFlow(flowName);
+  const enhancedWriteQueue = {};
+  const flowResponse = newFlowResponse(theFlow, jobId);
+
+  // Iterate over all steps; we'll support a subset later
+  let currentContentArray = contentArray;
+  Object.keys(theFlow.steps).forEach(stepNumber => {
+    const startDateTime = fn.currentDateTime().add(xdmp.elapsedTime());
+    flowResponse.lastAttemptedStep = stepNumber;
+
+    hubUtils.hubTrace(traceEvent, `Running step number ${stepNumber} in flow ${flowName}`);
+    const stepExecutionContext = newStepExecutionContext(theFlow, stepNumber, jobId, runtimeOptions);
+    currentContentArray = processContentWithStep(stepExecutionContext, currentContentArray, enhancedWriteQueue);
+    hubUtils.hubTrace(traceEvent, `Finished step number ${stepNumber} in flow ${flowName}`);
+
+    flowResponse.lastCompletedStep = stepNumber;
+    flowResponse.stepResponses[stepNumber] = stepExecutionContext.buildStepResponse(startDateTime);
+  });
+
+  persistWriteQueue(enhancedWriteQueue);
+  hubUtils.hubTrace(traceEvent, `Finished processing content with flow ${flowName}`);
+
+  flowResponse.jobStatus = "finished";
+  flowResponse.timeEnded = fn.currentDateTime().add(xdmp.elapsedTime());
+  return flowResponse;
+}
+
+function newFlowResponse(theFlow, jobId) {
+  return {
+    jobId,
+    jobStatus: "started",
+    flow: theFlow.name,
+    user: xdmp.getCurrentUser(),
+    timeStarted: fn.currentDateTime(),
+    stepResponses: {}
+  };
+}
+
+function newStepExecutionContext(theFlow, stepNumber, jobId, runtimeOptions) {
+  const flowStep = theFlow.steps[stepNumber];
+  const stepDefinition = findStepDefinition(theFlow.name, stepNumber, flowStep);
+  return new StepExecutionContext(theFlow, stepNumber, stepDefinition, jobId, runtimeOptions);
+}
+
+/**
+ * Ignoring provenance for now; ignoring invoking step against a different database for now
+ *
+ * @param stepExecutionContext
+ * @param contentArray
+ * @param enhancedWriteQueue
+ */
+function processContentWithStep(stepExecutionContext, contentArray, enhancedWriteQueue) {
+  prepareContentBeforeStepIsRun(contentArray, stepExecutionContext);
+
+  let outputContentArray = stepExecutionContext.stepModuleAcceptsBatch() ?
+    runStepOnBatch(contentArray, stepExecutionContext) :
+    runStepOnEachItem(contentArray, stepExecutionContext);
+
+  // Copies regular flow behavior, where collections from options are added after the step module runs
+  stepExecutionContext.addCollectionsFromOptionsToContentObjects(outputContentArray);
+  addOutputContentToWriteQueue(stepExecutionContext, outputContentArray, enhancedWriteQueue);
+  return outputContentArray;
+}
+
+/**
+ * When a step has acceptsBatch=true, then the step module will be invoked once with the entire content array
+ * passed to it.
+ *
+ * @param contentArray
+ * @param stepExecutionContext
+ */
+function runStepOnBatch(contentArray, stepExecutionContext) {
+  const stepMainFunction = stepExecutionContext.getStepMainFunction();
+  const contentSequence = hubUtils.normalizeToSequence(contentArray);
+  const outputContentArray = [];
+  const batchItems = contentArray.map(content => content.uri);
+  if (xdmp.traceEnabled(consts.TRACE_FLOW_RUNNER_DEBUG)) {
+    hubUtils.hubTrace(consts.TRACE_FLOW_RUNNER_DEBUG, `Running step on items: ${xdmp.toJsonString(batchItems)}`);
+  }
+
+  try {
+    const outputSequence = hubUtils.normalizeToSequence(stepMainFunction(contentSequence, stepExecutionContext.combinedOptions));
+    for (const outputContent of outputSequence) {
+      addMetadataToContent(outputContent, stepExecutionContext.flow.name, stepExecutionContext.flowStep.name, stepExecutionContext.jobId);
+      outputContentArray.push(outputContent);
+    }
+    stepExecutionContext.setCompletedItems(batchItems);
+  } catch (error) {
+    stepExecutionContext.addErrorForEntireBatch(error, batchItems);
+  }
+  return outputContentArray;
+}
+
+/**
+ * When a step does not have acceptsBatch=true, then the step module is invoked on each item in the content array.
+ *
+ * @param contentArray
+ * @param stepExecutionContext
+ */
+function runStepOnEachItem(contentArray, stepExecutionContext) {
+  const stepMainFunction = stepExecutionContext.getStepMainFunction();
+  const outputContentArray = [];
+  contentArray.map(contentObject => {
+    const thisItem = contentObject.uri;
+    if (xdmp.traceEnabled(consts.TRACE_FLOW_RUNNER_DEBUG)) {
+      hubUtils.hubTrace(consts.TRACE_FLOW_RUNNER_DEBUG, `Running step on item: ${thisItem}`);
+    }
+    try {
+      const outputSequence = hubUtils.normalizeToSequence(stepMainFunction(contentObject, stepExecutionContext.combinedOptions));
+      for (const outputContent of outputSequence) {
+        outputContent.previousUri = thisItem;
+        addMetadataToContent(outputContent, stepExecutionContext.flow.name, stepExecutionContext.flowStep.name, stepExecutionContext.jobId);
+        stepExecutionContext.addCompletedItem(thisItem);
+        outputContentArray.push(outputContent);
+      }
+    } catch (error) {
+      stepExecutionContext.addBatchError(error, thisItem);
+    }
+  });
+  return outputContentArray;
+}
+
+
+/**
+ * TODO This should likely go into flowUtils once that's a library module and not a class.
+ *
+ * @param content
+ * @param flowName
+ * @param stepName
+ * @param jobId
+ */
+function addMetadataToContent(content, flowName, stepName, jobId) {
+  content.context = content.context || {};
+  content.context.metadata = flowUtils.createMetadata(content.context.metadata || {}, flowName, stepName, jobId);
+
+  if (content.context.collections) {
+    content.context.collections = hubUtils.normalizeToArray(content.context.collections);
+  }
+
+  if (content.context.permissions) {
+    content.context.permissions = hubUtils.normalizeToArray(content.context.permissions).map(perm => {
+      if (perm instanceof Element) {
+        const roleName = xdmp.roleName(fn.string(perm.xpath("*:role-id")));
+        const capability = fn.string(perm.xpath("*:capability"));
+        return xdmp.permission(roleName, capability);
+      }
+      return perm;
+    });
+  }
+}
+
+/**
+ * @param flowName needed for nice error messages
+ * @param stepNumber needed for nice error messages
+ * @param flowStep
+ */
+function findStepDefinition(flowName, stepNumber, flowStep) {
+  const name = flowStep.stepDefinitionName;
+  if (!name) {
+    httpUtils.throwBadRequest(`stepDefinitionName not found in step '${stepNumber}' in flow '${flowName}'`);
+  }
+  const type = flowStep.stepDefinitionType;
+  if (!type) {
+    httpUtils.throwBadRequest(`stepDefinitionType not found in step '${stepNumber}' in flow '${flowName}'`);
+  }
+  const stepDef = new StepDefinition().getStepDefinitionByNameAndType(name, type);
+  if (!stepDef) {
+    let message = `stepDefinition not found for step '${stepNumber}' in flow '${flowName}';`;
+    message += `name: '${name}'; type: '${type}'`;
+    httpUtils.throwBadRequest(message);
+  }
+  return stepDef;
+}
+
+/**
+ * Step modules and custom hooks expect content values to be document nodes.
+ *
+ * @param contentArray
+ */
+function prepareContentBeforeStepIsRun(contentArray, stepExecutionContext) {
+  const options = stepExecutionContext.combinedOptions;
+  const permissions = options.permissions ? hubUtils.parsePermissions(options.permissions) : null;
+  contentArray.forEach(content => {
+    if (content.value && "document" !== xdmp.nodeKind(content.value)) {
+      content.value = xdmp.toJSON(content.value);
+    }
+
+    // This copies what queryToContentDesciptorArray does with permissions
+    if (!content.context) {
+      content.context = {};
+    } else if (content.context.permissions) {
+      content.context.originalPermissions = content.context.permissions;
+    }
+    if (permissions) {
+      content.context.permissions = permissions;
+    }
+
+    // This emulates what queryToContentDescriptor does, which does not set collections before a step
+    // is run, but rather afterwards. If collections do exist from the queried document, they're instead
+    // added under "originalCollections"
+    if (content.context.collections) {
+      content.context.originalCollections = content.context.collections;
+      content.context.collections = [];
+    }
+  });
+}
+
+/**
+ * When a content object is added to the write queue, a deep copy must be made. That allows the content object
+ * to be modified by subsequent steps without modifying what will be persisted as a particular step's output.
+ *
+ * @param stepExecutionContext
+ * @param outputContentArray
+ * @param enhancedWriteQueue
+ */
+function addOutputContentToWriteQueue(stepExecutionContext, outputContentArray, enhancedWriteQueue) {
+  const targetDatabase = stepExecutionContext.getTargetDatabase();
+  let databaseContentMap = enhancedWriteQueue[targetDatabase];
+  if (!databaseContentMap) {
+    databaseContentMap = {};
+    enhancedWriteQueue[targetDatabase] = databaseContentMap;
+  }
+  outputContentArray.forEach(contentObject => {
+    if (contentObject.uri) {
+      // parse/quote is used instead of parse/stringify to account for the fact that content.value may be a node
+      // or may be an object with an embedded node. parse/stringify doesn't work on nodes, but parse/quote does.
+      databaseContentMap[contentObject.uri] = JSON.parse(xdmp.quote(contentObject));
+    }
+  });
+}
+
+/**
+ * TODO Once we do job data, we'll have to figure out what to do with multiple transaction IDs and timestamps,
+ * as those aren't at the step level but rather at the batch level, and per database.
+ *
+ * TODO Add error handling. Each step may have succeeded, but the batch fails.
+ */
+function persistWriteQueue(enhancedWriteQueue) {
+  Object.keys(enhancedWriteQueue).forEach(databaseName => {
+    const databaseContent = enhancedWriteQueue[databaseName];
+    const contentArray = Object.keys(databaseContent).map(key => databaseContent[key]);
+    hubUtils.writeDocuments(contentArray, xdmp.defaultPermissions(), [], databaseName);
+  });
+}
+
+module.exports = {
+  addMetadataToContent,
+  processContentWithFlow
+}
+

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/stepExecutionContext.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/stepExecutionContext.sjs
@@ -1,0 +1,158 @@
+/**
+  Copyright (c) 2021 MarkLogic Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+'use strict';
+
+const httpUtils = require("/data-hub/5/impl/http-utils.sjs");
+const StepDefinition = require("/data-hub/5/impl/stepDefinition.sjs");
+
+class StepExecutionContext {
+  constructor(theFlow, stepNumber, stepDefinition, jobId, runtimeOptions) {
+    this.flow = theFlow;
+    this.stepDefinition = stepDefinition;
+    this.stepNumber = stepNumber;
+    this.flowStep = theFlow.steps[stepNumber];
+    this.jobId = jobId;
+
+    runtimeOptions = runtimeOptions || {};
+    this.combinedOptions = Object.assign({}, stepDefinition.options, theFlow.options, this.flowStep.options, runtimeOptions);
+
+    // Copies what flow.sjs does for combining collections from options
+    this.collectionsFromOptions = [
+      runtimeOptions.collections,
+      ((this.flowStep.options || {}).collections || (stepDefinition.options || {}).collections),
+      (theFlow.options || {}).collections
+    ]
+    .reduce((previousValue, currentValue) => (previousValue || []).concat(currentValue || []))
+    .filter(col => !!col); // filter out any null/empty collections that may exist
+
+    this.completedItems = [];
+    this.failedItems = [];
+    this.batchErrors = [];
+    this.stepOutputErrorMessages = undefined;
+  }
+
+  buildStepResponse(startDateTime) {
+    const hasFailures = this.failedItems.length > 0;
+    const stepResponse = {
+      flowName: this.flow.name,
+      stepName: this.flowStep.name,
+      stepDefinitionName: this.stepDefinition.name,
+      stepDefinitionType: this.stepDefinition.type,
+      targetEntityType: this.flowStep.options.targetEntityType,
+      targetDatabase: this.combinedOptions.targetDatabase,
+      stepOutput: this.stepOutputErrorMessages,
+      status: this.determineStepStatus(),
+      totalEvents: this.failedItems.length + this.completedItems.length,
+      successfulEvents: this.completedItems.length,
+      failedEvents: this.failedItems.length,
+      successfulBatches: !hasFailures && this.completedItems.length > 0 ? 1 : 0,
+      failedBatches: hasFailures ? 1 : 0,
+      success: !hasFailures,
+      stepStartTime: startDateTime,
+      stepEndTime: fn.currentDateTime().add(xdmp.elapsedTime())
+    };
+    return stepResponse;
+  }
+
+  // No concept of "stopped" yet
+  determineStepStatus() {
+    if (this.failedItems.length > 0) {
+      return this.completedItems.length > 0 ? "completed with errors step " + this.stepNumber : "failed step " + this.stepNumber;
+    }
+    return "completed step " + this.stepNumber;
+  }
+
+  /**
+   * "collections from options" refers to the array of collections built when this class was constructed.
+   * 
+   * @param contentArray
+   */
+  addCollectionsFromOptionsToContentObjects(contentArray) {
+    contentArray.forEach(contentObject => {
+      if (contentObject) {
+        if (!contentObject.context) {
+          contentObject.context = {};
+        }
+        contentObject.context.collections = this.collectionsFromOptions.concat(contentObject.context.collections || []);  
+      }
+    })
+  }
+  
+  setCompletedItems(items) {
+    this.completedItems = items;
+  }
+
+  setFailedItems(items) {
+    this.failedItems = items;
+  }
+
+  addCompletedItem(item) {
+    this.completedItems.push(item);
+  }
+
+  addErrorForEntireBatch(error, batchItems) {
+    this.failedItems = batchItems;
+    this.completedItems = [];
+    this.addBatchError(error, null);
+  }
+
+  addBatchError(error, batchItem) {
+    const batchError = {
+      "stack": error.stack,
+      "code": error.code,
+      "data": error.data,
+      "message": error.message,
+      "name": error.name,
+      "retryable": error.retryable,
+      "stackFrames": error.stackFrames,
+      "uri": batchItem
+    };
+
+    if (!batchItem) {
+      this.failedItems.push(batchItem);
+    }
+
+    if (error.message) {
+      if (!this.stepOutputErrorMessages) {
+        this.stepOutputErrorMessages = [];
+      }
+      this.stepOutputErrorMessages.push(error.message);
+    }
+
+    this.batchErrors.push(batchError);
+  }
+
+  getTargetDatabase() {
+    return this.combinedOptions.targetDatabase;
+  }
+
+  getStepMainFunction() {
+    const modulePath = this.stepDefinition.modulePath;
+    const stepMainFunction = new StepDefinition().makeFunction(null, "main", modulePath);
+    if (!stepMainFunction) {
+      let message = `No 'main' function found for step number '${this.stepNumber} in flow '${this.flow.name}`;
+      message += `; step definition module path: '${modulePath}'`;
+      httpUtils.throwBadRequest(message);
+    }
+    return stepMainFunction;  
+  }
+
+  stepModuleAcceptsBatch() {
+    return this.stepDefinition.acceptsBatch;
+  }
+}
+
+module.exports = StepExecutionContext;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/consts.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/consts.sjs
@@ -83,5 +83,6 @@ module.exports = {
 
   // Define all DH trace events here
   TRACE_STEP: "hub-step",
-  TRACE_FLOW_RUNNER: "hub-flow-runner"
+  TRACE_FLOW_RUNNER: "hub-flow-runner",
+  TRACE_FLOW_RUNNER_DEBUG: "hub-flow-runner-debug"
 };

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils.sjs
@@ -28,6 +28,23 @@ function deleteDocument(docUri, database) {
   });
 }
 
+/**
+ * @param event 
+ * @param message Expected to be a string; if you have JSON, call hubTraceJson
+ */
+function hubTrace(event, message) {
+  xdmp.trace(event, `[Request:${xdmp.request()}] ${message}`);
+}
+
+/**
+ * Convenience method for logging a JSON node.
+ * @param event
+ * @param json
+ */
+function hubTraceJson(event, json) {
+  hubTrace(event, xdmp.toJsonString(json));
+}
+
 function invokeFunction(queryFunction, database) {
   return xdmp.invokeFunction(queryFunction, {
     commit: 'auto',
@@ -75,7 +92,6 @@ function parsePermissions(permissionsString = "") {
 }
 
 function queryToContentDescriptorArray(query, options = {}, database) {
-  let hubUtils = this;
   let content = [];
   invokeFunction(function () {
     let results = cts.search(query, cts.indexOrder(cts.uriReference()));
@@ -146,6 +162,8 @@ function writeDocuments(writeQueue, permissions = xdmp.defaultPermissions(), col
 module.exports = {
   capitalize,
   deleteDocument,
+  hubTrace,
+  hubTraceJson,
   invokeFunction,
   normalizeToArray,
   normalizeToSequence,

--- a/marklogic-data-hub/src/main/resources/ml-modules/services/hubFlowRunner.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/services/hubFlowRunner.sjs
@@ -1,0 +1,30 @@
+/**
+ Copyright (c) 2021 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+const flowRunner = require("/data-hub/5/flow/flowRunner.sjs");
+
+function post(context, params, input) {
+  xdmp.securityAssert("http://marklogic.com/data-hub/privileges/run-step", "execute");
+  input = input.toObject();
+
+  // This will become user-configurable in a subsequent user story
+  const jobId = sem.uuidString();
+  
+  return flowRunner.processContentWithFlow(input.flowName, input.content, jobId, input.options);
+};
+
+exports.POST = post;

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/connected/HubFlowRunnerResource.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/connected/HubFlowRunnerResource.java
@@ -1,0 +1,64 @@
+package com.marklogic.hub.flow.connected;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.extensions.ResourceManager;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.client.util.RequestParameters;
+import com.marklogic.hub.flow.RunFlowResponse;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class HubFlowRunnerResource extends ResourceManager {
+
+    protected HubFlowRunnerResource(DatabaseClient client) {
+        super();
+        client.init("hubFlowRunner", this);
+    }
+
+    public RunFlowResponse runFlow(Input input) {
+        JsonNode json = getServices().post(new RequestParameters(), new JacksonHandle(input.getRootNode()), new JacksonHandle()).get();
+        try {
+            return new ObjectMapper().readerFor(RunFlowResponse.class).readValue(json);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static class Input {
+        private ArrayNode contentArray;
+        private ObjectMapper objectMapper;
+        private ObjectNode rootNode;
+
+        public Input(String flowName) {
+            objectMapper = new ObjectMapper();
+            rootNode = objectMapper.createObjectNode();
+            rootNode.put("flowName", flowName);
+        }
+
+        /**
+         * @param uri
+         * @return the "value" object for easy customization
+         */
+        public ObjectNode addContent(String uri) {
+            if (contentArray == null) {
+                contentArray = rootNode.putArray("content");
+            }
+            ObjectNode content = contentArray.addObject();
+            content.put("uri", uri);
+            return content.putObject("value");
+        }
+
+        public ObjectNode getContentObject(int index) {
+            return (ObjectNode) contentArray.get(index);
+        }
+
+        public ObjectNode getRootNode() {
+            return rootNode;
+        }
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/connected/IngestAndMapWithConnectedStepsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/connected/IngestAndMapWithConnectedStepsTest.java
@@ -1,0 +1,65 @@
+package com.marklogic.hub.flow.connected;
+
+import com.marklogic.hub.AbstractHubCoreTest;
+import com.marklogic.hub.DatabaseKind;
+import com.marklogic.hub.flow.RunFlowResponse;
+import com.marklogic.hub.step.RunStepResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class IngestAndMapWithConnectedStepsTest extends AbstractHubCoreTest {
+
+    /**
+     * This test has a lot of duplication with the related ml-unit-test, but the goal is to verify that a) the HTTP
+     * endpoint works, and b) the JSON returned by it is correctly deserialized into a RunFlowResponse.
+     */
+    @Test
+    void test() {
+        installProjectFromUnitTestFolder("data-hub/5/flow/ingestAndMapConnected");
+
+        HubFlowRunnerResource.Input input = new HubFlowRunnerResource.Input("ingestAndMap");
+        input.addContent("/customer1.json").put("customerId", "1");
+        input.addContent("/customer2.json").put("customerId", "2");
+
+        RunFlowResponse runFlowResponse = new HubFlowRunnerResource(getHubClient().getStagingClient()).runFlow(input);
+        verifyFlowResponseFields(runFlowResponse);
+        verifyIngestResponse(runFlowResponse);
+
+        assertNotNull(getStagingDoc("/customer1.json"));
+        assertNotNull(getStagingDoc("/customer2.json"));
+        assertNotNull(getFinalDoc("/customer1.json"));
+        assertNotNull(getFinalDoc("/customer2.json"));
+    }
+
+    private void verifyFlowResponseFields(RunFlowResponse response) {
+        assertNotNull("job123", response.getJobId());
+        assertEquals("finished", response.getJobStatus());
+        assertEquals("2", response.getLastAttemptedStep());
+        assertEquals("2", response.getLastCompletedStep());
+        assertEquals(getHubClient().getUsername(), response.getUser());
+        assertNotNull(response.getStartTime());
+        assertNotNull(response.getEndTime());
+    }
+
+    private void verifyIngestResponse(RunFlowResponse runFlowResponse) {
+        RunStepResponse ingestResponse = runFlowResponse.getStepResponses().get("1");
+        assertEquals("ingestAndMap", ingestResponse.getFlowName());
+        assertEquals("ingestCustomer", ingestResponse.getStepName());
+        assertEquals("default-ingestion", ingestResponse.getStepDefinitionName());
+        assertEquals("ingestion", ingestResponse.getStepDefinitionType());
+        assertNull(ingestResponse.getTargetEntityType());
+        assertEquals(getHubClient().getDbName(DatabaseKind.STAGING), ingestResponse.getTargetDatabase());
+        assertNull(ingestResponse.getStepOutput());
+        assertNull(ingestResponse.getFullOutput());
+        assertEquals("completed step 1", ingestResponse.getStatus());
+        assertEquals(2, ingestResponse.getTotalEvents());
+        assertEquals(2, ingestResponse.getSuccessfulEvents());
+        assertEquals(0, ingestResponse.getFailedEvents());
+        assertEquals(1, ingestResponse.getSuccessfulBatches());
+        assertEquals(0, ingestResponse.getFailedBatches());
+        assertTrue(ingestResponse.isSuccess());
+        assertNotNull(ingestResponse.getStepStartTime());
+        assertNotNull(ingestResponse.getStepEndTime());
+    }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/artifacts/mappingTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/artifacts/mappingTest.sjs
@@ -17,7 +17,7 @@ function createMappingWithSameNameButDifferentEntityType(artifactName) {
     return new Error("Expected a failure because another mapping exists with the same name but a different entity type. " +
       "Mapping names must be globally unique.");
   } catch (e) {
-    let msg = e.data[2];
+    let msg = e.data[1];
     return test.assertEqual("A mapping with the same name but for a different entity type already exists. Please choose a different name.", msg);
   }
 }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/oneJsonDocWithOptions.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/oneJsonDocWithOptions.sjs
@@ -1,0 +1,54 @@
+const flowRunner = require("/data-hub/5/flow/flowRunner.sjs");
+const hubTest = require("/test/data-hub-test-helper.sjs");
+const test = require("/test/test-helper.xqy");
+
+/**
+ * This test verifies that runtime options are honored. It also verifies the details of the two documents that are 
+ * persisted, while the twoJsonDocs test is focused more on the response object.
+ */
+const flowName = "ingestAndMap";
+const jobId = sem.uuidString();
+const options = {
+  "permissions": "data-hub-operator,read,data-hub-operator,update"
+};
+const contentArray = [
+  { "uri": "/customer1.json", "value": { "customerId": "1" }}
+];
+
+const response = flowRunner.processContentWithFlow(flowName, contentArray, jobId, options);
+
+const finalCustomer = hubTest.getRecord("/customer1.json");
+const assertions = [
+  test.assertEqual("finished", response.jobStatus),
+  test.assertEqual(1, finalCustomer.document.envelope.instance.Customer.customerId, 
+    "Verifies that the entity was mapped correctly"),
+  test.assertEqual("Customer", finalCustomer.document.envelope.instance.info.title),
+  test.assertEqual("0.0.1", finalCustomer.document.envelope.instance.info.version),
+  test.assertEqual("http://example.org/", finalCustomer.document.envelope.instance.info.baseUri),
+  test.assertEqual(2, finalCustomer.collections.length),
+  test.assertEqual("Customer", finalCustomer.collections[0]),
+  test.assertEqual("mapCustomer", finalCustomer.collections[1]),
+  test.assertEqual("read", finalCustomer.permissions["data-hub-operator"][0], 
+    "Verifies that the runtime options overrode the step options for permissions"),
+  test.assertEqual("update", finalCustomer.permissions["data-hub-operator"][1]),
+  test.assertEqual(xdmp.getCurrentUser(), finalCustomer.metadata.datahubCreatedBy),
+  test.assertEqual("mapCustomer", finalCustomer.metadata.datahubCreatedByStep),
+  test.assertEqual("ingestAndMap", finalCustomer.metadata.datahubCreatedInFlow),
+  test.assertNotEqual(null, finalCustomer.metadata.datahubCreatedOn),
+  test.assertEqual(response.jobId, finalCustomer.metadata.datahubCreatedByJob)
+];
+
+const stagingCustomer = hubTest.getStagingRecord("/customer1.json");
+assertions.concat(
+  test.assertEqual("1", stagingCustomer.document.envelope.instance.customerId),
+  test.assertEqual(1, stagingCustomer.collections.length),
+  test.assertEqual("ingestCustomer", stagingCustomer.collections[0]),
+  test.assertEqual("read", stagingCustomer.permissions["data-hub-operator"][0], 
+    "Verifies that permissions was overridden by the runtime options"),
+  test.assertEqual("update", stagingCustomer.permissions["data-hub-operator"][1]),
+  test.assertEqual(xdmp.getCurrentUser(), stagingCustomer.metadata.datahubCreatedBy),
+  test.assertEqual("ingestCustomer", stagingCustomer.metadata.datahubCreatedByStep),
+  test.assertEqual("ingestAndMap", stagingCustomer.metadata.datahubCreatedInFlow),
+  test.assertNotEqual(null, stagingCustomer.metadata.datahubCreatedOn),
+  test.assertEqual(response.jobId, stagingCustomer.metadata.datahubCreatedByJob)
+);

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/setup.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/setup.xqy
@@ -1,0 +1,12 @@
+xquery version "1.0-ml";
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+hub-test:reset-hub();
+
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+import module namespace test = "http://marklogic.com/test" at "/test/test-helper.xqy";
+hub-test:load-entities($test:__CALLER_FILE__);
+
+xquery version "1.0-ml";
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+import module namespace test = "http://marklogic.com/test" at "/test/test-helper.xqy";
+hub-test:load-non-entities($test:__CALLER_FILE__)

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/test-data/entities/Customer.entity.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/test-data/entities/Customer.entity.json
@@ -1,0 +1,20 @@
+{
+  "info": {
+    "title": "Customer",
+    "version": "0.0.1",
+    "baseUri": "http://example.org/"
+  },
+  "definitions": {
+    "Customer": {
+      "properties": {
+        "customerId": {
+          "datatype": "integer"
+        },
+        "name": {
+          "datatype": "string",
+          "collation": "http://marklogic.com/collation/codepoint"
+        }
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/test-data/flows/ingestAndMap.flow.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/test-data/flows/ingestAndMap.flow.json
@@ -1,0 +1,11 @@
+{
+  "name": "ingestAndMap",
+  "steps": {
+    "1": {
+      "stepId": "ingestCustomer-ingestion"
+    },
+    "2": {
+      "stepId": "mapCustomer-mapping"
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/test-data/steps/ingestion/ingestCustomer.step.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/test-data/steps/ingestion/ingestCustomer.step.json
@@ -1,0 +1,15 @@
+{
+  "name": "ingestCustomer",
+  "stepId": "ingestCustomer-ingestion",
+  "stepDefinitionName": "default-ingestion",
+  "stepDefinitionType": "ingestion",
+  "sourceFormat": "json",
+  "targetFormat": "json",
+  "collections": [
+    "ingestCustomer"
+  ],
+  "targetDatabase": "data-hub-STAGING",
+  "permissions": "data-hub-common,read,data-hub-common,update",
+  "provenanceGranularityLevel": "off",
+  "disableJobOutput": true
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/test-data/steps/mapping/mapCustomer.step.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/test-data/steps/mapping/mapCustomer.step.json
@@ -1,0 +1,23 @@
+{
+  "name": "mapCustomer",
+  "stepId": "mapCustomer-mapping",
+  "stepDefinitionName": "entity-services-mapping",
+  "stepDefinitionType": "MAPPING",
+  "sourceQuery": "cts.collectionQuery('customer-input')",
+  "sourceDatabase": "data-hub-STAGING",
+  "targetDatabase": "data-hub-FINAL",
+  "collections": [
+    "Customer",
+    "mapCustomer"
+  ],
+  "permissions": "data-hub-common,read,data-hub-common,update",
+  "targetFormat": "json",
+  "targetEntityType": "http://example.org/Customer-0.0.1/Customer",
+  "properties": {
+    "customerId": {
+      "sourcedFrom": "customerId"
+    }
+  },
+  "provenanceGranularityLevel": "off",
+  "selectedSource": "query"
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/twoJsonDocs.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/twoJsonDocs.sjs
@@ -1,0 +1,72 @@
+const flowRunner = require("/data-hub/5/flow/flowRunner.sjs");
+const hubTest = require("/test/data-hub-test-helper.sjs");
+const test = require("/test/test-helper.xqy");
+
+/**
+ * This test focuses on the details of the response object, while the one JSON doc test 
+ * focuses on the details of the documents that are persisted.
+ */
+const flowName = "ingestAndMap";
+const jobId = sem.uuidString();
+const options = {};
+const contentArray = [
+  { "uri": "/customer1.json", "value": { "customerId": "1" } },
+  { "uri": "/customer2.json", "value": { "customerId": "2" } }
+];
+
+const response = flowRunner.processContentWithFlow(flowName, contentArray, jobId, options);
+
+const assertions = [
+  test.assertNotEqual(null, response.jobId),
+  test.assertEqual("finished", response.jobStatus),
+  test.assertEqual("ingestAndMap", response.flow),
+  test.assertEqual(xdmp.getCurrentUser(), response.user),
+  test.assertEqual("2", response.lastAttemptedStep),
+  test.assertEqual("2", response.lastCompletedStep),
+  test.assertNotEqual(null, response.timeStarted),
+  test.assertNotEqual(null, response.timeEnded),
+  test.assertTrue(new Date(response.timeStarted) < new Date(response.timeEnded)),
+  test.assertEqual(2, Object.keys(response.stepResponses).length)
+];
+
+const ingestResponse = response.stepResponses["1"];
+const mapResponse = response.stepResponses["2"];
+
+assertions.push(
+  test.assertEqual("ingestAndMap", ingestResponse.flowName),
+  test.assertEqual("ingestCustomer", ingestResponse.stepName),
+  test.assertEqual("default-ingestion", ingestResponse.stepDefinitionName),
+  test.assertEqual("ingestion", ingestResponse.stepDefinitionType),
+  test.assertEqual("data-hub-STAGING", ingestResponse.targetDatabase),
+  test.assertEqual("completed step 1", ingestResponse.status),
+  test.assertEqual(2, ingestResponse.totalEvents),
+  test.assertEqual(2, ingestResponse.successfulEvents),
+  test.assertEqual(0, ingestResponse.failedEvents),
+  test.assertEqual(1, ingestResponse.successfulBatches),
+  test.assertEqual(0, ingestResponse.failedBatches),
+  test.assertEqual(true, ingestResponse.success),
+  test.assertTrue(new Date(ingestResponse.stepStartTime) < new Date(ingestResponse.stepEndTime)),
+
+  test.assertEqual("ingestAndMap", mapResponse.flowName),
+  test.assertEqual("mapCustomer", mapResponse.stepName),
+  test.assertEqual("entity-services-mapping", mapResponse.stepDefinitionName),
+  test.assertEqual("mapping", mapResponse.stepDefinitionType),
+  test.assertEqual("http://example.org/Customer-0.0.1/Customer", mapResponse.targetEntityType),
+  test.assertEqual("data-hub-FINAL", mapResponse.targetDatabase),
+  test.assertEqual("completed step 2", mapResponse.status),
+  test.assertEqual(2, mapResponse.totalEvents),
+  test.assertEqual(2, mapResponse.successfulEvents),
+  test.assertEqual(0, mapResponse.failedEvents),
+  test.assertEqual(1, mapResponse.successfulBatches),
+  test.assertEqual(0, mapResponse.failedBatches),
+  test.assertEqual(true, mapResponse.success),
+  test.assertTrue(new Date(mapResponse.stepStartTime) < new Date(mapResponse.stepEndTime))  
+);
+
+// Verify that the expected documents exist
+assertions.concat(
+  test.assertNotEqual(null, hubTest.getRecord("/customer1.json")),
+  test.assertNotEqual(null, hubTest.getStagingRecord("/customer1.json")),
+  test.assertNotEqual(null, hubTest.getRecord("/customer2.json")),
+  test.assertNotEqual(null, hubTest.getStagingRecord("/customer2.json"))
+);

--- a/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
+++ b/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
@@ -162,20 +162,38 @@ public abstract class AbstractHubTest extends AbstractHubClientTest {
         installProjectInFolder(folderInClasspath, false);
     }
 
+    protected void installProjectFromUnitTestFolder(String folderPath) {
+        Path projectPath = Paths.get("marklogic-data-hub");
+        if (!projectPath.toFile().exists()) {
+            projectPath = Paths.get(".");
+        }
+        Path modulesPath = projectPath.resolve("src").resolve("test").resolve("ml-modules");
+        File testDir = modulesPath.resolve("root").resolve("test").resolve("suites").resolve(folderPath).resolve("test-data").toFile();
+        installProjectInFolder(testDir, false);
+    }
+
+    protected void installProjectInFolder(String folderInClasspath, boolean loadQueryOptions) {
+        File dir;
+        try {
+            dir = new ClassPathResource(folderInClasspath).getFile();
+        } catch (IOException ex) {
+            throw new RuntimeException("Unable to resolve: " + folderInClasspath, ex);
+        }
+        installProjectInFolder(dir, loadQueryOptions);
+    }
+
     /**
      * Intended to make it easy to specify a set of project files to load for a particular test. You likely will want to
      * call "resetProject" before calling this.
      *
-     * @param folderInClasspath
+     * @param testProjectDir
      * @param loadQueryOptions
      */
-    protected void installProjectInFolder(String folderInClasspath, boolean loadQueryOptions) {
+    protected void installProjectInFolder(File testProjectDir, boolean loadQueryOptions) {
         long start = System.currentTimeMillis();
         boolean loadModules = false;
         HubProject hubProject = getHubConfig().getHubProject();
         try {
-            File testProjectDir = new ClassPathResource(folderInClasspath).getFile();
-
             File dataDir = new File(testProjectDir, "data");
             if (dataDir.exists()) {
                 FileUtils.copyDirectory(dataDir, new File(hubProject.getProjectDir().toFile(), "data"));
@@ -236,7 +254,7 @@ public abstract class AbstractHubTest extends AbstractHubClientTest {
             installUserArtifacts();
         }
 
-        logger.info("Installed project from folder in classpath: " + folderInClasspath + "; time: " +
+        logger.info("Installed project from folder in classpath: " + testProjectDir + "; time: " +
             (System.currentTimeMillis() - start));
     }
 


### PR DESCRIPTION
### Description

The two key new modules here are flowRunner.sjs and stepExecutionContext.sjs. They'll be changing a lot as more stories are done here. 

Also removed datahub.sjs dependencies from the artifact libraries to "lighten" them up. Their inclusion was causing some circular dependencies. flow.sjs no longer needs to do any gymnastics to use artifacts/core.sjs either. 

Also added installProjectFromUnitTestFolder to the JUnit tests so that an ml-unit-test project can easily be reused in a JUnit test. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

