### PR TITLE
DHFPROD-4996: added option to add step to flow from Curate Tile

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/addCustomStepToFlow.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/addCustomStepToFlow.spec.tsx
@@ -1,0 +1,99 @@
+import "cypress-wait-until";
+import {Application} from "../../../support/application.config";
+import {toolbar, tiles} from "../../../support/components/common/index";
+import curatePage from "../../../support/pages/curate";
+import loadPage from "../../../support/pages/load";
+import runPage from "../../../support/pages/run";
+import LoginPage from "../../../support/pages/login";
+
+const stepName = "mapping-step";
+const flowName = "testAddCustomStepToFlow";
+const stepType = "Custom";
+
+describe("Add Custom step to a flow", () => {
+  before(() => {
+    cy.visit("/");
+    cy.contains(Application.title);
+    cy.loginAsDeveloper().withRequest();
+    LoginPage.postLogin();
+  });
+  beforeEach(() => {
+    cy.loginAsDeveloper().withRequest();
+  });
+  afterEach(() => {
+    cy.resetTestUser();
+  });
+  after(() => {
+    cy.loginAsDeveloper().withRequest();
+    cy.deleteFlows(flowName);
+    cy.resetTestUser();
+  });
+
+  it("Create new flow", () => {
+    cy.waitUntil(() => toolbar.getRunToolbarIcon()).click();
+    runPage.createFlowButton().click();
+    cy.findByText("New Flow").should("be.visible");
+    runPage.setFlowName(flowName);
+    runPage.setFlowDescription(`test flow for adding custom step`);
+    loadPage.confirmationOptions("Save").click();
+    cy.waitForAsyncRequest();
+  });
+
+  it("Add custom step from Run tile", () => {
+    cy.waitUntil(() => toolbar.getRunToolbarIcon()).click();
+    runPage.expandFlow(flowName);
+    cy.waitForAsyncRequest();
+
+    runPage.addStep(flowName);
+    runPage.addStepToFlow(stepName);
+    cy.waitForAsyncRequest();
+
+    runPage.verifyStepInFlow("Custom", stepName);
+  });
+
+  it("Run steps", () => {
+    cy.waitUntil(() => toolbar.getRunToolbarIcon()).click();
+    runPage.expandFlow(flowName);
+    cy.waitForAsyncRequest();
+
+    runPage.runStep(stepName).click();
+    cy.waitForAsyncRequest();
+    cy.verifyStepRunResult("success", stepType, stepName);
+    tiles.closeRunMessage();
+  });
+
+  it("Remove custom steps from flow", () => {
+    runPage.deleteStep(stepName).click();
+    loadPage.confirmationOptions("Yes").click();
+    cy.waitForAsyncRequest();
+  });
+
+  it("Add custom steps from Curate tile", () => {
+    cy.waitUntil(() => toolbar.getCurateToolbarIcon()).click();
+    cy.waitUntil(() => curatePage.getEntityTypePanel("Customer").should("be.visible"));
+    curatePage.toggleEntityTypeId("Customer");
+    curatePage.selectCustomTab("Customer");
+    cy.waitForAsyncRequest();
+
+    curatePage.openExistingFlowDropdown("Customer", stepName);
+    curatePage.getExistingFlowFromDropdown(flowName).click();
+    curatePage.confirmAddStepToFlow(stepName, flowName);
+    cy.waitForAsyncRequest();
+
+    cy.waitUntil(() => toolbar.getRunToolbarIcon()).click();
+    runPage.expandFlow(flowName);
+
+    runPage.verifyStepInFlow("Custom", stepName);
+  });
+
+  it("Run steps", () => {
+    cy.waitUntil(() => toolbar.getRunToolbarIcon()).click();
+    runPage.expandFlow(flowName);
+    cy.waitForAsyncRequest();
+
+    runPage.runStep(stepName).click();
+    cy.waitForAsyncRequest();
+    cy.verifyStepRunResult("success", stepType, stepName);
+    tiles.closeRunMessage();
+  });
+});

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/curate.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/curate.tsx
@@ -74,6 +74,10 @@ class CuratePage {
     cy.findByTestId(`${entityTypeId}-Match`).click();
   }
 
+  selectCustomTab(entityTypeId: string) {
+    cy.findByTestId(`${entityTypeId}-Custom`).click();
+  }
+
   addNewStep() {
     return cy.findByLabelText("icon: plus-circle");
   }

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/run.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/run.tsx
@@ -44,7 +44,7 @@ class RunPage {
 
   verifyStepInFlow(stepType: string, stepName: string) {
     cy.waitForModalToDisappear();
-    cy.findByText(stepType).should("be.visible");
+    cy.findAllByText(stepType).first().should("be.visible");
     cy.findAllByText(stepName).first().should("be.visible");
   }
 

--- a/marklogic-data-hub-central/ui/src/components/entities/custom/custom-card.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/custom/custom-card.module.scss
@@ -44,3 +44,45 @@
 .viewStepSettingsIcon:hover{
     color: var(--hoverColor);
 }
+
+.cardLinks {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 999;
+    background-color: rgba(255, 255, 255, 0.6);
+}
+
+.cardLink {
+    color: #3f4692;
+    background-color: #ecf6fe;
+    padding: 20px 8px 8px 8px;
+    font-size: 14px;
+    cursor: pointer;
+    &:hover{
+        color: var(--hoverColor) !important;
+    }
+}
+
+.cardDisabledLink {
+    color: #3f4692;
+    background-color: #ecf6fe;
+    padding: 20px 8px 8px 8px;
+    font-size: 14px;
+    cursor: not-allowed;
+}
+
+.cardNonLink {
+    color: rgba(0, 0, 0, 0.65);
+    background-color: #ecf6fe;
+    margin-bottom: 0px;
+    padding: 8px;
+    font-size: 14px;
+    cursor: default;
+}
+
+.cardLinkSelect {
+    margin-top: 7px;
+    margin-bottom: 10px;
+}

--- a/marklogic-data-hub-central/ui/src/components/entities/custom/custom-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/custom/custom-card.test.tsx
@@ -51,6 +51,43 @@ describe("Custom Card component", () => {
     await waitForElement(() => getByText(AdvCustomTooltips.viewCustom));
   });
 
+  test("Can add step to flow", async () => {
+    const authorityService = new AuthoritiesService();
+    authorityService.setAuthorities(["readCustom"]);
+    let customData = data.customSteps.data.stepsWithEntity[0].artifacts;
+    let flows = data.flows.data;
+    const {getByText, getByLabelText, getByTestId} = render(
+      <Router><AuthoritiesContext.Provider value={authorityService}>
+        <CustomCard
+          data={customData}
+          flows={flows}
+          canReadOnly={true}
+          canReadWrite={false}
+          canWriteFlow={true}
+          entityModel={{entityTypeId: "Customer"}}
+          addStepToFlow={() => {}}
+        />
+      </AuthoritiesContext.Provider></Router>);
+
+    expect(getByText("customJSON")).toBeInTheDocument();
+
+    // hover over card to see options
+    fireEvent.mouseOver(getByText("customJSON"));
+    expect(getByTestId("customJSON-toNewFlow")).toBeInTheDocument(); // 'Add to a new Flow'
+    expect(getByTestId("customJSON-toExistingFlow")).toBeInTheDocument(); // 'Add to an existing Flow'
+
+    // Open menu, choose flow
+    fireEvent.click(getByTestId("customJSON-flowsList"));
+    fireEvent.click(getByLabelText("testFlow-option"));
+
+    // Dialog appears, click 'Yes' button
+    expect(getByLabelText("step-not-in-flow")).toBeInTheDocument();
+    fireEvent.click(getByTestId("customJSON-to-testFlow-Confirm"));
+
+    // Check if the /tiles/run/add route has been called
+    wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/add"); });
+  });
+
   test("Open advanced settings", async () => {
     const authorityService = new AuthoritiesService();
     authorityService.setAuthorities(["readCustom"]);

--- a/marklogic-data-hub-central/ui/src/components/entities/entity-tiles.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/entity-tiles.tsx
@@ -362,8 +362,15 @@ const EntityTiles = (props) => {
       output = <div className={styles.cardView}>
         <div className={styles.customEntityTitle} aria-label={"customEntityTitle"}>You can create Custom steps either manually or using Gradle, then deploy them. Deployed Custom steps appear here. Hub Central only allows running Custom steps, not editing or deleting them.</div>
         <CustomCard data={ customCardData ? sortStepsByUpdated(customCardData.artifacts) : []}
+          flows={props.flows}
+          entityTypeTitle={entityType}
+          entityModel={props.entityModels[entityType]}
           canReadOnly={props.canReadCustom}
-          canReadWrite = {props.canWriteCustom}/>
+          canReadWrite = {props.canWriteCustom}
+          addStepToFlow={props.addStepToFlow}
+          addStepToNew={props.addStepToNew}
+          canWriteFlow={props.canWriteFlow}
+        />
       </div>;
     } else {
       output = <div><br/>This functionality implemented yet.</div>;
@@ -407,8 +414,15 @@ const EntityTiles = (props) => {
             <div className={styles.customNoEntityTitle} aria-label={"customNoEntityTitle"}>Steps that are created outside Hub Central and are not associated with any entity type appear here. Hub Central only allows running these steps, not editing or deleting them.</div>
             {props.canReadCustom ? <div className={styles.cardView}>
               <CustomCard data={customArtifactsWithoutEntity}
+                flows={props.flows}
+                entityTypeTitle={/** entityType */""}
+                entityModel={/** props.entityModels[entityType] */""}
                 canReadOnly={props.canReadCustom}
-                canReadWrite = {props.canWriteCustom}/>
+                canReadWrite = {props.canWriteCustom}
+                canWriteFlow={props.canWriteFlow}
+                addStepToFlow={props.addStepToFlow}
+                addStepToNew={props.addStepToNew}
+              />
             </div>: null}
           </Panel>: null}
       </Collapse>

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
@@ -780,62 +780,92 @@ const MappingCard: React.FC<Props> = (props) => {
             <br/>
             <p className={styles.addNewContent}>Add New</p>
           </Card></MLTooltip>
-        </Col>}{props.data && props.data.length > 0 ? props.data.map((elem, index) => (
-          <Col key={index}>
-            <div
-              data-testid={`${props.entityTypeTitle}-${elem.name}-step`}
-              onMouseOver={(e) => handleMouseOver(e, elem.name)}
-              onMouseLeave={(e) => handleMouseLeave()}
-            >
-              <Card
-                actions={[
-                  <MLTooltip title={"Step Details"} placement="bottom"><i className={styles.stepDetails}><FontAwesomeIcon icon={faPencilAlt} onClick={() => openSourceToEntityMapping(elem.name, index)} data-testid={`${elem.name}-stepDetails`}/></i></MLTooltip>,
-                  <MLTooltip title={"Step Settings"} placement="bottom"><i className={styles.editIcon} role="edit-mapping button" key ="last"><FontAwesomeIcon icon={faCog} data-testid={elem.name+"-edit"} onClick={() => OpenStepSettings(index)}/></i></MLTooltip>,
-                  props.canReadWrite ? <MLTooltip title={"Run"} placement="bottom"><i aria-label="icon: run"><Icon type="play-circle" theme="filled" className={styles.runIcon} data-testid={elem.name+"-run"} onClick={() => handleStepRun(elem.name)}/></i></MLTooltip> : <MLTooltip title={"Run: " + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: "200px"}}><i role="disabled-run-mapping button" data-testid={elem.name+"-disabled-run"}><Icon type="play-circle" theme="filled" onClick={(event) => event.preventDefault()} className={styles.disabledIcon}/></i></MLTooltip>,
-                  props.canReadWrite ? <MLTooltip title={"Delete"} placement="bottom"><i key ="last" role="delete-mapping button" data-testid={elem.name+"-delete"} onClick={() => handleCardDelete(elem.name)}><FontAwesomeIcon icon={faTrashAlt} className={styles.deleteIcon} size="lg"/></i></MLTooltip> : <MLTooltip title={"Delete: " + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: "200px"}}><i role="disabled-delete-mapping button" data-testid={elem.name+"-disabled-delete"} onClick={(event) => event.preventDefault()}><FontAwesomeIcon icon={faTrashAlt} className={styles.disabledIcon} size="lg"/></i></MLTooltip>,
-                ]}
-                className={styles.cardStyle}
-                size="small"
-              >
-                <div className={styles.formatFileContainer}>
-                  <span aria-label={`${elem.name}-step-label`} className={styles.mapNameStyle}>{getInitialChars(elem.name, 27, "...")}</span>
+        </Col>}
+        {
+          props.data && props.data.length > 0 ?
+            props.data.map((elem, index) => (
+              <Col key={index}>
+                <div
+                  data-testid={`${props.entityTypeTitle}-${elem.name}-step`}
+                  onMouseOver={(e) => handleMouseOver(e, elem.name)}
+                  onMouseLeave={(e) => handleMouseLeave()}
+                >
+                  <Card
+                    actions={[
+                      <MLTooltip title={"Step Details"} placement="bottom"><i className={styles.stepDetails}><FontAwesomeIcon icon={faPencilAlt} onClick={() => openSourceToEntityMapping(elem.name, index)} data-testid={`${elem.name}-stepDetails`}/></i></MLTooltip>,
+                      <MLTooltip title={"Step Settings"} placement="bottom"><i className={styles.editIcon} role="edit-mapping button" key ="last"><FontAwesomeIcon icon={faCog} data-testid={elem.name+"-edit"} onClick={() => OpenStepSettings(index)}/></i></MLTooltip>,
+                      props.canReadWrite ? <MLTooltip title={"Run"} placement="bottom"><i aria-label="icon: run"><Icon type="play-circle" theme="filled" className={styles.runIcon} data-testid={elem.name+"-run"} onClick={() => handleStepRun(elem.name)}/></i></MLTooltip> : <MLTooltip title={"Run: " + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: "200px"}}><i role="disabled-run-mapping button" data-testid={elem.name+"-disabled-run"}><Icon type="play-circle" theme="filled" onClick={(event) => event.preventDefault()} className={styles.disabledIcon}/></i></MLTooltip>,
+                      props.canReadWrite ? <MLTooltip title={"Delete"} placement="bottom"><i key ="last" role="delete-mapping button" data-testid={elem.name+"-delete"} onClick={() => handleCardDelete(elem.name)}><FontAwesomeIcon icon={faTrashAlt} className={styles.deleteIcon} size="lg"/></i></MLTooltip> : <MLTooltip title={"Delete: " + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: "200px"}}><i role="disabled-delete-mapping button" data-testid={elem.name+"-disabled-delete"} onClick={(event) => event.preventDefault()}><FontAwesomeIcon icon={faTrashAlt} className={styles.disabledIcon} size="lg"/></i></MLTooltip>,
+                    ]}
+                    className={styles.cardStyle}
+                    size="small"
+                  >
+                    <div className={styles.formatFileContainer}>
+                      <span aria-label={`${elem.name}-step-label`} className={styles.mapNameStyle}>{getInitialChars(elem.name, 27, "...")}</span>
 
-                </div><br />
-                {elem.selectedSource === "collection" ? <div className={styles.sourceQuery}>Collection: {extractCollectionFromSrcQuery(elem.sourceQuery)}</div> : <div className={styles.sourceQuery}>Source Query: {getInitialChars(elem.sourceQuery, 32, "...")}</div>}
-                <br /><br />
-                <p className={styles.lastUpdatedStyle}>Last Updated: {convertDateFromISO(elem.lastUpdated)}</p>
-                <div className={styles.cardLinks} style={{display: showLinks === elem.name ? "block" : "none"}}>
-                  { props.canWriteFlow ? <Link id="tiles-run-add" to={
-                    {pathname: "/tiles/run/add",
-                      state: {
-                        stepToAdd: elem.name,
-                        targetEntityType: props.entityModel.entityTypeId,
-                        stepDefinitionType: "mapping"
-                      }}}><div className={styles.cardLink} data-testid={`${elem.name}-toNewFlow`}> Add step to a new flow</div></Link> : <div className={styles.cardDisabledLink} data-testid={`${elem.name}-disabledToNewFlow`}> Add step to a new flow</div> }
-                  <div className={styles.cardNonLink} data-testid={`${elem.name}-toExistingFlow`}>
-                                        Add step to an existing flow
-                    {selectVisible ? <MLTooltip title={"Curate: "+SecurityTooltips.missingPermission} placement={"bottom"} visible={tooltipVisible && !props.canWriteFlow}><div className={styles.cardLinkSelect}>
-                      <Select
-                        style={{width: "100%"}}
-                        value={selected[elem.name] ? selected[elem.name] : undefined}
-                        onChange={(flowName) => handleSelect({flowName: flowName, mappingName: elem.name})}
-                        placeholder="Select Flow"
-                        defaultActiveFirstOption={false}
-                        disabled={!props.canWriteFlow}
-                        data-testid={`${elem.name}-flowsList`}
-                        getPopupContainer={() => document.getElementById("entityTilesContainer") || document.body}
-                      >
-                        { props.flows && props.flows.length > 0 ? props.flows.map((f, i) => (
-                          <Option aria-label={`${f.name}-option`} value={f.name} key={i}>{f.name}</Option>
-                        )) : null}
-                      </Select>
-                    </div></MLTooltip> : null}
-                  </div>
+                    </div><br />
+                    {elem.selectedSource === "collection" ? <div className={styles.sourceQuery}>Collection: {extractCollectionFromSrcQuery(elem.sourceQuery)}</div> : <div className={styles.sourceQuery}>Source Query: {getInitialChars(elem.sourceQuery, 32, "...")}</div>}
+                    <br /><br />
+                    <p className={styles.lastUpdatedStyle}>Last Updated: {convertDateFromISO(elem.lastUpdated)}</p>
+                    <div className={styles.cardLinks} style={{display: showLinks === elem.name ? "block" : "none"}}>
+                      {
+                        props.canWriteFlow ?
+                          <Link id="tiles-run-add" to={
+                            {
+                              pathname: "/tiles/run/add",
+                              state: {
+                                stepToAdd: elem.name,
+                                targetEntityType: props.entityModel.entityTypeId,
+                                stepDefinitionType: "mapping"
+                              }
+                            }
+                          }>
+                            <div className={styles.cardLink} data-testid={`${elem.name}-toNewFlow`}>
+                          Add step to a new flow
+                            </div>
+                          </Link>
+                          :
+                          <div className={styles.cardDisabledLink} data-testid={`${elem.name}-disabledToNewFlow`}>
+                        Add step to a new flow
+                          </div>
+                      }
+                      <div className={styles.cardNonLink} data-testid={`${elem.name}-toExistingFlow`}>
+                      Add step to an existing flow
+                        {
+                          selectVisible ?
+                            <MLTooltip title={"Curate: "+SecurityTooltips.missingPermission} placement={"bottom"} visible={tooltipVisible && !props.canWriteFlow}><div className={styles.cardLinkSelect}>
+                              <Select
+                                style={{width: "100%"}}
+                                value={selected[elem.name] ? selected[elem.name] : undefined}
+                                onChange={(flowName) => handleSelect({flowName: flowName, mappingName: elem.name})}
+                                placeholder="Select Flow"
+                                defaultActiveFirstOption={false}
+                                disabled={!props.canWriteFlow}
+                                data-testid={`${elem.name}-flowsList`}
+                                getPopupContainer={() => document.getElementById("entityTilesContainer") || document.body}
+                              >
+                                {
+                                  props.flows && props.flows.length > 0 ?
+                                    props.flows.map((f, i) => (
+                                      <Option aria-label={`${f.name}-option`} value={f.name} key={i}>{f.name}</Option>
+                                    ))
+                                    :
+                                    null
+                                }
+                              </Select>
+                            </div></MLTooltip>
+                            :
+                            null
+                        }
+                      </div>
+                    </div>
+                  </Card>
                 </div>
-              </Card>
-            </div>
-          </Col>
-        )) : <span></span> }</Row>
+              </Col>
+            ))
+            : <span></span>
+        }
+      </Row>
       {deleteConfirmation}
       <SourceToEntityMap
         sourceData={sourceData}


### PR DESCRIPTION
### Description
Adding custom steps to a flow from the Run tile has already been addressed in another ticket.  This PR allows users with sufficient permissions to add custom steps to a flow from the Curate tile.
Tests added account for both features.
Changes to mapping-card.tsx are purely-cosmetic syntax changes.
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [X] JIRA_ID included in all the commit messages
- [X] PR title is in the format JIRA_ID:Title
- [X] Rebase the branch with upstream
- [X] Squashed all commits into a single commit
- [X] Code passes ESLint tests
- [X] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

