### PR TITLE
DHFPROD-7009: Fixing bug with saving step definition

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/stepDefinition.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/artifacts/stepDefinition.sjs
@@ -53,17 +53,13 @@ function getArtifactNode(artifactName, artifactVersion) {
 function getDirectory(artifactName, artifact) {
     let doc = getArtifactNode(artifactName, null);
     let dir = "/step-definitions/";
-    let type;
     if(!doc && artifact && artifactName) {
         dir = dir + artifact.type.toLowerCase() + "/" + artifact.name +"/"
     }
     else if (doc) {
-        let mutableArtifact = doc.toObject();
-        if(mutableArtifact.name.startsWith("default-") || mutableArtifact.name == 'entity-services-mapping'){
-            dir = dir + mutableArtifact.toLowerCase() + "/" + "/marklogic/";
-        }
-        else {
-            dir = dir + mutableArtifact.type.toLowerCase() + "/" + mutableArtifact.name + "/";
+        let stepDefinition = doc.toObject();
+        if (stepDefinition.type && stepDefinition.name) {
+            dir = dir + stepDefinition.type.toLowerCase() + "/" + stepDefinition.name + "/";
         }
     }
     return dir;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/artifacts/saveStepDefinition.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/artifacts/saveStepDefinition.sjs
@@ -1,0 +1,19 @@
+const test = require("/test/test-helper.xqy");
+const ArtifactService = require('../lib/artifactService.sjs');
+
+const stepDef =  {
+  name: "default-myStepDef", 
+  type: "custom"
+};
+
+const firstResponse = ArtifactService.invokeSetService('stepDefinition', stepDef.name, stepDef);
+const secondResponse = ArtifactService.invokeSetService('stepDefinition', stepDef.name, stepDef);
+
+const assertions = [
+  test.assertEqual("default-myStepDef", firstResponse.name, 
+    "Verifying that a user can create a custom step def whose name starts with 'default-', which was a problem in 5.4.0"),
+  test.assertEqual("default-myStepDef", secondResponse.name, 
+    "Verifying that the step def was updated successfully")
+];
+
+assertions 


### PR DESCRIPTION
### Description

The logic for checking on "default-" isn't needed because OOTB DHF step definitions are loaded via /v1/documents, not the artifacts endpoint. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

