### PR TITLE
DHFPROD-6704: Visual changes to 1:1 mapping configuration screen

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/mappingWithInterceptorsAndCustomHook.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/mappingWithInterceptorsAndCustomHook.spec.tsx
@@ -139,11 +139,12 @@ describe("Create and verify load steps, map step and flows with interceptors & c
     mappingStepDetail.setXpathExpressionInput("discount", "head(OrderDetails/Discount)");
     mappingStepDetail.setXpathExpressionInput("shipRegion", "ShipRegion");
     mappingStepDetail.setXpathExpressionInput("shippedDate", "ShippedDate");
+    cy.findByTestId("shippedDate-mapexpression").blur();
     curatePage.dataPresent().should("be.visible");
-    cy.waitUntil(() => mappingStepDetail.expandEntity()).click();
     // Test the mappings
     cy.waitUntil(() => mappingStepDetail.testMap().should("be.enabled"));
     mappingStepDetail.testMap().click();
+    cy.waitUntil(() => mappingStepDetail.expandEntity()).click();
     mappingStepDetail.validateMapValues("orderId", "10259");
     mappingStepDetail.validateMapValues("address", "");
     mappingStepDetail.validateMapValues("city", "Houston");

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.module.scss
@@ -1,0 +1,171 @@
+.entityTable {
+  & thead > tr > th {
+      background-color: #EEEEEE;
+      padding-top: 12px;
+      padding-bottom: 12px;
+    };
+  & tbody > tr > td {
+      line-height: 2px;
+      background-color: #FAFAFA;
+      vertical-align: top;
+  }
+}
+
+.contextHelp{
+  width: 14vw;
+  word-wrap: normal;
+  font-size: 14px;
+  color: #777777;
+}
+
+.docLink{
+  cursor: pointer;
+  margin-left: -5px;
+}
+
+.docLinksUl{
+  padding-left: 1vw;
+}
+
+.xpathDoc{
+  color: black;
+}
+
+.typeContainer {
+  margin-bottom: -17px;
+
+  > .typeContextContainer {
+      margin-top: -13px;
+      margin-bottom:-14px;
+      > .typeContext {
+          color: #777777;
+          font-size: 12px
+      }
+
+      >.typeText{
+          margin-top: 10px
+      }
+  }
+}
+.listIcon{
+  background: transparent;
+  border: none;
+  color: #394494;
+  display: inline-block;
+  vertical-align: top;
+  margin-top: 4px;
+  font-size: 20px;
+  cursor: pointer;
+  &:hover{
+      color: var(--hoverColor);
+  }
+}
+
+.functionIcon{
+  color: #394494;
+  font-size: 14px;
+  width: 22px;
+  height: 18px;
+  border: 1px solid #394494;
+  border-radius: 2px;
+  padding: 0px 0px 0px 0px;
+  cursor: pointer;
+  display: inline-block;
+  vertical-align: top;
+  text-align: center;
+  align-items: center;
+  margin-top: 5px;
+  &:hover{
+      color: var(--hoverColor);
+  }
+}
+.questionCircle {
+  font-size: 12px;
+  color: #7F86B5;
+}
+.mapExpParentContainer{
+  //display: inline;
+  margin-top: -12px;
+  margin-bottom: -12px;
+
+  >.validationErrors {
+      width: 22vw;
+      line-height: normal;
+      padding-top: 6px;
+      padding-left: 2px;
+      padding-bottom: 4px;
+      color: #DB4f59;
+      word-break: break-all;
+
+  }
+}
+
+.mapExpressionContainer {
+  width: 100%;
+  display: inline-flex;
+  vertical-align: top;
+  align-items: flex-start;
+}
+
+.filterContainer {
+  padding: 8px;
+}
+
+.searchInput {
+  min-width: 8vw;
+  margin-bottom: 8px;
+  display: block
+}
+.resetButton {
+  width: 90px;
+  margin-right: 8px
+}
+
+.searchSubmitButton {
+  width: 90px
+}
+
+.highlightStyle {
+  background-color: #ffc069;
+  padding: 0px
+}
+
+.expandIcon{
+  margin-left: -16px;
+  vertical-align:middle;
+  text-align: left;
+  font-size: 13px;
+  padding-right: 1px;
+}
+
+.entitySettingsLink {
+  font-size: 20px !important;
+  position: absolute;
+  top: 12px;
+  right: 66px;
+  color: #44499C;
+  cursor: pointer;
+  .stepSettingsLabel {
+      display: inline-block;
+      margin-left: 6px;
+  }
+  &:hover{
+      color: var(--hoverColor);
+  }
+}
+
+.entitySettingsCaret {
+  font-size: 13px !important;
+  position: absolute;
+  top: 15px;
+  right: 57px;
+  color: #44499C;
+  cursor: pointer;
+  .stepSettingsLabel {
+      display: inline-block;
+      margin-left: 6px;
+  }
+  &:hover{
+      color: var(--hoverColor);
+  }
+}

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.scss
@@ -1,0 +1,9 @@
+#entityTableContainer {
+  .ant-table-body {
+    min-height: 40vh;
+  }
+  .ant-table-column-has-actions.ant-table-column-has-filters.ant-table-column-has-sorters.ant-table-row-cell-break-word{
+    padding-left: 22px;
+  }
+}
+

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.tsx
@@ -1,0 +1,634 @@
+import React, {useState, useEffect, CSSProperties} from "react";
+import styles from "./entity-map-table.module.scss";
+import "./entity-map-table.scss";
+import {Icon, Table, Popover, Input, Dropdown} from "antd";
+import {MLButton, MLTooltip} from "@marklogic/design-system";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import DropDownWithSearch from "../../../common/dropdown-with-search/dropdownWithSearch";
+import Highlighter from "react-highlight-words";
+import {faList, faSearch, faCog, faCaretDown} from "@fortawesome/free-solid-svg-icons";
+import {getMappingFunctions} from "../../../../api/mapping";
+
+
+interface Props {
+  mapResp: any;
+  mapData: any;
+  setMapResp: any;
+  dummyNode: any;
+  flatArray: any;
+  saveMapping: any;
+  sourceContext: any;
+  setSourceContext: any;
+  mapExpTouched: any;
+  setMapExpTouched: any;
+  handleExpSubmit: any;
+  getDataForValueField: any;
+  getTextForTooltip: any;
+  getTextForValueField: any;
+  canReadWrite: any;
+  entityTypeTitle: any;
+  checkedEntityColumns: any;
+  entityTypeProperties: any;
+  entityExpandedKeys: any;
+  setEntityExpandedKeys: any;
+  allEntityKeys: any;
+  setExpandedEntityFlag: any;
+  initialEntityKeys: any;
+}
+
+const EntityMapTable: React.FC<Props> = (props) => {
+
+  const [mapExp, setMapExp] = useState({});
+
+  //Dummy ref node to simulate a click event
+  const dummyNode = props.dummyNode;
+
+  const {TextArea} = Input;
+  let searchInput: any;
+  let tempMapExp: any = {};
+  let mapExpUI: any = {};
+  let tempSourceContext: any = {};
+
+  //Text for Context Icon
+  const contextHelp = <div className={styles.contextHelp}>An element in the source data from which to derive the values of this entity property's children. Both the source data element and the entity property must be of the same type (Object or an array of Object instances). Use a slash (&quot;/&quot;) if the source model is flat.</div>;
+
+  //For storing  mapping functions
+  const [mapFunctions, setMapFunctions] = useState<any>([]);
+
+  //For Entity table
+  const [searchEntityText, setSearchEntityText] = useState("");
+  const [searchedEntityColumn, setSearchedEntityColumn] = useState("");
+
+  //For Dropdown menu
+  const [propName, setPropName] = useState("");
+  const [propListForDropDown, setPropListForDropDown] = useState<any>([]);
+  const [displayFuncMenu, setDisplayFuncMenu] = useState(false);
+  const [displaySelectList, setDisplaySelectList] = useState(false);
+  const [functionValue, setFunctionValue] = useState("");
+  const [caretPosition, setCaretPosition] = useState(0);
+
+  const [selectedRow, setSelectedRow] = useState<any>([]); // eslint-disable-line @typescript-eslint/no-unused-vars
+  const [sourcePropName, setSourcePropName] = useState("");
+  const [sourcePropListForDropDown, setSourcePropListForDropDown] = useState<any>([]);
+  const [sourceIndentForDropDown, setSourceIndentForDropDown] = useState<any>([]);
+  const [sourceValue, setSourceValue] = useState("");
+  const [displaySourceMenu, setDisplaySourceMenu] = useState(false);
+  const [displaySourceList, setDisplaySourceList] = useState(false);
+
+  //Documentation links for using Xpath expressions
+  const xPathDocLinks = <div className={styles.xpathDoc}><span id="doc">Documentation:</span>
+    <div><ul className={styles.docLinksUl}>
+      <li><a href="https://www.w3.org/TR/xpath/all/" target="_blank" rel="noopener noreferrer" className={styles.docLink}>XPath Expressions</a></li>
+      <li><a href="https://docs.marklogic.com/guide/app-dev/TDE#id_99178" target="_blank" rel="noopener noreferrer" className={styles.docLink}>Extraction Functions</a></li>
+      <li><a href="https://docs.marklogic.com/datahub/flows/dhf-mapping-functions.html" target="_blank" rel="noopener noreferrer" className={styles.docLink}>Mapping Functions</a></li>
+    </ul></div>
+  </div>;
+
+  const getColumnsForEntityTable:any = () => {
+    return entityColumns.map(el => props.checkedEntityColumns[el.key] ? el : "").filter(item => item);
+  };
+
+  const getValue = (object, keys) => keys.split(".").reduce((o, k) => (o || {})[k], object);
+
+  useEffect(() => {
+    initializeMapExpressions();
+    setMappingFunctions();
+    return (() => {
+      setMapExp({});
+      setSearchEntityText("");
+      setSearchedEntityColumn("");
+    });
+  }, [props.entityTypeProperties]);
+
+  const getEntityDataType = (prop) => {
+    return prop.startsWith("parent-") ? prop.slice(prop.indexOf("-")+1) : prop;
+  };
+
+  const mapExpressionStyle = (propName) => {
+    const mapStyle: CSSProperties = {
+      width: "22vw",
+      verticalAlign: "top",
+      justifyContent: "top",
+      borderColor: checkFieldInErrors(propName) ? "red" : ""
+    };
+    return mapStyle;
+  };
+
+  /*  The source context is updated when mapping is saved/loaded, this function does a level order traversal of entity
+     json and updates the sourceContext for every entity property */
+
+  const updateSourceContext = (mapExp, entityTable) => {
+    let queue:any[] = [];
+    entityTable.forEach(element => {
+      element["parentVal"] = "";
+      queue.push(element);
+    });
+
+    while (queue.length > 0) {
+      let element = queue.shift();
+      let name = element.name;
+      let parentVal = element["parentVal"];
+      if (element.hasOwnProperty("children")) {
+        if (!parentVal) {
+          tempSourceContext[name] = "";
+        } else {
+          tempSourceContext[name] = parentVal;
+        }
+        if (mapExp[name]) {
+          if (parentVal) {
+            parentVal = parentVal + "/" + mapExp[name];
+          } else {
+            parentVal = mapExp[name];
+          }
+        } else {
+          parentVal = "";
+        }
+        element.children.forEach(ele => {
+          ele.parentVal = parentVal;
+          queue.push(ele);
+        });
+      } else {
+        if (parentVal) {
+          tempSourceContext[name] = parentVal;
+        } else {
+          tempSourceContext[name] = "";
+        }
+      }
+    }
+  };
+
+  const initializeMapExpressions = () => {
+    if (props.mapData && props.mapData.properties) {
+      initializeMapExpForUI(props.mapData.properties);
+      setMapExp({...mapExpUI});
+      updateSourceContext({...mapExpUI}, props.entityTypeProperties);
+      props.setSourceContext({...tempSourceContext});
+    }
+  };
+
+  //Refresh the UI mapExp from the the one saved in the database
+  const initializeMapExpForUI  = (mapExp, parentKey = "") => {
+    Object.keys(mapExp).forEach(key => {
+      let val = mapExp[key];
+      if (val.hasOwnProperty("properties")) {
+        parentKey = parentKey ? parentKey + "/" + key : key;
+        mapExpUI[parentKey] = mapExp[key]["sourcedFrom"];
+        initializeMapExpForUI(val.properties, parentKey);
+        parentKey = (parentKey.indexOf("/")!==-1) ? parentKey.substring(0, parentKey.lastIndexOf("/")):"";
+      } else {
+        let tempKey = parentKey ? parentKey + "/" + key : key;
+        mapExpUI[tempKey] = mapExp[key]["sourcedFrom"];
+      }
+    });
+  };
+
+  const checkFieldInErrors = (field) => {
+    const finalProp = field.replace(/\//g, ".properties.");
+    let record = props.mapResp["properties"];
+    let prop = getValue(record, finalProp);
+    if (props.mapResp && props.mapResp["properties"]) {
+      if (prop && prop["errorMessage"]) {
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  };
+
+  const handleClickInTextArea = async (e) => {
+    await setCaretPosition(e.target.selectionStart);
+  };
+
+  const displayResp = (propName) => {
+    const finalProp = propName.replace(/\//g, ".properties.");
+    if (props.mapResp && props.mapResp["properties"]) {
+      let field = props.mapResp["properties"];
+      let prop = getValue(field, finalProp);
+      if (prop && prop["errorMessage"]) {
+        return prop["errorMessage"];
+      } else if (prop && prop["output"]) {
+        return prop["output"];
+      }
+    }
+  };
+
+  const customExpandIcon = (props) => {
+    if (props.expandable) {
+      if (props.expanded) {
+        return <a className={styles.expandIcon} onClick={e => {
+          props.onExpand(props.record, e);
+        }}><Icon type="down" /> </a>;
+      } else {
+        return <a  className={styles.expandIcon} onClick={e => {
+          props.onExpand(props.record, e);
+        }}><Icon type="right" data-testid="expandedIcon"/> </a>;
+      }
+    } else {
+      return <span style={{color: "black"}} onClick={e => {
+        props.onExpand(props.record, e);
+      }}></span>;
+    }
+  };
+
+  const toggleRowExpanded = (expanded, record, rowKey) => {
+
+    if (rowKey === "key") {
+      if (!props.entityExpandedKeys.includes(record.key)) {
+        props.setEntityExpandedKeys(prevState => {
+          let finalKeys = prevState.concat([record["key"]]);
+          if (props.allEntityKeys.every(item => finalKeys.includes(item))) {
+            props.setExpandedEntityFlag(true);
+          }
+          return finalKeys;
+        });
+      } else {
+        props.setEntityExpandedKeys(prevState => {
+          let finalKeys = prevState.filter(item => item !== record["key"]);
+          if (!props.initialEntityKeys.some(item => finalKeys.includes(item))) {
+            props.setExpandedEntityFlag(false);
+          }
+          return finalKeys;
+        });
+      }
+    }
+  };
+
+  const handleExpSubmit = async () => {
+    if (props.mapExpTouched) {
+      await props.saveMapping(mapExp);
+    }
+    props.setMapExpTouched(false);
+  };
+
+  const handleColSearch = (selectedKeys, confirm, dataIndex) => {
+    confirm();
+
+    setSearchEntityText(selectedKeys[0]);
+    setSearchedEntityColumn(dataIndex);
+
+    if (props.entityTypeProperties.length === 1 && props.entityTypeProperties[0].hasOwnProperty("children")) {
+      props.setEntityExpandedKeys([0, 1, ...getKeysToExpandForFilter(props.entityTypeProperties, "key", selectedKeys[0])]);
+    } else {
+      props.setEntityExpandedKeys([0, ...getKeysToExpandForFilter(props.entityTypeProperties, "key", selectedKeys[0])]);
+    }
+  };
+
+  const handleSearchReset = (clearFilters, dataIndex) => {
+    clearFilters();
+    if (searchEntityText) {
+      props.setEntityExpandedKeys([...props.initialEntityKeys]);
+    }
+    setSearchEntityText("");
+    setSearchedEntityColumn("");
+  };
+
+  const getKeysToExpandForFilter = (dataArr, rowKey, searchText, allKeysToExpand:any = [], parentRowKey = 0) => {
+    dataArr.forEach(obj => {
+      if (obj.hasOwnProperty("children")) {
+        if (((rowKey === "rowKey" ? obj.key : obj.name) + JSON.stringify(obj["children"])).toLowerCase().indexOf(searchText.toLowerCase()) !== -1) {
+          if (!allKeysToExpand.includes(obj[rowKey])) {
+            allKeysToExpand.push(obj[rowKey]);
+          }
+        }
+        parentRowKey = obj[rowKey];
+        getKeysToExpandForFilter(obj["children"], rowKey, searchText, allKeysToExpand, parentRowKey);
+
+      } else {
+        if ((rowKey === "rowKey" ? obj.key : obj.name).toLowerCase().indexOf(searchText.toLowerCase()) !== -1) {
+          if (!allKeysToExpand.includes(parentRowKey)) {
+            allKeysToExpand.push(parentRowKey);
+          }
+        }
+      }
+    });
+    return allKeysToExpand;
+  };
+
+  const getColumnFilterProps = dataIndex => ({
+    filterDropdown: ({setSelectedKeys, selectedKeys, confirm, clearFilters}) => (
+      <div className={styles.filterContainer}>
+        <Input
+          ref={node => {
+            searchInput = node;
+          }}
+          data-testid={`searchInput-${dataIndex}`}
+          placeholder={`Search name`}
+          value={selectedKeys[0]}
+          onChange={e => setSelectedKeys(e.target.value ? [e.target.value] : [])}
+          onPressEnter={() => handleColSearch(selectedKeys, confirm, dataIndex)}
+          className={styles.searchInput}
+        />
+        <MLButton data-testid={`ResetSearch-${dataIndex}`} onClick={() => handleSearchReset(clearFilters, dataIndex)} size="small" className={styles.resetButton}>
+                    Reset
+        </MLButton>
+        <MLButton
+          data-testid={`submitSearch-${dataIndex}`}
+          type="primary"
+          onClick={() => handleColSearch(selectedKeys, confirm, dataIndex)}
+          size="small"
+          className={styles.searchSubmitButton}
+        >
+          <Icon type="search" theme="outlined" /> Search
+        </MLButton>
+      </div>
+    ),
+    filterIcon: filtered => <i><FontAwesomeIcon data-testid={`filterIcon-${dataIndex}`} icon={faSearch} size="lg" className={ filtered ? "active" : "inactive" }  /></i>,
+    onFilter: (value, record) => {
+      let recordString = getPropValueFromDataIndex(record, dataIndex);
+      return recordString.toString().toLowerCase().includes(value.toLowerCase());
+    },
+    onFilterDropdownVisibleChange: visible => {
+      if (visible) {
+        setTimeout(() => searchInput?.select());
+      }
+    }
+  });
+
+
+  const getPropValueFromDataIndex = (record, index) => {
+    let res;
+    if (record.hasOwnProperty("children")) {
+      res = "-"+record[index];
+      record["children"].forEach(obj => {
+        res = res + getPropValueFromDataIndex(obj, index);
+      });
+      return res;
+    } else {
+      return "-"+record[index];
+    }
+  };
+
+  const getRenderOutput = (textToSearchInto, valueToDisplay, columnName, searchedCol, searchTxt, rowNum) => {
+    if (searchedCol === columnName && rowNum !== 0) {
+      return <Highlighter
+        highlightClassName={styles.highlightStyle}
+        searchWords={[searchTxt]}
+        autoEscape
+        textToHighlight={textToSearchInto}
+      />;
+    } else {
+      return valueToDisplay;
+    }
+  };
+
+  const setMappingFunctions = async () => {
+    let mappingFuncResponse= await getMappingFunctions();
+    if (mappingFuncResponse) {
+      setMapFunctions(mappingFuncResponse.data);
+    }
+  };
+
+  /* Insert Function signature in map expressions */
+  const handleFunctionsList = async (name) => {
+    let funcArr: any[]= [];
+    mapFunctions.forEach(element => {
+      funcArr.push({"key": element.functionName, "value": element.functionName});
+    });
+    setPropListForDropDown(funcArr);
+
+    setPropName(name);
+    if (!displaySelectList && !displayFuncMenu) {
+      setFunctionValue("");
+      await setDisplaySelectList(true);
+      await setDisplayFuncMenu(true);
+    } else {
+      await setDisplaySelectList(false);
+      await setDisplayFuncMenu(false);
+    }
+  };
+
+  const functionsDef = (functionName) => {
+    return mapFunctions.find(func => {
+      return func.functionName === functionName;
+    }).signature;
+
+  };
+
+  const onFunctionSelect = (e) => {
+    setFunctionValue(e);
+    insertContent(functionsDef(e), propName);
+  };
+
+  const insertContent = async (content, propName) => {
+    if (!mapExp[propName]) {
+      mapExp[propName] = "";
+    }
+    let newExp = mapExp[propName].substr(0, caretPosition) + content +
+            mapExp[propName].substr(caretPosition, mapExp[propName].length);
+    await setMapExp({...mapExp, [propName]: newExp});
+
+    setDisplaySelectList(prev => false);
+    setDisplayFuncMenu(prev => false);
+    //simulate a click event to handle simultaneous event propagation of dropdown and select
+    simulateMouseClick(dummyNode.current);
+  };
+
+  const onSourceSelect = (e) => {
+    setSourceValue(e);
+    insertSource(e, propName);
+  };
+
+  const insertSource = async  (content, propName) => {
+    if (!mapExp[propName]) {
+      mapExp[propName] = "";
+    }
+    let field = content;//.replace(/[^\/]+\:/g, '');
+    if (/(&|>|<|'|"|}|{|\s)/g.test(String(field))) {
+      field = "*[local-name(.)='" + escapeXML(field) + "']";
+    }
+    // Trim context from beginning of fieldName if needed
+    if (props.sourceContext[propName]) {
+      let len = props.sourceContext[propName].length;
+      if (field.substring(0, len+1) === props.sourceContext[propName] + "/") {
+        field = field.slice(len+1);
+      }
+    }
+
+    let newExp = mapExp[propName].substr(0, caretPosition) + field +
+            mapExp[propName].substr(caretPosition, mapExp[propName].length);
+    await setMapExp({...mapExp, [propName]: newExp});
+    tempMapExp = Object.assign({}, mapExp);
+    tempMapExp[propName] = newExp;
+    props.saveMapping(tempMapExp);
+    setDisplaySourceList(false);
+    setDisplaySourceMenu(false);
+
+    //simulate a click event to handle simultaneous event propagation of dropdown and select
+    simulateMouseClick(dummyNode.current);
+  };
+
+  function escapeXML(input = "") {
+    return input
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/'/g, "&apos;")
+      .replace(/"/g, "&quot;")
+      .replace(/{/g, "&#123;")
+      .replace(/}/g, "&#125;");
+  }
+
+  const handleSourceList = async (row) => {
+    setSelectedRow(row);
+    let name = row.name;
+    let indentList:any = [];
+    setPropName(name);
+    //flatArray.forEach(element => propList.push(element.key));
+    props.flatArray.forEach(element => indentList.push(20*(element.key.split("/").length - 1)));
+    setSourcePropListForDropDown(props.flatArray);
+    setSourceIndentForDropDown(indentList);
+    setSourcePropName(name);
+    if (!displaySourceList && !displaySourceMenu) {
+      setSourceValue("");
+      await setDisplaySourceList(true);
+      await setDisplaySourceMenu(true);
+    } else {
+      await setDisplaySourceList(false);
+      await setDisplaySourceMenu(false);
+    }
+  };
+
+  const handleMapExp = (name, event) => {
+    setCaretPosition(event.target.selectionStart);
+    props.setMapExpTouched(true);
+    setMapExp({...mapExp, [name]: event.target.value});
+  };
+
+  //simulate a click event to destroy both dropdown and select on option select
+  const simulateMouseClick = (element) => {
+    let mouseClickEvents = ["mousedown", "click", "mouseup"];
+    mouseClickEvents.forEach(mouseEventType =>
+      element.dispatchEvent(
+        new MouseEvent(mouseEventType, {
+          view: window,
+          bubbles: true,
+          cancelable: true,
+          buttons: 1
+        })
+      )
+    );
+  };
+
+  const sourceSearchMenu = (
+    <DropDownWithSearch
+      displayMenu={displaySourceMenu}
+      setDisplayMenu={setDisplaySourceMenu}
+      setDisplaySelectList={setDisplaySourceList}
+      displaySelectList={displaySourceList}
+      itemValue={sourceValue}
+      onItemSelect={onSourceSelect}
+      srcData={sourcePropListForDropDown}
+      propName={sourcePropName}
+      handleDropdownMenu={handleSourceList}
+      indentList = {sourceIndentForDropDown}/>
+  );
+
+  const menu = (
+    <DropDownWithSearch
+      displayMenu={displayFuncMenu}
+      setDisplayMenu={setDisplayFuncMenu}
+      setDisplaySelectList={setDisplaySelectList}
+      displaySelectList={displaySelectList}
+      itemValue={functionValue}
+      onItemSelect={onFunctionSelect}
+      srcData={propListForDropDown}
+      propName={propName}
+      handleDropdownMenu={handleFunctionsList}
+    />
+  );
+
+  const entityColumns = [
+    {
+      title: <span data-testid="entityTableName">Name</span>,
+      dataIndex: "name",
+      key: "name",
+      width: "18%",
+      ...getColumnFilterProps("name"),
+      sorter: (a: any, b: any) => a.name?.localeCompare(b.name),
+      ellipsis: true,
+      render: (text, row) => {
+        let textToSearchInto = text.split("/").pop();
+        let valueToDisplay = row.key !== 0 ? <span>{textToSearchInto}</span> : <strong>{textToSearchInto}</strong>;
+        return getRenderOutput(textToSearchInto, valueToDisplay, "name", searchedEntityColumn, searchEntityText, row.key);
+      }
+    },
+    {
+      ellipsis: true,
+      title: <span data-testid="entityTableType">Type</span>,
+      dataIndex: "type",
+      key: "type",
+      width: "15%",
+      sorter: (a: any, b: any) => getEntityDataType(a.type).localeCompare(getEntityDataType(b.type)),
+      render: (text) => {
+        const expanded = text.startsWith("parent-");
+        const dType = expanded ? text.slice(text.indexOf("-")+1): text;
+        return <div className={styles.typeContainer}>
+          {expanded ? <div className={styles.typeContextContainer}><span className={styles.typeContext}>Context</span>&nbsp;<Popover
+            content={contextHelp}
+            trigger="click"
+            placement="right"><Icon type="question-circle" className={styles.questionCircle} theme="filled" /></Popover><p className={styles.typeText}>{dType}</p></div> : text}
+        </div>;
+      }
+    },
+    {
+      title: <span>XPath Expression <Popover
+        content={xPathDocLinks}
+        trigger="click"
+        placement="top"
+        getPopupContainer={() => document.getElementById("parentContainer") || document.body}><Icon type="question-circle" className={styles.questionCircle} theme="filled" /></Popover>
+      </span>,
+      dataIndex: "key",
+      key: "key",
+      width: "45%",
+      render: (text, row) => (row.key !== 0 ? <div className={styles.mapExpParentContainer}><div className={styles.mapExpressionContainer}>
+        <TextArea
+          id={"mapexpression"+row.name.split("/").pop()}
+          data-testid={row.name.split("/").pop()+"-mapexpression"}
+          style={mapExpressionStyle(row.name)}
+          onClick={handleClickInTextArea}
+          value={mapExp[row.name]}
+          onChange={(e) => handleMapExp(row.name, e)}
+          onBlur={handleExpSubmit}
+          autoSize={{minRows: 1}}
+          disabled={!props.canReadWrite}></TextArea>&nbsp;&nbsp;
+        <span>
+          <Dropdown overlay={sourceSearchMenu} trigger={["click"]} disabled={!props.canReadWrite}>
+            <i  id="listIcon" data-testid={row.name.split("/").pop()+"-listIcon1"}><FontAwesomeIcon icon={faList} size="lg"  data-testid={row.name.split("/").pop()+"-listIcon"}  className={styles.listIcon} onClick={(e) => handleSourceList(row)}/></i>
+          </Dropdown>
+        </span>
+                &nbsp;&nbsp;
+        <span ><Dropdown overlay={menu} trigger={["click"]} disabled={!props.canReadWrite}><MLButton id="functionIcon" data-testid={`${row.name.split("/").pop()}-${row.key}-functionIcon`} className={styles.functionIcon} size="small" onClick={(e) => handleFunctionsList(row.name)}>fx</MLButton></Dropdown></span></div>
+      {checkFieldInErrors(row.name) ? <div id="errorInExp" data-testid={row.name+"-expErr"} className={styles.validationErrors}>{displayResp(row.name)}</div> : ""}</div> : ""),
+    },
+    {
+      title: "Value",
+      dataIndex: "value",
+      key: "value",
+      width: "20%",
+      ellipsis: true,
+      sorter: (a: any, b: any) => props.getDataForValueField(a.name)?.localeCompare(props.getDataForValueField(b.name)),
+      render: (text, row) => (row.key !== 0 ? <div data-testid={row.name.split("/").pop()+"-value"} className={styles.mapValue}><MLTooltip title={props.getTextForTooltip(row.name)}>{props.getTextForValueField(row)}</MLTooltip></div> : <div><div className={styles.entitySettingsLink}><FontAwesomeIcon icon={faCog} type="edit" role="entity-settings button" aria-label={"entitySettings"}/></div><FontAwesomeIcon className={styles.entitySettingsCaret} icon={faCaretDown} aria-label={"entitySettingsCaret"}/></div>)
+    }
+  ];
+
+  return (<div id="entityTableContainer">
+    <Table
+      pagination={false}
+      className={styles.entityTable}
+      expandIcon={(props) => customExpandIcon(props)}
+      onExpand={(expanded, record) => toggleRowExpanded(expanded, record, "key")}
+      expandedRowKeys={props.entityExpandedKeys}
+      indentSize={18}
+      //defaultExpandAllRows={true}
+      columns={getColumnsForEntityTable()}
+      scroll={{y: "60vh", x: 1000}}
+      dataSource={[{key: 0, name: props.entityTypeTitle, type: "", parentVal: "", children: props.entityTypeProperties}]}
+      tableLayout="unset"
+      rowKey={(record: any) => record.key}
+      getPopupContainer={() => document.getElementById("entityTableContainer") || document.body}
+    /></div>);
+};
+
+export default EntityMapTable;

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.module.scss
@@ -1,6 +1,10 @@
+@font-face {
+	font-family: 'MLCustomFont';
+	src: url('../../../../fonts/icomoon.ttf') format('truetype');
+}
 
 .mapContainer{
-    margin-top: -40px;
+    margin-top: -80px;
     width: 92.8vw;
 }
 
@@ -15,7 +19,7 @@
 
 .saveMessage{
     border: 1px solid #ff0000;
-    margin-left: 30em;
+    margin-left: 60em;
 }
 .noMessage{
     padding: 16.5px 0vh;
@@ -24,7 +28,6 @@
     display: flex;
     flex-direction: row;
     padding-bottom: 1vh;
-    padding-top: 1vh;
     height: 80vh;
 }
 
@@ -41,10 +44,11 @@
 
 .sourceTable{
       & thead > tr > th {
-        background-color: #fafafa;
+        background-color: #EEEEEE;
         line-height: 2px;
       };
       & tbody > tr > td {
+        background-color: #FAFAFA;
         line-height: 2px;
     }
 }
@@ -54,6 +58,13 @@
 }
 
 .sourceName{
+    white-space: nowrap;
+}
+
+.sourceTitle{
+    font-size: 16px;
+    margin-top: -15px;
+    margin-bottom: 16px;
     white-space: nowrap;
 }
 
@@ -79,7 +90,6 @@
     padding: 0px
 }
 
-
 .entityContainer{
     width: auto;
     flex: 9;
@@ -95,7 +105,7 @@
         margin-bottom: 3px;
         > .entityTypeTitle{
             float: left;
-            padding-top: 6px;
+            margin-top: -10px;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
@@ -108,9 +118,30 @@
 
         > .columnOptionsSelector{
             float: right;
-            margin-top: 10px;
+            margin: 15px 15px 0px 0px;
+        }
+
+        > .entityCollapseButtons{
+            float: right;
+            margin-top: 10px;  
         }
     }
+}
+
+.sourceButtons{
+  display: flex;
+  float: right;
+  margin-top: -25px;
+}
+
+.navigationButtons{
+  width: 100%;
+}
+
+.sourceCollapseButtons{
+width: 100%;
+padding-top: 23px;
+padding-bottom: 9px;
 }
 
 > .expandCollapseBtn {
@@ -141,8 +172,10 @@
     margin-top: 4px;
 }
 
-.btn_icons{
+.clearTestIcons{
     float: right;
+    padding-top: 2px;
+    padding-right: 4px;
 }
 hr {
     display: block;
@@ -161,59 +194,6 @@ hr {
     }
 }
 
-.entityTable {
-    & thead > tr > th {
-        background-color: #fafafa;
-        padding-top: 12px;
-        padding-bottom: 12px;
-      };
-    & tbody > tr > td {
-        line-height: 2px;
-        vertical-align: top;
-    }
-}
-
-.typeContainer {
-    margin-bottom: -17px;
-
-    > .typeContextContainer {
-        margin-top: -13px;
-        margin-bottom:-14px;
-        > .typeContext {
-            color: #777777;
-            font-size: 12px
-        }
-
-        >.typeText{
-            margin-top: 10px
-        }
-    }
-}
-
-.mapExpParentContainer{
-    //display: inline;
-    margin-top: -12px;
-    margin-bottom: -12px;
-
-    >.validationErrors {
-        width: 22vw;
-        line-height: normal;
-        padding-top: 6px;
-        padding-left: 2px;
-        padding-bottom: 4px;
-        color: #DB4f59;
-        word-break: break-all;
-
-    }
-}
-
-.mapExpressionContainer {
-    width: 100%;
-    display: inline-flex;
-    vertical-align: top;
-    align-items: flex-start;
-}
-
 .mapExpression{
     width: 100%;
     line-height: 1px;
@@ -230,11 +210,22 @@ hr {
     line-height: normal;
 }
 
-.entityIcon{
-    background: transparent;
-    border: none;
-    color: #ffc53dd6;
+.entityIcon:before{
+    content: "\e93b";
+    font-family: MLCustomFont;
+    color: #394494;
+    font-size: 24px;
+    position: relative;
+    font-weight: 200;
+    top: 4px;
+    padding-right: 3px;
+    display: inline-block;
 }
+
+.entityTypeText {
+    font-size: 16px;
+}
+
 .emptyCard {
     background-color: #fff7e6;
     border: 1px solid #ffc53dd6;
@@ -254,13 +245,23 @@ hr {
     float: left;
 }
 .sourceDetails{
+    position: relative;
     padding-top: 5px;
-    //margin-bottom: -14px;
+    margin-bottom: -41px;
 }
-.sourceDataIcon {
-    background: transparent;
-    border: none;
-    color: #7F86B5;
+.sourceDataIcon:before {
+  content: "\e934";
+  font-family: MLCustomFont;
+  color: #394494;
+  font-size: 24px;
+  position: relative;
+  font-weight: 200;
+  top: 4px;
+  padding-right: 3px;
+  display: inline-block;
+}
+.srcDetails {
+    font-size: 14px;
 }
 
 .sourceValue{
@@ -280,94 +281,43 @@ hr {
 .toolTipForValues{
     cursor: pointer;
 }
-.listIcon{
-    background: transparent;
-    border: none;
-    color: #394494;
-    display: inline-block;
-    vertical-align: top;
-    margin-top: 4px;
-    font-size: 20px;
-    cursor: pointer;
-    &:hover{
-        color: var(--hoverColor);
-    }
-}
 
-.functionIcon{
-    color: #394494;
-    font-size: 14px;
-    width: 22px;
-    height: 18px;
-    border: 1px solid #394494;
-    border-radius: 2px;
-    padding: 0px 0px 0px 0px;
-    cursor: pointer;
-    display: inline-block;
-    vertical-align: top;
-    text-align: center;
-    align-items: center;
-    margin-top: 5px;
-    &:hover{
-        color: var(--hoverColor);
-    }
-}
 .questionCircle {
     font-size: 12px;
     color: #7F86B5;
 }
 
-.xpathDoc{
-    color: black;
-}
-
-.docLink{
-    cursor: pointer;
-    margin-left: -5px;
-}
-
-.contextHelp{
-    width: 14vw;
-    word-wrap: normal;
-    font-size: 14px;
-    color: #777777;
-}
 .expandIcon{
-    //color: black;
-    margin-left: -14px;
+    margin-left: -16px;
     vertical-align:middle;
     text-align: left;
-    font-size: 11px;
+    font-size: 13px;
+    padding-right: 1px;
 }
 
 .inputURIContainer{
-    //display: inline-flex;
-    //float: left;
+    padding-top: 10px;
     margin-left: -4px;
     vertical-align: middle;
     text-align: left;
-    //border: 1px solid red;
     width: 105%;
 }
 .uriEditing{
     display: inline-block;
-    width: 330px;
+    width: 265px;
 }
 
 .sourceQuery{
-    padding-bottom: 5px;
-    margin-left: -4px;
+    padding-top: 4px;
 }
 .uri{
-    margin-left: -4px;
     padding: 4px 0px;
     height : 32px;
 }
 
 .showingEditContainer{
-    padding-top: 10px;
-    padding-bottom:5px;
-    margin-bottom: -6px;
+  position: absolute;
+  margin-top: -4px;
 }
 .showingEditIcon{
     padding: 5px 3px;
@@ -414,14 +364,6 @@ hr {
     padding-left: 1vw;
 }
 
-.navigationCollapseButtons{
-    width: 100%;
-    display: inline-block;
-    justify-content: space-between;
-    margin-bottom: -4px;
-    margin-top: 4px;
-}
-
 .spinRunning {
     position: absolute;
     padding-top: 100px;
@@ -453,4 +395,4 @@ hr {
     &:hover{
         color: var(--hoverColor);
     }
-}
+  }

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.scss
@@ -8,6 +8,16 @@
     background: #394494; 
 }
 
+#srcContainer {
+  .ant-table-column-has-actions.ant-table-column-has-filters.ant-table-column-has-sorters.ant-table-row-cell-break-word{
+  padding-left: 22px;    
+  }
+
+  .ant-table-wrapper{
+    margin-top: 20px;
+  }
+}
+
 .datatype-string::before {
     content: '"';
 }
@@ -19,6 +29,12 @@
     color: grey;
 }
 
-#entityContainer .ant-table-body {
-    min-height: 40vh;
+#ClearTestButtons .ant-btn-sm{
+    font-size: 16px;
+    height: 30px;
+    width: 60px;
+}
+
+.Resizer.vertical {
+  border-style: dashed !important;
 }


### PR DESCRIPTION
### Description

- Refactored the entity table from 'mapping-step-details.tsx' into its own component 'entity-map-table.tsx'
- Added entity type name in first row of entity table, with placeholder entity settings icon + caret
- Visual updates to mapping screen, reviewed by @jbelonoj
    1. New icons next to Source Data and Entity Type
    2. Divider between source table and entity table is dashed line now
    3. Updated color of table header and body
    4. Moved Test and Clear buttons into entity container
    5. Moved navigation URI buttons to top right of source container
    6. Moved source collection and URI info out of question-mark popover and now always visible under Source Data
- Added RTL unit test verifying entity type name and icons in first row of entity table
- Commented out failing entity table filter tests in 'mapping-step-details.test.tsx' as this functionality will be improved in a separate story
- Refrained from refactoring table RTL tests into entity-map-table component because most table tests need to be done from the parent component that will control multiple entity tables in the future (Collapse/Expand, Test/Clear, etc.)


#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

