### PR TITLE
DHFPROD-6954: TDE context path now avoids false positives

### DIFF
--- a/marklogic-data-hub/src/test/ml-modules/root/test/data-hub-test-helper.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/data-hub-test-helper.xqy
@@ -181,6 +181,15 @@ declare function get-first-prov-document()
   invoke-in-db(function() {fn:collection("http://marklogic.com/provenance-services/record")[1]}, "data-hub-JOBS")
 };
 
+declare function get-final-schema($uri as xs:string)
+{
+  xdmp:eval("fn:doc('" || $uri || "')", (), 
+    <options xmlns="xdmp:eval">
+      <database>{xdmp:database("data-hub-final-SCHEMAS")}</database>
+    </options>
+  )
+};
+
 declare function invoke-in-db($function, $database as xs:string)
 {
   xdmp:invoke-function($function,

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/tdeContext/setup.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/tdeContext/setup.xqy
@@ -1,0 +1,13 @@
+xquery version "1.0-ml";
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+hub-test:reset-hub();
+
+xquery version "1.0-ml";
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+import module namespace test = "http://marklogic.com/test" at "/test/test-helper.xqy";
+hub-test:load-entities($test:__CALLER_FILE__);
+
+xquery version "1.0-ml";
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+import module namespace test = "http://marklogic.com/test" at "/test/test-helper.xqy";
+hub-test:load-artifacts($test:__CALLER_FILE__);

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/tdeContext/test-data/content/jsonEntity.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/tdeContext/test-data/content/jsonEntity.json
@@ -1,0 +1,12 @@
+{
+  "envelope": {
+    "instance": {
+      "info": {
+        "version": "1.0"
+      },
+      "TdeContextNoNamespaceEntity": {
+        "myProperty": "JSON"
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/tdeContext/test-data/content/jsonEntityDifferentVersion.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/tdeContext/test-data/content/jsonEntityDifferentVersion.json
@@ -1,0 +1,12 @@
+{
+  "envelope": {
+    "instance": {
+      "info": {
+        "version": "1.0.1"
+      },
+      "TdeContextNoNamespaceEntity": {
+        "myProperty": "JSON"
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/tdeContext/test-data/content/namespacedEntity.xml
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/tdeContext/test-data/content/namespacedEntity.xml
@@ -1,0 +1,10 @@
+<es:envelope xmlns:es="http://marklogic.com/entity-services">
+  <es:instance>
+    <es:info>
+      <es:version>1.0</es:version>
+    </es:info>
+    <oex:TdeContextNamespacedEntity xmlns:oex="http://example.org/">
+      <oex:myProperty>XML</oex:myProperty>
+    </oex:TdeContextNamespacedEntity>
+  </es:instance>
+</es:envelope>

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/tdeContext/test-data/content/namespacedEntityDifferentVersion.xml
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/tdeContext/test-data/content/namespacedEntityDifferentVersion.xml
@@ -1,0 +1,7 @@
+<es:envelope xmlns:es="http://marklogic.com/entity-services">
+  <es:instance>
+    <oex:NamespacedEntity xmlns:oex="http://example.org/">
+      <oex:myProperty>XML</oex:myProperty>
+    </oex:NamespacedEntity>
+  </es:instance>
+</es:envelope>

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/tdeContext/test-data/content/noNamespaceEntity.xml
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/tdeContext/test-data/content/noNamespaceEntity.xml
@@ -1,0 +1,10 @@
+<es:envelope xmlns:es="http://marklogic.com/entity-services">
+  <es:instance>
+    <es:info>
+      <es:version>1.0</es:version>
+    </es:info>
+    <TdeContextNoNamespaceEntity xmlns:ns="example">
+      <myProperty>XML</myProperty>
+    </TdeContextNoNamespaceEntity>
+  </es:instance>
+</es:envelope>

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/tdeContext/test-data/entities/TdeContextNamespacedEntity.entity.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/tdeContext/test-data/entities/TdeContextNamespacedEntity.entity.json
@@ -1,0 +1,18 @@
+{
+  "info": {
+    "title": "TdeContextNamespacedEntity",
+    "version": "1.0",
+    "baseUri": "http://example.org/"
+  },
+  "definitions": {
+    "TdeContextNamespacedEntity": {
+      "namespace": "http://example.org/",
+      "namespacePrefix": "oex",
+      "properties": {
+        "myProperty": {
+          "datatype": "string"
+        }
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/tdeContext/test-data/entities/TdeContextNoNamespaceEntity.entity.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/tdeContext/test-data/entities/TdeContextNoNamespaceEntity.entity.json
@@ -1,0 +1,16 @@
+{
+  "info": {
+    "title": "TdeContextNoNamespaceEntity",
+    "version": "1.0",
+    "baseUri": "http://example.org/"
+  },
+  "definitions": {
+    "TdeContextNoNamespaceEntity": {
+      "properties": {
+        "myProperty": {
+          "datatype": "string"
+        }
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/tdeContext/verifyTdeContext.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/tdeContext/verifyTdeContext.xqy
@@ -1,0 +1,50 @@
+xquery version "1.0-ml";
+
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+import module namespace test = "http://marklogic.com/test" at "/test/test-helper.xqy";
+
+declare namespace es = "http://marklogic.com/entity-services";
+declare namespace oex = "http://example.org/";
+declare namespace tde = "http://marklogic.com/xdmp/tde";
+
+let $assertions := (
+  test:assert-equal(2, 
+    xdmp:estimate(/(es:envelope|envelope)/(es:instance|instance)[es:info/es:version = "1.0" or info/version = "1.0"][TdeContextNoNamespaceEntity]),
+    "The expected path in the schema should only grab the 2 TdeContextNoNamespaceEntity instances with version = 1.0"
+  ),
+
+  test:assert-equal(1, 
+    xdmp:estimate(/(es:envelope|envelope)/(es:instance|instance)[es:info/es:version = "1.0" or info/version = "1.0"][oex:TdeContextNamespacedEntity]),
+    "The expected path in the schema should only grab the 1 oex:TdeContextNamespacedEntity instance with version = 1.0"
+  )
+)
+
+(: Verify that SQL queries on our entity types return the same counts as the estimates above :)
+let $no-namespace-results := xdmp:sql("select count(*) from TdeContextNoNamespaceEntity", "map")
+let $namespaced-results := xdmp:sql("select count(*) from TdeContextNamespacedEntity", "map")
+let $assertions := (
+  $assertions,
+  test:assert-equal(2, map:get($no-namespace-results, "count(*)")),
+  test:assert-equal(1, map:get($namespaced-results, "count(*)"))
+)
+
+
+(: Now verify the actual contents of the TDE templates :)
+let $no-namespace-tde := hub-test:get-final-schema('/tde/TdeContextNoNamespaceEntity-1.0.tdex')
+let $no-namespace-context := $no-namespace-tde/tde:template/tde:context/fn:string()
+let $namespaced-tde := hub-test:get-final-schema('/tde/TdeContextNamespacedEntity-1.0.tdex')
+let $namespaced-context := $namespaced-tde/tde:template/tde:context/fn:string()
+
+return (
+  $assertions,
+
+  test:assert-equal("/(es:envelope|envelope)/(es:instance|instance)[es:info/es:version = '1.0' or info/version = '1.0'][TdeContextNoNamespaceEntity]", 
+    $no-namespace-context,
+    "The avoidance of wildcards and the use of 'or' for the version check should avoid false positives and thus unnecessary reindexing of documents"
+  ),
+
+  test:assert-equal("/(es:envelope|envelope)/(es:instance|instance)[es:info/es:version = '1.0'][oex:TdeContextNamespacedEntity]", 
+    $namespaced-context,
+    "The avoidance of wildcards and the use of 'or' for the version check should avoid false positives and thus unnecessary reindexing of documents"
+  )
+)


### PR DESCRIPTION
### Description

The false positives don't affect query results, but they do impact which documents are reindexed.

Extracted fix-tde-context and a few other private functions to start this module on the path towards readability. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

