### PR TITLE
DHFPROD-5080: Reorder steps in a flow via arrows

### DIFF
--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/FlowController.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/FlowController.java
@@ -16,6 +16,7 @@
 package com.marklogic.hub.central.controllers;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.marklogic.hub.dataservices.FlowService;
 import com.marklogic.hub.flow.FlowInputs;
 import com.marklogic.hub.flow.FlowRunner;
@@ -69,10 +70,11 @@ public class FlowController extends BaseController {
 
     @RequestMapping(value = "/{flowName}", method = RequestMethod.PUT)
     @ResponseBody
-    @ApiOperation(value = "Update a flow", response = FlowInfo.class)
+    @ApiOperation(value = "Update a flow", response = UpdateFlow.class)
     @Secured("ROLE_writeFlow")
-    public ResponseEntity<JsonNode> updateFlowInfo(@PathVariable String flowName, @RequestBody UpdateFlowInfo info) {
-        return ResponseEntity.ok(newFlowService().updateFlowInfo(flowName, info.description));
+    public ResponseEntity<JsonNode> updateFlow(@RequestBody JsonNode updatedFlow) {
+
+        return ResponseEntity.ok(newFlowService().updateFlow(updatedFlow));
     }
 
     @RequestMapping(value = "/{flowName}", method = RequestMethod.DELETE)
@@ -145,8 +147,10 @@ public class FlowController extends BaseController {
         public String description;
     }
 
-    public static class UpdateFlowInfo {
+    public static class UpdateFlow {
         public String description;
+        public String name;
+        public List<String> steps;
     }
 
     public static class FlowsWithStepDetails extends ArrayList<FlowWithStepDetails> {

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/run/reorderSteps.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/run/reorderSteps.spec.tsx
@@ -1,0 +1,91 @@
+import {Application} from "../../../support/application.config";
+import {tiles, toolbar} from "../../../support/components/common";
+import runPage from "../../../support/pages/run";
+import loadPage from "../../../support/pages/load";
+import browsePage from "../../../support/pages/browse";
+import LoginPage from "../../../support/pages/login";
+
+describe("Run Tile tests", () => {
+
+  beforeEach(() => {
+    cy.visit("/");
+    cy.contains(Application.title);
+    cy.loginAsTestUserWithRoles("hub-central-flow-writer").withRequest();
+    LoginPage.postLogin();
+    cy.waitUntil(() => toolbar.getRunToolbarIcon()).click();
+    cy.waitUntil(() => runPage.getFlowName("personJSON").should("be.visible"));
+  });
+
+  after(() => {
+    cy.deleteRecordsInFinal("master-xml-person", "mapPersonXML");
+    cy.deleteFlows("testPersonXML");
+    cy.resetTestUser();
+  });
+
+  it("can create flow and add steps to flow, reorder flow, and should load xml merged document and display content", () => {
+
+    const flowName = "testPersonXML";
+    //Verify create flow and add all user-defined steps to flow via Run tile
+    runPage.createFlowButton().click();
+    runPage.newFlowModal().should("be.visible");
+    runPage.setFlowName(flowName);
+    loadPage.confirmationOptions("Save").click();
+    runPage.addStep(flowName);
+    runPage.addStepToFlow("loadPersonXML");
+    runPage.verifyStepInFlow("Load", "loadPersonXML");
+    runPage.addStep(flowName);
+    runPage.addStepToFlow("mapPersonXML");
+    runPage.verifyStepInFlow("Map", "mapPersonXML");
+    runPage.addStep(flowName);
+    runPage.addStepToFlow("match-xml-person");
+    runPage.verifyStepInFlow("Match", "match-xml-person");
+    runPage.addStep(flowName);
+    runPage.addStepToFlow("merge-xml-person");
+    runPage.verifyStepInFlow("Merge", "merge-xml-person");
+    runPage.addStep(flowName);
+    runPage.addStepToFlow("master-person");
+    runPage.verifyStepInFlow("Master", "master-person");
+    runPage.addStep(flowName);
+
+    // Reorder steps
+    runPage.moveStepRight("mapPersonXML");
+    runPage.moveStepRight("mapPersonXML");
+    runPage.moveStepLeft("mapPersonXML");
+    runPage.moveStepRight("match-xml-person");
+    runPage.moveStepRight("loadPersonXML");
+    runPage.moveStepLeft("loadPersonXML");
+    runPage.moveStepLeft("master-person");
+    runPage.moveStepLeft("merge-xml-person");
+
+    //Run map,match and merge step for Person entity using xml documents
+    runPage.runStep("mapPersonXML");
+    cy.verifyStepRunResult("success", "Mapping", "mapPersonXML");
+    tiles.closeRunMessage();
+    cy.waitForAsyncRequest();
+    runPage.runStep("match-xml-person");
+    cy.verifyStepRunResult("success", "Matching", "match-xml-person");
+    tiles.closeRunMessage();
+    cy.waitForAsyncRequest();
+    runPage.runStep("merge-xml-person");
+    cy.verifyStepRunResult("success", "Merging", "merge-xml-person");
+
+    //Navigate to explorer tile using the explorer link
+    runPage.explorerLink().click();
+    browsePage.waitForSpinnerToDisappear();
+    cy.waitForAsyncRequest();
+    browsePage.waitForTableToLoad();
+
+    //Verify detail page renders with expected content
+    browsePage.getSelectedEntity().should("contain", "Person");
+    browsePage.getTotalDocuments().should("eq", 1);
+    browsePage.getSelectedFacet("sm-Person-merged").should("exist");
+    browsePage.getSourceViewIcon().first().click();
+    cy.waitForAsyncRequest();
+    browsePage.waitForSpinnerToDisappear();
+
+    cy.contains("URI: /com.marklogic.smart-mastering/merged/").should("be.visible");
+    cy.contains("123 Wilson St").scrollIntoView().should("be.visible");
+    cy.contains("123 Wilson Rd").should("be.visible");
+  });
+
+});

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/run.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/run.tsx
@@ -88,6 +88,17 @@ class RunPage {
   expandFlow(flowName: string) {
     return cy.get(`#${flowName}`).click();
   }
+
+  moveStepRight(stepName: string) {
+    cy.waitUntil(() => cy.findAllByLabelText(`rightArrow-${stepName}`)).last().click({force: true});
+    cy.waitForAsyncRequest();
+  }
+
+  moveStepLeft(stepName: string) {
+    cy.waitUntil(() => cy.findAllByLabelText(`leftArrow-${stepName}`)).last().click({force: true});
+    cy.waitForAsyncRequest();
+  }
+
 }
 
 const runPage = new RunPage();

--- a/marklogic-data-hub-central/ui/src/components/flows/flows.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/flows/flows.module.scss
@@ -1,3 +1,4 @@
+
 .flowsContainer {
     min-width: 800px;
 
@@ -54,6 +55,7 @@
         width: 100%;
         display: flex;
         justify-content: flex-start;
+
         .actions {
             .run {
                 position: relative;
@@ -102,26 +104,82 @@
                 opacity: 0.5;
                 cursor: not-allowed;
             }
+
         }
+        
+        .reorder {
+            align-items: center; 
+            display: flex;
+            flex: 1;
+            flex-direction: row;
+
+            .reorderRight {
+                display: flex;
+                flex: 1;
+                flex-direction: row;
+                justify-content: flex-end;
+                font-size: 20px;
+            }
+            
+            .reorderLeft {
+                display: flex;
+                flex: 1;
+                flex-direction: row;
+                justify-content: flex-start;
+                font-size: 20px;
+            }
+            
+            .reorderFlowRight {
+                display: inline-block;
+                color: #777777;
+                font-size: 21px;
+                cursor: pointer;
+                margin-right: 12px;
+            }
+        
+            .reorderFlowLeft {
+                display: inline-block;
+                color: #777777;
+                font-size: 21px;
+                cursor: pointer;
+                margin-left: 12px;
+            }
+
+            .reorderFlowLeft:hover {
+                display: inline-block;
+                color: #7FADE3;
+                font-size: 21px;
+                cursor: pointer;
+            }
+
+            .reorderFlowRight:hover {
+                display: inline-block;
+                color: #7FADE3;
+                font-size: 21px;
+                cursor: pointer;
+            }
+        }   
+
         .successfulRun {
             display: inline-block;
             color: #008000;
             font-size: 20px;
             cursor: pointer;
         }
+
         .unSuccessfulRun {
             display: inline-block;
             color: #DB4f59;
             font-size: 20px;
             cursor: pointer;
         }
+        
         .stepResponse {
-            padding-top: 1px;
-            padding-bottom: 1px;
             padding-right: 15px;
             padding-left: 1px;
             float: right;
         }
+
         .cardContent {
             border: solid 1px #ddd;
             padding: 10px;
@@ -188,6 +246,7 @@
 .cardStyle {
     width: 300px;
     margin-right: 20px;
+    
     ul {
         border-top: 0px;
         background: #ffffff;
@@ -199,5 +258,7 @@
         height: 33.3px;
     }
 }
+
+    
 
 

--- a/marklogic-data-hub-central/ui/src/components/flows/flows.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/flows/flows.test.tsx
@@ -29,6 +29,7 @@ describe("Flows component", () => {
     flowsDefaultActiveKey: [],
     showStepRunResponse: () => null,
     runEnded: {},
+    onReorderFlow: () => null,
   };
   const flowName = data.flows.data[0].name;
   const flowStepName = data.flows.data[0].steps[1].stepName;
@@ -233,4 +234,51 @@ describe("Flows component", () => {
 
   });
 
+
+  it("user with write privileges can reorder a flow", () => {
+    const {getByText, getByLabelText, queryByLabelText} = render(
+      <Router history={history}><Flows
+        {...flowsProps}
+        canReadFlow={true}
+        canWriteFlow={true}
+        hasOperatorRole={true}
+      /></Router>
+    );
+
+    let flowButton = getByLabelText("icon: right");
+    fireEvent.click(flowButton);
+    expect(getByText(flowStepName)).toBeInTheDocument();
+
+    // Middle step(s) have both left and right arrows
+    expect(getByLabelText("rightArrow-"+flowStepName)).toBeInTheDocument();
+    expect(getByLabelText("leftArrow-"+flowStepName)).toBeInTheDocument();
+
+    // First step only has right arrow, and no left arrow
+    const firstFlowStep = data.flows.data[0].steps[0].stepName;
+    expect(getByLabelText("rightArrow-"+firstFlowStep)).toBeInTheDocument();
+    expect(queryByLabelText("leftArrow-"+firstFlowStep)).not.toBeInTheDocument();
+
+    // Last step only has left arrow, and no right arrow
+    const lastFlowStep = data.flows.data[0].steps[data.flows.data[0].steps.length-1].stepName;
+    expect(getByLabelText("leftArrow-"+lastFlowStep)).toBeInTheDocument();
+    expect(queryByLabelText("rightArrow-"+lastFlowStep)).not.toBeInTheDocument();
+
+  });
+
+  it("user without write privileges can't reorder a flow", () => {
+    const {getByText, getByLabelText, queryByLabelText} = render(
+      <Router history={history}><Flows
+        {...flowsProps}
+        canReadFlow={true}
+        canWriteFlow={false}
+        hasOperatorRole={true}
+      /></Router>
+    );
+
+    let flowButton = getByLabelText("icon: right");
+    fireEvent.click(flowButton);
+    expect(getByText(flowStepName)).toBeInTheDocument();
+    expect(queryByLabelText("rightArrow-"+flowStepName)).not.toBeInTheDocument();
+    expect(queryByLabelText("leftArrow-"+flowStepName)).not.toBeInTheDocument();
+  });
 });

--- a/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
+++ b/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
@@ -2,11 +2,12 @@ import React, {useState, CSSProperties, useEffect, useContext, createRef} from "
 import {Collapse, Icon, Card, Modal, Menu, Dropdown} from "antd";
 import {DownOutlined} from "@ant-design/icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faTrashAlt} from "@fortawesome/free-regular-svg-icons";
+import {faTrashAlt, faArrowAltCircleRight, faArrowAltCircleLeft} from "@fortawesome/free-regular-svg-icons";
 import {MLButton} from "@marklogic/design-system";
 import NewFlowDialog from "./new-flow-dialog/new-flow-dialog";
 import sourceFormatOptions from "../../config/formats.config";
 import {RunToolTips, SecurityTooltips} from "../../config/tooltips.config";
+import "./flows.scss";
 import styles from "./flows.module.scss";
 import {MLTooltip, MLSpin} from "@marklogic/design-system";
 import {useDropzone} from "react-dropzone";
@@ -14,28 +15,34 @@ import {AuthoritiesContext} from "../../util/authorities";
 import {Link, useLocation} from "react-router-dom";
 import axios from "axios";
 import {UserContext} from "../../util/user-context";
-import "./flows.scss";
+
+
+enum ReorderFlowOrderDirection {
+  LEFT = "left",
+  RIGHT = "right"
+}
 
 const {Panel} = Collapse;
 
 interface Props {
-    flows: any;
-    steps: any;
-    deleteFlow: any;
-    createFlow: any;
-    updateFlow: any;
-    deleteStep: any;
-    runStep: any;
-    canReadFlow: boolean;
-    canWriteFlow: boolean;
-    hasOperatorRole: boolean;
-    running: any;
-    uploadError:string;
-    newStepToFlowOptions: any;
-    addStepToFlow: any;
-    flowsDefaultActiveKey: any;
-    showStepRunResponse: any;
-    runEnded:any;
+  flows: any;
+  steps: any;
+  deleteFlow: any;
+  createFlow: any;
+  updateFlow: any;
+  deleteStep: any;
+  runStep: any;
+  canReadFlow: boolean;
+  canWriteFlow: boolean;
+  hasOperatorRole: boolean;
+  running: any;
+  uploadError: string;
+  newStepToFlowOptions: any;
+  addStepToFlow: any;
+  flowsDefaultActiveKey: any;
+  showStepRunResponse: any;
+  runEnded: any;
+  onReorderFlow: (flowIndex: number, newSteps: Array<any>) => void
 }
 
 const StepDefinitionTypeTitles = {
@@ -81,7 +88,7 @@ const Flows: React.FC<Props> = (props) => {
   const location = useLocation();
 
   // maintain a list of panel refs
-  const flowPanels : any = props.flows.reduce((p, n) => ({...p, ...{[n.name]: createRef()}}), {});
+  const flowPanels: any = props.flows.reduce((p, n) => ({...p, ...{[n.name]: createRef()}}), {});
 
   // If a step was just added scroll the flow step panel fully to the right
   useEffect(() => {
@@ -132,7 +139,7 @@ const Flows: React.FC<Props> = (props) => {
             setStartRun(false);
           }
         }
-      //run step that is already inside a flow
+        //run step that is already inside a flow
       } else if (props.newStepToFlowOptions && !props.newStepToFlowOptions.addingStepToFlow && props.newStepToFlowOptions.startRunStep && props.newStepToFlowOptions.flowsDefaultKey && props.newStepToFlowOptions.flowsDefaultKey !== -1) {
         let runStepNum = stepsInFlow.findIndex(s => s.stepName === props.newStepToFlowOptions?.newStepName);
         if (startRun) {
@@ -178,11 +185,13 @@ const Flows: React.FC<Props> = (props) => {
     }
   }, [props.runEnded]);
 
+
   useEffect(() => {
     if (props.newStepToFlowOptions && props.newStepToFlowOptions.startRunStep) {
       setStartRun(true);
     }
   }, [props.newStepToFlowOptions]);
+
 
   // For role-based privileges
   const authorityService = useContext(AuthoritiesContext);
@@ -367,58 +376,58 @@ const Flows: React.FC<Props> = (props) => {
     return (
       <Menu>
         <Menu.ItemGroup title="Load">
-          { props.steps && props.steps["ingestionSteps"] && props.steps["ingestionSteps"].length > 0 ? props.steps["ingestionSteps"].map((elem, index) => (
+          {props.steps && props.steps["ingestionSteps"] && props.steps["ingestionSteps"].length > 0 ? props.steps["ingestionSteps"].map((elem, index) => (
             <Menu.Item key={index} aria-label={`${elem.name}-to-flow`}>
               <div
                 onClick={() => { handleStepAdd(elem.name, flowName, "ingestion"); }}
               >{elem.name}</div>
             </Menu.Item>
-          )) : null }
+          )) : null}
         </Menu.ItemGroup>
         <Menu.ItemGroup title="Map">
-          { props.steps && props.steps["mappingSteps"] && props.steps["mappingSteps"].length > 0 ? props.steps["mappingSteps"].map((elem, index) => (
+          {props.steps && props.steps["mappingSteps"] && props.steps["mappingSteps"].length > 0 ? props.steps["mappingSteps"].map((elem, index) => (
             <Menu.Item key={index} aria-label={`${elem.name}-to-flow`}>
               <div
                 onClick={() => { handleStepAdd(elem.name, flowName, "mapping"); }}
               >{elem.name}</div>
             </Menu.Item>
-          )) : null }
+          )) : null}
         </Menu.ItemGroup>
         <Menu.ItemGroup title="Match">
-          { props.steps && props.steps["matchingSteps"] && props.steps["matchingSteps"].length > 0 ? props.steps["matchingSteps"].map((elem, index) => (
+          {props.steps && props.steps["matchingSteps"] && props.steps["matchingSteps"].length > 0 ? props.steps["matchingSteps"].map((elem, index) => (
             <Menu.Item key={index} aria-label={`${elem.name}-to-flow`}>
               <div
                 onClick={() => { handleStepAdd(elem.name, flowName, "matching"); }}
               >{elem.name}</div>
             </Menu.Item>
-          )) : null }
+          )) : null}
         </Menu.ItemGroup>
         <Menu.ItemGroup title="Merge">
-          { props.steps && props.steps["mergingSteps"] && props.steps["mergingSteps"].length > 0 ? props.steps["mergingSteps"].map((elem, index) => (
+          {props.steps && props.steps["mergingSteps"] && props.steps["mergingSteps"].length > 0 ? props.steps["mergingSteps"].map((elem, index) => (
             <Menu.Item key={index} aria-label={`${elem.name}-to-flow`}>
               <div
                 onClick={() => { handleStepAdd(elem.name, flowName, "merging"); }}
               >{elem.name}</div>
             </Menu.Item>
-          )) : null }
+          )) : null}
         </Menu.ItemGroup>
         <Menu.ItemGroup title="Master">
-          { props.steps && props.steps["masteringSteps"] && props.steps["masteringSteps"].length > 0 ? props.steps["masteringSteps"].map((elem, index) => (
+          {props.steps && props.steps["masteringSteps"] && props.steps["masteringSteps"].length > 0 ? props.steps["masteringSteps"].map((elem, index) => (
             <Menu.Item key={index} aria-label={`${elem.name}-to-flow`}>
               <div
                 onClick={() => { handleStepAdd(elem.name, flowName, "mastering"); }}
               >{elem.name}</div>
             </Menu.Item>
-          )) : null }
+          )) : null}
         </Menu.ItemGroup>
         <Menu.ItemGroup title="Custom">
-          { props.steps && props.steps["customSteps"] && props.steps["customSteps"].length > 0 ? props.steps["customSteps"].map((elem, index) => (
+          {props.steps && props.steps["customSteps"] && props.steps["customSteps"].length > 0 ? props.steps["customSteps"].map((elem, index) => (
             <Menu.Item key={index} aria-label={`${elem.name}-to-flow`}>
               <div
                 onClick={() => { handleStepAdd(elem.name, flowName, "custom"); }}
               >{elem.name}</div>
             </Menu.Item>
-          )) : null }
+          )) : null}
         </Menu.ItemGroup>
       </Menu>
     );
@@ -452,7 +461,7 @@ const Flows: React.FC<Props> = (props) => {
               <MLButton
                 className={styles.addStep}
                 size="default"
-                aria-label={"addStepDisabled-"+i}
+                aria-label={"addStepDisabled-" + i}
                 style={{backgroundColor: "#f5f5f5", borderColor: "#f5f5f5", pointerEvents: "none"}}
                 type="primary"
                 disabled={!props.canWriteFlow}
@@ -470,7 +479,7 @@ const Flows: React.FC<Props> = (props) => {
                 onClick={() => { handleFlowDelete(name); }}
                 data-testid={`deleteFlow-${name}`}
                 className={styles.deleteIcon}
-                size="lg"/>
+                size="lg" />
             </i>
           </MLTooltip>
           :
@@ -480,9 +489,9 @@ const Flows: React.FC<Props> = (props) => {
                 icon={faTrashAlt}
                 data-testid={`deleteFlow-${name}`}
                 className={styles.disabledDeleteIcon}
-                size="lg"/>
+                size="lg" />
             </i>
-          </MLTooltip> }
+          </MLTooltip>}
       </span>
     </div>
   );
@@ -549,31 +558,86 @@ const Flows: React.FC<Props> = (props) => {
       stepEndTime = new Date(step.stepEndTime).toLocaleString();
     }
     if (!step.lastRunStatus) {
-      return ;
+      return;
     } else if (step.lastRunStatus === "completed step " + step.stepNumber) {
-      tooltipText = "Step last ran successfully on "+ stepEndTime;
+      tooltipText = "Step last ran successfully on " + stepEndTime;
       return (
-        <MLTooltip overlayStyle={{maxWidth: "200px"}} title= {tooltipText} placement="bottom" onClick={(e) => showStepRunResponse(step)}>
+        <MLTooltip overlayStyle={{maxWidth: "200px"}} title={tooltipText} placement="bottom" getPopupContainer={() => document.getElementById("flowSettings") || document.body}
+          onClick={(e) => showStepRunResponse(step)}>
           <Icon type="check-circle" theme="filled" className={styles.successfulRun} />
         </MLTooltip>
       );
 
     } else if (step.lastRunStatus === "completed with errors step " + step.stepNumber) {
-      tooltipText = "Step last ran with errors on "+ stepEndTime;
+      tooltipText = "Step last ran with errors on " + stepEndTime;
       return (
-        <MLTooltip overlayStyle={{maxWidth: "190px"}} title={tooltipText} placement="bottom"  onClick={(e) => showStepRunResponse(step)}>
+        <MLTooltip overlayStyle={{maxWidth: "190px"}} title={tooltipText} placement="bottom" getPopupContainer={() => document.getElementById("flowSettings") || document.body}
+          onClick={(e) => showStepRunResponse(step)}>
           <Icon type="exclamation-circle" theme="filled" className={styles.unSuccessfulRun} />
         </MLTooltip>
       );
     } else {
-      tooltipText = "Step last failed on "+ stepEndTime;
+      tooltipText = "Step last failed on " + stepEndTime;
       return (
-        <MLTooltip overlayStyle={{maxWidth: "175px"}} title={tooltipText} placement="bottom"  onClick={(e) => showStepRunResponse(step)}>
+        <MLTooltip overlayStyle={{maxWidth: "175px"}} title={tooltipText} placement="bottom" getPopupContainer={() => document.getElementById("flowSettings") || document.body}
+          onClick={(e) => showStepRunResponse(step)}>
           <Icon type="exclamation-circle" theme="filled" className={styles.unSuccessfulRun} />
         </MLTooltip>
       );
     }
   };
+
+  const updateFlow = async (flowName, flowDesc, steps) => {
+    let updatedFlow;
+    try {
+      updatedFlow = {
+        name: flowName,
+        steps: steps,
+        description: flowDesc
+      };
+      await axios.put(`/api/flows/` + flowName, updatedFlow);
+
+    } catch (error) {
+      console.error("Error updating flow", error);
+    }
+  };
+
+
+  const reorderFlow = (id, flowName, direction: ReorderFlowOrderDirection) => {
+    let flowNum = props.flows.findIndex((flow) => flow.name === flowName);
+    let flowDesc = props.flows[flowNum]["description"];
+    const stepList = props.flows[flowNum]["steps"];
+    let newSteps = stepList;
+
+    if (direction === ReorderFlowOrderDirection.RIGHT) {
+      if (id <= stepList.length - 2) {
+        newSteps = [...stepList];
+        const oldLeftStep = newSteps[id];
+        const oldRightStep = newSteps[id + 1];
+        newSteps[id] = oldRightStep;
+        newSteps[id + 1] = oldLeftStep;
+      }
+    } else {
+      if (id >= 1) {
+        newSteps = [...stepList];
+        const oldLeftStep = newSteps[id - 1];
+        const oldRightStep = newSteps[id];
+        newSteps[id - 1] = oldRightStep;
+        newSteps[id] = oldLeftStep;
+      }
+    }
+
+    let steps : string[] = [];
+    for (let i = 0; i < newSteps.length; i++) {
+      newSteps[i].stepNumber = String(i+1);
+      steps.push(newSteps[i].stepId);
+    }
+
+    const reorderedList = [...newSteps];
+    props.onReorderFlow(flowNum, reorderedList);
+    updateFlow(flowName, flowDesc, steps);
+  };
+
 
   const getFlowWithJobInfo = async (flowNum) => {
     let currentFlow = props.flows[flowNum];
@@ -600,27 +664,56 @@ const Flows: React.FC<Props> = (props) => {
         let sourceFormat = step.sourceFormat;
         let stepNumber = step.stepNumber;
         let viewStepId = `${flowName}-${stepNumber}`;
-        let stepDefinitionType = step.stepDefinitionType ? step.stepDefinitionType.toLowerCase():"";
+        let stepDefinitionType = step.stepDefinitionType ? step.stepDefinitionType.toLowerCase() : "";
         let stepDefinitionTypeTitle = StepDefinitionTypeTitles[stepDefinitionType];
         return (
-          <div key={viewStepId}>
+          <div key={viewStepId} id="flowSettings">
             <Card
               className={styles.cardStyle}
               title={StepDefToTitle(step.stepDefinitionType)}
               size="small"
               actions={[
-                <span className={styles.stepResponse}>{
-                  latestJobData && latestJobData[flowName] && latestJobData[flowName][index]
-                    ? lastRunResponse(latestJobData[flowName][index])
-                    : ""
-                }</span>
+                <div className={styles.reorder}>
+                  {index !== 0 && props.canWriteFlow &&
+                    <div className={styles.reorderLeft}>
+                      <MLTooltip title={"Move left"} placement="bottom" getPopupContainer={() => document.getElementById("flowSettings") || document.body}>
+                        <FontAwesomeIcon
+                          aria-label={`leftArrow-${step.stepName}`}
+                          icon={faArrowAltCircleLeft}
+                          aria-required="true"
+                          className={styles.reorderFlowLeft}
+                          role="button"
+                          onClick={() => reorderFlow(index, flowName, ReorderFlowOrderDirection.LEFT)} />
+                      </MLTooltip>
+                    </div>
+                  }
+                  <div className={styles.reorderRight}>
+                    <div className={styles.stepResponse}>
+                      {latestJobData && latestJobData[flowName] && latestJobData[flowName][index]
+                        ? lastRunResponse(latestJobData[flowName][index])
+                        : ""
+                      }
+                    </div>
+                    {index < flow.steps.length - 1 && props.canWriteFlow &&
+                      <MLTooltip title={"Move right"} placement="bottom" getPopupContainer={() => document.getElementById("flowSettings") || document.body}>
+                        <FontAwesomeIcon
+                          aria-label={`rightArrow-${step.stepName}`}
+                          icon={faArrowAltCircleRight}
+                          aria-required="true"
+                          className={styles.reorderFlowRight}
+                          role="button"
+                          onClick={() => reorderFlow(index, flowName, ReorderFlowOrderDirection.RIGHT)} />
+                      </MLTooltip>
+                    }
+                  </div>
+                </div>
               ]}
               extra={
                 <div className={styles.actions}>
                   {props.hasOperatorRole ?
                     step.stepDefinitionType.toLowerCase() === "ingestion" ?
                       <div {...getRootProps()} style={{display: "inline-block"}}>
-                        <input {...getInputProps()} id="fileUpload"/>
+                        <input {...getInputProps()} id="fileUpload" />
                         <div
                           className={styles.run}
                           aria-label={`runStep-${step.stepName}`}
@@ -672,20 +765,20 @@ const Flows: React.FC<Props> = (props) => {
                 </div>
               }
             >
-              <div  aria-label={viewStepId + "-content"} className={styles.cardContent}
+              <div aria-label={viewStepId + "-content"} className={styles.cardContent}
                 onMouseOver={(e) => handleMouseOver(e, viewStepId)}
                 onMouseLeave={(e) => setShowLinks("")} >
-                { sourceFormat ?
+                {sourceFormat ?
                   <div className={styles.format} style={sourceFormatStyle(sourceFormat)} >{sourceFormatOptions[sourceFormat].label}</div>
-                  : null }
+                  : null}
                 <div className={styles.name}>{step.stepName}</div>
                 <div className={styles.cardLinks}
-                  style={{display: showLinks === viewStepId && step.stepId && authorityByStepType[stepDefinitionType]  ? "block" : "none"}}
+                  style={{display: showLinks === viewStepId && step.stepId && authorityByStepType[stepDefinitionType] ? "block" : "none"}}
                   aria-label={viewStepId + "-cardlink"}
                 >
-                  <Link id={"tiles-step-view-"+viewStepId}
+                  <Link id={"tiles-step-view-" + viewStepId}
                     to={{
-                      pathname: `/tiles/${stepDefinitionType === "ingestion" ? "load": "curate"}`,
+                      pathname: `/tiles/${stepDefinitionType === "ingestion" ? "load" : "curate"}`,
                       state: {
                         stepToView: step.stepId,
                         stepDefinitionType: stepDefinitionType,
@@ -697,11 +790,11 @@ const Flows: React.FC<Props> = (props) => {
                   </Link>
                 </div>
               </div>
-              <div className = {styles.uploadError}>
-                { showUploadError && flowName === runningFlow && stepNumber === runningStep.stepNumber ? props.uploadError : ""}
+              <div className={styles.uploadError}>
+                {showUploadError && flowName === runningFlow && stepNumber === runningStep.stepNumber ? props.uploadError : ""}
               </div>
-              <div className={styles.running} style={{display: isRunning(flowName, stepNumber)  ? "block" : "none"}}>
-                <div><MLSpin data-testid="spinner"/></div>
+              <div className={styles.running} style={{display: isRunning(flowName, stepNumber) ? "block" : "none"}}>
+                <div><MLSpin data-testid="spinner" /></div>
                 <div className={styles.runningLabel}>Running...</div>
               </div>
             </Card>

--- a/marklogic-data-hub-central/ui/src/pages/Run.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Run.tsx
@@ -138,7 +138,8 @@ const Run = (props) => {
       setIsLoading(true);
       let updatedFlow = {
         name: payload.name,
-        description: payload.description,
+        steps: payload.steps,
+        description: payload.description
       };
       let response = await axios.put(`/api/flows/` + flowId, updatedFlow);
       if (response.status === 200) {
@@ -188,6 +189,14 @@ const Run = (props) => {
       setIsLoading(false);
     }
   };
+
+  const onReorderFlow = (flowIndex: number, newSteps: Array<any>) => {
+    const newFlow = {...flows[flowIndex], steps: newSteps};
+    const newFlows = [...flows];
+    newFlows[flowIndex] = newFlow;
+    setFlows(newFlows);
+  };
+
 
   // function formatStepType(stepType){
   //     stepType = stepType.toLowerCase();
@@ -465,6 +474,7 @@ const Run = (props) => {
                 flowsDefaultActiveKey={flowsDefaultActiveKey}
                 showStepRunResponse={showStepRunResponse}
                 runEnded={runEnded}
+                onReorderFlow={onReorderFlow}
               />
             ]
             :

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/FlowService.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/dataservices/FlowService.java
@@ -47,13 +47,13 @@ public interface FlowService {
             private DatabaseClient dbClient;
             private BaseProxy baseProxy;
 
+            private BaseProxy.DBFunctionRequest req_updateFlow;
             private BaseProxy.DBFunctionRequest req_getFlow;
             private BaseProxy.DBFunctionRequest req_deleteFlow;
             private BaseProxy.DBFunctionRequest req_addStepToFlow;
             private BaseProxy.DBFunctionRequest req_getFlowsWithStepDetails;
             private BaseProxy.DBFunctionRequest req_getFlowWithLatestJobInfo;
             private BaseProxy.DBFunctionRequest req_removeStepFromFlow;
-            private BaseProxy.DBFunctionRequest req_updateFlowInfo;
             private BaseProxy.DBFunctionRequest req_createFlow;
             private BaseProxy.DBFunctionRequest req_getFullFlow;
 
@@ -61,6 +61,8 @@ public interface FlowService {
                 this.dbClient  = dbClient;
                 this.baseProxy = new BaseProxy("/data-hub/5/data-services/flow/", servDecl);
 
+                this.req_updateFlow = this.baseProxy.request(
+                    "updateFlow.sjs", BaseProxy.ParameterValuesKind.SINGLE_NODE);
                 this.req_getFlow = this.baseProxy.request(
                     "getFlow.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC);
                 this.req_deleteFlow = this.baseProxy.request(
@@ -73,12 +75,25 @@ public interface FlowService {
                     "getFlowWithLatestJobInfo.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC);
                 this.req_removeStepFromFlow = this.baseProxy.request(
                     "removeStepFromFlow.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_ATOMICS);
-                this.req_updateFlowInfo = this.baseProxy.request(
-                    "updateFlowInfo.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_ATOMICS);
                 this.req_createFlow = this.baseProxy.request(
                     "createFlow.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_ATOMICS);
                 this.req_getFullFlow = this.baseProxy.request(
                     "getFullFlow.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC);
+            }
+
+            @Override
+            public com.fasterxml.jackson.databind.JsonNode updateFlow(com.fasterxml.jackson.databind.JsonNode updatedFlow) {
+                return updateFlow(
+                    this.req_updateFlow.on(this.dbClient), updatedFlow
+                    );
+            }
+            private com.fasterxml.jackson.databind.JsonNode updateFlow(BaseProxy.DBFunctionRequest request, com.fasterxml.jackson.databind.JsonNode updatedFlow) {
+              return BaseProxy.JsonDocumentType.toJsonNode(
+                request
+                      .withParams(
+                          BaseProxy.documentParam("updatedFlow", false, BaseProxy.JsonDocumentType.fromJsonNode(updatedFlow))
+                          ).responseSingle(false, Format.JSON)
+                );
             }
 
             @Override
@@ -170,22 +185,6 @@ public interface FlowService {
             }
 
             @Override
-            public com.fasterxml.jackson.databind.JsonNode updateFlowInfo(String name, String description) {
-                return updateFlowInfo(
-                    this.req_updateFlowInfo.on(this.dbClient), name, description
-                    );
-            }
-            private com.fasterxml.jackson.databind.JsonNode updateFlowInfo(BaseProxy.DBFunctionRequest request, String name, String description) {
-              return BaseProxy.JsonDocumentType.toJsonNode(
-                request
-                      .withParams(
-                          BaseProxy.atomicParam("name", false, BaseProxy.StringType.fromString(name)),
-                          BaseProxy.atomicParam("description", false, BaseProxy.StringType.fromString(description))
-                          ).responseSingle(false, Format.JSON)
-                );
-            }
-
-            @Override
             public com.fasterxml.jackson.databind.JsonNode createFlow(String name, String description) {
                 return createFlow(
                     this.req_createFlow.on(this.dbClient), name, description
@@ -221,6 +220,14 @@ public interface FlowService {
     }
 
   /**
+   * Invokes the updateFlow operation on the database server
+   *
+   * @param updatedFlow	provides input
+   * @return	Return the updated flow document
+   */
+    com.fasterxml.jackson.databind.JsonNode updateFlow(com.fasterxml.jackson.databind.JsonNode updatedFlow);
+
+  /**
    * Invokes the getFlow operation on the database server
    *
    * @param name	provides input
@@ -232,7 +239,7 @@ public interface FlowService {
    * Invokes the deleteFlow operation on the database server
    *
    * @param name	provides input
-   * 
+   *
    */
     void deleteFlow(String name);
 
@@ -249,7 +256,7 @@ public interface FlowService {
   /**
    * Invokes the getFlowsWithStepDetails operation on the database server
    *
-   * 
+   *
    * @return	Return an array of flow documents, where each step has a few identifying data points and abstracts whether it's inline or referenced
    */
     com.fasterxml.jackson.databind.JsonNode getFlowsWithStepDetails();
@@ -270,15 +277,6 @@ public interface FlowService {
    * @return	Return the updated flow document
    */
     com.fasterxml.jackson.databind.JsonNode removeStepFromFlow(String flowName, String stepNumber);
-
-  /**
-   * Invokes the updateFlowInfo operation on the database server
-   *
-   * @param name	provides input
-   * @param description	provides input
-   * @return	Return the updated flow document
-   */
-    com.fasterxml.jackson.databind.JsonNode updateFlowInfo(String name, String description);
 
   /**
    * Invokes the createFlow operation on the database server

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/flow/updateFlow.api
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/flow/updateFlow.api
@@ -1,13 +1,10 @@
 {
-    "functionName": "updateFlowInfo",
+    "functionName": "updateFlow",
     "params": [
         {
-            "name": "name",
-            "datatype": "string"
-        },
-        {
-            "name": "description",
-            "datatype": "string"
+            "name": "updatedFlow",
+            "datatype": "jsonDocument",
+            "$javaClass": "com.fasterxml.jackson.databind.JsonNode"
         }
     ],
     "return": {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/flow/updateFlow.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/flow/updateFlow.sjs
@@ -19,14 +19,30 @@ xdmp.securityAssert("http://marklogic.com/data-hub/privileges/write-flow", "exec
 
 const Artifacts = require('/data-hub/5/artifacts/core.sjs');
 
-var name;
-var description;
+var updatedFlow;
+let newSteps = {};
 
-const flow = Artifacts.getArtifact("flow", name);
-if (!description && flow.description) {
-  delete flow.description;
-} else {
-  flow.description = description;
+updatedFlow = fn.head(xdmp.fromJSON(updatedFlow));
+let name = updatedFlow.name;
+let description = updatedFlow.description;
+let steps = updatedFlow.steps;
+
+const oldFlow = Artifacts.getArtifact("flow", name);
+
+if (!description && oldFlow.description) {
+  delete updatedFlow.description;
 }
 
-Artifacts.setArtifact("flow", name, flow);
+if (steps) {
+  steps = Array.from(steps);
+  steps.forEach(function (stepId, i) {
+    newSteps[(i+1)] = {"stepId": stepId}
+  });
+  updatedFlow.steps = newSteps;
+} else if (!steps && oldFlow.steps) {
+  updatedFlow.steps = oldFlow.steps;
+} else {
+  updatedFlow.steps = {};
+}
+
+Artifacts.setArtifact("flow", name, updatedFlow);

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/flow/manageFlow.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/flow/manageFlow.sjs
@@ -26,12 +26,6 @@ try {
   test.assertTrue(fn.contains(e.data[1], 'already exists'), "Exception should thrown due to already existing flow.");
 }
 
-// Update the description and verify
-serviceResponse = flowService.updateFlowInfo(flowName, "modified");
-expectedFlow.description = "modified";
-hubJsTest.verifyJson(expectedFlow, serviceResponse, assertions);
-hubJsTest.verifyJson(expectedFlow, flowService.getFlow(flowName), assertions);
-
 // Create 3 mapping steps and add them to the flow
 ["firstMapper", "secondMapper", "thirdMapper"].forEach(mappingName => {
   let info = {

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/flow/updateFlow.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/flow/updateFlow.sjs
@@ -1,0 +1,87 @@
+const flowService = require("../lib/flowService.sjs");
+const hubTest = require("/test/data-hub-test-helper.xqy");
+const hubJsTest = require("/test/data-hub-test-helper.sjs");
+const stepService = require("../lib/stepService.sjs");
+const test = require("/test/test-helper.xqy");
+
+const assertions = [];
+const newFlowName = "newTestFlow";
+const unchangedFlowName = "newUnchangedFlow"
+const stepList = {};
+
+let newFlow = {
+  "name": newFlowName,
+  "description": "description",
+  "steps": {}
+}
+
+let unchangedFlow = {
+  "name": unchangedFlowName,
+  "description": "description",
+  "steps": {}
+}
+
+// Create a flow and add steps
+let flowTest = flowService.createFlow(newFlowName, "description");
+let unchangedFlowTest = flowService.createFlow(unchangedFlowName, "description");
+flowTest.steps = ["firstMapper-mapping", "secondMapper-mapping", "thirdMapper-mapping"];
+flowTest = flowService.updateFlow(flowTest);
+unchangedFlowTest.steps = ["firstMapper-mapping", "secondMapper-mapping", "thirdMapper-mapping"];
+unchangedFlowTest = flowService.updateFlow(unchangedFlowTest);
+
+// Get flows and verify they have 3 steps
+flowTest = flowService.getFlow(newFlowName);
+unchangedFlowTest = flowService.getFlow(unchangedFlowName);
+
+assertions.push(
+  test.assertEqual(3, Object.keys(flowTest.steps).length),
+  test.assertEqual("firstMapper-mapping", flowTest.steps["1"].stepId),
+  test.assertEqual("secondMapper-mapping", flowTest.steps["2"].stepId),
+  test.assertEqual("thirdMapper-mapping", flowTest.steps["3"].stepId)
+);
+
+assertions.push(
+  test.assertEqual(3, Object.keys(unchangedFlowTest.steps).length),
+  test.assertEqual("firstMapper-mapping", unchangedFlowTest.steps["1"].stepId),
+  test.assertEqual("secondMapper-mapping", unchangedFlowTest.steps["2"].stepId),
+  test.assertEqual("thirdMapper-mapping", unchangedFlowTest.steps["3"].stepId)
+);
+
+// Update the description and verify
+flowTest.description = "modified";
+flowTest.steps = ["firstMapper-mapping", "secondMapper-mapping", "thirdMapper-mapping"];
+flowTest = flowService.updateFlow(flowTest);
+
+flowTest = flowService.getFlow(newFlowName);
+assertions.push(
+  test.assertEqual(flowTest.description, "modified"),
+  test.assertEqual(flowTest.steps["1"].stepId, unchangedFlowTest.steps["1"].stepId),
+  test.assertEqual(flowTest.steps["2"].stepId, unchangedFlowTest.steps["2"].stepId),
+  test.assertEqual(flowTest.steps["3"].stepId, unchangedFlowTest.steps["3"].stepId),
+);
+
+// Reorder steps and verify
+flowTest.steps = ["secondMapper-mapping", "firstMapper-mapping", "thirdMapper-mapping"];
+let newFlowTest = flowService.updateFlow(flowTest);
+
+newFlowTest = flowService.getFlow(newFlowName);
+assertions.push(
+  test.assertEqual(3, Object.keys(newFlowTest.steps).length),
+  test.assertEqual("secondMapper-mapping", newFlowTest.steps["1"].stepId),
+  test.assertEqual("firstMapper-mapping", newFlowTest.steps["2"].stepId),
+  test.assertEqual("thirdMapper-mapping", newFlowTest.steps["3"].stepId)
+);
+
+// Reorder steps again and verify
+flowTest.steps = ["secondMapper-mapping", "thirdMapper-mapping", "firstMapper-mapping"];
+newFlowTest = flowService.updateFlow(flowTest);
+
+newFlowTest = flowService.getFlow(newFlowName);
+assertions.push(
+  test.assertEqual(3, Object.keys(newFlowTest.steps).length),
+  test.assertEqual("secondMapper-mapping", newFlowTest.steps["1"].stepId),
+  test.assertEqual("thirdMapper-mapping", newFlowTest.steps["2"].stepId),
+  test.assertEqual("firstMapper-mapping", newFlowTest.steps["3"].stepId)
+);
+
+assertions

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/lib/flowService.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/lib/flowService.sjs
@@ -34,8 +34,8 @@ function removeStepFromFlow(flowName, stepNumber) {
   return invoke("removeStepFromFlow.sjs", {flowName, stepNumber});
 }
 
-function updateFlowInfo(name, description) {
-  return invoke("updateFlowInfo.sjs", {name, description});
+function updateFlow(updatedFlow) {
+  return invoke("updateFlow.sjs", {updatedFlow});
 }
 
 module.exports = {
@@ -46,6 +46,6 @@ module.exports = {
   getFlowsWithStepDetails,
   getFullFlow,
   removeStepFromFlow,
-  updateFlowInfo,
+  updateFlow,
   getFlowWithLatestJobInfo
 };


### PR DESCRIPTION
### Description
This PR adds the feature of reordering steps. 
- The first step should only show a right arrow. The middle steps show both left and right arrows. The last step should only show a left arrow.
- The steps should persist after reordering.
- There was a change to updateFlowInfo api. It is now called updateFlow and contains an arg for a step array. It still updates the description the same way; that feature was not changed at all. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

