### PR TITLE
DHFPROD-2445: adjust flow options to include overrides before writing batch report

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow.sjs
@@ -258,7 +258,12 @@ class Flow {
     this.globalContext.sourceDatabase = combinedOptions.sourceDatabase || this.globalContext.sourceDatabase;
 
     if (!(combinedOptions.noBatchWrite || combinedOptions.disableJobOutput)) {
-      let batchDoc = this.datahub.jobs.createBatch(jobDoc, flowStep, stepNumber);
+      const flowStepWithOptions = Object.assign(
+        {},
+        flowStep,
+        {"options": Object.assign({}, flowStep.options, combinedOptions)}
+      );
+      let batchDoc = this.datahub.jobs.createBatch(jobDoc, flowStepWithOptions, stepNumber);
       this.globalContext.batchId = batchDoc.batch.batchId;
     }
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/impl/FlowRunnerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/impl/FlowRunnerTest.java
@@ -316,10 +316,13 @@ public class FlowRunnerTest extends AbstractHubCoreTest {
 
         Map<String,Object> opts = new HashMap<>();
         List<String> coll = new ArrayList<>();
+        String mappingJobId = UUID.randomUUID().toString();
+
         coll.add("test-collection");
         opts.put("targetDatabase", HubConfig.DEFAULT_FINAL_NAME);
         opts.put("collections", coll);
         opts.put("sourceQuery", "cts.collectionQuery('test-collection')");
+
         RunFlowResponse resp = runFlow("testFlow", "1,2", UUID.randomUUID().toString(), opts, null);
         flowRunner.awaitCompletion();
         Assertions.assertEquals(2, getDocCount(HubConfig.DEFAULT_FINAL_NAME, "test-collection"));
@@ -327,10 +330,14 @@ public class FlowRunnerTest extends AbstractHubCoreTest {
 
         opts.put("targetDatabase", HubConfig.DEFAULT_STAGING_NAME);
         opts.put("sourceDatabase", HubConfig.DEFAULT_FINAL_NAME);
-        resp = runFlow("testFlow", "5", UUID.randomUUID().toString(), opts, null);
+        opts.put("testRunFlowOption", "xyzzy");
+        resp = runFlow("testFlow", "5", mappingJobId, opts, null);
         flowRunner.awaitCompletion();
+        JsonNode batchDoc = findFirstBatchDocument(mappingJobId);
         Assertions.assertEquals(2, getDocCount(HubConfig.DEFAULT_STAGING_NAME, "test-collection"));
         Assertions.assertTrue(JobStatus.FINISHED.toString().equalsIgnoreCase(resp.getJobStatus()));
+        Assertions.assertEquals("cts.collectionQuery('test-collection')", batchDoc.get("batch").get("step").get("options").get("sourceQuery").asText());
+        Assertions.assertEquals("xyzzy", batchDoc.get("batch").get("step").get("options").get("testRunFlowOption").asText());
     }
 
     @Test

--- a/specs/models/Batch.schema.json
+++ b/specs/models/Batch.schema.json
@@ -22,7 +22,7 @@
     },
     "step": {
       "type": "object",
-      "description": "A copy of the step from its flow"
+      "description": "A copy of the step from its flow, plus runtime options"
     },
     "stepNumber": {
       "type": "string"

--- a/specs/models/Step.schema.json
+++ b/specs/models/Step.schema.json
@@ -23,6 +23,12 @@
         }
       }
     },
+    "options": {
+      "type": "object",
+      "description": "Default options for the step, or in a batch context, options as actually run.",
+      "properties": {
+      }
+    },
     "customHook": {
       "type": "object",
       "$ref": "./CustomHook.schema.json"


### PR DESCRIPTION
### Description
Fixes DHFPROD-2445 by adding overridden options to flow object options before writing initial batch report. The initial batch report is included in any intermediate updates.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

