### PR TITLE
DHFPROD-6953: Add Join Property setting to Add Property dialog

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario1.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario1.spec.tsx
@@ -55,6 +55,8 @@ describe("Entity Modeling Senario 1: Writer Role", () => {
     propertyModal.openPropertyDropdown();
     propertyModal.getTypeFromDropdown("Related Entity").click();
     propertyModal.getCascadedTypeFromDropdown("Person").click();
+    propertyModal.openJoinPropertyDropdown();
+    propertyModal.getJoinProperty("id").click();
     propertyModal.getYesRadio("multiple").click();
     propertyModal.getSubmitButton().click();
     propertyTable.getMultipleIcon("user").should("exist");
@@ -98,6 +100,8 @@ describe("Entity Modeling Senario 1: Writer Role", () => {
     propertyModal.openPropertyDropdown();
     propertyModal.getTypeFromDropdown("Related Entity").click();
     propertyModal.getCascadedTypeFromDropdown("Customer").click();
+    propertyModal.openJoinPropertyDropdown();
+    propertyModal.getJoinProperty("customerId").click();
     propertyModal.getYesRadio("idenifier").should("not.exist");
     propertyModal.getYesRadio("multiple").click();
     propertyModal.getNoRadio("pii").should("not.exist");

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario2.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario2.spec.tsx
@@ -156,6 +156,8 @@ describe("Entity Modeling: Writer Role", () => {
     propertyModal.openPropertyDropdown();
     propertyModal.getTypeFromDropdown("Related Entity").click();
     propertyModal.getCascadedTypeFromDropdown("Person").click();
+    propertyModal.openJoinPropertyDropdown();
+    propertyModal.getJoinProperty("Address").click();
     propertyModal.getYesRadio("multiple").click();
     propertyModal.getYesRadio("idenifier").should("not.exist");
     propertyModal.getYesRadio("pii").should("not.exist");
@@ -176,6 +178,19 @@ describe("Entity Modeling: Writer Role", () => {
     propertyTable.expandStructuredTypeIcon("alt_address").click();
     propertyTable.getProperty("streetAlt").should("exist");
   });
+  it("Add join property with type as Related Entity", () => {
+    propertyTable.getAddPropertyButton("User3").click();
+    propertyModal.newPropertyName("OrderedBy");
+    propertyModal.getJoinPropertyDropdown().should("not.exist");
+    propertyModal.openPropertyDropdown();
+    propertyModal.getTypeFromDropdown("Related Entity").click();
+    propertyModal.getCascadedTypeFromDropdown("Customer").click();
+    propertyModal.openJoinPropertyDropdown();
+    propertyModal.getJoinProperty("nicknames").should("not.be.enabled");
+    propertyModal.getJoinProperty("customerId").click();
+    propertyModal.getSubmitButton().click();
+    propertyTable.getProperty("OrderedBy").should("exist");
+  });
   it("Delete a property, a structured property and then the entity", () => {
     //Structured Property
     propertyTable.getDeleteStructuredPropertyIcon("User3", "Address", "streetAlt").click();
@@ -187,9 +202,14 @@ describe("Entity Modeling: Writer Role", () => {
     confirmationModal.getDeletePropertyWarnText().should("exist");
     confirmationModal.getYesButton(ConfirmationType.DeletePropertyWarn).click();
     propertyTable.getProperty("alt_address").should("not.exist");
+    propertyTable.getDeletePropertyIcon("User3", "OrderedBy").click();
+    confirmationModal.getDeletePropertyWarnText().should("exist");
+    confirmationModal.getYesButton(ConfirmationType.DeletePropertyWarn).click();
+    propertyTable.getProperty("OrderedBy").should("not.exist");
     entityTypeTable.getSaveEntityIcon("User3").click();
     confirmationModal.getSaveEntityText().should("be.visible");
     confirmationModal.getYesButton(ConfirmationType.SaveEntity).click();
+    cy.waitForAsyncRequest();
     confirmationModal.getSaveEntityText().should("exist");
     confirmationModal.getSaveEntityText().should("not.exist");
     //Entity
@@ -253,6 +273,8 @@ describe("Entity Modeling: Writer Role", () => {
     propertyModal.openPropertyDropdown();
     propertyModal.getTypeFromDropdown("Related Entity").click();
     propertyModal.getCascadedTypeFromDropdown("Order").click();
+    propertyModal.openJoinPropertyDropdown();
+    propertyModal.getJoinProperty("orderId").click();
     propertyModal.getYesRadio("multiple").click();
     propertyModal.getSubmitButton().click();
     propertyTable.getMultipleIcon("order").should("exist");
@@ -287,12 +309,14 @@ describe("Entity Modeling: Writer Role", () => {
     //propertyTable.getWildcardIcon('patientID').should('exist');
     propertyTable.getAddPropertyButton("Patient").should("exist");
     propertyTable.getAddPropertyButton("Patient").click();
-    propertyModal.newPropertyName("conceptType");
+    propertyModal.newPropertyName("personType");
     propertyModal.openPropertyDropdown();
     propertyModal.getTypeFromDropdown("Related Entity").click();
-    propertyModal.getCascadedTypeFromDropdown("Concept").click();
+    propertyModal.getCascadedTypeFromDropdown("Person").click();
+    propertyModal.openJoinPropertyDropdown();
+    propertyModal.getJoinProperty("id").click();
     propertyModal.getSubmitButton().click();
-    propertyTable.getProperty("conceptType").should("exist");
+    propertyTable.getProperty("personType").should("exist");
   });
   it("Add second property to Patient Entity and delete it", () => {
     propertyTable.getAddPropertyButton("Patient").click();
@@ -322,6 +346,7 @@ describe("Entity Modeling: Writer Role", () => {
     //Save Changes
     modelPage.getSaveAllButton().click();
     confirmationModal.getYesButton(ConfirmationType.SaveAll).click();
+    cy.waitForAsyncRequest();
     confirmationModal.getSaveAllEntityText().should("exist");
     confirmationModal.getSaveAllEntityText().should("not.exist");
     modelPage.getEntityModifiedAlert().should("not.exist");
@@ -331,10 +356,8 @@ describe("Entity Modeling: Writer Role", () => {
     propertyTable.getSortIcon("health").should("exist");
     //Delete Entity
     entityTypeTable.getDeleteEntityIcon("Concept").click();
-    confirmationModal.getYesButton(ConfirmationType.DeleteEntityRelationshipWarn).click();
-    confirmationModal.getDeleteEntityRelationshipText().should("exist");
+    confirmationModal.getYesButton(ConfirmationType.DeleteEntity).click();
     confirmationModal.getDeleteEntityRelationshipText().should("not.exist");
     entityTypeTable.getEntity("Concept").should("not.exist");
-    propertyTable.getProperty("conceptType").should("not.exist");
   });
 });

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/property-modal.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/property-modal.tsx
@@ -56,6 +56,18 @@ class PropertyModal {
   getToggleStepsButton() {
     return cy.findByLabelText("toggle-steps");
   }
+
+  getJoinPropertyDropdown() {
+    return  cy.findByPlaceholderText("Select a join property");
+  }
+
+  openJoinPropertyDropdown() {
+    cy.findByLabelText("joinProperty-select").trigger("mouseover").click();
+  }
+
+  getJoinProperty(propertyName: string) {
+    return cy.waitUntil(() => cy.findByLabelText(`${propertyName}-option`));
+  }
 }
 
 const propertyModal = new PropertyModal();

--- a/marklogic-data-hub-central/ui/src/App.scss
+++ b/marklogic-data-hub-central/ui/src/App.scss
@@ -193,6 +193,11 @@ tr.ant-table-row:hover > td {
   color: #333333;
 }
 
+span.join-property-menu + div .ant-cascader-menu-item-disabled {
+  cursor: not-allowed;
+  color: #CCCCCC;
+}
+
 ul.ant-cascader-menu {
   height: auto;
   width: 165px;

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
@@ -58,6 +58,8 @@ const DEFAULT_SELECTED_PROPERTY_OPTIONS: PropertyOptions = {
   propertyType: PropertyType.Basic,
   type: "",
   identifier: "no",
+  joinPropertyName: "",
+  joinPropertyType: "",
   multiple: "no",
   pii: "no",
   facetable: false,
@@ -343,7 +345,10 @@ const PropertyTable: React.FC<Props> = (props) => {
     if (propertyOptions.propertyType === PropertyType.RelatedEntity && !multiple) {
       let externalEntity = modelingOptions.entityTypeNamesArray.find(entity => entity.name === propertyOptions.type);
       return {
-        $ref: externalEntity.entityTypeId,
+        datatype: propertyOptions.joinPropertyType,
+        relatedEntityType: externalEntity.entityTypeId,
+        joinPropertyName: propertyOptions.joinPropertyName,
+        //joinPropertyType: propertyOptions.joinPropertyType
       };
 
     } else if (propertyOptions.propertyType === PropertyType.RelatedEntity && multiple) {
@@ -353,7 +358,10 @@ const PropertyTable: React.FC<Props> = (props) => {
         facetable: facetable,
         sortable: sortable,
         items: {
-          $ref: externalEntity.entityTypeId,
+          datatype: propertyOptions.joinPropertyType,
+          relatedEntityType: externalEntity.entityTypeId,
+          joinPropertyName: propertyOptions.joinPropertyName,
+          //joinPropertyType: propertyOptions.joinPropertyType
         }
       };
 
@@ -444,7 +452,7 @@ const PropertyTable: React.FC<Props> = (props) => {
     let parseKey = record.key.split(",");
     let propertyType = PropertyType.Basic;
     let newStructuredTypes: StructuredTypeOptions = DEFAULT_STRUCTURED_TYPE_OPTIONS;
-    let relationshipType = modelingOptions.entityTypeNamesArray.find(entity => entity.name === record.type);
+    let relationshipType = record.joinPropertyName;
 
     if (record.hasOwnProperty("structured")) {
       if (record.hasOwnProperty("add")) {
@@ -482,6 +490,8 @@ const PropertyTable: React.FC<Props> = (props) => {
     const propertyOptions: PropertyOptions = {
       propertyType: propertyType,
       type: record.type,
+      joinPropertyName: record.joinPropertyName,
+      joinPropertyType: record.joinPropertyType,
       identifier: record.identifier ? "yes" : "no",
       multiple: record.multiple ? "yes" : "no",
       pii: record.pii ? "yes" : "no",
@@ -725,6 +735,8 @@ const PropertyTable: React.FC<Props> = (props) => {
           key: property.name + "," + index,
           propertyName: property.name,
           type: property.datatype,
+          joinPropertyName: property.joinPropertyName,
+          joinPropertyType: property.joinPropertyType,
           identifier: entityTypeDefinition?.primaryKey === property.name ? property.name : "",
           multiple: property.multiple ? property.name : "",
           facetable: property.facetable ? property.name : "",

--- a/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
+++ b/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
@@ -44,6 +44,9 @@ const ModelingTooltips = {
     'Names must start with a letter and can contain letters, numbers, hyphens, and underscores.',  /* intended dupe: all names */
   descriptionEntityProperty: 'A description of this entity property.',
 
+  /* Form fields */
+  joinProperty: 'Structured type properties and arrays cannot be used as join properties.',
+
 
   /* TO BE DEPRECATED. Use ModelingTooltips.nameEntityType. */
   nameRegex: 'Names must start with a letter and can contain letters, numbers, hyphens, and underscores.',

--- a/marklogic-data-hub-central/ui/src/types/modeling-types.ts
+++ b/marklogic-data-hub-central/ui/src/types/modeling-types.ts
@@ -29,6 +29,9 @@ export interface Property {
   description: string,
   datatype: string,
   ref: string,
+  relatedEntityType: string,
+  joinPropertyName: string,
+  joinPropertyType: string,
   collation: string,
   multiple: boolean,
   facetable: boolean,
@@ -60,6 +63,8 @@ export interface EditPropertyOptions {
 export interface PropertyOptions {
   propertyType: PropertyType,
   type: string,
+  joinPropertyName: string,
+  joinPropertyType: string,
   identifier: string,
   multiple: string,
   pii: string,

--- a/marklogic-data-hub-central/ui/src/util/data-conversion.tsx
+++ b/marklogic-data-hub-central/ui/src/util/data-conversion.tsx
@@ -353,6 +353,9 @@ export const definitionsParser = (definitions: any): Definition[] => {
             datatype: "",
             description: "",
             ref: "",
+            relatedEntityType: "",
+            joinPropertyName: "",
+            joinPropertyType: "",
             collation: "",
             multiple: false,
             facetable: false,
@@ -367,6 +370,15 @@ export const definitionsParser = (definitions: any): Definition[] => {
           if (definitions[definition][entityKeys][properties]["datatype"]) {
             property.datatype = definitions[definition][entityKeys][properties]["datatype"];
 
+            // Handle join props if present
+            property.relatedEntityType = definitions[definition][entityKeys][properties]["relatedEntityType"];
+            property.joinPropertyName = definitions[definition][entityKeys][properties]["joinPropertyName"];
+            if (definitions[definition][entityKeys][properties]["relatedEntityType"]) {
+              // Parse type from relatedEntityType URI
+              let typeSplit = definitions[definition][entityKeys][properties]["relatedEntityType"].split("/");
+              property.joinPropertyType = typeSplit[typeSplit.length - 1];
+            }
+
             if (definitions[definition][entityKeys][properties]["datatype"] === "array") {
               property.multiple = true;
 
@@ -378,6 +390,13 @@ export const definitionsParser = (definitions: any): Definition[] => {
                   property.datatype = definitions[definition][entityKeys][properties]["items"]["$ref"].split("/").pop();
                 }
                 property.ref = definitions[definition][entityKeys][properties]["items"]["$ref"];
+              } else if (definitions[definition][entityKeys][properties]["items"].hasOwnProperty("relatedEntityType")) {
+                // Array of related entity type
+                property.relatedEntityType = definitions[definition][entityKeys][properties]["items"]["relatedEntityType"];
+                property.joinPropertyName = definitions[definition][entityKeys][properties]["items"]["joinPropertyName"];
+                // Parse type from relatedEntityType URI
+                let typeSplit = definitions[definition][entityKeys][properties]["items"]["relatedEntityType"].split("/");
+                property.joinPropertyType = typeSplit[typeSplit.length - 1];
               } else if (definitions[definition][entityKeys][properties]["items"].hasOwnProperty("datatype")) {
                 // Array of datatype
                 property.datatype = definitions[definition][entityKeys][properties]["items"]["datatype"];


### PR DESCRIPTION
### Description

This PR allows users to create relationships between entities in the Modeling UI by exposing a Join Property menu in the Add Property dialog when a Related Entity type is selected.

Screencast: https://drive.google.com/file/d/1AzEfoFXTC_lGmbt1pFqzbTf2ix0wZ6Bj/view

Structured type properties and arrays cannot be used as related entity properties currently; I've added tooltip next to the menu explaining this. 

When you save the properties, the following is saved in the entity artifact:

https://project.marklogic.com/jira/browse/DHFPROD-6953?focusedCommentId=196954&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-196954

Notes:

- There is an auto-scrolling bug for new properties with multiple set to yes. This is not specific to the Join Property work and I've filed a bug: https://project.marklogic.com/jira/browse/DHFPROD-7062
- There is some additional testing work to be performed for this. A unit test is currently skipped (but this functionality is covered in the e2e tests). I've created a task: https://project.marklogic.com/jira/browse/DHFPROD-7062

Thanks for the assistance: @xnikhil08, @briantang, @ngodugu-marklogic 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

