### PR TITLE
DHFPROD-7066: fixed misaligned help icons in new/edit curate step dialog

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.module.scss
@@ -31,25 +31,30 @@
     cursor: not-allowed;
 }
 
+.questionCircle:before,
+.questionCircleCollection:before,
+.questionCircleQuery:before {
+    position: absolute;
+}
+
 .questionCircle {
     font-size: 12px;
     color: #7F86B5;
+    margin: 15px 0px 0px;
 }
 
 .questionCircleCollection {
     font-size: 12px;
     color: #7F86B5;
-    margin-left: 92px;
+    margin-left: -8px;
     margin-top: 14px;
-    position: absolute;
 }
 
 .questionCircleQuery {
+    margin-left: -112px;
+    margin-top: 14px;
     font-size: 12px;
     color: #7F86B5;
-    margin-left: -10px;
-    margin-top: 14px;
-    position: absolute;
 }
 
 .searchIcon {

--- a/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.tsx
@@ -469,9 +469,6 @@ const CreateEditStep: React.FC<Props>  = (props) => {
         validateStatus={((collections && selectedSource === "collection") || (srcQuery && selectedSource !== "collection") || (!isSelectedSourceTouched && !isCollectionsTouched && !isSrcQueryTouched)) ? "" : "error"}
         help={((collections && selectedSource === "collection") || (srcQuery && selectedSource !== "collection") || (!isSelectedSourceTouched && !isCollectionsTouched && !isSrcQueryTouched)) ? "" : "Collection or Query is required"}
         >
-          <MLTooltip title={CommonStepTooltips.radioCollection} placement={"top"}>
-            <Icon type="question-circle" className={styles.questionCircleCollection} theme="filled" data-testid="collectionTooltip"/>
-          </MLTooltip>
 
           <Radio.Group
             id="srcType"
@@ -481,6 +478,10 @@ const CreateEditStep: React.FC<Props>  = (props) => {
             disabled={!props.canReadWrite}
           >
           </Radio.Group>
+
+          <MLTooltip title={CommonStepTooltips.radioCollection} placement={"top"}>
+            <Icon type="question-circle" className={styles.questionCircleCollection} theme="filled" data-testid="collectionTooltip"/>
+          </MLTooltip>
 
           <MLTooltip title={CommonStepTooltips.radioQuery} placement={"top"}>
             <Icon type="question-circle" className={styles.questionCircleQuery} theme="filled" data-testid="queryTooltip"/>


### PR DESCRIPTION
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [X] JIRA_ID included in all the commit messages
- [X] PR title is in the format JIRA_ID:Title
- [X] Rebase the branch with upstream
- [X] Squashed all commits into a single commit
- [X] Code passes ESLint tests

[NA] Added Tests
  

- ##### Reviewer:

[NA] Reviewed Tests

