### PR TITLE
DHFPROD-6717: Running connected steps against varying databases

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.datamovement.*;
 import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.HubClient;
-import com.marklogic.hub.collector.Collector;
 import com.marklogic.hub.collector.DiskQueue;
 import com.marklogic.hub.collector.impl.CollectorImpl;
 import com.marklogic.hub.dataservices.StepRunnerService;
@@ -113,32 +112,11 @@ public class QueryStepRunner implements StepRunner {
 
     @Override
     @SuppressWarnings("unchecked")
-    public StepRunner withOptions(Map<String, Object> options) {
+    public StepRunner withOptions(Map<String, Object> runtimeOptions) {
         if(flow == null){
             throw new DataHubConfigurationException("Flow has to be set before setting options");
         }
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, Object> stepDefMap = null;
-        if(stepDef != null) {
-            stepDefMap = mapper.convertValue(stepDef.getOptions(), Map.class);
-        }
-        Map<String, Object> stepMap = mapper.convertValue(this.flow.getStep(step).getOptions(), Map.class);
-        Map<String,Object> flowMap = mapper.convertValue(flow.getOptions(), Map.class);
-        Map<String, Object> combinedOptions = new HashMap<>();
-
-        if(stepDefMap != null){
-            combinedOptions.putAll(stepDefMap);
-        }
-        if(flowMap != null) {
-            combinedOptions.putAll(flowMap);
-        }
-        if(stepMap != null){
-            combinedOptions.putAll(stepMap);
-        }
-        if(options != null) {
-            combinedOptions.putAll(options);
-        }
-        this.options = combinedOptions;
+        this.options = StepRunnerUtil.makeCombinedOptions(this.flow, this.stepDef, this.step, runtimeOptions);
         return this;
     }
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/StepRunnerUtil.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/StepRunnerUtil.java
@@ -8,18 +8,20 @@ import com.marklogic.hub.flow.Flow;
 import com.marklogic.hub.job.JobDocManager;
 import com.marklogic.hub.job.JobStatus;
 import com.marklogic.hub.step.RunStepResponse;
+import com.marklogic.hub.step.StepDefinition;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 public class StepRunnerUtil {
 
-    protected static RunStepResponse getResponse(JsonNode jobNode, String step){
+    protected static RunStepResponse getResponse(JsonNode jobNode, String step) {
         RunStepResponse stepDoc;
         ObjectMapper objectMapper = new ObjectMapper();
         try {
             stepDoc = objectMapper.treeToValue(jobNode.get("job").get("stepResponses").get(step), RunStepResponse.class);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
         return stepDoc;
@@ -46,15 +48,10 @@ public class StepRunnerUtil {
     protected static void initializeStepRun(JobDocManager jobDocManager, RunStepResponse runStepResponse, Flow flow, String step, String jobId) {
         JsonNode json = jobDocManager.getJobDocument(jobId);
         if (json == null) {
-            jobDocManager.createJob(jobId,flow.getName());
+            jobDocManager.createJob(jobId, flow.getName());
         }
 
-        try {
-            jobDocManager.postJobs(jobId, JobStatus.RUNNING_PREFIX + step, flow.getName(), step, null, runStepResponse);
-        }
-        catch (Exception ex) {
-            throw ex;
-        }
+        jobDocManager.postJobs(jobId, JobStatus.RUNNING_PREFIX + step, flow.getName(), step, null, runStepResponse);
     }
 
     protected static String objectToString(Object obj) {
@@ -63,9 +60,81 @@ public class StepRunnerUtil {
             objStr = (String) obj;
         } else if (obj instanceof TextNode) {
             objStr = ((TextNode) obj).textValue();
-        } else if (obj != null){
+        } else if (obj != null) {
             objStr = obj.toString();
         }
         return objStr;
+    }
+
+    /**
+     * Note that this logic exists in flow-utils.sjs as well; this is apparently because FlowRunner needs to combine
+     * options before it runs any steps. But each call to process a batch of items also needs to combine steps, as
+     * it's not always invoked by FlowRunner. So there's some duplication that would be good to get rid of, possibly
+     * by having FlowRunner make a call to ML to combine options.
+     *
+     * @param flow
+     * @param stepDef
+     * @param stepNumber
+     * @param runtimeOptions
+     * @return
+     */
+    public static Map<String, Object> makeCombinedOptions(Flow flow, StepDefinition stepDef, String stepNumber, Map<String, Object> runtimeOptions) {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, Object> stepDefMap = null;
+        if (stepDef != null) {
+            stepDefMap = mapper.convertValue(stepDef.getOptions(), Map.class);
+        }
+
+        Map<String, Object> stepMap = null;
+        if (flow.getStep(stepNumber) != null) {
+            stepMap = mapper.convertValue(flow.getStep(stepNumber).getOptions(), Map.class);
+        }
+
+        Map<String, Object> flowMap = mapper.convertValue(flow.getOptions(), Map.class);
+
+        Map<String, Object> combinedOptions = new HashMap<>();
+        if (stepDefMap != null) {
+            combinedOptions.putAll(stepDefMap);
+        }
+        if (flowMap != null) {
+            combinedOptions.putAll(flowMap);
+        }
+        if (stepMap != null) {
+            combinedOptions.putAll(stepMap);
+        }
+        if (runtimeOptions != null) {
+            combinedOptions.putAll(runtimeOptions);
+            applyStepSpecificOptions(combinedOptions, stepNumber, runtimeOptions);
+        }
+
+        return combinedOptions;
+    }
+
+    /**
+     * Introduced in 5.5 as a way for step-specific options to be provided in the runtime options. A try/catch is used
+     * here in case the user does not conform to the schema of:
+     * - stepOptions must be a JSON object
+     * - each key should be a step number
+     * - the value of each key should be a JSON object containing the options specific to that step
+     *
+     * @param combinedOptions
+     * @param stepNumber
+     * @param runtimeOptions
+     */
+    private static void applyStepSpecificOptions(Map<String, Object> combinedOptions, String stepNumber, Map<String, Object> runtimeOptions) {
+        if (runtimeOptions.containsKey("stepOptions")) {
+            try {
+                Map<String, Object> stepOptions = (Map<String, Object>) runtimeOptions.get("stepOptions");
+                if (stepOptions.containsKey(stepNumber)) {
+                    Map<String, Object> stepSpecificOptions = (Map<String, Object>) stepOptions.get(stepNumber);
+                    combinedOptions.putAll(stepSpecificOptions);
+                }
+            } catch (Exception ex) {
+                String message = "Unable to apply step-specific options found in 'stepOptions' in runtime options; " +
+                    "stepOptions must be a JSON object whose keys are step numbers, and each key has a JSON object as its value, which contains " +
+                    "the options specific to that step; error cause: " + ex.getMessage();
+                throw new IllegalArgumentException(message);
+            }
+        }
     }
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
-import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.datamovement.DataMovementManager;
 import com.marklogic.client.datamovement.JacksonCSVSplitter;
 import com.marklogic.client.datamovement.JobTicket;
@@ -35,13 +34,11 @@ import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.HubClient;
-import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.HubProject;
 import com.marklogic.hub.collector.DiskQueue;
 import com.marklogic.hub.collector.impl.FileCollector;
 import com.marklogic.hub.error.DataHubConfigurationException;
 import com.marklogic.hub.flow.Flow;
-import com.marklogic.hub.impl.HubConfigImpl;
 import com.marklogic.hub.job.JobDocManager;
 import com.marklogic.hub.job.JobStatus;
 import com.marklogic.hub.step.RunStepResponse;
@@ -178,32 +175,11 @@ public class WriteStepRunner implements StepRunner {
 
     @Override
     @SuppressWarnings("unchecked")
-    public StepRunner withOptions(Map<String, Object> options) {
+    public StepRunner withOptions(Map<String, Object> runtimeOptions) {
         if(flow == null){
             throw new DataHubConfigurationException("Flow has to be set before setting options");
         }
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, Object> stepDefMap = null;
-        if(stepDef != null) {
-            stepDefMap = mapper.convertValue(stepDef.getOptions(), Map.class);
-        }
-        Map<String, Object> stepMap = mapper.convertValue(this.flow.getStep(step).getOptions(), Map.class);
-        Map<String,Object> flowMap = mapper.convertValue(flow.getOptions(), Map.class);
-        Map<String, Object> combinedOptions = new HashMap<>();
-
-        if(stepDefMap != null){
-            combinedOptions.putAll(stepDefMap);
-        }
-        if(flowMap != null) {
-            combinedOptions.putAll(flowMap);
-        }
-        if(stepMap != null){
-            combinedOptions.putAll(stepMap);
-        }
-        if(options != null) {
-            combinedOptions.putAll(options);
-        }
-        this.options = combinedOptions;
+        this.options = StepRunnerUtil.makeCombinedOptions(this.flow, this.stepDef, this.step, runtimeOptions);
         return this;
     }
 

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepRunner/processBatch.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/stepRunner/processBatch.sjs
@@ -30,6 +30,9 @@ if (!fn.exists(flowName)) {
 
 const stepNumber = inputs.stepNumber;
 const jobId = inputs.jobId;
+
+// These are not just the runtime options that a user can provide. It is expected that this is
+// called by the Java QueryStepRunner class, which has its own logic for combining options. 
 const options = inputs.options;
 
 const datahub = DataHubSingleton.instance({

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/stepExecutionContext.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/stepExecutionContext.sjs
@@ -15,19 +15,19 @@
 */
 'use strict';
 
+const flowUtils = require("/data-hub/5/impl/flow-utils.sjs");
 const httpUtils = require("/data-hub/5/impl/http-utils.sjs");
 const StepDefinition = require("/data-hub/5/impl/stepDefinition.sjs");
 
 class StepExecutionContext {
-  constructor(theFlow, stepNumber, stepDefinition, jobId, runtimeOptions) {
+  constructor(theFlow, stepNumber, stepDefinition, jobId, runtimeOptions = {}) {
     this.flow = theFlow;
     this.stepDefinition = stepDefinition;
     this.stepNumber = stepNumber;
     this.flowStep = theFlow.steps[stepNumber];
     this.jobId = jobId;
 
-    runtimeOptions = runtimeOptions || {};
-    this.combinedOptions = Object.assign({}, stepDefinition.options, theFlow.options, this.flowStep.options, runtimeOptions);
+    this.combinedOptions = flowUtils.makeCombinedOptions(theFlow, stepDefinition, stepNumber, runtimeOptions);
 
     // Copies what flow.sjs does for combining collections from options
     this.collectionsFromOptions = [

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/writeQueue.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/writeQueue.sjs
@@ -1,0 +1,111 @@
+/**
+ Copyright (c) 2021 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+const consts = require("/data-hub/5/impl/consts.sjs");
+const flowUtils = require("/data-hub/5/impl/flow-utils.sjs");
+const hubUtils = require("/data-hub/5/impl/hub-utils.sjs");
+
+/**
+ * Captures the content objects that should be written to a database after one or more steps 
+ * have been executed on a batch of items. Supports multiple databases, such that the same URI 
+ * can be written to multiple databases.
+ * 
+ * If multiple content objects are added that have the same URI and are to be written to the same 
+ * database, the newer content object will replaced the existing one. This is intended both to avoid 
+ * conflicting update errors and to facilitate the need when running connected steps for the output of 
+ * one step to replace the output of a previous step. Trace logging is used to record this so that a
+ * user can have visibility into when this happens.
+ */
+class WriteQueue {
+
+  constructor() {
+    this.databaseToContentMap = {};
+  }
+
+  /**
+   * @param databaseName 
+   * @param contentObject 
+   * @param flowName only needed for logging
+   * @param stepNumber only needed for logging
+   */
+  addContent(databaseName, contentObject, flowName, stepNumber) {
+    let contentMap = this.databaseToContentMap[databaseName];
+    if (!contentMap) {
+      contentMap = {};
+      this.databaseToContentMap[databaseName] = contentMap;
+    }
+
+    const traceEvent = consts.TRACE_FLOW_RUNNER;
+    const traceEnabled = xdmp.traceEnabled(traceEvent);
+
+    const uri = contentObject.uri;
+    if (!uri) {
+      if (traceEnabled) {
+        let message = `Could not add content object ${xdmp.toJsonString(contentObject)} to write queue because it has `;
+        message += `no 'uri' property; flow: ${flowName}; step number: ${stepNumber}`;
+        hubUtils.hubTrace(traceEvent, message);  
+      }
+    } else {
+      if (contentMap[uri] && traceEnabled) {
+        let message = `URI '${uri}' already exists in writeQueue, will be overwritten with new content object`;
+        message += `; flow: ${flowName}; step number: ${stepNumber}`;
+        hubUtils.hubTrace(traceEvent, message);
+      }      
+      contentMap[uri] = contentObject;
+    }
+  }
+
+  /**
+   * @param databaseName 
+   * @returns an array of URIs corresponding to the content objects that will be persisted to the given database
+   */
+  getContentUris(databaseName) {
+    if (this.databaseToContentMap[databaseName]) {
+      return Object.keys(this.databaseToContentMap[databaseName]);
+    } else {
+      return [];
+    }
+  }
+
+  /**
+   * @param databaseName
+   * @returns an array of content objects that will be persisted to the given database
+   */
+  getContentArray(databaseName) {
+    if (this.databaseToContentMap[databaseName]) {
+      return Object.values(this.databaseToContentMap[databaseName]);
+    } else {
+      return [];
+    }
+  }
+
+  /**
+   * TODO Once we do job data, we'll have to figure out what to do with multiple transaction IDs and timestamps,
+   * as those aren't at the step level but rather at the batch level, and per database.
+   *
+   * TODO Add error handling. Each step may have succeeded, but the batch fails.
+   */
+  persist() {
+    Object.keys(this.databaseToContentMap).forEach(databaseName => {
+      const databaseContent = this.databaseToContentMap[databaseName];
+      const contentArray = Object.values(databaseContent);
+      flowUtils.writeContentArray(contentArray, databaseName);
+    });
+  }
+}
+
+module.exports = WriteQueue;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow-utils.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow-utils.sjs
@@ -733,6 +733,36 @@ function writeContentArray(contentArray, databaseName, baseCollections = []) {
   return fn.head(xdmp.invoke('/data-hub/5/impl/hub-utils/invoke-queue-write.sjs', vars, options));
 }
 
+/**
+ * 
+ * @param theFlow 
+ * @param stepDefinition 
+ * @param stepNumber 
+ * @param runtimeOptions 
+ * @returns the "combined" options based on the order of precedence of option sources. 
+ * If stepOptions is present in runtimeOptions, and stepOptions has a key matching that of the 
+ * stepNumber, then the value of that key will also be applied to the combined options. Note that
+ * the combined options will also have "stepOptions" present in it if that exists in the runtime 
+ * options.
+ */
+function makeCombinedOptions(theFlow, stepDefinition, stepNumber, runtimeOptions) {
+  theFlow = theFlow || {};
+  const flowSteps = theFlow.steps || {};
+  stepDefinition = stepDefinition || {};
+  runtimeOptions = runtimeOptions || {};
+
+  const stepRuntimeOptions = runtimeOptions.stepOptions ? runtimeOptions.stepOptions[stepNumber] : {};
+  const stepOptions = flowSteps[stepNumber] ? flowSteps[stepNumber].options : {};
+  
+  return Object.assign({}, 
+    stepDefinition.options,
+    theFlow.options,
+    stepOptions, 
+    runtimeOptions, 
+    stepRuntimeOptions
+  );
+}
+
 module.exports = {
   addMetadataToContent,
   cleanData,
@@ -748,6 +778,7 @@ module.exports = {
   getTriplesAsObject,
   isNonStringIterable,
   jsonToXml,
+  makeCombinedOptions,
   makeEnvelope,
   mergeHeaders,
   normalizeValuesInNode,

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/RunFlowThatWritesDuplicateUrisTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/RunFlowThatWritesDuplicateUrisTest.java
@@ -1,0 +1,31 @@
+package com.marklogic.hub.flow;
+
+import com.marklogic.hub.AbstractHubCoreTest;
+import com.marklogic.hub.test.ReferenceModelProject;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RunFlowThatWritesDuplicateUrisTest extends AbstractHubCoreTest {
+
+    @Test
+    void test() {
+        installProjectInFolder("test-projects/simple-custom-step");
+        new ReferenceModelProject(getHubClient()).createRawCustomer(1, "Jane");
+
+        Map<String, Object> options = new HashMap<>();
+        options.put("sourceQuery", "Sequence.from(['/customer1.json', '/customer1.json'])");
+        options.put("sourceQueryIsScript", true);
+
+        RunFlowResponse r = runFlow(new FlowInputs("simpleCustomStepFlow").withOptions(options));
+        assertEquals("finished", r.getJobStatus(), "Job should have finished because only one document was written " +
+            "to the duplicate URI, instead of a conflicting updates error being thrown; " + r.toJson());
+        assertEquals(2, r.getStepResponses().get("1").getSuccessfulEvents(),
+            "Both URIs should have been processed, even though only one was written");
+        assertEquals(1, getFinalDocCount("simpleCustomStep-output"),
+            "Only one doc should have been written to the step output collection");
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/step/impl/MakeCombinedOptionsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/step/impl/MakeCombinedOptionsTest.java
@@ -1,0 +1,119 @@
+package com.marklogic.hub.step.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.hub.flow.impl.FlowImpl;
+import com.marklogic.hub.step.StepDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MakeCombinedOptionsTest {
+
+    FlowImpl flow;
+    ObjectNode flowOptions;
+
+    StepDefinition stepDef;
+    Map<String, Object> stepDefOptions;
+
+    String stepNumber = "1";
+    Map<String, Object> stepOptions;
+    Map<String, Object> runtimeOptions;
+
+    Map<String, Object> result;
+
+    @BeforeEach
+    void setup() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        flow = new FlowImpl();
+        flowOptions = mapper.createObjectNode();
+        flowOptions.put("winner", "flow");
+        flow.setOptions(flowOptions);
+
+        Step step = new Step();
+        stepOptions = new HashMap<>();
+        step.setOptions(stepOptions);
+        Map<String, Step> steps = new HashMap<>();
+        steps.put(stepNumber, step);
+        flow.setSteps(steps);
+
+        CustomStepDefinitionImpl customStepDef = new CustomStepDefinitionImpl("stepTypeDoesntMatter");
+        stepDefOptions = new HashMap<>();
+        stepDefOptions.put("winner", "stepDef");
+        customStepDef.setOptions(stepDefOptions);
+        this.stepDef = customStepDef;
+
+        runtimeOptions = new HashMap<>();
+    }
+
+    @Test
+    void flowOverridesStepDef() {
+        makeCombinedOptions();
+        assertEquals("flow", result.get("winner"), "flow takes precedence over step def");
+    }
+
+    @Test
+    void stepOverridesFlow() {
+        stepOptions.put("winner", "step");
+        makeCombinedOptions();
+        assertEquals("step", result.get("winner"), "step takes precedence over flow");
+    }
+
+    @Test
+    void runtimeOverridesStep() {
+        stepOptions.put("winner", "step");
+        runtimeOptions.put("winner", "runtime");
+        makeCombinedOptions();
+        assertEquals("runtime", result.get("winner"), "runtime takes precedence over step");
+    }
+
+    @Test
+    void stepSpecificOverridesEverything() {
+        Map<String, Object> stepOptions = new HashMap<>();
+        Map<String, Object> stepOneOptions = new HashMap<>();
+        stepOneOptions.put("winner", "stepSpecific1");
+        Map<String, Object> stepTwoOptions = new HashMap<>();
+        stepTwoOptions.put("winner", "stepSpecific2");
+        stepOptions.put("1", stepOneOptions);
+        stepOptions.put("2", stepTwoOptions);
+        runtimeOptions.put("stepOptions", stepOptions);
+        runtimeOptions.put("winner", "runtime");
+
+        makeCombinedOptions();
+        assertEquals("stepSpecific1", result.get("winner"), "stepOptions takes precedence over everything");
+
+        stepNumber = "2";
+        makeCombinedOptions();
+        assertEquals("stepSpecific2", result.get("winner"), "stepOptions takes precedence over everything");
+    }
+
+    @Test
+    void invalidStepOptions() {
+        Map<String, Object> stepOptions = new HashMap<>();
+        runtimeOptions.put("stepOptions", "this is invalid");
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> makeCombinedOptions(),
+            "stepOptions must be a JSON object");
+        assertTrue(ex.getMessage().contains("Unable to apply step-specific options"), "Unexpected message: " + ex.getMessage());
+    }
+
+    @Test
+    void invalidStepSpecificOptions() {
+        Map<String, Object> stepOptions = new HashMap<>();
+        stepOptions.put(stepNumber, "this is invalid");
+        runtimeOptions.put("stepOptions", stepOptions);
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> makeCombinedOptions(),
+            "The value of a key under stepOptions must be a JSON object");
+        assertTrue(ex.getMessage().contains("Unable to apply step-specific options"), "Unexpected message: " + ex.getMessage());
+    }
+
+    private void makeCombinedOptions() {
+        result = StepRunnerUtil.makeCombinedOptions(flow, stepDef, stepNumber, runtimeOptions);
+    }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/ingestAndMapToStaging.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/ingestAndMapToStaging.sjs
@@ -1,0 +1,37 @@
+const config = require("/com.marklogic.hub/config.sjs");
+const flowRunner = require("/data-hub/5/flow/flowRunner.sjs");
+const hubTest = require("/test/data-hub-test-helper.sjs");
+const test = require("/test/test-helper.xqy");
+
+const flowName = "ingestAndMap";
+const jobId = sem.uuidString();
+const runtimeOptions = {
+  "stepOptions": {
+    "1": {
+      "targetDatabase": "data-hub-STAGING"
+    },
+    "2": {
+      "targetDatabase": "data-hub-STAGING"
+    }
+  }
+};
+
+const contentArray = [
+  { "uri": "/customer1.json", "value": { "customerId": "1" } }
+];
+
+flowRunner.processContentWithFlow(flowName, contentArray, jobId, runtimeOptions);
+
+const mappedCustomer = hubTest.getStagingRecord("/customer1.json");
+const assertions = [
+  test.assertEqual(1, mappedCustomer.document.envelope.instance.Customer.customerId,
+    "Because both the ingestion and mapping step are writing the same URI to the same database, and the " +
+    "mapping step runs after the ingestion step, the content object outputted by the mapping step " +
+    "should overwrite the one outputted by the ingestion step")
+];
+
+const isAvailable = fn.head(xdmp.eval("fn.docAvailable('/customer1.json')", {}, { database: xdmp.database(config.FINALDATABASE) }));
+
+assertions.concat(
+  test.assertEqual(false, isAvailable, "The doc should not exist in final since both steps write to staging")
+)

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/ingestToFinalMapToStaging.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/ingestToFinalMapToStaging.sjs
@@ -1,0 +1,39 @@
+/**
+ * Simple test to make sure that connected steps work for any target database.
+ * Also a good exercise of step-specific options.
+ */
+
+const flowRunner = require("/data-hub/5/flow/flowRunner.sjs");
+const hubTest = require("/test/data-hub-test-helper.sjs");
+const test = require("/test/test-helper.xqy");
+
+const flowName = "ingestAndMap";
+const jobId = sem.uuidString();
+const runtimeOptions = {
+  "stepOptions": {
+    "1": {
+      "targetDatabase": "data-hub-FINAL"
+    },
+    "2": {
+      "targetDatabase": "data-hub-STAGING"
+    }
+  }
+};
+
+const contentArray = [
+  { "uri": "/customer1.json", "value": { "customerId": "1" }}
+];
+
+flowRunner.processContentWithFlow(flowName, contentArray, jobId, runtimeOptions);
+
+const mappedCustomer = hubTest.getStagingRecord("/customer1.json");
+const assertions = [
+  test.assertEqual(1, mappedCustomer.document.envelope.instance.Customer.customerId,
+    "The mapping step should write to the staging database")
+];
+
+const ingestedCustomer = hubTest.getRecord("/customer1.json");
+assertions.concat(
+  test.assertEqual("1", ingestedCustomer.document.envelope.instance.customerId, 
+    "The ingestion step should write to the final database")
+);

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/ingestionProducesDuplicateUris.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/ingestionProducesDuplicateUris.sjs
@@ -1,0 +1,31 @@
+const config = require("/com.marklogic.hub/config.sjs");
+const flowRunner = require("/data-hub/5/flow/flowRunner.sjs");
+const hubTest = require("/test/data-hub-test-helper.sjs");
+const test = require("/test/test-helper.xqy");
+
+const flowName = "ingestAndMap";
+const jobId = sem.uuidString();
+const runtimeOptions = {};
+
+const contentArray = [
+  { "uri": "/duplicateCustomer.json", "value": { "customerId": "1" } },
+  { "uri": "/duplicateCustomer.json", "value": { "customerId": "2" } }
+];
+
+const assertions = [];
+
+const response = flowRunner.processContentWithFlow(flowName, contentArray, jobId, runtimeOptions);
+
+assertions.push(
+  test.assertEqual("finished", response.jobStatus, 
+    "Job should have finished successfully with no conflicting updates error"),
+  test.assertEqual(2, response.stepResponses["1"].successfulEvents)
+);
+
+const stagingRecord = hubTest.getStagingRecord("/duplicateCustomer.json");
+assertions.push(
+  test.assertEqual("2", stagingRecord.document.envelope.instance.customerId, 
+    "The second content object should have overwritten the first one in the write queue")
+);
+
+assertions;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/oneJsonDocWithOptions.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/oneJsonDocWithOptions.sjs
@@ -3,7 +3,7 @@ const hubTest = require("/test/data-hub-test-helper.sjs");
 const test = require("/test/test-helper.xqy");
 
 /**
- * This test verifies that runtime options are honored. It also verifies the details of the two documents that are 
+ * This test verifies that runtime options are honored. It also verifies the details of the two documents that are
  * persisted, while the twoJsonDocs test is focused more on the response object.
  */
 const flowName = "ingestAndMap";
@@ -20,7 +20,7 @@ const response = flowRunner.processContentWithFlow(flowName, contentArray, jobId
 const finalCustomer = hubTest.getRecord("/customer1.json");
 const assertions = [
   test.assertEqual("finished", response.jobStatus),
-  test.assertEqual(1, finalCustomer.document.envelope.instance.Customer.customerId, 
+  test.assertEqual(1, finalCustomer.document.envelope.instance.Customer.customerId,
     "Verifies that the entity was mapped correctly"),
   test.assertEqual("Customer", finalCustomer.document.envelope.instance.info.title),
   test.assertEqual("0.0.1", finalCustomer.document.envelope.instance.info.version),
@@ -28,7 +28,7 @@ const assertions = [
   test.assertEqual(2, finalCustomer.collections.length),
   test.assertEqual("Customer", finalCustomer.collections[0]),
   test.assertEqual("mapCustomer", finalCustomer.collections[1]),
-  test.assertEqual("read", finalCustomer.permissions["data-hub-operator"][0], 
+  test.assertEqual("read", finalCustomer.permissions["data-hub-operator"][0],
     "Verifies that the runtime options overrode the step options for permissions"),
   test.assertEqual("update", finalCustomer.permissions["data-hub-operator"][1]),
   test.assertEqual(xdmp.getCurrentUser(), finalCustomer.metadata.datahubCreatedBy),
@@ -43,7 +43,7 @@ assertions.concat(
   test.assertEqual("1", stagingCustomer.document.envelope.instance.customerId),
   test.assertEqual(1, stagingCustomer.collections.length),
   test.assertEqual("ingestCustomer", stagingCustomer.collections[0]),
-  test.assertEqual("read", stagingCustomer.permissions["data-hub-operator"][0], 
+  test.assertEqual("read", stagingCustomer.permissions["data-hub-operator"][0],
     "Verifies that permissions was overridden by the runtime options"),
   test.assertEqual("update", stagingCustomer.permissions["data-hub-operator"][1]),
   test.assertEqual(xdmp.getCurrentUser(), stagingCustomer.metadata.datahubCreatedBy),

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/flowStepWithErrorOnWrite.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/flowStepWithErrorOnWrite.sjs
@@ -13,7 +13,7 @@ const output = datahub.flow.runFlow('myNewFlow', 'error-on-write-job', [
     value: cts.doc('/customer1.json'),
     context: {}
   }
-], {}, 1);
+], {}, 2);
 
 [
   test.assertEqual(2, output.errorCount, `This should show an error count of 2 since it failed on write. Output: ${xdmp.toJsonString(output)}`),

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/provenance/writeProvenanceThrowsError.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/provenance/writeProvenanceThrowsError.sjs
@@ -9,7 +9,7 @@ const flowName = "doesntMatter";
 const flowStep = {"name":"myStep", "stepDefinitionName": "myCustomStep", "stepDefinitionType": "custom"};
 
 // Simulate a processed URI so that prov can be generated
-datahub.flow.writeQueue.push({"uri": "test.json"});
+datahub.flow.writeQueue.addContent(xdmp.databaseName(xdmp.database()), {"uri": "test.json"});
 datahub.flow.globalContext.completedItems = ["test.json"];
 
 // Try writing with an invalid input

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/suite-setup.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/suite-setup.xqy
@@ -27,6 +27,12 @@ declare option xdmp:mapping "false";
 
 xdmp:invoke-function(function() {
   xdmp:document-insert(
+    "/testModuleThrowsError.sjs",
+    test:get-test-file("testModuleThrowsError.sjs"),
+    (xdmp:default-permissions(), xdmp:permission("rest-extension-user", "execute"), xdmp:permission("data-hub-module-reader", "read"), xdmp:permission("data-hub-module-writer", "update")),
+    ()
+  ),
+  xdmp:document-insert(
     "/test/custom-null-step/main.sjs",
     test:get-test-file("nullStep.sjs"),
     (xdmp:default-permissions(), xdmp:permission("rest-extension-user", "execute"), xdmp:permission("data-hub-module-reader", "read"), xdmp:permission("data-hub-module-writer", "update")),

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/test-data/flows/myNewFlow.flow.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/test-data/flows/myNewFlow.flow.json
@@ -12,6 +12,14 @@
         "sourceDatabase": "data-hub-FINAL",
         "targetDatabase": "data-hub-FINAL"
       }
+    },
+    "2": {
+      "stepDefinitionName": "errorStep",
+      "stepDefinitionType": "CUSTOM",
+      "options": {
+        "sourceDatabase": "data-hub-FINAL",
+        "targetDatabase": "data-hub-FINAL"
+      }
     }
   }
 }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/test-data/step-definitions/errorStep.step.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/test-data/step-definitions/errorStep.step.json
@@ -1,0 +1,10 @@
+{
+  "name" : "errorStep",
+  "type" : "CUSTOM",
+  "options" : {
+    "sourceDatabase": "data-hub-FINAL",
+    "targetDatabase": "data-hub-FINAL"
+  },
+  "lang" : "zxx",
+  "modulePath" : "/testModuleThrowsError.sjs"
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/test-data/testModuleThrowsError.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/test-data/testModuleThrowsError.sjs
@@ -1,0 +1,7 @@
+function main(content, options) {
+  throw Error("This is intentional");
+}
+
+module.exports = {
+  main
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/flow-utils/makeCombinedOptions.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/flow-utils/makeCombinedOptions.sjs
@@ -1,0 +1,57 @@
+const test = require("/test/test-helper.xqy");
+const flowUtils = require("/data-hub/5/impl/flow-utils.sjs");
+
+function make(flow, stepDefOptions, stepNumber, runtimeOptions) {
+  return flowUtils.makeCombinedOptions(flow, {"options": stepDefOptions}, stepNumber, runtimeOptions);
+}
+
+function flowOverridesStepDef() {
+  const result = make({ "options": {"winner": "flow" }}, { "winner": "stepDef" }, null, null);
+  return [
+    test.assertEqual("flow", result.winner, "flow takes precedence over step def")
+  ];
+}
+
+function stepOverridesFlow() {
+  const step = {"options": {"winner": "step"}};
+  const flow = {"options": {"winner": "flow"}, "steps": {"1": step}};
+  const result = make(flow, { "winner": "stepDef" }, "1", null);
+  return [
+    test.assertEqual("step", result.winner, "step takes precedence over step def")
+  ];
+}
+
+function runtimeOverridesStep() {
+  const runtime = {"winner": "runtime"};
+  const step = {"options": {"winner": "step"}};
+  const flow = {"options": {"winner": "flow"}, "steps": {"1": step}};
+  const result = make(flow, { "winner": "stepDef" }, "1", runtime);
+  return [
+    test.assertEqual("runtime", result.winner, "runtime takes precedence over step")
+  ];
+}
+
+function stepSpecificOverridesRuntime() {
+  const runtime = {
+    "winner": "runtime",
+    "stepOptions": {
+      "1": {
+        "winner": "stepSpecific1"
+      }, 
+      "2": {
+        "winner": "stepSpecific2"
+      }
+    }
+  };
+  const step = {"options": {"winner": "step"}};
+  const flow = {"options": {"winner": "flow"}, "steps": {"1": step}};
+  const result = make(flow, { "winner": "stepDef" }, "1", runtime);
+  return [
+    test.assertEqual("stepSpecific1", result.winner, "stepOptions takes precedence over everything")
+  ];
+}
+
+[]
+  .concat(flowOverridesStepDef())
+  .concat(stepOverridesFlow())
+  .concat(runtimeOverridesStep())

--- a/marklogic-data-hub/src/test/resources/test-projects/simple-custom-step/flows/simpleCustomStepFlow.flow.json
+++ b/marklogic-data-hub/src/test/resources/test-projects/simple-custom-step/flows/simpleCustomStepFlow.flow.json
@@ -9,6 +9,7 @@
         "sourceQuery": "cts.collectionQuery('Customer')",
         "sourceDatabase": "data-hub-STAGING",
         "targetDatabase": "data-hub-FINAL",
+        "collections": ["simpleCustomStep-output"],
         "permissions": "data-hub-common,read,data-hub-common,update"
       }
     }

--- a/marklogic-data-hub/src/test/resources/test-projects/simple-custom-step/modules/root/custom-modules/custom/simpleCustomStep/simpleCustomStep.sjs
+++ b/marklogic-data-hub/src/test/resources/test-projects/simple-custom-step/modules/root/custom-modules/custom/simpleCustomStep/simpleCustomStep.sjs
@@ -1,4 +1,8 @@
 function main(contentItem, options) {
+  // If no value exists, it's probably because the test is using sourceQueryIsScript, so add a simple document so it can be persisted
+  if (!contentItem.value) {
+    contentItem.value = {"hello":"world"};
+  }
   return contentItem;
 }
 


### PR DESCRIPTION
### Description

To facilitate testing, I added support for step-specific options as well (really makes testing easier, as you don't have to create as many artifacts). 

Did the following cleanup too:

- Moved the duplicated Java code for combining options into StepRunnerUtil and added tests for it
- Moved the code for combining options in ML into flow-utils and added tests for it
- Created writeQueue.sjs so that flowRunner.sjs and flow.sjs can reuse it

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

