### PR TITLE
DHFPROD-7035: New test module for writing ML tests

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/marklogic-unit-test/hub-test-helper.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/marklogic-unit-test/hub-test-helper.xqy
@@ -1,0 +1,79 @@
+(:
+  Copyright (c) 2021 MarkLogic Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+:)
+xquery version "1.0-ml";
+
+module namespace dhmut = "http://marklogic.com/data-hub/marklogic-unit-test";
+
+import module namespace config = "http://marklogic.com/data-hub/config"
+  at "/com.marklogic.hub/config.xqy";
+
+(:
+Prepares the staging, final, and jobs databases so that a test can run in a clean environment. "clean" in this 
+context is defined as: the staging and final databases only contain user and DHF artifacts, and the jobs database 
+has been cleared of jobs data. 
+:)
+declare function prepare-databases() as empty-sequence()
+{
+  let $_ := (
+    prepare-database($config:STAGING-DATABASE),
+    prepare-database($config:FINAL-DATABASE),
+    prepare-jobs-database()
+  )
+  return ()
+};
+
+(:
+Prepare the given database for a test run by deleting all data other than user-defined and OOTB DHF artifacts.
+:)
+declare function prepare-database($database-name as xs:string) as empty-sequence()
+{
+  let $user-artifact-collections := (
+    "http://marklogic.com/entity-services/models",
+    "http://marklogic.com/data-hub/flow",
+    "http://marklogic.com/data-hub/step-definition",
+    "http://marklogic.com/data-hub/steps"
+  )
+  let $collections-to-preserve := ($user-artifact-collections, "hub-core-artifact")
+
+  let $query := cts:not-query(cts:collection-query($collections-to-preserve))
+  let $_ := invoke-in-database(function() {cts:uris((), (), $query) ! xdmp:document-delete(.)}, $database-name)
+  return ()
+};
+
+(:
+Clears the jobs collection via a collection delete. The database/forests are not cleared
+in case the jobs database has other data that should remain in between test suite runs.
+
+Provenance data is not deleted by this due to the protected collection restriction on 
+provenance documents. That restriction requires either an admin user or a user with the 
+ps-internal role, neither of which is recommended for running tests. User tests may instead
+install their own amp to allow for the provenance collection to be deleted, assuming that is 
+necessary to prepare the jobs database.
+:)
+declare function prepare-jobs-database() as empty-sequence()
+{
+  let $_ := invoke-in-database(function() {xdmp:collection-delete("Jobs")}, $config:JOB-DATABASE)
+  return ()
+};
+
+declare private function invoke-in-database($function, $database-name as xs:string)
+{
+  xdmp:invoke-function($function,
+    <options xmlns="xdmp:eval">
+      <database>{xdmp:database($database-name)}</database>
+    </options>
+  )
+};

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/marklogic-unit-test/hub-test-helper/prepareDatabasesTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/marklogic-unit-test/hub-test-helper/prepareDatabasesTest.sjs
@@ -1,0 +1,65 @@
+const consts = require("/data-hub/5/impl/consts.sjs");
+const dhmut = require("/data-hub/marklogic-unit-test/hub-test-helper.xqy");
+const hubTest = require("/test/data-hub-test-helper.xqy");
+const test = require("/test/test-helper.xqy");
+
+const DataHub = require("/data-hub/5/datahub.sjs");
+const datahub = new DataHub();
+
+// Insert some job documents so we can verify that they're deleted
+const fakeJob = datahub.jobs.createJob("myFlow");
+datahub.jobs.createBatch(fakeJob, {}, "1");
+
+const assertions = [];
+
+assertions.push(
+  test.assertEqual(1, hubTest.getStagingCollectionSize("raw-content"), "The user content should exist"),
+  test.assertEqual(1, hubTest.getFinalCollectionSize("raw-content"), "The user content should exist"),
+  test.assertEqual(1, hubTest.getJobCollectionSize("Job")),
+  test.assertEqual(1, hubTest.getJobCollectionSize("Batch")),
+
+  test.assertEqual(15, hubTest.getStagingCollectionSize(consts.HUB_ARTIFACT_COLLECTION), 
+    "Assuming 15 OOTB DHF artifacts; adjust this test as that number increases"),
+  test.assertEqual(1, hubTest.getStagingCollectionSize(consts.ENTITY_MODEL_COLLECTION)),
+  test.assertEqual(7, hubTest.getStagingCollectionSize(consts.FLOW_COLLECTION), 
+    "Expecting the 6 OOTB DHF flows and 1 user one"),
+  test.assertEqual(10, hubTest.getStagingCollectionSize(consts.STEP_DEFINITION_COLLECTION), 
+    "Expecting the 9 OOTB DHF step definitions and 1 user one"),
+  test.assertEqual(1, hubTest.getStagingCollectionSize(consts.STEP_COLLECTION), "Expecting 1 user step"),
+
+  test.assertEqual(15, hubTest.getFinalCollectionSize(consts.HUB_ARTIFACT_COLLECTION)),
+  test.assertEqual(1, hubTest.getFinalCollectionSize(consts.ENTITY_MODEL_COLLECTION)),
+  test.assertEqual(7, hubTest.getFinalCollectionSize(consts.FLOW_COLLECTION)),
+  test.assertEqual(10, hubTest.getFinalCollectionSize(consts.STEP_DEFINITION_COLLECTION)),
+  test.assertEqual(1, hubTest.getFinalCollectionSize(consts.STEP_COLLECTION))
+);
+
+// A user will normally put this in her suiteSetup or setup module; we need to call it here because the setup 
+// for this test involves first loading some user artifacts so we can verify they're not deleted.
+// Note also that if a user were to use setup.sjs, they'll need to include declareUpdate. If they use 
+// setup.xqy, they of course do not need to.
+xdmp.invokeFunction(function(){declareUpdate();dhmut.prepareDatabases();});
+
+assertions.push(
+  // Data that should have been deleted
+  test.assertEqual(0, hubTest.getStagingCollectionSize("raw-content"), "The user content should have been deleted"),
+  test.assertEqual(0, hubTest.getFinalCollectionSize("raw-content"), "The user content should have been deleted"),
+  test.assertEqual(0, hubTest.getJobCollectionSize("Job"), "Job doc should have been deleted"),
+  test.assertEqual(0, hubTest.getJobCollectionSize("Batch"), "Batch doc should have been deleted"),
+
+  // Data that should still exist
+  test.assertEqual(15, hubTest.getStagingCollectionSize(consts.HUB_ARTIFACT_COLLECTION), 
+    "Should still have all OOTB DHF artifacts"),
+  test.assertEqual(1, hubTest.getStagingCollectionSize(consts.ENTITY_MODEL_COLLECTION), "User artifacts should still exist"),
+  test.assertEqual(7, hubTest.getStagingCollectionSize(consts.FLOW_COLLECTION), "All flow should still exist"),
+  test.assertEqual(10, hubTest.getStagingCollectionSize(consts.STEP_DEFINITION_COLLECTION), "All step definitions should still exist"),
+  test.assertEqual(1, hubTest.getStagingCollectionSize(consts.STEP_COLLECTION), "The step should still exist"),
+
+  test.assertEqual(15, hubTest.getFinalCollectionSize(consts.HUB_ARTIFACT_COLLECTION)),
+  test.assertEqual(1, hubTest.getFinalCollectionSize(consts.ENTITY_MODEL_COLLECTION)),
+  test.assertEqual(7, hubTest.getFinalCollectionSize(consts.FLOW_COLLECTION)),
+  test.assertEqual(10, hubTest.getFinalCollectionSize(consts.STEP_DEFINITION_COLLECTION)),
+  test.assertEqual(1, hubTest.getFinalCollectionSize(consts.STEP_COLLECTION))
+);
+
+assertions 

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/marklogic-unit-test/hub-test-helper/setup.xqy
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/marklogic-unit-test/hub-test-helper/setup.xqy
@@ -1,0 +1,12 @@
+xquery version "1.0-ml";
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+hub-test:reset-hub();
+
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+import module namespace test = "http://marklogic.com/test" at "/test/test-helper.xqy";
+hub-test:load-entities($test:__CALLER_FILE__);
+
+xquery version "1.0-ml";
+import module namespace hub-test = "http://marklogic.com/data-hub/test" at "/test/data-hub-test-helper.xqy";
+import module namespace test = "http://marklogic.com/test" at "/test/test-helper.xqy";
+hub-test:load-non-entities($test:__CALLER_FILE__)

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/marklogic-unit-test/hub-test-helper/test-data/content/aCustomer.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/marklogic-unit-test/hub-test-helper/test-data/content/aCustomer.json
@@ -1,0 +1,3 @@
+{
+  "customerId": 1
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/marklogic-unit-test/hub-test-helper/test-data/entities/Customer.entity.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/marklogic-unit-test/hub-test-helper/test-data/entities/Customer.entity.json
@@ -1,0 +1,16 @@
+{
+  "info": {
+    "title": "Customer",
+    "version": "0.0.1",
+    "baseUri": "http://example.org/"
+  },
+  "definitions": {
+    "Customer": {
+      "properties": {
+        "customerId": {
+          "datatype": "integer"
+        }
+      }
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/marklogic-unit-test/hub-test-helper/test-data/flows/myFlow.flow.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/marklogic-unit-test/hub-test-helper/test-data/flows/myFlow.flow.json
@@ -1,0 +1,8 @@
+{
+  "name": "myFlow",
+  "steps": {
+    "1": {
+      "stepId": "myCustomStep-custom"
+    }
+  }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/marklogic-unit-test/hub-test-helper/test-data/step-definitions/custom/myCustomStep/myCustomStep.step.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/marklogic-unit-test/hub-test-helper/test-data/step-definitions/custom/myCustomStep/myCustomStep.step.json
@@ -1,0 +1,6 @@
+{
+  "lang": "zxx",
+  "name": "myCustomStep",
+  "type": "CUSTOM",
+  "modulePath": "/doesnt-matter.sjs"
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/marklogic-unit-test/hub-test-helper/test-data/steps/custom/myCustomStep.step.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/marklogic-unit-test/hub-test-helper/test-data/steps/custom/myCustomStep.step.json
@@ -1,0 +1,9 @@
+{
+  "name": "myCustomStep",
+  "stepId": "myCustomStep-custom",
+  "stepDefinitionName": "myCustomStep",
+  "stepDefinitionType": "CUSTOM",
+  "sourceQuery": "cts.collectionQuery('doesnt-matter')",
+  "sourceDatabase": "data-hub-STAGING",
+  "targetDatabase": "data-hub-FINAL"
+}


### PR DESCRIPTION
### Description

Picked "dhmut" as a prefix - "data hub marklogic unit test". Open to suggestions. 

I realized we can't use this in the DHF tests because this helper needs to retain user artifacts, whereas DHF tests almost always want to delete user artifacts. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

