### PR TITLE
DHFPROD-7081: Removed redundant methods from HubConfig

### DIFF
--- a/installer-for-dhs/src/main/java/com/marklogic/hub/dhs/installer/command/AbstractInstallerCommand.java
+++ b/installer-for-dhs/src/main/java/com/marklogic/hub/dhs/installer/command/AbstractInstallerCommand.java
@@ -38,7 +38,7 @@ public abstract class AbstractInstallerCommand extends LoggingObject implements 
 
         logger.info("Initializing DHF into project directory: " + projectDir);
 
-        hubConfig.createProject(projectDir.getAbsolutePath());
+        hubConfig.getHubProject().createProject(projectDir.getAbsolutePath());
         hubConfig.initHubProject();
 
         Map<String, String> params = options.getParams();

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/AbstractHubCentralTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/AbstractHubCentralTest.java
@@ -128,7 +128,7 @@ public abstract class AbstractHubCentralTest extends AbstractHubTest {
     @Override
     protected HubClient doRunAsUser(String username, String password) {
         // Need to create the project directory before applying properties
-        testHubConfig.createProject(testProjectDirectory);
+        testHubConfig.getHubProject().createProject(testProjectDirectory);
         testHubConfig.applyProperties(hubCentral.buildPropertySource(username, password));
 
         // Update the provider with a new HubClient
@@ -206,7 +206,7 @@ public abstract class AbstractHubCentralTest extends AbstractHubTest {
 
         runAsAdmin();
         Path dir = getHubProject().getEntityDatabaseDir();
-        List<String> filePaths = Arrays.asList(HubConfig.FINAL_ENTITY_DATABASE_FILE, HubConfig.STAGING_ENTITY_DATABASE_FILE);
+        List<String> filePaths = Arrays.asList(HubProject.FINAL_ENTITY_DATABASE_FILE, HubProject.STAGING_ENTITY_DATABASE_FILE);
         for (String filePath: filePaths) {
             File dbFile = Paths.get(dir.toString(), filePath).toFile();
             DeployHubDatabaseCommand dbCommand = new DeployHubDatabaseCommand(getHubConfig(), dbFile, dbFile.getName());

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/DataHub.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/DataHub.java
@@ -23,19 +23,7 @@ import com.marklogic.hub.flow.FlowRunner;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Handles creation and orchastration of DHF with a MarkLogic server.
- *
- * Includes installs, version validation, updates, and the init of a DHF project.
- */
 public interface DataHub {
-
-    /**
-     * Clears the database of all documents
-     * @param database - the name of the database in string form
-     */
-
-    void clearDatabase(String database);
 
     /**
      * Determines if the data hub is installed in MarkLogic
@@ -52,21 +40,9 @@ public interface DataHub {
     boolean isServerVersionValid(String versionString);
 
     /**
-     * Initializes the project on disk, creates scaffold project code
-     */
-    void initProject();
-
-    /**
      * Removes user's modules from the modules db
      */
     void clearUserModules();
-
-    /**
-     * Deletes document based on supplied doc uri in supplied database
-     * @param uri - document uri
-     * @param databaseKind - database type
-     */
-    void deleteDocument(String uri, DatabaseKind databaseKind);
 
     /**
      * Runs the pre-install check for the datahub populating the object
@@ -97,57 +73,10 @@ public interface DataHub {
     void updateIndexes();
 
     /**
-     * Uninstalls the data hub configuration, server-side config files and final databases and servers from MarkLogic
-     * Must be run as a user with sufficient privileges to install a data hub.
-     */
-    void uninstall();
-
-    /**
-     * Uninstalls the data hub configuration, server-side config files and final databases and servers from MarkLogic
-     * Must be run as a user with sufficient privileges to install a data hub.
-     * @param listener - the callback method to receive status updates
-     */
-    void uninstall(HubDeployStatusListener listener);
-
-    /**
-     * Checks to make sure all the versions and database in a valid configuration with version check
-     * Must be run as a user with sufficient privileges to install a data hub.
-     * @return boolean - if not, returns false, if safe to proceed ahead returns true
-     */
-    boolean isSafeToInstall();
-
-    /**
-     * Checks to see if the port is in use
-     * @param kind - the DatabaseKind enum value (ex STAGING or JOB)
-     * @return true if the port is in use, false if it is not
-     */
-    boolean isPortInUse(DatabaseKind kind);
-
-    /**
-     * Sets what appserver name is using the port
-     * @param kind - the DatabaseKind enum value (ex STAGING or JOB)
-     * @param usedBy - string name of what is using the port
-     */
-    void setPortInUseBy(DatabaseKind kind, String usedBy);
-
-    /**
-     * Returns name of what is using the port
-     * @param kind - the DatabaseKind enum value (ex STAGING or JOB)
-     * @return name of who using the port
-     */
-    String getPortInUseBy(DatabaseKind kind);
-
-    /**
      * Checks to see if the datahub and server versions are compatible
      * @return true if the server version matches, false if it does not
      */
     boolean isServerVersionOk();
-
-    /**
-     * Sets true or false if the server version is okay with this version of DHF
-     * @param serverVersionOk - true if it compatible or false if it is not
-     */
-    void setServerVersionOk(boolean serverVersionOk);
 
     /**
      * Returns the string presentation of the server version, eg: "9.03-1"
@@ -156,22 +85,9 @@ public interface DataHub {
     String getServerVersion();
 
     /**
-     * Sets the server version holder on the datahub object - currently unused
-     * @param serverVersion - server version as a string, eg: "9.03-1"
-     */
-    void setServerVersion(String serverVersion);
-
-    /**
      * Upgrades the installed datahub on the server to this version of the DataHub
      * Must be run as a user with sufficient privileges to install a data hub.
      * @return true or false based on success of the upgrade
      */
     boolean upgradeHub();
-
-    /**
-     * Creates and returns the FlowRunner object using the datahub's autowired hubconfig
-     *
-     * @return FlowRunner object with current hubconfig already set
-     */
-    FlowRunner getFlowRunner();
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/HubConfig.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/HubConfig.java
@@ -16,43 +16,16 @@
 package com.marklogic.hub;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.marklogic.appdeployer.AppConfig;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;
-import com.marklogic.hub.impl.HubConfigImpl;
-import com.marklogic.hub.step.StepDefinition;
 import com.marklogic.mgmt.ManageClient;
 import com.marklogic.mgmt.admin.AdminManager;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
-import java.nio.file.Path;
 
-/**
- * An interface to set, manage and recall the Data Hub's Configuration.
- * HubConfig has a singleton scope so set everything you want at the start of the application and
- * and then call {@link #refreshProject()} to wire up all clients and load the properties from gradle.properties
- * (optionally overridden with gradle-{env}.properties).
- */
-@JsonDeserialize(as = HubConfigImpl.class)
-@JsonSerialize(as = HubConfigImpl.class)
 public interface HubConfig {
-
-    String USER_MODULES_DEPLOY_TIMESTAMPS_PROPERTIES = "user-modules-deploy-timestamps.properties";
-
-    String PATH_PREFIX = "src/main/";
-    String HUB_CONFIG_DIR = PATH_PREFIX + "hub-internal-config";
-    String USER_CONFIG_DIR = PATH_PREFIX + "ml-config";
-    String ENTITY_CONFIG_DIR = PATH_PREFIX + "entity-config";
-    String STAGING_ENTITY_QUERY_OPTIONS_FILE = "staging-entity-options.xml";
-    String FINAL_ENTITY_QUERY_OPTIONS_FILE = "final-entity-options.xml";
-    String EXP_STAGING_ENTITY_QUERY_OPTIONS_FILE = "exp-staging-entity-options.xml";
-    String EXP_FINAL_ENTITY_QUERY_OPTIONS_FILE = "exp-final-entity-options.xml";
-    String STAGING_ENTITY_DATABASE_FILE = "staging-database.json";
-    String FINAL_ENTITY_DATABASE_FILE = "final-database.json";
-
 
     String DEFAULT_STAGING_NAME = "data-hub-STAGING";
     String DEFAULT_FINAL_NAME = "data-hub-FINAL";
@@ -63,23 +36,6 @@ public interface HubConfig {
     String DEFAULT_STAGING_SCHEMAS_DB_NAME = "data-hub-staging-SCHEMAS";
     String DEFAULT_FINAL_SCHEMAS_DB_NAME = "data-hub-final-SCHEMAS";
 
-    String DEFAULT_ROLE_NAME = "flow-operator-role";
-    String DEFAULT_USER_NAME = "flow-operator";
-    String DEFAULT_DEVELOPER_ROLE_NAME = "flow-developer-role";
-    String DEFAULT_DEVELOPER_USER_NAME = "flow-developer";
-
-    Integer DEFAULT_STAGING_PORT = 8010;
-    Integer DEFAULT_FINAL_PORT = 8011;
-    Integer DEFAULT_JOB_PORT = 8013;
-
-    String DEFAULT_AUTH_METHOD = "digest";
-    String DEFAULT_HUB_LOG_LEVEL = "default";
-
-    String DEFAULT_SCHEME = "http";
-
-    Integer DEFAULT_FORESTS_PER_HOST = 4;
-
-    String DEFAULT_CUSTOM_FOREST_PATH = "forests";
     String PII_QUERY_ROLESET_FILE = "pii-reader.json";
     String PII_PROTECTED_PATHS_FILE = "pii-protected-paths.json";
 
@@ -278,56 +234,6 @@ public interface HubConfig {
      */
     void setExternalName(DatabaseKind kind, String externalName);
 
-    // roles and users
-
-    /**
-     * Get the roleName the hub uses
-     * @return the name of the role the DHF uses
-     */
-    String getFlowOperatorRoleName();
-
-    /**
-     * Set the role name that the hub uses
-     * @param flowOperatorRoleName the name to use
-     */
-    void setFlowOperatorRoleName(String flowOperatorRoleName);
-
-    /**
-     * Get the current marklogic user name the hub uses
-     * @return the username
-     */
-    String getFlowOperatorUserName();
-
-    /**
-     * Sets the username for the hub to use in MarkLogic
-     * @param flowOperatorUserName - username to use
-     */
-    void setFlowOperatorUserName(String flowOperatorUserName);
-
-    /**
-     * Get the roleName the hub uses for developing flows
-     * @return the name of the role the DHF uses for developing flows
-     */
-    String getFlowDeveloperRoleName();
-
-    /**
-     * Set the role name that the hub uses for developing flows
-     * @param flowDeveloperRoleName the name to use for developing flows
-     */
-    void setFlowDeveloperRoleName(String flowDeveloperRoleName);
-
-    /**
-     * Get the current marklogic user name the hub uses to develop flows
-     * @return the username
-     */
-    String getFlowDeveloperUserName();
-
-    /**
-     * Sets the username for the hub to use in MarkLogic for developing flows
-     * @param flowDeveloperUserName - username to use
-     */
-    void setFlowDeveloperUserName(String flowDeveloperUserName);
-
     /**
      * Signifies if the host is a load balancer host.
      * @return a Boolean.
@@ -393,33 +299,17 @@ public interface HubConfig {
     String getStepDefinitionPermissions();
 
     /**
-     * Obtains the project directory as a string
-     * @return project directory
-     */
-    String getProjectDir();
-
-    /**
-     * Sets the directory for the current project
-     * @param projectDir - a string that represents the path to the project directory
-     */
-    void setProjectDir(String projectDir);
-
-    /**
      * Returns the HubProject associated with the HubConfig
      * @return current hubProject associated with the HubConfig
      */
     HubProject getHubProject();
 
     /**
-     * Initializes the hub project on disk
+     * Initializes the hub project on disk. As of 5.4, this requires access to all the project properties, as those
+     * properties affect how the project is initialized. This doesn't really seem to make sense though, because the
+     * primary way of specifying properties is by reading in a properties file from the project.
      */
     void initHubProject();
-
-    /**
-     * Creates a new DatabaseClient for accessing the AppServices app
-     * @return - a DatabaseClient
-     */
-    DatabaseClient newAppServicesClient();
 
     /**
      * Creates a new DatabaseClient for accessing the Job database
@@ -428,124 +318,15 @@ public interface HubConfig {
     DatabaseClient newJobDbClient();
 
     /**
-     * Use newJobDbClient instead.  This function returns a client to
-     * the JOBS database.
-     * @return - a DatabaseClient
-     */
-    @Deprecated
-    DatabaseClient newTraceDbClient();
-
-    /**
      * Creates a new DatabaseClient for accessing the Hub Modules database
      * @return - a DatabaseClient
      */
     DatabaseClient newModulesDbClient();
 
     /**
-     * Gets the path for the modules directory
-     * @return the path for the modules directory
-     */
-    Path getModulesDir();
-
-    /**
-     * Gets the path for the hub plugins directory
-     * @return the path for the hub plugins directory
-     */
-    Path getHubPluginsDir();
-
-    /**
-     * Gets the path for the hub entities directory
-     * @return the path for the hub entities directory
-     */
-    Path getHubEntitiesDir();
-
-    /**
-     * Gets the path for the hub mappings directory
-     * @return the path for the hub mappings directory
-     */
-    Path getHubMappingsDir();
-
-    Path getStepDefinitionPath(StepDefinition.StepDefinitionType type);
-
-    /**
-     * Gets the path for the hub's config directory
-     * @return the path for the hub's config directory
-     */
-    Path getHubConfigDir();
-
-    /**
-     * Gets the path for the hub's database directory
-     * @return the path for the hub's database directory
-     */
-    Path getHubDatabaseDir();
-
-    /**
-     * Gets the path for the hub servers directory
-     * @return the path for the hub servers database directory
-     */
-    Path getHubServersDir();
-
-    /**
-     * Gets the path for the hub's security directory
-     * @return the path for the hub's security directory
-     */
-    Path getHubSecurityDir();
-
-    /**
-     * Gets the path for the user config directory
-     * @return the path for the user config directory
-     */
-    Path getUserConfigDir();
-
-    /**
-     * Gets the path for the user security directory
-     * @return the path for the user security directory
-     */
-    Path getUserSecurityDir();
-
-    /**
-     * Gets the path for the user database directory
-     * @return the path for the user database directory
-     */
-    Path getUserDatabaseDir();
-
-    /**
-     * Gets the path for the user schemas directory
-     * @return the path for the user schemas directory
-     */
-    Path getUserSchemasDir();
-
-    /**
-     * Gets the path for the user servers directory
-     * @return the path for the user servers database directory
-     */
-    Path getUserServersDir();
-
-    /**
-     * Gets the path for the entity database directory
-     * @return the path for the entity's database directory
-     */
-    Path getEntityDatabaseDir();
-
-    /**
-     * Gets the path for the flows directory
-     *
-     * @return the path for the flows directory
-     */
-    Path getFlowsDir();
-
-    /**
-     * Gets the path for the step definitions directory
-     *
-     * @return the path for the step definitions directory
-     */
-    Path getStepDefinitionsDir();
-
-    /**
      * Returns the current AppConfig object attached to the HubConfig
      * @return Returns current AppConfig object set for HubConfig
      */
-    @JsonIgnore
     AppConfig getAppConfig();
 
     /**
@@ -609,34 +390,5 @@ public interface HubConfig {
      */
     DatabaseClient newFinalClient(String dbName);
 
-    /**
-     * Gets information on a datahub configuration
-     * @return information on the datahub configuration as a string
-     */
-    String getInfo();
-
-
-    /**
-     * Initializes the java application state to a specific location.  A properties file
-     * is expected to be found in this directory.
-     * @param projectDirString The directory in which to find properties for a project.
-     */
-    void createProject(String projectDirString);
-
-    /**
-     * In a non-Gradle environment, a client can use this to load properties from a "gradle-(environment).properties"
-     * file, similar to how the Gradle properties plugin would process such a file in a Gradle context.
-     *
-     * @param environment - The name of the environment to use (local,dev,qa,prod,...)
-     * @return A HubConfig
-     */
     HubConfig withPropertiesFromEnvironment(String environment);
-
-    /**
-     * Loads HubConfig object with values from gradle.properties (optionally overridden with
-     * gradle-(environment).properties). Once Spring creates HubConfig object and the project is initialized with
-     * {@link #createProject(String)} you can use setter methods to change HubConfig properties
-     * and then call this method.
-     */
-    void refreshProject();
 }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/HubProject.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/HubProject.java
@@ -34,6 +34,16 @@ public interface HubProject {
     String HUB_CONFIG_DIR = PATH_PREFIX + "hub-internal-config";
     String USER_CONFIG_DIR = PATH_PREFIX + "ml-config";
 
+    String USER_MODULES_DEPLOY_TIMESTAMPS_PROPERTIES = "user-modules-deploy-timestamps.properties";
+
+    String ENTITY_CONFIG_DIR = PATH_PREFIX + "entity-config";
+    String STAGING_ENTITY_QUERY_OPTIONS_FILE = "staging-entity-options.xml";
+    String FINAL_ENTITY_QUERY_OPTIONS_FILE = "final-entity-options.xml";
+    String EXP_STAGING_ENTITY_QUERY_OPTIONS_FILE = "exp-staging-entity-options.xml";
+    String EXP_FINAL_ENTITY_QUERY_OPTIONS_FILE = "exp-final-entity-options.xml";
+    String STAGING_ENTITY_DATABASE_FILE = "staging-database.json";
+    String FINAL_ENTITY_DATABASE_FILE = "final-database.json";
+
     /**
      * Gets the string used to originally make the project
      *
@@ -184,35 +194,11 @@ public interface HubProject {
     Path getFlowsDir();
 
     /**
-     * Gets the path for the hub staging modules
-     *
-     * @return the path for the hub staging modules
-     */
-    @Deprecated
-    Path getHubStagingModulesDir();
-
-    /**
-     * Gets the path for the user staging modules
-     *
-     * @return the path for the user staging modules
-     */
-    @Deprecated
-    Path getUserStagingModulesDir();
-
-    /**
      * Gets the path for the modules directory
      *
      * @return the path for the modules directory
      */
     Path getModulesDir();
-
-    /**
-     * Gets the path for the user final modules
-     *
-     * @return the path for the user final modules
-     */
-    @Deprecated
-    Path getUserFinalModulesDir();
 
     /**
      * Gets the path for the custom modules directory
@@ -253,16 +239,6 @@ public interface HubProject {
      * Exports the project content to disk
      */
     void exportProject(File location);
-
-    /**
-     * Exports the project content to output stream
-     */
-    void exportProject(OutputStream outputStream);
-
-    /**
-     * Returns the name of the project
-     */
-    String getProjectName();
 
     String getUserModulesDeployTimestampFile();
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/DeployHubDatabaseCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/DeployHubDatabaseCommand.java
@@ -137,8 +137,8 @@ public class DeployHubDatabaseCommand extends DeployDatabaseCommand {
      * @throws IOException
      */
     protected ObjectNode mergePayloadWithEntityConfigFileIfItExists(CommandContext context, ObjectNode payloadNode) throws IOException {
-        if (hubConfig.getEntityDatabaseDir() != null && this.databaseFilename != null) {
-            File entityDatabaseDir = hubConfig.getEntityDatabaseDir().toFile();
+        if (hubConfig.getHubProject().getEntityDatabaseDir() != null && this.databaseFilename != null) {
+            File entityDatabaseDir = hubConfig.getHubProject().getEntityDatabaseDir().toFile();
             if (entityDatabaseDir != null) {
                 File entityDatabaseFile = new File(entityDatabaseDir, this.databaseFilename);
                 if (entityDatabaseFile != null && entityDatabaseFile.exists()) {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateHubTDETemplateCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/GenerateHubTDETemplateCommand.java
@@ -116,7 +116,7 @@ public class GenerateHubTDETemplateCommand extends GenerateModelArtifactsCommand
 
         } else {
             logger.info("No data hub entity files found under {} or its sub-directories.",
-                hubConfig.getHubEntitiesDir());
+                hubConfig.getHubProject().getHubEntitiesDir());
         }
 
     }
@@ -157,7 +157,7 @@ public class GenerateHubTDETemplateCommand extends GenerateModelArtifactsCommand
             entityNameFileMapKeys.retainAll(entityNamesAsList);
 
             if (entityNameFileMapKeys.isEmpty()) {
-                logger.warn("No entities files found under {} or its sub-directories with the entity name(s) {}", hubConfig.getHubEntitiesDir(),entityNamesAsList);
+                logger.warn("No entities files found under {} or its sub-directories with the entity name(s) {}", hubConfig.getHubProject().getHubEntitiesDir(),entityNamesAsList);
             }
         }
     }
@@ -172,7 +172,7 @@ public class GenerateHubTDETemplateCommand extends GenerateModelArtifactsCommand
 
     protected List<File> findEntityFiles() {
         List<File> entities = new ArrayList<>();
-        Path entitiesPath = hubConfig.getHubEntitiesDir();
+        Path entitiesPath = hubConfig.getHubProject().getHubEntitiesDir();
         File[] entityDefs = entitiesPath.toFile().listFiles(pathname -> pathname.toString().endsWith(ENTITY_FILE_EXTENSION) && !pathname.isHidden());
         if (entityDefs != null) {
             entities.addAll(Arrays.asList(entityDefs));

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommand.java
@@ -129,7 +129,7 @@ public class LoadUserArtifactsCommand extends AbstractCommand {
      * @throws IOException
      */
     private void loadModels(HubClient hubClient) throws IOException {
-        final Path modelsPath = hubConfig.getHubEntitiesDir();
+        final Path modelsPath = hubConfig.getHubProject().getHubEntitiesDir();
         if (modelsPath.toFile().exists()) {
             ArrayNode modelsArray = objectMapper.createArrayNode();
             EntityDefModulesFinder modulesFinder = new EntityDefModulesFinder();
@@ -163,7 +163,7 @@ public class LoadUserArtifactsCommand extends AbstractCommand {
      * @throws IOException
      */
     private void loadLegacyMappings(HubClient hubClient) throws IOException {
-        Path mappingsPath = hubConfig.getHubMappingsDir();
+        Path mappingsPath = hubConfig.getHubProject().getHubMappingsDir();
         if (mappingsPath.toFile().exists()) {
             JSONDocumentManager finalDocMgr = hubClient.getFinalClient().newJSONDocumentManager();
             JSONDocumentManager stagingDocMgr = hubClient.getStagingClient().newJSONDocumentManager();

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserModulesCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserModulesCommand.java
@@ -36,6 +36,7 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.hub.EntityManager;
 import com.marklogic.hub.HubConfig;
+import com.marklogic.hub.HubProject;
 import com.marklogic.hub.deploy.util.HubFileFilter;
 import com.marklogic.hub.impl.EntityManagerImpl;
 import com.marklogic.hub.legacy.LegacyFlowManager;
@@ -192,7 +193,7 @@ public class LoadUserModulesCommand extends LoadModulesCommand {
         DatabaseClient stagingClient = hubConfig.newStagingClient();
         DatabaseClient finalClient = hubConfig.newFinalClient();
 
-        Path userModulesPath = hubConfig.getHubPluginsDir();
+        Path userModulesPath = hubConfig.getHubProject().getHubPluginsDir();
         String baseDir = userModulesPath.normalize().toAbsolutePath().toString();
         Path startPath = userModulesPath.resolve("entities");
 
@@ -216,7 +217,7 @@ public class LoadUserModulesCommand extends LoadModulesCommand {
         // deploy the auto-generated ES search options, but not if mlWatch is being run, as it will result in the same
         // options being generated and loaded over and over
         if (loadQueryOptions) {
-            Path entityConfigDir = Paths.get(hubConfig.getHubProject().getProjectDirString(), HubConfig.ENTITY_CONFIG_DIR);
+            Path entityConfigDir = Paths.get(hubConfig.getHubProject().getProjectDirString(), HubProject.ENTITY_CONFIG_DIR);
             if (!entityConfigDir.toFile().exists()) {
                 entityConfigDir.toFile().mkdirs();
             }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/EntityManagerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/EntityManagerImpl.java
@@ -33,6 +33,7 @@ import com.marklogic.client.util.RequestParameters;
 import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.EntityManager;
 import com.marklogic.hub.HubConfig;
+import com.marklogic.hub.HubProject;
 import com.marklogic.hub.dataservices.ModelsService;
 import com.marklogic.hub.entity.*;
 import com.marklogic.hub.error.DataHubProjectException;
@@ -81,10 +82,10 @@ public class EntityManagerImpl extends LoggingObject implements EntityManager {
                 dir.toFile().mkdirs();
             }
 
-            File stagingFile = Paths.get(dir.toString(), HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile();
-            File finalFile = Paths.get(dir.toString(), HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile();
-            File expStagingFile = Paths.get(dir.toString(), HubConfig.EXP_STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile();
-            File expFinalFile = Paths.get(dir.toString(), HubConfig.EXP_FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile();
+            File stagingFile = Paths.get(dir.toString(), HubProject.STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile();
+            File finalFile = Paths.get(dir.toString(), HubProject.FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile();
+            File expStagingFile = Paths.get(dir.toString(), HubProject.EXP_STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile();
+            File expFinalFile = Paths.get(dir.toString(), HubProject.EXP_FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile();
 
             List<JsonNode> entities = getAllEntities();
             String options = generator.generateOptions(entities, false);
@@ -115,12 +116,12 @@ public class EntityManagerImpl extends LoggingObject implements EntityManager {
 
         HashMap<Enum, Boolean> loadedResources = new HashMap<>();
 
-        if (deployQueryOptions(hubConfig.newFinalClient(), HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE) &&
-            deployQueryOptions(hubConfig.newFinalClient(), HubConfig.EXP_FINAL_ENTITY_QUERY_OPTIONS_FILE)) {
+        if (deployQueryOptions(hubConfig.newFinalClient(), HubProject.FINAL_ENTITY_QUERY_OPTIONS_FILE) &&
+            deployQueryOptions(hubConfig.newFinalClient(), HubProject.EXP_FINAL_ENTITY_QUERY_OPTIONS_FILE)) {
             loadedResources.put(DatabaseKind.FINAL, true);
         }
-        if (deployQueryOptions(hubConfig.newStagingClient(), HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE) &&
-            deployQueryOptions(hubConfig.newStagingClient(), HubConfig.EXP_STAGING_ENTITY_QUERY_OPTIONS_FILE)) {
+        if (deployQueryOptions(hubConfig.newStagingClient(), HubProject.STAGING_ENTITY_QUERY_OPTIONS_FILE) &&
+            deployQueryOptions(hubConfig.newStagingClient(), HubProject.EXP_STAGING_ENTITY_QUERY_OPTIONS_FILE)) {
             loadedResources.put(DatabaseKind.STAGING, true);
         }
 
@@ -155,9 +156,9 @@ public class EntityManagerImpl extends LoggingObject implements EntityManager {
     @Override
     public boolean saveDbIndexes() {
         try {
-            Path dir = hubConfig.getEntityDatabaseDir();
-            File finalFile = Paths.get(dir.toString(), HubConfig.FINAL_ENTITY_DATABASE_FILE).toFile();
-            File stagingFile = Paths.get(dir.toString(), HubConfig.STAGING_ENTITY_DATABASE_FILE).toFile();
+            Path dir = hubConfig.getHubProject().getEntityDatabaseDir();
+            File finalFile = Paths.get(dir.toString(), HubProject.FINAL_ENTITY_DATABASE_FILE).toFile();
+            File stagingFile = Paths.get(dir.toString(), HubProject.STAGING_ENTITY_DATABASE_FILE).toFile();
             if (!dir.toFile().exists()) {
                 dir.toFile().mkdirs();
             }
@@ -192,7 +193,7 @@ public class EntityManagerImpl extends LoggingObject implements EntityManager {
 
     private List<JsonNode> getAllEntities() {
         List<JsonNode> entities = new ArrayList<>(getAllLegacyEntities());
-        Path entitiesPath = hubConfig.getHubEntitiesDir();
+        Path entitiesPath = hubConfig.getHubProject().getHubEntitiesDir();
         File[] entityDefs = entitiesPath.toFile().listFiles(pathname -> pathname.toString().endsWith(ENTITY_FILE_EXTENSION) && !pathname.isHidden());
         if (entityDefs != null) {
             ObjectMapper objectMapper = new ObjectMapper();
@@ -376,7 +377,7 @@ public class EntityManagerImpl extends LoggingObject implements EntityManager {
     @Override
     public List<HubEntity> getEntities(Boolean extendSubEntities) {
         List<HubEntity> entities = new ArrayList<>();
-        Path entitiesPath = hubConfig.getHubEntitiesDir();
+        Path entitiesPath = hubConfig.getHubProject().getHubEntitiesDir();
         ObjectMapper objectMapper = new ObjectMapper();
         File[] entityDefs = entitiesPath.toFile().listFiles((dir, name) -> name.endsWith(ENTITY_FILE_EXTENSION));
         if (entityDefs != null) {
@@ -431,7 +432,7 @@ public class EntityManagerImpl extends LoggingObject implements EntityManager {
                 }
             }
         } else {
-            Path dir = hubConfig.getHubEntitiesDir();
+            Path dir = hubConfig.getHubProject().getHubEntitiesDir();
             if (!dir.toFile().exists()) {
                 dir.toFile().mkdirs();
             }
@@ -473,7 +474,7 @@ public class EntityManagerImpl extends LoggingObject implements EntityManager {
     }
 
     public void deleteEntity(String entity) {
-        Path entityPath = hubConfig.getHubEntitiesDir().resolve(entity + ENTITY_FILE_EXTENSION);
+        Path entityPath = hubConfig.getHubProject().getHubEntitiesDir().resolve(entity + ENTITY_FILE_EXTENSION);
         if (entityPath.toFile().exists()) {
             entityPath.toFile().delete();
         }
@@ -501,8 +502,8 @@ public class EntityManagerImpl extends LoggingObject implements EntityManager {
     @Override
     public boolean savePii() {
         try {
-            Path protectedPaths = hubConfig.getUserSecurityDir().resolve("protected-paths");
-            Path queryRolesets = hubConfig.getUserSecurityDir().resolve("query-rolesets");
+            Path protectedPaths = hubConfig.getHubProject().getUserSecurityDir().resolve("protected-paths");
+            Path queryRolesets = hubConfig.getHubProject().getUserSecurityDir().resolve("query-rolesets");
             if (!protectedPaths.toFile().exists()) {
                 protectedPaths.toFile().mkdirs();
             }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/FlowManagerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/FlowManagerImpl.java
@@ -125,7 +125,7 @@ public class FlowManagerImpl extends LoggingObject implements FlowManager {
     }
 
     public ObjectNode getLocalFlowAsJSON(String flowName) {
-        Path flowPath = Paths.get(hubConfig.getFlowsDir().toString(), flowName + FLOW_FILE_EXTENSION);
+        Path flowPath = Paths.get(hubConfig.getHubProject().getFlowsDir().toString(), flowName + FLOW_FILE_EXTENSION);
         InputStream inputStream = null;
         // first, let's check our resources
         inputStream = getClass().getResourceAsStream("/hub-internal-artifacts/flows/" + flowName + FLOW_FILE_EXTENSION);
@@ -184,7 +184,7 @@ public class FlowManagerImpl extends LoggingObject implements FlowManager {
     @Override
     public List<String> getLocalFlowNames() {
         // Get all the files with flow.json extension from flows dir
-        File flowsDir = hubConfig.getFlowsDir().toFile();
+        File flowsDir = hubConfig.getHubProject().getFlowsDir().toFile();
         if (flowsDir == null || !flowsDir.exists()) {
             return new ArrayList<>();
         }
@@ -239,7 +239,7 @@ public class FlowManagerImpl extends LoggingObject implements FlowManager {
 
     @Override
     public void deleteFlow(String flowName) {
-        File flowFile = Paths.get(hubConfig.getFlowsDir().toString(), flowName + FLOW_FILE_EXTENSION).toFile();
+        File flowFile = Paths.get(hubConfig.getHubProject().getFlowsDir().toString(), flowName + FLOW_FILE_EXTENSION).toFile();
         if (flowFile.exists()) {
             try {
                 FileUtils.forceDelete(flowFile);
@@ -311,12 +311,12 @@ public class FlowManagerImpl extends LoggingObject implements FlowManager {
     }
 
     public File getFileForLocalFlow(String flowName) {
-        File flowsDir = hubConfig.getFlowsDir().toFile();
+        File flowsDir = hubConfig.getHubProject().getFlowsDir().toFile();
         if (!flowsDir.exists()) {
             flowsDir.mkdirs();
         }
         String flowFileName = flowName + FLOW_FILE_EXTENSION;
-        return Paths.get(hubConfig.getFlowsDir().toString(), flowFileName).toFile();
+        return Paths.get(hubConfig.getHubProject().getFlowsDir().toString(), flowFileName).toFile();
     }
 
     @Override
@@ -333,7 +333,7 @@ public class FlowManagerImpl extends LoggingObject implements FlowManager {
     public Pair<File, String> addStepToFlow(String flowName, String stepName, String stepType) {
         StepDefinition.StepDefinitionType stepDefType = StepDefinition.StepDefinitionType.getStepDefinitionType(stepType);
         Assert.notNull(stepDefType, "Unrecognized step type: " + stepType);
-        File flowFile = hubConfig.getFlowsDir().resolve(flowName + ".flow.json").toFile();
+        File flowFile = hubConfig.getHubProject().getFlowsDir().resolve(flowName + ".flow.json").toFile();
         JsonNode flow;
         try{
             DatabaseClient stagingClient = hubConfig.newHubClient().getStagingClient();
@@ -355,7 +355,7 @@ public class FlowManagerImpl extends LoggingObject implements FlowManager {
 
     @Override
     public boolean isFlowExisted(String flowName) {
-        File flowFile = Paths.get(hubConfig.getFlowsDir().toString(), flowName + FLOW_FILE_EXTENSION).toFile();
+        File flowFile = Paths.get(hubConfig.getHubProject().getFlowsDir().toString(), flowName + FLOW_FILE_EXTENSION).toFile();
         if (flowFile.exists()) {
             return true;
         }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubConfigImpl.java
@@ -244,10 +244,6 @@ public class HubConfigImpl extends HubClientConfig implements HubConfig
         return hubProject;
     }
 
-    public void createProject(String projectDirString) {
-        requireHubProject().createProject(projectDirString);
-    }
-
     public String getHost() { return appConfig != null ? appConfig.getHost() : super.getHost(); }
 
     @Override public String getDbName(DatabaseKind kind){
@@ -815,31 +811,31 @@ public class HubConfigImpl extends HubClientConfig implements HubConfig
     }
 
     // roles and users
-    @Override public String getFlowOperatorRoleName() {
+    public String getFlowOperatorRoleName() {
         return flowOperatorRoleName;
     }
-    @Override public void setFlowOperatorRoleName(String flowOperatorRoleName) {
+    public void setFlowOperatorRoleName(String flowOperatorRoleName) {
         this.flowOperatorRoleName = flowOperatorRoleName;
     }
 
-    @Override public String getFlowOperatorUserName() {
+    public String getFlowOperatorUserName() {
         return flowOperatorUserName;
     }
-    @Override  public void setFlowOperatorUserName(String flowOperatorUserName) {
+    public void setFlowOperatorUserName(String flowOperatorUserName) {
         this.flowOperatorUserName = flowOperatorUserName;
     }
 
-    @Override public String getFlowDeveloperRoleName() {
+    public String getFlowDeveloperRoleName() {
         return flowDeveloperRoleName;
     }
-    @Override public void setFlowDeveloperRoleName(String flowDeveloperRoleName) {
+    public void setFlowDeveloperRoleName(String flowDeveloperRoleName) {
         this.flowDeveloperRoleName = flowDeveloperRoleName;
     }
 
-    @Override public String getFlowDeveloperUserName() {
+    public String getFlowDeveloperUserName() {
         return flowDeveloperUserName;
     }
-    @Override  public void setFlowDeveloperUserName(String flowDeveloperUserName) {
+    public void setFlowDeveloperUserName(String flowDeveloperUserName) {
         this.flowDeveloperUserName = flowDeveloperUserName;
     }
 
@@ -921,19 +917,6 @@ public class HubConfigImpl extends HubClientConfig implements HubConfig
         this.jobPermissions = jobPermissions;
     }
 
-
-    @Override
-    @Deprecated
-    public String getProjectDir() {
-        return requireHubProject().getProjectDirString();
-    }
-
-    @Override
-    @Deprecated
-    public void setProjectDir(String projectDir) {
-        createProject(projectDir);
-    }
-
     public void setEntityModelPermissions(String entityModelPermissions) {
         this.entityModelPermissions = entityModelPermissions;
     }
@@ -967,11 +950,6 @@ public class HubConfigImpl extends HubClientConfig implements HubConfig
         this.requireHubProject().init(appConfig.getCustomTokens());
     }
 
-    @JsonIgnore
-    public void refreshProject() {
-        loadConfigurationFromProperties(null, true);
-    }
-
     /**
      * Use this when you need to apply properties, and you likely also want to load properties from Gradle files.
      * As of 5.3.0, this is really only intended for use within QuickStart, which depends on getting properties from
@@ -998,7 +976,7 @@ public class HubConfigImpl extends HubClientConfig implements HubConfig
                         logger.info("Loading additional properties from " + envPropertiesFile.getAbsolutePath());
                     }
                     loadPropertiesFromFile(envPropertiesFile, gradleAndUserProperties);
-                    requireHubProject().setUserModulesDeployTimestampFile(envString + "-" + USER_MODULES_DEPLOY_TIMESTAMPS_PROPERTIES);
+                    requireHubProject().setUserModulesDeployTimestampFile(envString + "-" + HubProject.USER_MODULES_DEPLOY_TIMESTAMPS_PROPERTIES);
                 }
             }
         }
@@ -1035,10 +1013,6 @@ public class HubConfigImpl extends HubClientConfig implements HubConfig
     }
     public void setAdminManager(AdminManager adminManager) { this.adminManager = adminManager; }
 
-    public DatabaseClient newAppServicesClient() {
-        return getAppConfig().newAppServicesDatabaseClient(getStagingDbName());
-    }
-
     @Override
     public DatabaseClient newStagingClient() {
         return newStagingClient(getStagingDbName());
@@ -1054,94 +1028,6 @@ public class HubConfigImpl extends HubClientConfig implements HubConfig
     @Override
     public DatabaseClient newFinalClient() {
         return newFinalClient(getFinalDbName());
-    }
-
-    @Deprecated
-    public DatabaseClient newTraceDbClient() {
-        return newJobDbClient();
-    }
-
-    @JsonIgnore
-    @Override public Path getModulesDir() {
-        return requireHubProject().getModulesDir();
-    }
-
-    @JsonIgnore
-    public Path getHubProjectDir() { return requireHubProject().getProjectDir(); }
-
-    @JsonIgnore
-    @Override public Path getHubPluginsDir() {
-        return requireHubProject().getHubPluginsDir();
-    }
-
-    @JsonIgnore
-    @Override public Path getHubEntitiesDir() { return requireHubProject().getHubEntitiesDir(); }
-
-    @JsonIgnore
-    @Override public Path getHubMappingsDir() { return requireHubProject().getHubMappingsDir(); }
-
-    @JsonIgnore
-    @Override
-    public Path getStepDefinitionPath(StepDefinition.StepDefinitionType type) {
-        return requireHubProject().getStepDefinitionPath(type);
-    }
-
-    @JsonIgnore
-    @Override public Path getHubConfigDir() {
-        return requireHubProject().getHubConfigDir();
-    }
-
-    @JsonIgnore
-    @Override public Path getHubDatabaseDir() {
-        return requireHubProject().getHubDatabaseDir();
-    }
-
-    @JsonIgnore
-    @Override public Path getHubServersDir() {
-        return requireHubProject().getHubServersDir();
-    }
-
-    @JsonIgnore
-    @Override public Path getHubSecurityDir() {
-        return requireHubProject().getHubSecurityDir();
-    }
-
-    @JsonIgnore
-    @Override public Path getUserSecurityDir() {
-        return requireHubProject().getUserSecurityDir();
-    }
-
-    @JsonIgnore
-    @Override public Path getUserConfigDir() {
-        return requireHubProject().getUserConfigDir();
-    }
-
-    @JsonIgnore
-    @Override public Path getUserDatabaseDir() {
-        return requireHubProject().getUserDatabaseDir();
-    }
-
-    @JsonIgnore
-    @Override public Path getUserSchemasDir() { return requireHubProject().getUserSchemasDir(); }
-
-    @JsonIgnore
-    @Override public Path getEntityDatabaseDir() {
-        return requireHubProject().getEntityDatabaseDir();
-    }
-
-    @Override
-    public Path getFlowsDir() {
-        return requireHubProject().getFlowsDir();
-    }
-
-    @Override
-    public Path getStepDefinitionsDir() {
-        return requireHubProject().getStepDefinitionsDir();
-    }
-
-    @JsonIgnore
-    @Override public Path getUserServersDir() {
-        return requireHubProject().getUserServersDir();
     }
 
     @JsonIgnore
@@ -1294,7 +1180,7 @@ public class HubConfigImpl extends HubClientConfig implements HubConfig
             initializeConfigDirs(config);
             initializeModulePaths(config);
             List<String> paths = new ArrayList<>();
-            paths.add(getUserSchemasDir().toString());
+            paths.add(getHubProject().getUserSchemasDir().toString());
             config.setSchemaPaths(paths);
         }
 
@@ -1323,8 +1209,8 @@ public class HubConfigImpl extends HubClientConfig implements HubConfig
 
         if (configDirsIsSetToTheMlAppDeployerDefault) {
             List<ConfigDir> configDirs = new ArrayList<>();
-            configDirs.add(new ConfigDir(getHubConfigDir().toFile()));
-            configDirs.add(new ConfigDir(getUserConfigDir().toFile()));
+            configDirs.add(new ConfigDir(getHubProject().getHubConfigDir().toFile()));
+            configDirs.add(new ConfigDir(getHubProject().getUserConfigDir().toFile()));
             config.setConfigDirs(configDirs);
         }
         else {
@@ -1385,18 +1271,13 @@ public class HubConfigImpl extends HubClientConfig implements HubConfig
     }
 
     @JsonIgnore
-    public String getInfo()
-    {
-
+    public String getInfo() {
         try {
             return new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(this);
         }
-        catch(Exception e)
-        {
-            throw new DataHubConfigurationException("Your datahub configuration could not serialize");
-
+        catch(Exception e) {
+            throw new RuntimeException("Unable to serialize HubConfigImpl: " + e.getMessage());
         }
-
     }
 
     /**
@@ -1410,7 +1291,7 @@ public class HubConfigImpl extends HubClientConfig implements HubConfig
     @JsonIgnore
     public HubConfig withPropertiesFromEnvironment(String environment) {
         this.envString = environment;
-        requireHubProject().setUserModulesDeployTimestampFile(envString + "-" + USER_MODULES_DEPLOY_TIMESTAMPS_PROPERTIES);
+        requireHubProject().setUserModulesDeployTimestampFile(envString + "-" + HubProject.USER_MODULES_DEPLOY_TIMESTAMPS_PROPERTIES);
         return this;
     }
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/HubProjectImpl.java
@@ -45,8 +45,6 @@ import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-import static com.marklogic.hub.HubConfig.USER_MODULES_DEPLOY_TIMESTAMPS_PROPERTIES;
-
 public class HubProjectImpl extends LoggingObject implements HubProject {
 
     public static final String ENTITY_CONFIG_DIR = PATH_PREFIX + "entity-config";
@@ -183,22 +181,7 @@ public class HubProjectImpl extends LoggingObject implements HubProject {
         return this.projectDir.resolve("flows");
     }
 
-    @Deprecated
-    @Override public Path getHubStagingModulesDir() {
-        return this.projectDir.resolve(MODULES_DIR);
-    }
-
-    @Deprecated
-    @Override public Path getUserStagingModulesDir() {
-        return this.projectDir.resolve(MODULES_DIR);
-    }
-
     @Override public Path getModulesDir() {
-        return this.projectDir.resolve(MODULES_DIR);
-    }
-
-    @Deprecated
-    @Override public Path getUserFinalModulesDir() {
         return this.projectDir.resolve(MODULES_DIR);
     }
 
@@ -349,7 +332,7 @@ public class HubProjectImpl extends LoggingObject implements HubProject {
         writeResourceFile("scaffolding/gradle/wrapper/gradle-wrapper.properties", gradleWrapperDir.resolve("gradle-wrapper.properties"), true);
 
         writeResourceFile("scaffolding/build_gradle", projectDir.resolve("build.gradle"));
-        writeResourceFileWithReplace(customTokens, "scaffolding/gradle_properties", projectDir.resolve("gradle.properties"));
+        writeResourceFileWithReplace(customTokens, projectDir.resolve("gradle.properties"));
         writeResourceFile("scaffolding/gradle-local_properties", projectDir.resolve("gradle-local.properties"));
     }
 
@@ -392,14 +375,11 @@ public class HubProjectImpl extends LoggingObject implements HubProject {
         }
     }
 
-    private void writeResourceFileWithReplace(Map<String, String> customTokens, String srcFile, Path dstFile) {
-        writeResourceFileWithReplace(customTokens, srcFile, dstFile, false);
-    }
-
-    private void writeResourceFileWithReplace(Map<String, String> customTokens, String srcFile, Path dstFile, boolean overwrite) {
+    private void writeResourceFileWithReplace(Map<String, String> customTokens, Path dstFile) {
         InputStream inputStream = null;
+        String srcFile = "scaffolding/gradle_properties";
         try {
-            if (overwrite || !dstFile.toFile().exists()) {
+            if (!dstFile.toFile().exists()) {
                 logger.debug("Getting file with replace: " + srcFile);
                 inputStream = HubProject.class.getClassLoader().getResourceAsStream(srcFile);
 
@@ -508,11 +488,6 @@ public class HubProjectImpl extends LoggingObject implements HubProject {
         }
     }
 
-    @Override
-    public void exportProject(OutputStream outputStream) {
-        exportProject(outputStream, new ArrayList<>());
-    }
-
     public void exportProject(OutputStream outputStream, List<String> additionalFilesTobeAdded){
         Stream<String> filesToBeAddedToZip = Stream.of("entities", "flows", "src/main", "step-definitions", "steps", "gradle",
             "gradlew", "gradlew.bat", "build.gradle", "gradle.properties");
@@ -547,11 +522,6 @@ public class HubProjectImpl extends LoggingObject implements HubProject {
         catch (Exception e){
             throw new RuntimeException("Unable to export project, cause: " + e.getMessage(), e);
         }
-    }
-
-    @Override
-    public String getProjectName() {
-        return getProjectDir().toFile().getName();
     }
 
     private void zipSubDirectory(String basePath, File fileToZip, ZipOutputStream zout) throws IOException {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/MappingManagerImpl.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/impl/MappingManagerImpl.java
@@ -138,7 +138,7 @@ public class MappingManagerImpl extends LoggingObject implements MappingManager 
     }
 
     @Override public ArrayList<String> getMappingsNames() {
-        return (ArrayList<String>)FileUtil.listDirectFolders(hubConfig.getHubMappingsDir().toFile());
+        return (ArrayList<String>)FileUtil.listDirectFolders(hubConfig.getHubProject().getHubMappingsDir().toFile());
     }
 
     @Override public ArrayList<Mapping> getMappings() {
@@ -160,7 +160,7 @@ public class MappingManagerImpl extends LoggingObject implements MappingManager 
 
     private Mapping getMappingVersion(String mappingName, int version){
         int mappingExtensionCount = MAPPING_FILE_EXTENSION.length();
-        Path mappingPath = Paths.get(hubConfig.getHubMappingsDir().toString(), mappingName);
+        Path mappingPath = Paths.get(hubConfig.getHubProject().getHubMappingsDir().toString(), mappingName);
         List<String> fileNames = FileUtil.listDirectFiles(mappingPath);
         String targetFileName = null;
         int    highestVersion  = -1;
@@ -238,6 +238,6 @@ public class MappingManagerImpl extends LoggingObject implements MappingManager 
     }
 
     private Path getMappingDirPath(String mappingName){
-        return Paths.get(hubConfig.getHubMappingsDir().toString(), mappingName);
+        return Paths.get(hubConfig.getHubProject().getHubMappingsDir().toString(), mappingName);
     }
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/core/HubProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/core/HubProjectTest.java
@@ -2,6 +2,7 @@ package com.marklogic.hub.core;
 
 import com.marklogic.hub.AbstractHubCoreTest;
 import com.marklogic.hub.DatabaseKind;
+import com.marklogic.hub.HubProject;
 import com.marklogic.hub.impl.HubConfigImpl;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
@@ -165,9 +166,9 @@ public class HubProjectTest extends AbstractHubCoreTest {
 
         HubConfigImpl hubConfig = new HubConfigImpl(getHubProject());
         hubConfig.withPropertiesFromEnvironment(envName);
-        hubConfig.refreshProject();
+        hubConfig.loadConfigurationFromProperties(null, true);
 
-        String expectedPath = Paths.get(getHubProject().getProjectDirString(), ".tmp", envName + "-" + hubConfig.USER_MODULES_DEPLOY_TIMESTAMPS_PROPERTIES).toString();
+        String expectedPath = Paths.get(getHubProject().getProjectDirString(), ".tmp", envName + "-" + HubProject.USER_MODULES_DEPLOY_TIMESTAMPS_PROPERTIES).toString();
 
         assertEquals(expectedPath, hubConfig.getHubProject().getUserModulesDeployTimestampFile());
     }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/DeployQueryOptionsCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/DeployQueryOptionsCommandTest.java
@@ -2,6 +2,7 @@ package com.marklogic.hub.deploy.commands;
 
 import com.marklogic.hub.AbstractHubCoreTest;
 import com.marklogic.hub.HubConfig;
+import com.marklogic.hub.HubProject;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -11,11 +12,11 @@ public class DeployQueryOptionsCommandTest extends AbstractHubCoreTest {
     @Test
     void test() {
         clearUserModules();
-        assertNull(getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE));
-        assertNull(getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE));
+        assertNull(getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubProject.STAGING_ENTITY_QUERY_OPTIONS_FILE));
+        assertNull(getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubProject.FINAL_ENTITY_QUERY_OPTIONS_FILE));
 
         new DeployQueryOptionsCommand(getHubConfig()).execute(newCommandContext());
-        assertNotNull(getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE));
-        assertNotNull(getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE));
+        assertNotNull(getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubProject.STAGING_ENTITY_QUERY_OPTIONS_FILE));
+        assertNotNull(getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubProject.FINAL_ENTITY_QUERY_OPTIONS_FILE));
     }
 }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserArtifactsCommandTest.java
@@ -171,7 +171,7 @@ public class LoadUserArtifactsCommandTest extends AbstractHubCoreTest {
         node.put("type", "mapping");
 
         String errorMessage = "Invalid name: 'my Artifact'; it must start with a letter and can contain letters, numbers, hyphens and underscores only.";
-        Path stepDefDir = hubConfig.getStepDefinitionPath(StepDefinition.StepDefinitionType.MAPPING).resolve("myArtifact");
+        Path stepDefDir = getHubProject().getStepDefinitionPath(StepDefinition.StepDefinitionType.MAPPING).resolve("myArtifact");
         stepDefDir.toFile().mkdirs();
         File stepDefFile = stepDefDir.resolve("myArtifact.step.json").toFile();
         stepDefFile.createNewFile();
@@ -186,7 +186,7 @@ public class LoadUserArtifactsCommandTest extends AbstractHubCoreTest {
         node.remove("type");
         stepDefFile.delete();
 
-        File flowFile = hubConfig.getFlowsDir().resolve("myArtifact.flow.json").toFile();
+        File flowFile = getHubProject().getFlowsDir().resolve("myArtifact.flow.json").toFile();
         flowFile.createNewFile();
         writer.writeValue(flowFile, node);
 
@@ -195,7 +195,7 @@ public class LoadUserArtifactsCommandTest extends AbstractHubCoreTest {
         assertEquals(errorMessage, ex.getServerMessage());
 
         flowFile.delete();
-        Path ingestionStepDir = hubConfig.getHubProjectDir().resolve("steps").resolve("ingestion");
+        Path ingestionStepDir = getHubProject().getProjectDir().resolve("steps").resolve("ingestion");
         ingestionStepDir.toFile().mkdirs();
         File ingestionStepFile = ingestionStepDir.resolve("myArtifact.step.json").toFile();
         ingestionStepFile.createNewFile();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/DeployCustomUserFieldsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/DeployCustomUserFieldsTest.java
@@ -26,7 +26,7 @@ public class DeployCustomUserFieldsTest extends AbstractHubCoreTest {
     void afterEach() {
         // dhsDeployer mucks around with appConfig, so gotta reset everything
         getHubConfig().applyDefaultPropertyValues();
-        getHubConfig().refreshProject();
+        getHubConfig().loadConfigurationFromProperties(null, true);
 
         resetFieldsAndIndexes();
     }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/DeployUserAmpsTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/dhs/DeployUserAmpsTest.java
@@ -121,7 +121,7 @@ public class DeployUserAmpsTest extends AbstractHubCoreTest {
         ObjectNode roleNode = objectMapper.createObjectNode();
         roleNode.put("role-name", "test-custom-role");
         roleNode.set("role", objectMapper.createArrayNode().add("data-hub-developer").add("pii-reader"));
-        writePayLoadToFileAndDeploy(getHubConfig().getUserSecurityDir().resolve("roles"), "customRole.json", roleNode);
+        writePayLoadToFileAndDeploy(getHubProject().getUserSecurityDir().resolve("roles"), "customRole.json", roleNode);
         ResourcesFragment amps;
         try {
             writeAmpFileToProjectAndDeploy(HubConfig.DEFAULT_MODULES_DB_NAME,"test-custom-role");
@@ -184,7 +184,7 @@ public class DeployUserAmpsTest extends AbstractHubCoreTest {
     }
 
     private void writeAmpFileToProjectAndDeploy(String dbName, String ... roleNames) {
-        writePayLoadToFileAndDeploy(getHubConfig().getUserSecurityDir().resolve("amps"), "getPiiData.json", getAmpNode(dbName, roleNames));
+        writePayLoadToFileAndDeploy(getHubProject().getUserSecurityDir().resolve("amps"), "getPiiData.json", getAmpNode(dbName, roleNames));
     }
 
     private ObjectNode getAmpNode(String dbName, String ... roleNames){

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/entity/EntityManagerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/entity/EntityManagerTest.java
@@ -17,6 +17,7 @@ package com.marklogic.hub.entity;
 
 import com.marklogic.hub.AbstractHubCoreTest;
 import com.marklogic.hub.HubConfig;
+import com.marklogic.hub.HubProject;
 import com.marklogic.hub.MarkLogicVersion;
 import com.marklogic.hub.impl.EntityManagerImpl;
 import com.marklogic.hub.util.FileUtil;
@@ -72,19 +73,19 @@ public class EntityManagerTest extends AbstractHubCoreTest {
         clearUserModules();
         Path dir = getHubProject().getEntityConfigDir();
 
-        assertNull(getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE));
+        assertNull(getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubProject.STAGING_ENTITY_QUERY_OPTIONS_FILE));
         // this should be true regardless
-        assertNull(getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE));
-        assertFalse(Paths.get(dir.toString(), HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
-        assertFalse(Paths.get(dir.toString(), HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
+        assertNull(getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubProject.FINAL_ENTITY_QUERY_OPTIONS_FILE));
+        assertFalse(Paths.get(dir.toString(), HubProject.STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
+        assertFalse(Paths.get(dir.toString(), HubProject.FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
 
         HashMap<Enum, Boolean> deployed = entityManager.deployQueryOptions();
 
         assertEquals(2, deployed.size());
-        assertTrue(Paths.get(dir.toString(), HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
-        assertTrue(Paths.get(dir.toString(), HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
-        assertNotNull(getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE));
-        assertNotNull(getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE));
+        assertTrue(Paths.get(dir.toString(), HubProject.STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
+        assertTrue(Paths.get(dir.toString(), HubProject.FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
+        assertNotNull(getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubProject.STAGING_ENTITY_QUERY_OPTIONS_FILE));
+        assertNotNull(getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubProject.FINAL_ENTITY_QUERY_OPTIONS_FILE));
     }
 
     @Test
@@ -96,20 +97,20 @@ public class EntityManagerTest extends AbstractHubCoreTest {
 
         runAsAdmin();
         Path dir = getHubProject().getEntityConfigDir();
-        assertNull(getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE));
-        assertNull(getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE));
-        assertFalse(Paths.get(dir.toString(), HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
-        assertFalse(Paths.get(dir.toString(), HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
+        assertNull(getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubProject.STAGING_ENTITY_QUERY_OPTIONS_FILE));
+        assertNull(getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubProject.FINAL_ENTITY_QUERY_OPTIONS_FILE));
+        assertFalse(Paths.get(dir.toString(), HubProject.STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
+        assertFalse(Paths.get(dir.toString(), HubProject.FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
 
         runAsDataHubDeveloper();
         entityManager.deployQueryOptions();
 
         // Gotta user admin in order to have read permission
         runAsAdmin();
-        assertNotNull(getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE));
-        assertNotNull(getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE));
-        assertTrue(Paths.get(dir.toString(), HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
-        assertTrue(Paths.get(dir.toString(), HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
+        assertNotNull(getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubProject.STAGING_ENTITY_QUERY_OPTIONS_FILE));
+        assertNotNull(getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubProject.FINAL_ENTITY_QUERY_OPTIONS_FILE));
+        assertTrue(Paths.get(dir.toString(), HubProject.STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
+        assertTrue(Paths.get(dir.toString(), HubProject.FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
     }
 
 
@@ -215,13 +216,13 @@ public class EntityManagerTest extends AbstractHubCoreTest {
                 .forEach(dbName -> assertNull(getModulesFile("/Default/" + dbName + "/rest-api/options/exp-default.xml"), "Did not expect exp-default.xml options file in " + dbName + "since we dont use it anymore."));
 
         Path dir = getHubProject().getEntityConfigDir();
-        assertTrue(Paths.get(dir.toString(), HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
-        assertTrue(Paths.get(dir.toString(), HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
-        assertTrue(Paths.get(dir.toString(), HubConfig.EXP_STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
-        assertTrue(Paths.get(dir.toString(), HubConfig.EXP_FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
+        assertTrue(Paths.get(dir.toString(), HubProject.STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
+        assertTrue(Paths.get(dir.toString(), HubProject.FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
+        assertTrue(Paths.get(dir.toString(), HubProject.EXP_STAGING_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
+        assertTrue(Paths.get(dir.toString(), HubProject.EXP_FINAL_ENTITY_QUERY_OPTIONS_FILE).toFile().exists());
 
-        String stagingOptions = getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubConfig.STAGING_ENTITY_QUERY_OPTIONS_FILE);
-        String finalOptions = getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubConfig.FINAL_ENTITY_QUERY_OPTIONS_FILE);
+        String stagingOptions = getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubProject.STAGING_ENTITY_QUERY_OPTIONS_FILE);
+        String finalOptions = getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubProject.FINAL_ENTITY_QUERY_OPTIONS_FILE);
         Stream<String> optionsString = Stream.of(stagingOptions, finalOptions);
         MarkLogicVersion version = new MarkLogicVersion(getHubClient().getManageClient());
         if(version.supportsRangeIndexConstraints()){
@@ -232,8 +233,8 @@ public class EntityManagerTest extends AbstractHubCoreTest {
         }
 
 
-        String stagingExplorerOptions = getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubConfig.EXP_STAGING_ENTITY_QUERY_OPTIONS_FILE);
-        String finalExplorerOptions = getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubConfig.EXP_FINAL_ENTITY_QUERY_OPTIONS_FILE);
+        String stagingExplorerOptions = getModulesFile("/Default/" + HubConfig.DEFAULT_STAGING_NAME + "/rest-api/options/" + HubProject.EXP_STAGING_ENTITY_QUERY_OPTIONS_FILE);
+        String finalExplorerOptions = getModulesFile("/Default/" + HubConfig.DEFAULT_FINAL_NAME + "/rest-api/options/" + HubProject.EXP_FINAL_ENTITY_QUERY_OPTIONS_FILE);
         Stream.of(stagingExplorerOptions, finalExplorerOptions).forEach(option -> {
             assertNotNull(option, "Expected the option to be deployed since the conflicting container constraint has been removed.");
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/hubcentral/GetProjectAsZipTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/hubcentral/GetProjectAsZipTest.java
@@ -162,7 +162,7 @@ public class GetProjectAsZipTest extends AbstractHubCoreTest {
 
     public void verifyZipProject() {
         assertEquals(HubConfig.DEFAULT_STAGING_NAME, gradleProps.getProperty("mlStagingDbName"));
-        assertEquals(String.valueOf(HubConfig.DEFAULT_FINAL_PORT), gradleProps.getProperty("mlFinalPort"));
+        assertEquals("8011", gradleProps.getProperty("mlFinalPort"));
         assertEquals(HubConfig.DEFAULT_JOB_NAME, gradleProps.getProperty("mlJobAppserverName"));
 
         assertEquals("", gradleDhsProps.getProperty("mlUsername"));

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/DataHubImplTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/DataHubImplTest.java
@@ -45,16 +45,14 @@ public class DataHubImplTest extends AbstractHubCoreTest {
     public void beforeTests() {
         serverManager = EasyMock.mock(ServerManager.class);
 
-        dh = EasyMock.createMockBuilder(DataHubImpl.class)
-            .withConstructor()
-            .createMock();
-        dh.setHubConfig(getHubConfig());
-
         versions = EasyMock.createMockBuilder(Versions.class)
             .withConstructor()
             .addMockedMethod("getMarkLogicVersionString")
             .createMock();
-        dh.setVersions(versions);
+
+        dh = EasyMock.createMockBuilder(DataHubImpl.class)
+            .withConstructor(getHubConfig(), versions)
+            .createMock();
     }
 
     @Test
@@ -243,7 +241,6 @@ public class DataHubImplTest extends AbstractHubCoreTest {
         dh.runPreInstallCheck(serverManager);
         assertTrue(dh.isServerVersionOk());
         assertTrue(dh.isPortInUse(DatabaseKind.STAGING));
-        assertEquals("port-stealer", dh.getPortInUseBy(DatabaseKind.STAGING));
         assertFalse(dh.isPortInUse(DatabaseKind.FINAL));
         assertFalse(dh.isPortInUse(DatabaseKind.JOB));
         assertFalse(dh.isSafeToInstall());
@@ -265,7 +262,6 @@ public class DataHubImplTest extends AbstractHubCoreTest {
         dh.runPreInstallCheck(serverManager);
         assertFalse(dh.isServerVersionOk());
         assertTrue(dh.isPortInUse(DatabaseKind.STAGING));
-        assertEquals("port-stealer", dh.getPortInUseBy(DatabaseKind.STAGING));
         assertFalse(dh.isPortInUse(DatabaseKind.FINAL));
         assertFalse(dh.isPortInUse(DatabaseKind.JOB));
         assertFalse(dh.isSafeToInstall());
@@ -288,7 +284,6 @@ public class DataHubImplTest extends AbstractHubCoreTest {
         assertTrue(dh.isServerVersionOk());
         assertFalse(dh.isPortInUse(DatabaseKind.STAGING));
         assertTrue(dh.isPortInUse(DatabaseKind.FINAL));
-        assertEquals("port-stealer", dh.getPortInUseBy(DatabaseKind.FINAL));
         assertFalse(dh.isPortInUse(DatabaseKind.JOB));
         assertFalse(dh.isSafeToInstall());
     }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/scaffolding/CreateStepTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/scaffolding/CreateStepTest.java
@@ -212,7 +212,7 @@ public class CreateStepTest extends AbstractHubCoreTest {
         assertTrue(getHubConfig().getHubProject().getStepFile(StepDefinitionType.getStepDefinitionType(stepType), stepName).exists());
         assertNotNull(getStagingDoc("/steps/" + stepType + "/" + stepName + ".step.json"));
         if(stepDefName != null){
-            assertTrue(getHubConfig().getStepDefinitionsDir().resolve(stepType).resolve(stepDefName).resolve(stepDefName + ".step.json").toFile().exists());
+            assertTrue(getHubProject().getStepDefinitionsDir().resolve(stepType).resolve(stepDefName).resolve(stepDefName + ".step.json").toFile().exists());
             assertNotNull(getStagingDoc("/step-definitions/" + stepType + "/" + stepDefName + "/" + stepDefName + ".step.json"));
         }
     }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/step/impl/WriteStepRunnerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/step/impl/WriteStepRunnerTest.java
@@ -30,7 +30,7 @@ public class WriteStepRunnerTest extends AbstractHubCoreTest {
 
     @BeforeEach
     public void setupEach() throws IOException {
-        FileUtils.copyDirectory(getResourceFile("flow-runner-test/flows"), getHubConfig().getFlowsDir().toFile());
+        FileUtils.copyDirectory(getResourceFile("flow-runner-test/flows"), getHubProject().getFlowsDir().toFile());
         installUserModules(runAsFlowDeveloper(), true);
     }
 

--- a/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
+++ b/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
@@ -311,7 +311,7 @@ public abstract class AbstractHubTest extends AbstractHubClientTest {
 
     // Update app config's config and modules dirs when not already in the hub config's project dir.
     private void resolveAppConfigDirectories(HubConfig hubConfig) {
-        String baseDirNormalized = Paths.get(hubConfig.getProjectDir()).normalize().toString();
+        String baseDirNormalized = Paths.get(hubConfig.getHubProject().getProjectDirString()).normalize().toString();
         AppConfig appConfig = hubConfig.getAppConfig();
         List<ConfigDir> configDirs = appConfig.getConfigDirs();
         for (ConfigDir configDir : configDirs) {

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/DataHubPlugin.groovy
@@ -91,7 +91,7 @@ class DataHubPlugin implements Plugin<Project> {
         setupHub(project)
 
         String setupGroup = "Data Hub Setup"
-        project.task("hubInit", group: setupGroup, type: InitProjectTask, 
+        project.task("hubInit", group: setupGroup, type: InitProjectTask,
             description: "Initialize the project directory before deploying to MarkLogic")
         project.task("hubUpdate", group: setupGroup, type: UpdateHubTask,
             description: "Update the project directory; typically run after upgrading the version of DHF used in this project's Gradle file")
@@ -154,7 +154,7 @@ class DataHubPlugin implements Plugin<Project> {
             description: "Clears user modules in the modules database, only leaving the modules " +
                 "that come with DataHub installation. Requires -Pconfirm=true to be set so this isn't accidentally executed.")
         project.task("hubCreateMapping", group: developGroup, type: CreateMappingTask,
-            description: "Create a legacy mapping file in the project directory (does not deploy it to MarkLogic); " + 
+            description: "Create a legacy mapping file in the project directory (does not deploy it to MarkLogic); " +
                 "only use this if your project has not been converted for Hub Central usage")
         project.task("hubCreateStepDefinition", group: developGroup, type: CreateStepDefinitionTask,
             description: "Create a new step definition in your project; specify a name via -PstepDefName=YourStepDefName, " +
@@ -294,7 +294,7 @@ class DataHubPlugin implements Plugin<Project> {
 
         def extensions = project.getExtensions()
 
-        hubConfig.createProject(project.getProjectDir().getAbsolutePath())
+        hubConfig.getHubProject().createProject(project.getProjectDir().getAbsolutePath())
 
         boolean calledHubInitOrUpdate = userCalledTask(project, "hubinit") || userCalledTask(project, "hubupdate")
         if (!calledHubInitOrUpdate && !hubProject.isInitialized()) {

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/InitProjectTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/InitProjectTask.groovy
@@ -23,7 +23,7 @@ class InitProjectTask extends HubTask {
 
     @TaskAction
     void initProject() {
-        getDataHub().initProject()
+        getHubConfig().initHubProject();
 
         println("\n\n############################################")
         println("# Your Data Hub Project is ready.")

--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/RunFlowTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/gradle/task/RunFlowTask.groovy
@@ -20,6 +20,7 @@ package com.marklogic.gradle.task
 
 import com.marklogic.gradle.exception.FlowNameRequiredException
 import com.marklogic.gradle.exception.HubNotInstalledException
+import com.marklogic.hub.flow.impl.FlowRunnerImpl
 import com.marklogic.hub.impl.CommandLineFlowInputs
 import com.marklogic.hub.flow.FlowInputs
 import com.marklogic.hub.flow.FlowRunner
@@ -209,7 +210,7 @@ class RunFlowTask extends HubTask {
         println(pair.getRight())
 
         FlowInputs flowInputs = pair.getLeft()
-        FlowRunner flowRunner = dataHub.getFlowRunner()
+        FlowRunner flowRunner = new FlowRunnerImpl(getHubConfig(), getFlowManager())
         RunFlowResponse runFlowResponse = flowRunner.runFlow(flowName, steps, jobId, flowInputs.getOptions(), flowInputs.getStepConfig())
         flowRunner.awaitCompletion()
 

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/fullcycle/SslTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/fullcycle/SslTest.groovy
@@ -161,7 +161,7 @@ class SslTest extends BaseTest {
             new File("src/test/resources/ssl-test/ssl-server.json"))
 
         createProperties()
-        hubConfig().refreshProject()
+        hubConfig().loadConfigurationFromProperties(null, true)
         try {
             clearDatabases(hubConfig().DEFAULT_MODULES_DB_NAME)
         } catch (e) {

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/fullcycle/TlsTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/fullcycle/TlsTest.groovy
@@ -228,7 +228,7 @@ class TlsTest extends BaseTest {
         createProperties()
         result = runTask("enableSSL")
         print(result.output)
-        hubConfig().refreshProject()
+        hubConfig().loadConfigurationFromProperties(null, true)
     }
 
 

--- a/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/BaseTest.groovy
+++ b/ml-data-hub-plugin/src/test/groovy/com/marklogic/gradle/task/BaseTest.groovy
@@ -302,7 +302,7 @@ class BaseTest extends Specification {
         ctx.refresh()
         _hubConfig = ctx.getBean(HubConfigImpl.class)
         createFullPropertiesFile()
-        _hubConfig.createProject(testProjectDir.root.getAbsolutePath())
-        _hubConfig.refreshProject()
+        _hubConfig.getHubProject().createProject(testProjectDir.root.getAbsolutePath())
+        _hubConfig.loadConfigurationFromProperties(null, true)
     }
 }


### PR DESCRIPTION
### Description

Main cleanup here is removing the methods that are just passthroughs to HubProject. 

Also did the following cleanup:

- Moved project-specific constants from HubConfig to HubProject
- Removed getters for DHF operator/developer roles/users (not used anywhere)
- Removed unused stuff from DataHub (there's a lot more to do here; install is only used by TestAppInstaller, will address that in a separate ticket)


#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

