### PR TITLE
DHFPROD-7043: Establish Session Storage for Retaining Current View in Hub Central

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestionListView.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestionListView.spec.tsx
@@ -144,7 +144,7 @@ describe("Validate CRUD functionality from list view", () => {
     loadPage.confirmationOptions("Yes").click();
     cy.waitForAsyncRequest();
     cy.waitUntil(() => toolbar.getLoadToolbarIcon()).click();
-    cy.waitUntil(() => loadPage.addNewButton("card").should("be.visible"));
+    cy.waitUntil(() => loadPage.addNewButton("list").should("be.visible"));
   });
   it("Verify Run in an existing flow", () => {
     loadPage.loadView("table").click();

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/persistence/persistence.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/persistence/persistence.spec.tsx
@@ -1,0 +1,35 @@
+import {Application} from "../../support/application.config";
+import {toolbar} from "../../support/components/common";
+import loadPage from "../../support/pages/load";
+import LoginPage from "../../support/pages/login";
+
+describe("Validate persistence across Hub Central", () => {
+  before(() => {
+    cy.visit("/");
+    cy.contains(Application.title);
+    cy.loginAsTestUserWithRoles("hub-central-load-writer", "hub-central-flow-writer").withRequest();
+    LoginPage.postLogin();
+    cy.waitForAsyncRequest();
+  });
+  beforeEach(() => {
+    cy.loginAsTestUserWithRoles("hub-central-load-writer", "hub-central-flow-writer").withRequest();
+    cy.waitForAsyncRequest();
+  });
+  afterEach(() => {
+    cy.resetTestUser();
+    cy.waitForAsyncRequest();
+  });
+  after(() => {
+    cy.resetTestUser();
+    cy.waitForAsyncRequest();
+  });
+  it("Switch to list view, sort, and then visit another tile. When returning to load tile the list view is persisted", () => {
+    cy.waitUntil(() => toolbar.getLoadToolbarIcon()).click();
+    loadPage.loadView("table").click();
+    cy.findByTestId("loadTableName").click();
+    cy.waitUntil(() => toolbar.getRunToolbarIcon()).click();
+    cy.waitUntil(() => toolbar.getLoadToolbarIcon()).click();
+    loadPage.addNewButton("list").should("be.visible");
+    cy.get("[aria-label=\"icon: caret-up\"]").should("have.class", "anticon anticon-caret-up ant-table-column-sorter-up on");
+  });
+});

--- a/marklogic-data-hub-central/ui/src/pages/Load.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Load.test.tsx
@@ -7,9 +7,11 @@ import mocks from "../api/__mocks__/mocks.data";
 import Load from "./Load";
 import {MemoryRouter} from "react-router-dom";
 import tiles from "../config/tiles.config";
+import {getViewSettings} from "../util/user-context";
 
 jest.mock("axios");
 jest.setTimeout(30000);
+
 
 const DEFAULT_VIEW = "card";
 
@@ -216,4 +218,77 @@ describe("Load component", () => {
 
   });
 
+});
+
+
+describe("getViewSettings", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  const sessionStorageMock = (() => {
+    let store = {};
+
+    return {
+      getItem(key) {
+        return store[key] || null;
+      },
+      setItem(key, value) {
+        store[key] = value.toString();
+      },
+      removeItem(key) {
+        delete store[key];
+      },
+      clear() {
+        store = {};
+      }
+    };
+  })();
+
+  Object.defineProperty(window, "sessionStorage", {
+    value: sessionStorageMock
+  });
+
+  it("should get page number from session storage", () => {
+    const getItemSpy = jest.spyOn(window.sessionStorage, "getItem");
+    window.sessionStorage.setItem("dataHubViewSettings", JSON.stringify({load: {page: 2}}));
+    const actualValue = getViewSettings();
+    expect(actualValue).toEqual({load: {page: 2}});
+    expect(getItemSpy).toBeCalledWith("dataHubViewSettings");
+  });
+
+  it("should get view mode from session storage", () => {
+    const getItemSpy = jest.spyOn(window.sessionStorage, "getItem");
+    window.sessionStorage.setItem("dataHubViewSettings", JSON.stringify({load: {viewMode: "list"}}));
+    let actualValue = getViewSettings();
+    expect(actualValue).toEqual({load: {viewMode: "list"}});
+    expect(getItemSpy).toBeCalledWith("dataHubViewSettings");
+
+    window.sessionStorage.setItem("dataHubViewSettings", JSON.stringify({load: {viewMode: "card"}}));
+    actualValue = getViewSettings();
+    expect(actualValue).toEqual({load: {viewMode: "card"}});
+    expect(getItemSpy).toBeCalledWith("dataHubViewSettings");
+  });
+
+  it("should get sort order from session storage", () => {
+    const getItemSpy = jest.spyOn(window.sessionStorage, "getItem");
+    window.sessionStorage.setItem("dataHubViewSettings", JSON.stringify({load: {columnKey: "name", order: "ascend"}}));
+    let actualValue = getViewSettings();
+    expect(actualValue).toEqual({load: {columnKey: "name", order: "ascend"}});
+    expect(getItemSpy).toBeCalledWith("dataHubViewSettings");
+
+    window.sessionStorage.setItem("dataHubViewSettings", JSON.stringify({load: {columnKey: "name", order: "descend"}}));
+    actualValue = getViewSettings();
+    expect(actualValue).toEqual({load: {columnKey: "name", order: "descend"}});
+    expect(getItemSpy).toBeCalledWith("dataHubViewSettings");
+  });
+
+  it("should get empty object if no info in session storage", () => {
+    const getItemSpy = jest.spyOn(window.sessionStorage, "getItem");
+    const actualValue = getViewSettings();
+    expect(actualValue).toEqual({});
+    expect(window.sessionStorage.getItem).toBeCalledWith("dataHubViewSettings");
+    expect(getItemSpy).toBeCalledWith("dataHubViewSettings");
+  });
 });

--- a/marklogic-data-hub-central/ui/src/pages/Load.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Load.tsx
@@ -5,7 +5,7 @@ import {useLocation} from "react-router-dom";
 import SwitchView from "../components/load/switch-view";
 import LoadList from "../components/load/load-list";
 import LoadCard from "../components/load/load-card";
-import {UserContext} from "../util/user-context";
+import {getViewSettings, setViewSettings, UserContext} from "../util/user-context";
 import axios from "axios";
 import {createStep, updateStep, getSteps, deleteStep} from "../api/steps";
 import {sortStepsByUpdated} from "../util/conversionFunctions";
@@ -14,11 +14,14 @@ import tiles from "../config/tiles.config";
 import {LoadingContext} from "../util/loading-context";
 import {MissingPagePermission} from "../config/messages.config";
 
-export type ViewType =  "card" | "list";
+export type ViewType = "card" | "list";
 
 const INITIAL_VIEW: ViewType = "card";
 
 const Load: React.FC = () => {
+
+  const storage = getViewSettings();
+  const storedViewMode = storage?.load?.viewMode;
 
   const {
     loadingOptions,
@@ -26,7 +29,7 @@ const Load: React.FC = () => {
   } = useContext(LoadingContext);
 
   const location = useLocation<any>();
-  let [view, setView] = useState(location.state?.viewMode ? location.state.viewMode : INITIAL_VIEW);
+  let [view, setView] = useState(storedViewMode ? storedViewMode : INITIAL_VIEW);
   const [loading, setLoading] = useState(false);
   const [loadArtifacts, setLoadArtifacts] = useState<any[]>([]);
   const [flows, setFlows] = useState<any[]>([]);
@@ -50,6 +53,16 @@ const Load: React.FC = () => {
     setView(location.state?.viewMode ? location.state?.viewMode : view);
     setSortedInfo(location.state?.sortOrderInfo);
   }, [location]);
+
+
+  useEffect(() => {
+    if (view === null) {
+      return;
+    }
+    const viewStorage = getViewSettings();
+    const newStorage = {...viewStorage, load: {...viewStorage.load, viewMode: view}};
+    setViewSettings(newStorage);
+  }, [view]);
 
   useEffect(() => {
     getLoadArtifacts();
@@ -226,7 +239,7 @@ const Load: React.FC = () => {
           <div className={styles.intro}>
             <p>{tiles.load.intro}</p>
             <div className={styles.switchViewContainer}>
-              <SwitchView handleSelection={handleViewSelection} defaultView={view}/>
+              <SwitchView handleSelection={handleViewSelection} defaultView={view} />
             </div>
           </div>
           {output}

--- a/marklogic-data-hub-central/ui/src/types/view-types.ts
+++ b/marklogic-data-hub-central/ui/src/types/view-types.ts
@@ -1,0 +1,10 @@
+export type ViewSettingsType = {
+    load?: {
+        page?: number,
+        viewMode?: string,
+        sortOrder?: {
+            columnKey?: string,
+            order?: string
+        },
+    },
+};

--- a/marklogic-data-hub-central/ui/src/util/loading-context.tsx
+++ b/marklogic-data-hub-central/ui/src/util/loading-context.tsx
@@ -1,4 +1,5 @@
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
+import {getViewSettings, setViewSettings} from "./user-context";
 
 type LoadingContextInterface = {
   start: number,
@@ -26,14 +27,43 @@ export const LoadingContext = React.createContext<ILoadingContextInterface>({
 
 const LoadingProvider: React.FC<{ children: any }> = ({children}) => {
 
-  const [loadingOptions, setLoadingOptions] = useState<LoadingContextInterface>(defaultLoadingOptions);
+  const storage = getViewSettings();
+  const storedPageNumber = storage?.load?.page;
 
-  const setPage = (pageNumber: number) => {
+  const [loadingOptions, setLoadingOptions] = useState<LoadingContextInterface>({
+    ...defaultLoadingOptions,
+    ...(storedPageNumber !== null ? {pageNumber: storedPageNumber} : {})
+  });
+
+  const setPage = (pageNumber) => {
     setLoadingOptions({
       ...loadingOptions,
       pageNumber: pageNumber,
     });
   };
+
+  useEffect(() => {
+    if (loadingOptions.pageNumber === undefined) {
+      return;
+    }
+    const pageStorage = getViewSettings();
+    const newStorage = {...pageStorage, load: {...pageStorage.load, page: loadingOptions.pageNumber}};
+    setViewSettings(newStorage);
+  }, [loadingOptions.pageNumber]);
+
+  useEffect(() => {
+    if (loadingOptions.pageNumber === undefined) {
+      const pageStorage = getViewSettings();
+      const storedPageNumber = pageStorage?.load?.page;
+      if (storedPageNumber !== null) {
+        setPage(storedPageNumber);
+      }
+
+      const newStorage = {...pageStorage, load: {...pageStorage.load, page: loadingOptions.pageNumber}};
+      setViewSettings(newStorage);
+    }
+  }, [loadingOptions.pageNumber]);
+
 
 
   const setPageSize = (current: number, pageSize: number) => {

--- a/marklogic-data-hub-central/ui/src/util/user-context.tsx
+++ b/marklogic-data-hub-central/ui/src/util/user-context.tsx
@@ -3,6 +3,7 @@ import {Subscription} from "rxjs";
 import axios from "axios";
 import {createUserPreferences, getUserPreferences, updateUserPreferences} from "../services/user-preferences";
 import {IUserContextInterface, UserContextInterface} from "../types/user-types";
+import {ViewSettingsType} from "../types/view-types";
 import {AuthoritiesContext} from "./authorities";
 import {StompContext, STOMPState} from "./stomp";
 import {resetEnvironment, setEnvironment} from "../util/environment";
@@ -22,6 +23,15 @@ const defaultUserData = {
 };
 
 let CryptoJS = require("crypto-js");
+
+export function getViewSettings (): ViewSettingsType {
+  const data: any = JSON.parse(sessionStorage.getItem("dataHubViewSettings") ?? JSON.stringify({}));
+  return data;
+}
+
+export function setViewSettings (data: ViewSettingsType): void {
+  sessionStorage.setItem("dataHubViewSettings", JSON.stringify(data));
+}
 
 export const UserContext = React.createContext<IUserContextInterface>({
   user: defaultUserData,
@@ -108,6 +118,7 @@ const UserProvider: React.FC<{ children: any }> = ({children}) => {
     localStorage.setItem("serviceName", session.data.serviceName);
     localStorage.setItem("hubCentralSessionToken", session.data.sessionToken);
     monitorSession();
+    sessionStorage.setItem("dataHubViewSettings", JSON.stringify({}));
 
     if (session.data.pendoKey) {
       window.usePendo && window.usePendo(session.data.pendoKey);


### PR DESCRIPTION
### Description
This PR adds sessionStorage for the Load tile. It establishes the data structure and functions that will be used for future session storage stories.

- Persistence on view mode (card/list)
- Persistence on page number
- Persistence on sort order

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

