### PR TITLE
DHFPROD-7045: Accessibility for reorder flows

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/flows/flows.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/flows/flows.test.tsx
@@ -281,4 +281,46 @@ describe("Flows component", () => {
     expect(queryByLabelText("rightArrow-"+flowStepName)).not.toBeInTheDocument();
     expect(queryByLabelText("leftArrow-"+flowStepName)).not.toBeInTheDocument();
   });
+
+  it("reorder flow buttons can be focused and pressed by keyboard", async () => {
+    const {getByLabelText} = render(
+      <Router history={history}><Flows
+        {...flowsProps}
+        canReadFlow={true}
+        canWriteFlow={true}
+        hasOperatorRole={true}
+      /></Router>
+    );
+    let flowButton = getByLabelText("icon: right");
+    fireEvent.click(flowButton);
+
+    const rightArrowButton = getByLabelText("rightArrow-"+flowStepName);
+    expect(rightArrowButton).toBeInTheDocument();
+    rightArrowButton.focus();
+    expect(rightArrowButton).toHaveFocus();
+
+    userEvent.tab();
+    expect(rightArrowButton).not.toHaveFocus();
+    userEvent.tab({shift: true});
+    expect(rightArrowButton).toHaveFocus();
+
+    const leftArrowButton = getByLabelText("leftArrow-"+flowStepName);
+    expect(leftArrowButton).toBeInTheDocument();
+    leftArrowButton.focus();
+    expect(leftArrowButton).toHaveFocus();
+
+    userEvent.tab();
+    expect(leftArrowButton).not.toHaveFocus();
+    userEvent.tab({shift: true});
+    expect(leftArrowButton).toHaveFocus();
+
+    // Verifying a user can press enter to reorder steps in a flow
+    rightArrowButton.onkeydown = jest.fn();
+    fireEvent.keyDown(rightArrowButton, {key: "Enter", code: "Enter"});
+    expect(rightArrowButton.onkeydown).toHaveBeenCalledTimes(1);
+
+    leftArrowButton.onkeydown = jest.fn();
+    fireEvent.keyDown(leftArrowButton, {key: "Enter", code: "Enter"});
+    expect(leftArrowButton.onkeydown).toHaveBeenCalledTimes(1);
+  });
 });

--- a/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
+++ b/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
@@ -683,7 +683,9 @@ const Flows: React.FC<Props> = (props) => {
                           aria-required="true"
                           className={styles.reorderFlowLeft}
                           role="button"
-                          onClick={() => reorderFlow(index, flowName, ReorderFlowOrderDirection.LEFT)} />
+                          onClick={() => reorderFlow(index, flowName, ReorderFlowOrderDirection.LEFT)}
+                          onKeyDown={(e) => reorderFlowKeyDownHandler(e, index, flowName, ReorderFlowOrderDirection.LEFT)}
+                          tabIndex={0}/>
                       </MLTooltip>
                     </div>
                   }
@@ -702,7 +704,9 @@ const Flows: React.FC<Props> = (props) => {
                           aria-required="true"
                           className={styles.reorderFlowRight}
                           role="button"
-                          onClick={() => reorderFlow(index, flowName, ReorderFlowOrderDirection.RIGHT)} />
+                          onClick={() => reorderFlow(index, flowName, ReorderFlowOrderDirection.RIGHT)}
+                          onKeyDown={(e) => reorderFlowKeyDownHandler(e, index, flowName, ReorderFlowOrderDirection.RIGHT)}
+                          tabIndex={0}/>
                       </MLTooltip>
                     }
                   </div>
@@ -827,6 +831,14 @@ const Flows: React.FC<Props> = (props) => {
       event.preventDefault();
     }
   };
+
+  const reorderFlowKeyDownHandler = (event, index, flowName, direction) => {
+    if (event.key === "Enter") {
+      reorderFlow(index, flowName, direction);
+      event.preventDefault();
+    }
+  };
+
 
   return (
     <div id="flows-container" className={styles.flowsContainer}>


### PR DESCRIPTION
### Description
This PR adds accessibility for reordering flows. You should be able to:

- Use tab to select a step arrow 
- Use shift tab to select the previously selected arrow
- Press enter to reorder the steps

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

