### PR TITLE
DHFPROD-7077:Workaround QB hang issue when deleting legacy mappings in FlowConverter

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/hubcentral/conversion/FlowConverter.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/hubcentral/conversion/FlowConverter.java
@@ -88,7 +88,8 @@ public class FlowConverter extends LoggingObject {
             );
             QueryBatcher queryBatcher = dmm.newQueryBatcher(query)
                 .withConsistentSnapshot()
-                .withThreadCount(1) // If not set, DMSDK logs an unattractive warning
+                .withBatchSize(100) // If not set, QB hangs https://github.com/marklogic/java-client-api/issues/1293
+                .withThreadCount(4) // If not set, DMSDK logs an unattractive warning
                 .onUrisReady(new DeleteListener());
             dmm.startJob(queryBatcher);
             queryBatcher.awaitCompletion();


### PR DESCRIPTION
### Description
Workaround QB hang issue when deleting legacy mappings in FlowConverter
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

