### PR TITLE
DHFPROD-6705: Filter for related entity types in Hub Central

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.module.scss
@@ -11,6 +11,48 @@
   }
 }
 
+.entityTopRow{
+  margin-top: -20px;
+}
+
+.entityTitle{
+  margin-top: -8px;
+  display: inline-block;
+}
+
+.entitySettingsLink {
+  display: inline-block;
+  padding-right: 20px;
+  margin-left: 90%;
+  font-size: 20px !important;
+  color: #44499C;
+  cursor: pointer;
+  &:hover{
+      color: var(--hoverColor);
+  }
+}
+
+.mapRelatedEntitiesText{
+  display: inline-block;
+  margin-left: -8px;
+}
+
+.entityFilterContainer{
+  width: 98%;
+  margin-top: 10px;
+}
+
+.entityFilter{
+  display: inline-block;
+  width: 91%;
+  padding-left: 15px;
+  padding-bottom: 3px;
+}
+
+.entityFilterDropdown{
+  top: 69px !important;
+}
+
 .contextHelp{
   width: 14vw;
   word-wrap: normal;
@@ -107,6 +149,15 @@
   align-items: flex-start;
 }
 
+.mapValue {
+  margin-top: -6px;
+  margin-bottom: -20px;
+  white-space: pre-wrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
 .filterContainer {
   padding: 8px;
 }
@@ -136,36 +187,4 @@
   text-align: left;
   font-size: 13px;
   padding-right: 1px;
-}
-
-.entitySettingsLink {
-  font-size: 20px !important;
-  position: absolute;
-  top: 12px;
-  right: 66px;
-  color: #44499C;
-  cursor: pointer;
-  .stepSettingsLabel {
-      display: inline-block;
-      margin-left: 6px;
-  }
-  &:hover{
-      color: var(--hoverColor);
-  }
-}
-
-.entitySettingsCaret {
-  font-size: 13px !important;
-  position: absolute;
-  top: 15px;
-  right: 57px;
-  color: #44499C;
-  cursor: pointer;
-  .stepSettingsLabel {
-      display: inline-block;
-      margin-left: 6px;
-  }
-  &:hover{
-      color: var(--hoverColor);
-  }
 }

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.scss
@@ -4,6 +4,14 @@
   }
   .ant-table-column-has-actions.ant-table-column-has-filters.ant-table-column-has-sorters.ant-table-row-cell-break-word{
     padding-left: 22px;
+    padding-right: 0px;
+  }
+  .ant-select-selection__clear {
+    margin-top: -5px;
+  }
+
+  .ant-select-dropdown-menu-item-selected {
+    background-color: #E9F7FE;
   }
 }
 

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.module.scss
@@ -200,15 +200,6 @@ hr {
     //justify-content: top;
 }
 
-.mapValue {
-    margin-top: -6px;
-    margin-bottom: -20px;
-    white-space: pre-wrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    line-height: normal;
-}
-
 .entityIcon:before{
     content: "\e93b";
     font-family: MLCustomFont;


### PR DESCRIPTION
### Description
- Baseline implementation for filter for related entity types in mapping
- Placeholder values used for related entities until backend or mock data is added in DHFPROD-6706
- UI designs approved by @jbelonoj 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

