### PR TITLE
DHFPROD-7100:Stop using Object.values() as it doesn't work in 9.x server

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/writeQueue.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/writeQueue.sjs
@@ -20,13 +20,13 @@ const flowUtils = require("/data-hub/5/impl/flow-utils.sjs");
 const hubUtils = require("/data-hub/5/impl/hub-utils.sjs");
 
 /**
- * Captures the content objects that should be written to a database after one or more steps 
- * have been executed on a batch of items. Supports multiple databases, such that the same URI 
+ * Captures the content objects that should be written to a database after one or more steps
+ * have been executed on a batch of items. Supports multiple databases, such that the same URI
  * can be written to multiple databases.
- * 
- * If multiple content objects are added that have the same URI and are to be written to the same 
- * database, the newer content object will replaced the existing one. This is intended both to avoid 
- * conflicting update errors and to facilitate the need when running connected steps for the output of 
+ *
+ * If multiple content objects are added that have the same URI and are to be written to the same
+ * database, the newer content object will replaced the existing one. This is intended both to avoid
+ * conflicting update errors and to facilitate the need when running connected steps for the output of
  * one step to replace the output of a previous step. Trace logging is used to record this so that a
  * user can have visibility into when this happens.
  */
@@ -37,8 +37,8 @@ class WriteQueue {
   }
 
   /**
-   * @param databaseName 
-   * @param contentObject 
+   * @param databaseName
+   * @param contentObject
    * @param flowName only needed for logging
    * @param stepNumber only needed for logging
    */
@@ -57,20 +57,20 @@ class WriteQueue {
       if (traceEnabled) {
         let message = `Could not add content object ${xdmp.toJsonString(contentObject)} to write queue because it has `;
         message += `no 'uri' property; flow: ${flowName}; step number: ${stepNumber}`;
-        hubUtils.hubTrace(traceEvent, message);  
+        hubUtils.hubTrace(traceEvent, message);
       }
     } else {
       if (contentMap[uri] && traceEnabled) {
         let message = `URI '${uri}' already exists in writeQueue, will be overwritten with new content object`;
         message += `; flow: ${flowName}; step number: ${stepNumber}`;
         hubUtils.hubTrace(traceEvent, message);
-      }      
+      }
       contentMap[uri] = contentObject;
     }
   }
 
   /**
-   * @param databaseName 
+   * @param databaseName
    * @returns an array of URIs corresponding to the content objects that will be persisted to the given database
    */
   getContentUris(databaseName) {
@@ -87,7 +87,7 @@ class WriteQueue {
    */
   getContentArray(databaseName) {
     if (this.databaseToContentMap[databaseName]) {
-      return Object.values(this.databaseToContentMap[databaseName]);
+      return hubUtils.getObjectValues(this.databaseToContentMap[databaseName]);
     } else {
       return [];
     }

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-utils.sjs
@@ -146,6 +146,19 @@ function writeDocument(docUri, content, permissions, collections, database) {
   }));
 }
 
+/**
+ * ML 9 does not support Object.values(). This function serves as its replacement so that datahub can be supported in ML 9
+ * @param object
+ * @returns  an array of a given object's property values
+ */
+function getObjectValues(object){
+    let valuesArray = [];
+    for (const property in object) {
+      valuesArray.push(object[property]);
+    }
+    return valuesArray;
+}
+
 module.exports = {
   capitalize,
   deleteDocument,
@@ -158,5 +171,6 @@ module.exports = {
   parsePermissions,
   queryToContentDescriptorArray,
   replaceLanguageWithLang,
-  writeDocument
+  writeDocument,
+  getObjectValues
 };


### PR DESCRIPTION
### Description
Stop using Object.values() as it doesn't work in 9.x server . I don't think it needs test, all existing tests should run fine
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [ n/a] Added Tests
  

- ##### Reviewer:

- [n/a ] Reviewed Tests

