### PR TITLE
DHFPROD-7036: Fix for hubGenerateTestSuite on Java 11

### DIFF
--- a/ml-data-hub-plugin/src/main/groovy/com/marklogic/hub/gradle/task/GenerateTestSuiteTask.groovy
+++ b/ml-data-hub-plugin/src/main/groovy/com/marklogic/hub/gradle/task/GenerateTestSuiteTask.groovy
@@ -20,9 +20,10 @@ class GenerateTestSuiteTask extends HubTask {
 
         Path sourcePath
         if (userDefinedSourcePath != null) {
-            sourcePath = Paths.get(userDefinedSourcePath)
-        }
-        else {
+            // The file path must be made relative to the project for this to work on Java 11 with Gradle 6; otherwise,
+            // files are written relative to the Gradle daemon directory
+            sourcePath = Paths.get(getProject().file(userDefinedSourcePath).getAbsolutePath())
+        } else {
             List<String> modulePaths = getHubConfig().getAppConfig().getModulePaths()
             if (modulePaths == null || modulePaths.isEmpty()) {
                 throw new GradleException("No module paths defined; either define a source path via -PsourcePath=path/to/modules, or define mlModulePaths")


### PR DESCRIPTION
### Description

Couldn't find a way to write a test for this, as it only fails on Java 9+ higher, but we run tests with Java 8. So resorted to using a comment to explain the line change. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

