### PR TITLE
DHFPROD-6538:Enable run of 2 spark connector tests on nightly on all platforms as server bug 55743 is fixed 

### DIFF
--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/reader/ReadArraysAndMapsTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/reader/ReadArraysAndMapsTest.java
@@ -1,5 +1,6 @@
 package com.marklogic.hub.spark.sql.sources.v2.reader;
 
+import com.marklogic.hub.MarkLogicVersion;
 import com.marklogic.hub.spark.sql.sources.v2.Options;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayData;
@@ -8,6 +9,7 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.OS;
@@ -32,9 +34,11 @@ public class ReadArraysAndMapsTest extends AbstractSparkReadTest {
 
     @Test
     void arrayOfStrings() {
-        assumeTrue(OS.LINUX.isCurrentOs(), "Running this test on Windows and mac result in SEGFAULT when trying to get partition's row count\n" +
-            "       (readLib.sjs's getRowCountForPartition() method. Once server bug https://bugtrack.marklogic.com/55743\n" +
-            "       is fixed, the test should run fine on all platforms.");
+        MarkLogicVersion version = new MarkLogicVersion(getHubClient().getManageClient());
+        assumeTrue(OS.LINUX.isCurrentOs() || (version.getMajor() >= 10 &&
+            version.isNightly()), "Running this test on Windows and mac used to result in SEGFAULT when trying to get" +
+            " partition's row count. The server bug https://bugtrack.marklogic.com/55743 is fixed so the test should run" +
+            " fine on any version > 10.0-5 on Linux and on 10.0-nightly in other platforms.");
         loadSimpleCustomers(1);
 
         StructType sparkSchema = new StructType(new StructField[]{

--- a/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/reader/ReadWithCustomSparkSchemaTest.java
+++ b/marklogic-data-hub-spark-connector/src/test/java/com/marklogic/hub/spark/sql/sources/v2/reader/ReadWithCustomSparkSchemaTest.java
@@ -1,5 +1,6 @@
 package com.marklogic.hub.spark.sql.sources.v2.reader;
 
+import com.marklogic.hub.MarkLogicVersion;
 import com.marklogic.hub.spark.sql.sources.v2.Options;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.DataTypes;
@@ -20,9 +21,11 @@ public class ReadWithCustomSparkSchemaTest extends AbstractSparkReadTest {
 
     @Test
     void validCustomSparkSchema() {
-        assumeTrue(OS.LINUX.isCurrentOs(), "Running this test on Windows and mac result in SEGFAULT when trying to get partition's row count\n" +
-            "     (reaadLib.sjs's getRowCountForPartition() method. Once server bug https://bugtrack.marklogic.com/55743\n" +
-            "     is fixed, the test should run fine on all platforms");
+        MarkLogicVersion version = new MarkLogicVersion(getHubClient().getManageClient());
+        assumeTrue(OS.LINUX.isCurrentOs() || (version.getMajor() >= 10 &&
+            version.isNightly()), "Running this test on Windows and mac used to result in SEGFAULT when trying to get" +
+            " partition's row count. The server bug https://bugtrack.marklogic.com/55743 is fixed so the test should run" +
+            " fine on any version > 10.0-5 on Linux and on 10.0-nightly in other platforms.");
         setupTenSimpleCustomers();
 
         Options options = newOptions()


### PR DESCRIPTION
### Description
Enable run of 2 spark connector tests on nightly on all platforms as server bug 55743 is fixed. The test ran fine on 10.0-nightly in my local on mac (it used to result in SEGFAULT earlier) 
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

