### PR TITLE
DHFPROD-6525: Can now control whether Batch docs are created

### DIFF
--- a/installer-for-dhs/src/main/java/com/marklogic/hub/dhs/installer/command/AbstractVerifyCommand.java
+++ b/installer-for-dhs/src/main/java/com/marklogic/hub/dhs/installer/command/AbstractVerifyCommand.java
@@ -34,7 +34,7 @@ public abstract class AbstractVerifyCommand extends AbstractInstallerCommand {
     protected void verifyAmps() {
         AmpManager ampManager = new AmpManager(hubConfig.getManageClient());
         List<String> ampNames = ampManager.getAsXml().getListItemNameRefs();
-        Stream.of("updateBatch", "updateJob", "map-to-xml", "construct-type", "locked-uris", "post-bulk-documents",
+        Stream.of("updateJob", "map-to-xml", "construct-type", "locked-uris", "post-bulk-documents",
             "do-refresh-extension-metadata", "xdmp-add-response-header", "xdmp-add-response-header").forEach(name -> {
             verify(ampNames.contains(name), "Expected amp to have been created: " + name);
         });

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/amps/amps-dhf-update-batch.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/amps/amps-dhf-update-batch.json
@@ -1,6 +1,0 @@
-{
-  "local-name" : "updateBatch",
-  "document-uri" : "/data-hub/5/impl/jobs.sjs",
-  "modules-database" : "%%mlModulesDbName%%",
-  "role" : [ "data-hub-job-internal" ]
-}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/stepExecutionContext.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/stepExecutionContext.sjs
@@ -173,6 +173,20 @@ class StepExecutionContext {
     return "finished";
   }
 
+  batchOutputIsEnabled() {
+    if (this.combinedOptions.disableJobOutput === true || this.combinedOptions.disableJobOutput === "true") {
+      return false;
+    }
+    const value = this.combinedOptions.enableBatchOutput;
+    if (value === "never") {
+      return false;
+    }
+    if (value === "onFailure") {
+      return this.failedItems.length > 0;
+    }
+    return true;
+  }
+
   /**
    * @returns {boolean} true if throwStopError=true in the combined options. The default DHF approach for handling errors
    * is to capture them in the RunFlowResponse (and optionally Batch documents). But in a scenario where that response cannot be 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/core/HubProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/core/HubProjectTest.java
@@ -71,11 +71,7 @@ public class HubProjectTest extends AbstractHubCoreTest {
         assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/data-hub-entity-model-reader.json").exists());
         assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/data-hub-entity-model-writer.json").exists());
         assertTrue(new File(projectPath, "src/main/hub-internal-config/security/roles/hub-central-entity-exporter.json").exists());
-
-
-        assertTrue(new File(projectPath, "src/main/hub-internal-config/security/amps/amps-dhf-update-batch.json").exists());
         assertTrue(new File(projectPath, "src/main/hub-internal-config/security/amps/amps-dhf-update-job.json").exists());
-
         assertTrue(new File(projectPath, "src/main/ml-config/servers/final-server.json").exists());
         assertTrue(new File(projectPath, "src/main/ml-config/databases/final-database.json").exists());
         assertTrue(new File(projectPath, "src/main/ml-config/databases/modules-database.json").exists());

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/ext/mlunittest/GenerateTestSuiteTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/ext/mlunittest/GenerateTestSuiteTest.java
@@ -74,7 +74,7 @@ public class GenerateTestSuiteTest extends AbstractHubCoreTest {
         assertEquals(0, getStagingDocCount("stagingTestData"), "The generated test suite should use the " +
             "DH prepareDatabases() helper function to delete documents that are not artifacts");
         assertEquals(0, getFinalDocCount("finalTestData"));
-        assertEquals(0, getJobDocCount("Jobs"), "The prepareDatabases helper function should delete everything " +
+        assertEquals(0, getJobsDocCount("Jobs"), "The prepareDatabases helper function should delete everything " +
             "in the 'Jobs' collection in the jobs database");
     }
 
@@ -89,7 +89,7 @@ public class GenerateTestSuiteTest extends AbstractHubCoreTest {
         writeJsonDoc(getHubClient().getJobsClient(), "/jobDoc.json", "{}", "Jobs");
         assertEquals(1, getStagingDocCount("stagingTestData"));
         assertEquals(1, getFinalDocCount("finalTestData"));
-        assertEquals(1, getJobDocCount("Jobs"));
+        assertEquals(1, getJobsDocCount("Jobs"));
     }
 
     private TestSuiteResult runGeneratedTestSuite(String expectedTestModuleFilename) {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/EnableBatchOutputTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/EnableBatchOutputTest.java
@@ -1,0 +1,55 @@
+package com.marklogic.hub.flow;
+
+import com.marklogic.hub.AbstractHubCoreTest;
+import com.marklogic.hub.test.Customer;
+import com.marklogic.hub.test.ReferenceModelProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EnableBatchOutputTest extends AbstractHubCoreTest {
+
+    @BeforeEach
+    void beforeEach() {
+        installProjectInFolder("test-projects/simple-custom-step");
+        new ReferenceModelProject(getHubClient()).createCustomerInstance(new Customer(1, "Jane"), "staging");
+
+        assertEquals(0, getJobDocCount());
+        assertEquals(0, getBatchDocCount());
+    }
+
+    @Test
+    void jobOutputDisabled() {
+        runSuccessfulFlow(new FlowInputs("simpleCustomStepFlow").withOption("disableJobOutput", "true"));
+
+        assertEquals(0, getJobDocCount());
+        assertEquals(0, getBatchDocCount());
+    }
+
+    @Test
+    void neverWithFailure() {
+        RunFlowResponse response = runFlow(new FlowInputs("simpleCustomStepFlow")
+            .withOption("throwErrorOnPurpose", true)
+            .withOption("enableBatchOutput", "never"));
+
+        assertEquals("failed", response.getJobStatus(), "The flow should have failed as the custom step should have " +
+            "thrown an error: " + response.toJson());
+
+        assertEquals(1, getJobDocCount());
+        assertEquals(0, getBatchDocCount(), "A job doc should be created, but not a batch doc, since batch output is disabled");
+    }
+
+    @Test
+    void onFailure() {
+        RunFlowResponse response = runFlow(new FlowInputs("simpleCustomStepFlow")
+            .withOption("throwErrorOnPurpose", true)
+            .withOption("enableBatchOutput", "onFailure"));
+
+        assertEquals("failed", response.getJobStatus());
+
+        assertEquals(1, getJobDocCount());
+        assertEquals(1, getBatchDocCount(), "Since a failure occurred and enableBatchOutput=onFailure, a batch " +
+            "document should have been created");
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/UpgradeProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/impl/UpgradeProjectTest.java
@@ -113,7 +113,6 @@ public class UpgradeProjectTest extends AbstractHubCoreTest {
         assertTrue(hubProject.getHubSecurityDir().resolve("roles").resolve("data-hub-step-definition-writer.json").toFile().exists());
         assertTrue(hubProject.getHubSecurityDir().resolve("roles").resolve("data-hub-entity-model-reader.json").toFile().exists());
         assertTrue(hubProject.getHubSecurityDir().resolve("roles").resolve("data-hub-entity-model-writer.json").toFile().exists());
-        assertTrue(hubProject.getHubSecurityDir().resolve("amps").resolve("amps-dhf-update-batch.json").toFile().exists());
         assertTrue(hubProject.getHubSecurityDir().resolve("amps").resolve("amps-dhf-update-job.json").toFile().exists());
 
         ObjectMapper mapper = new ObjectMapper();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/legacy/job/LegacyJobManagerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/legacy/job/LegacyJobManagerTest.java
@@ -17,7 +17,6 @@ package com.marklogic.hub.legacy.job;
 
 import com.marklogic.client.eval.EvalResultIterator;
 import com.marklogic.hub.AbstractHubCoreTest;
-import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.legacy.flow.*;
 import com.marklogic.hub.legacy.impl.LegacyFlowManagerImpl;
@@ -121,13 +120,13 @@ public class LegacyJobManagerTest extends AbstractHubCoreTest {
 
     @Test
     public void deleteOneJob() {
-        assertEquals(4, getJobDocCount());
+        assertEquals(4, getLegacyJobDocCount());
         assertEquals(8, getTracingDocCount());
         String jobs = jobIds.get(1);
 
         JobDeleteResponse actual = jobManager.deleteJobs(jobs);
 
-        assertEquals(3, getJobDocCount());
+        assertEquals(3, getLegacyJobDocCount());
         assertEquals(6, getTracingDocCount());
         assertEquals(1, actual.totalCount);
         assertEquals(0, actual.errorCount);
@@ -143,13 +142,13 @@ public class LegacyJobManagerTest extends AbstractHubCoreTest {
     @Test
     public void deleteMultipleJobs() {
         assertEquals(3, jobIds.size());
-        assertEquals(4, getJobDocCount());
+        assertEquals(4, getLegacyJobDocCount());
         assertEquals(8, getTracingDocCount());
         String jobs = jobIds.get(0) + "," + jobIds.get(2);
 
         JobDeleteResponse actual = jobManager.deleteJobs(jobs);
 
-        assertEquals(2, getJobDocCount());
+        assertEquals(2, getLegacyJobDocCount());
         assertEquals(4, getTracingDocCount());
         assertEquals(2, actual.totalCount);
         assertEquals(0, actual.errorCount);
@@ -167,7 +166,7 @@ public class LegacyJobManagerTest extends AbstractHubCoreTest {
     public void deleteInvalidJob() {
         JobDeleteResponse actual = jobManager.deleteJobs("InvalidId");
 
-        assertEquals(4, getJobDocCount());
+        assertEquals(4, getLegacyJobDocCount());
         assertEquals(8, getTracingDocCount());
         assertEquals(0, actual.totalCount);
         assertEquals(1, actual.errorCount);
@@ -177,7 +176,7 @@ public class LegacyJobManagerTest extends AbstractHubCoreTest {
     public void deleteEmptyStringJob() {
         JobDeleteResponse actual = jobManager.deleteJobs("");
 
-        assertEquals(4, getJobDocCount());
+        assertEquals(4, getLegacyJobDocCount());
         assertEquals(8, getTracingDocCount());
         assertEquals(0, actual.totalCount);
         assertEquals(0, actual.errorCount);
@@ -187,7 +186,7 @@ public class LegacyJobManagerTest extends AbstractHubCoreTest {
     public void deleteNullJob() {
         JobDeleteResponse actual = jobManager.deleteJobs(null);
 
-        assertEquals(4, getJobDocCount());
+        assertEquals(4, getLegacyJobDocCount());
         assertEquals(8, getTracingDocCount());
         assertEquals(0, actual.totalCount);
         assertEquals(0, actual.errorCount);
@@ -275,12 +274,12 @@ public class LegacyJobManagerTest extends AbstractHubCoreTest {
         resetDatabases();
         runAsFlowDeveloper();
 
-        assertEquals(0, getJobDocCount());
+        assertEquals(0, getLegacyJobDocCount());
         assertEquals(0, getTracingDocCount());
 
         jobManager.importJobs(Paths.get(url.toURI()));
 
-        assertEquals(4, getJobDocCount());
+        assertEquals(4, getLegacyJobDocCount());
         assertEquals(8, getTracingDocCount());
 
         // Check one of the (known) JSON trace documents to make sure it was loaded as JSON

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub_integration/EndToEndFlowTests.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub_integration/EndToEndFlowTests.java
@@ -923,7 +923,7 @@ public class EndToEndFlowTests extends AbstractHubCoreTest {
 
         final int existingStagingCount = getStagingDocCount();
         final int existingFinalCount = getFinalDocCount();
-        final int existingJobsCount = getJobDocCount();
+        final int existingJobsCount = getJobsDocCount();
 
         String transform = codeFormat.equals(CodeFormat.JAVASCRIPT) ? "mlSjsInputFlow" : "mlInputFlow";
         ServerTransform serverTransform = new ServerTransform(transform);
@@ -961,7 +961,7 @@ public class EndToEndFlowTests extends AbstractHubCoreTest {
 
         int stagingCount = getStagingDocCount();
         int finalCount = getFinalDocCount();
-        int jobsCount = getJobDocCount();
+        int jobsCount = getJobsDocCount();
 
         assertEquals(finalCounts.stagingCount, stagingCount - existingStagingCount);
         assertEquals(finalCounts.finalCount, finalCount - existingFinalCount);
@@ -1003,7 +1003,7 @@ public class EndToEndFlowTests extends AbstractHubCoreTest {
         String flowName = getFlowName(prefix, codeFormat, dataFormat, FlowType.INPUT, useEs);
         final int existingStagingCount = getStagingDocCount();
         final int existingFinalCount = getFinalDocCount();
-        final int existingJobsCount = getJobDocCount();
+        final int existingJobsCount = getJobsDocCount();
 
         String transform = codeFormat.equals(CodeFormat.JAVASCRIPT) ? "mlSjsInputFlow" : "mlInputFlow";
 		ServerTransform serverTransform = new ServerTransform(transform);
@@ -1039,7 +1039,7 @@ public class EndToEndFlowTests extends AbstractHubCoreTest {
 
         int stagingCount = getStagingDocCount();
         int finalCount = getFinalDocCount();
-        int jobsCount = getJobDocCount();
+        int jobsCount = getJobsDocCount();
 
         assertEquals(finalCounts.stagingCount, stagingCount - existingStagingCount);
         assertEquals(finalCounts.finalCount, finalCount - existingFinalCount);

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub_integration/MappingE2E.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub_integration/MappingE2E.java
@@ -396,7 +396,7 @@ public class MappingE2E extends AbstractHubCoreTest {
 
         final int originalStagingCount = getStagingDocCount();
         final int originalFinalCount = getFinalDocCount();
-        final int originalJobsCount = getJobDocCount();
+        final int originalJobsCount = getLegacyJobDocCount();
 
         Tuple<LegacyFlowRunner, JobTicket> tuple = runHarmonizeFlow(flowName, dataFormat, completed, failed, options, srcClient, destDb, waitForCompletion);
 
@@ -406,7 +406,7 @@ public class MappingE2E extends AbstractHubCoreTest {
 
             assertEquals(finalCounts.stagingCount + originalStagingCount, getStagingDocCount());
             assertEquals(finalCounts.finalCount + originalFinalCount, getFinalDocCount());
-            assertEquals(finalCounts.jobCount + originalJobsCount, getJobDocCount());
+            assertEquals(finalCounts.jobCount + originalJobsCount, getLegacyJobDocCount());
 
             assertEquals(finalCounts.completedCount, completed.size());
             assertEquals(finalCounts.failedCount, failed.size());

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/stepExecutionContext/batchOutputIsEnabledTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/stepExecutionContext/batchOutputIsEnabledTest.sjs
@@ -1,0 +1,56 @@
+/**
+ Copyright (c) 2021 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+const StepExecutionContext = require("/data-hub/5/flow/stepExecutionContext.sjs");
+const test = require("/test/test-helper.xqy");
+
+const fakeFlow = {
+  "name": "fakeFlow",
+  "steps": {
+    "1": {}
+  }
+};
+const stepNumber = "1";
+const jobId = "dont-matter";
+const stepDef = {};
+
+const assertions = [];
+let context;
+
+function verifyBatchOutputIsEnabled(options, message) {
+  context = new StepExecutionContext(fakeFlow, stepNumber, stepDef, jobId, options);
+  assertions.push(test.assertEqual(true, context.batchOutputIsEnabled(), message));
+}
+
+function verifyBatchOutputIsDisabled(options, message) {
+  context = new StepExecutionContext(fakeFlow, stepNumber, stepDef, jobId, options);
+  assertions.push(test.assertEqual(false, context.batchOutputIsEnabled(), message));
+}
+
+verifyBatchOutputIsEnabled({}, "Batch output is enabled by default");
+
+verifyBatchOutputIsEnabled({ "disableJobOutput": false });
+
+verifyBatchOutputIsDisabled({ "disableJobOutput": true }, "When job output is disabled, so is batch output");
+
+verifyBatchOutputIsDisabled({"enableBatchOutput": "never"});
+
+verifyBatchOutputIsDisabled({"enableBatchOutput": "onFailure"}, "Since there are no failed items, batch output is disabled");
+context.failedItems = ["test failure"];
+assertions.push(test.assertEqual(true, context.batchOutputIsEnabled(), 
+  "Since there's now a failed item (even though it's not a real one), batch output is enabled"));
+
+assertions;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/ext/marklogic-unit-test/hub-test-helper/prepareDatabasesTest.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/ext/marklogic-unit-test/hub-test-helper/prepareDatabasesTest.sjs
@@ -2,11 +2,16 @@ const consts = require("/data-hub/5/impl/consts.sjs");
 const dhmut = require("/data-hub/ext/marklogic-unit-test/hub-test-helper.xqy");
 const hubTest = require("/test/data-hub-test-helper.xqy");
 const jobs = require("/data-hub/5/impl/jobs.sjs");
+const StepExecutionContext = require("/data-hub/5/flow/stepExecutionContext.sjs");
 const test = require("/test/test-helper.xqy");
 
+const fakeFlow = {"name": "myFlow", "steps": {"1": {}}};
+
 // Insert some job documents so we can verify that they're deleted
-const fakeJob = jobs.createJob("myFlow");
-jobs.createBatch(fakeJob, {}, "1");
+const fakeJob = jobs.createJob(fakeFlow.name);
+
+const stepExecutionContext = new StepExecutionContext(fakeFlow, "1", {}, fakeJob.job.jobId, {});
+jobs.insertBatch(fakeJob, stepExecutionContext, [], {});
 
 const assertions = [];
 

--- a/marklogic-data-hub/src/test/resources/test-projects/simple-custom-step/modules/root/custom-modules/custom/simpleCustomStep/simpleCustomStep.sjs
+++ b/marklogic-data-hub/src/test/resources/test-projects/simple-custom-step/modules/root/custom-modules/custom/simpleCustomStep/simpleCustomStep.sjs
@@ -3,6 +3,9 @@ function main(contentItem, options) {
   if (!contentItem.value) {
     contentItem.value = {"hello":"world"};
   }
+  if (options.throwErrorOnPurpose === true) {
+    throw Error("Throwing error on purpose");
+  }
   return contentItem;
 }
 

--- a/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
+++ b/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
@@ -43,6 +43,8 @@ import java.util.List;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 /**
  * Abstract base class for tests that depend on a HubConfigImpl (which generally means they depend on both a HubClient
  * and a HubProject).
@@ -410,6 +412,18 @@ public abstract class AbstractHubTest extends AbstractHubClientTest {
         return response;
     }
 
+    /**
+     * Convenience method for running a flow when it's expected to finish successfully.
+     *
+     * @param flowInputs
+     * @return
+     */
+    protected RunFlowResponse runSuccessfulFlow(FlowInputs flowInputs) {
+        RunFlowResponse response = runFlow(flowInputs);
+        assertEquals("finished", response.getJobStatus(), "Unexpected job status: " + response.toJson());
+        return response;
+    }
+
     protected void waitForReindex(HubClient hubClient, String database){
         String query = "(\n" +
             "  for $forest-id in xdmp:database-forests(xdmp:database('" + database + "'))\n" +
@@ -506,13 +520,32 @@ public abstract class AbstractHubTest extends AbstractHubClientTest {
     }
 
     /**
-     * @return a count of documents in the "job" collection - i.e. actual "Job" documents.
+     * @return a count of legacy (DHF 4) job documents; these are in the "job" collection while DHF job documents are
+     * in the "Job" collection
      */
-    protected int getJobDocCount() {
+    protected int getLegacyJobDocCount() {
         return getDocCount(HubConfig.DEFAULT_JOB_NAME, "job");
     }
 
-    protected int getJobDocCount(String collection) {
+    /**
+     * @return count of DHF 5 job documents
+     */
+    protected int getJobDocCount() {
+        return getDocCount(HubConfig.DEFAULT_JOB_NAME, "Job");
+    }
+
+    /**
+     * @return count of DHF 5 batch documents
+     */
+    protected int getBatchDocCount() {
+        return getDocCount(HubConfig.DEFAULT_JOB_NAME, "Batch");
+    }
+
+    /**
+     * @param collection
+     * @return the number of documents in the given collection in the Jobs database
+     */
+    protected int getJobsDocCount(String collection) {
         return getDocCount(HubConfig.DEFAULT_JOB_NAME, collection);
     }
 


### PR DESCRIPTION
### Description

createBatch/updateBatch are gone; we only have insertBatch now. So no amp needed for updateBatch anymore.

Also fixed an issue in the test plumbing where "getJobDocCount" was actually get legacy job docs, not DHF 5 job docs. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

