### PR TITLE
DHFPROD-7130: Display error messaging if user wants to create an enti…

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-modal/entity-type-modal.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-modal/entity-type-modal.test.tsx
@@ -163,5 +163,29 @@ describe("EntityTypeModal Component", () => {
     expect(axiosMock.put).toHaveBeenCalledWith(url, payload);
     expect(axiosMock.put).toHaveBeenCalledTimes(1);
   });
+
+
+  test("Adding a restricted Entity name shows error message", async () => {
+    const {getByText, getByPlaceholderText} = render(
+      <EntityTypeModal
+        isVisible={true}
+        toggleModal={jest.fn()}
+        updateEntityTypesAndHideModal={jest.fn()}
+        isEditModal={false}
+        name={""}
+        description={""}
+      />);
+    expect(getByText(/Add Entity Type/i)).toBeInTheDocument();
+
+    const entityName = "Collection";
+    userEvent.type(getByPlaceholderText("Enter name"), entityName);
+    userEvent.type(getByPlaceholderText("Enter description"), "test");
+
+    await wait(() => {
+      userEvent.click(getByText("Add"));
+    });
+
+    expect(getByText(entityName + ModelingTooltips.reservedEntityNames)).toBeInTheDocument();
+  });
 });
 

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-modal/entity-type-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-modal/entity-type-modal.tsx
@@ -32,6 +32,8 @@ const EntityTypeModal: React.FC<Props> = (props) => {
   const [errorMessage, setErrorMessage] = useState("");
   const [loading, toggleLoading] = useState(false);
 
+  const reservedEntityNamesArray = ["Collection", "createdByJob", "createdByStep", "entity-type"];
+
   useEffect(() => {
     if (props.isVisible) {
       if (props.isEditModal) {
@@ -105,6 +107,8 @@ const EntityTypeModal: React.FC<Props> = (props) => {
     } else {
       if (!NAME_REGEX.test(name)) {
         setErrorMessage(ModelingTooltips.nameRegex);
+      } else if (reservedEntityNamesArray.indexOf(name) > -1) {
+        setErrorMessage(name + ModelingTooltips.reservedEntityNames);
       } else {
         toggleLoading(true);
         createEntityType(name, description);

--- a/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
+++ b/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
@@ -43,6 +43,7 @@ const ModelingTooltips = {
   nameEntityProperty: 'The name of this entity property. ' +
     'Names must start with a letter and can contain letters, numbers, hyphens, and underscores.',  /* intended dupe: all names */
   descriptionEntityProperty: 'A description of this entity property.',
+  reservedEntityNames: ' is not an allowed entity name. Choose another.',
 
   /* Form fields */
   joinProperty: 'Structured type properties and arrays cannot be used as join properties.',


### PR DESCRIPTION
…ection" entity

### Description
This PR adds error messaging to prevent a bug that throws an error if a user tries to create these entity names:
"Collection", "createdByJob", "createdByStep", and "entity-type"

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests

