### PR TITLE
DHFPROD-6727: Steps can be configured to not write their output

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/RunStepResponse.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/RunStepResponse.java
@@ -16,6 +16,7 @@
 package com.marklogic.hub.step;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -41,7 +42,7 @@ public class RunStepResponse {
     private String targetDatabase;
 
     public List<String> stepOutput;
-    private Map<String, Object> fullOutput;
+    private Map<String, JsonNode> fullOutput;
     private String status;
 
     private long totalEvents = 0;
@@ -113,7 +114,7 @@ public class RunStepResponse {
         return this;
     }
 
-    public RunStepResponse withFullOutput(Map<String,Object>  fullOutput) {
+    public RunStepResponse withFullOutput(Map<String,JsonNode>  fullOutput) {
         this.fullOutput = fullOutput;
         return this;
     }
@@ -157,7 +158,7 @@ public class RunStepResponse {
         return flowName;
     }
 
-    public Map<String, Object> getFullOutput() {
+    public Map<String, JsonNode> getFullOutput() {
         return fullOutput;
     }
 

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/QueryStepRunner.java
@@ -319,7 +319,7 @@ public class QueryStepRunner extends LoggingObject implements StepRunner {
 
         HashMap<String, JobTicket> ticketWrapper = new HashMap<>();
 
-        Map<String,Object> fullResponse = new HashMap<>();
+        Map<String,JsonNode> fullOutputMap = new HashMap<>();
         queryBatcher = dataMovementManager.newQueryBatcher(uris.iterator())
             .withBatchSize(batchSize)
             .withThreadCount(threadCount)
@@ -358,11 +358,11 @@ public class QueryStepRunner extends LoggingObject implements StepRunner {
                         try {
                             for (JsonNode node : response.documents) {
                                 if (node.has("uri")) {
-                                    fullResponse.put(node.get("uri").asText(), node.toString());
+                                    fullOutputMap.put(node.get("uri").asText(), node);
                                 }
                             }
                         } catch (Exception ex) {
-                            logger.warn("Unable to add written documents to fullResponse map in RunStepResponse; cause: " + ex.getMessage(), ex);
+                            logger.warn("Unable to add written documents to fullOutput map in RunStepResponse; cause: " + ex.getMessage());
                         }
                     }
 
@@ -454,7 +454,7 @@ public class QueryStepRunner extends LoggingObject implements StepRunner {
                 runStepResponse.withStepOutput(errorMessages);
             }
             if(isFullOutput) {
-                runStepResponse.withFullOutput(fullResponse);
+                runStepResponse.withFullOutput(fullOutputMap);
             }
 
             if (jobOutputIsEnabled()) {

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
@@ -94,7 +94,6 @@ public class WriteStepRunner implements StepRunner {
     private Map<String, Object> options;
     private boolean stopOnFailure = false;
     private String jobId;
-    private boolean isFullOutput = false;
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     private String step = "1";
@@ -464,7 +463,6 @@ public class WriteStepRunner implements StepRunner {
         HashMap<String, JobTicket> ticketWrapper = new HashMap<>();
 
         double uriSize = uris.size();
-        Map<String,Object> fullResponse = new HashMap<>();
 
         ServerTransform serverTransform = new ServerTransform("mlRunIngest");
         serverTransform.addParameter("job-id", jobId);
@@ -607,9 +605,6 @@ public class WriteStepRunner implements StepRunner {
             runStepResponse.withStatus(stepStatus);
             if (errorMessages.size() > 0) {
                 runStepResponse.withStepOutput(errorMessages);
-            }
-            if(isFullOutput) {
-                runStepResponse.withFullOutput(fullResponse);
             }
 
             if (jobOutputIsEnabled()) {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/stepExecutionContext.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/stepExecutionContext.sjs
@@ -60,6 +60,10 @@ class StepExecutionContext {
     this.stepOutputErrorMessages = undefined;
   }
 
+  getLabelForLogging() {
+    return `step ${this.stepNumber} in flow '${this.flow.name}'`;
+  }
+
   getSourceDatabase() {
     return this.combinedOptions.sourceDatabase || config.STAGINGDATABASE;
   }
@@ -70,7 +74,7 @@ class StepExecutionContext {
 
   buildStepResponse(startDateTime) {
     const hasFailures = this.failedItems.length > 0;
-    const stepResponse = {
+    return {
       flowName: this.flow.name,
       stepName: this.flowStep.name,
       stepDefinitionName: this.stepDefinition.name,
@@ -88,7 +92,6 @@ class StepExecutionContext {
       stepStartTime: startDateTime,
       stepEndTime: fn.currentDateTime().add(xdmp.elapsedTime())
     };
-    return stepResponse;
   }
 
   // No concept of "stopped" yet
@@ -211,6 +214,10 @@ class StepExecutionContext {
    */
   stepErrorShouldBeThrown() {
     return true == this.combinedOptions.throwStepError;
+  }
+
+  stepOutputShouldBeWritten() {
+    return false !== this.combinedOptions.writeStepOutput;
   }
 
   makeCustomHookRunner(contentArray) {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow.sjs
@@ -234,7 +234,7 @@ class Flow {
 
     let writeTransactionInfo = {};
     //let's update our jobdoc now
-    if (!combinedOptions.noWrite) {
+    if (stepExecutionContext.stepOutputShouldBeWritten()) {
       try {
         const configCollections = [
           options.collections,
@@ -286,11 +286,6 @@ class Flow {
     return resp;
   }
 
-  /**
-   *
-   * @param stepExecutionContext
-   * @param content
-   */
   runStep(stepExecutionContext, content) {
     const stepNumber = stepExecutionContext.stepNumber;
     const flowName = stepExecutionContext.flow.name;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/transforms/mlcp-flow-transform.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/transforms/mlcp-flow-transform.sjs
@@ -81,7 +81,7 @@ function transform(content, context = {}) {
       return Sequence.from([]);
     } else {
       const step = params['step'] ? xdmp.urlDecode(params['step']) : null;
-      options.noWrite = true;
+      options.writeStepOutput = false;
       options.fullOutput = true;
       // This maps to the ResponseHolder Java class; it's not a RunFlowResponse or RunStepResponse
       const responseHolder = datahub.flow.runFlow(flowName, jobId, contentArray, options, step);

--- a/marklogic-data-hub/src/main/resources/ml-modules/services/mlSmMerge.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/services/mlSmMerge.sjs
@@ -41,7 +41,9 @@ function post(context, params, input) {
   let sourceDatabase = combinedOptions.sourceDatabase || config.STAGINGDATABASE;
 
   combinedOptions.fullOutput = true;
-  combinedOptions.noWrite = params.preview === 'true';
+  if (params.preview === "true") {
+    combinedOptions.writeStepOutput = false;
+  }
   combinedOptions.acceptsBatch = true;
   let jobId = params["job-id"];
   let uris = hubUtils.normalizeToArray(params.uri);
@@ -71,7 +73,7 @@ function deleteFunction(context, params) {
     options.retainAuditTrail = xs.boolean(options.retainAuditTrail);
   }
   options.fullOutput = true;
-  options.noWrite = true;
+  options.writeStepOutput = false;
   const datahub = DataHubSingleton.instance({
     performanceMetrics: !!options.performanceMetrics
   });

--- a/marklogic-data-hub/src/main/resources/ml-modules/transforms/mlRunIngest.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/transforms/mlRunIngest.sjs
@@ -31,10 +31,10 @@ function transform(context, params, content) {
     content = content.content;
   }
 
-  options.noWrite = true;
+  options.writeStepOutput = false;
   options.fullOutput = true;
   options.enableBatchOutput = "never";
-  
+
   let newContent = {};
   newContent.uri=context.uri;
   newContent.value=content;

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/ReturnFullOutputTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/ReturnFullOutputTest.java
@@ -1,0 +1,57 @@
+package com.marklogic.hub.flow;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.hub.AbstractHubCoreTest;
+import com.marklogic.hub.test.Customer;
+import com.marklogic.hub.test.ReferenceModelProject;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReturnFullOutputTest extends AbstractHubCoreTest {
+
+    /**
+     * Verifies that both writeStepOutput and fullOutput work for an independent step.
+     *
+     * @throws Exception
+     */
+    @Test
+    void fullOutputForStep() throws Exception {
+        installProjectInFolder("test-projects/simple-custom-step");
+        new ReferenceModelProject(getHubClient()).createCustomerInstance(new Customer(1, "Jane"), "staging");
+
+        String s = "{\n" +
+            "  \"stepOptions\": {\n" +
+            "    \"1\": {\n" +
+            "      \"writeStepOutput\": false,\n" +
+            "      \"fullOutput\": true\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
+        RunFlowResponse response = runSuccessfulFlow(new FlowInputs("simpleCustomStepFlow")
+            .withOptions(objectMapper.readValue(s, HashMap.class)));
+
+        final String uri = "/Customer1.json";
+        assertNotNull(getHubClient().getStagingClient().newDocumentManager().exists(uri),
+            "The document should exist in staging, as it was written there before the flow was run");
+        assertNull(getHubClient().getFinalClient().newDocumentManager().exists(uri),
+            "No document should exist in final since writeStepOutput=false");
+
+        Map<String, JsonNode> fullOutput = response.getStepResponses().get("1").getFullOutput();
+        assertTrue(fullOutput.containsKey(uri), "The initial 5.0 design of fullOutput is that it's a map " +
+            "of URI to content objects, as opposed to an array of content objects");
+
+        JsonNode node = fullOutput.get(uri);
+        assertEquals(uri, node.get("uri").asText());
+        assertEquals("Jane", node.get("value").get("envelope").get("instance").get("Customer").get("name").asText(),
+            "Prior to 5.5, I think the fix for DHFPROD-3176 was made under the assumption that the 'documents' returned " +
+                "in ResponseHolder were actual documents, vs content objects, and thus it was safer to call node.toString(). " +
+                "But we know that these are JSON content objects, and not documents, so for 5.5, a change was made so that " +
+                "RunStepResponse.fullOutput is now a map of JsonNodes instead of Object, since we know for certain that the " +
+                "value must be a JsonNode.");
+    }
+}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/data-hub-test-helper.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/data-hub-test-helper.sjs
@@ -107,6 +107,18 @@ function getRecordInCollection(collection) {
   return getRecord(uris[0]);
 }
 
+function stagingDocumentExists(uri) {
+  return documentExists(uri, config.STAGINGDATABASE);
+}
+
+function finalDocumentExists(uri) {
+  return documentExists(uri, config.FINALDATABASE);
+}
+
+function documentExists(uri, databaseName) {
+  return fn.head(xdmp.eval(`fn.docAvailable('${uri}')`, {}, { database: xdmp.database(databaseName) }));
+}
+
 /**
  * Makes life easy for verifying permissions by building a map of them, keyed on role name, with arrays of capabilities
  * as values.
@@ -201,10 +213,12 @@ function makeSimpleMappingStep(stepName, mappingStepProperties) {
 
 module.exports = {
   createSimpleMappingProject,
+  finalDocumentExists,
   getModulesRecord,
   getRecord,
   getRecordInCollection,
   getStagingRecord,
+  stagingDocumentExists,
   verifyJson,
   runWithRolesAndPrivileges: module.amp(runWithRolesAndPrivileges)
 };

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/flowRunner/copyContentObject/copyJsonNodeValue.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/flowRunner/copyContentObject/copyJsonNodeValue.sjs
@@ -1,0 +1,24 @@
+const flowRunner = require("/data-hub/5/flow/flowRunner.sjs");
+const test = require("/test/test-helper.xqy");
+
+// Ignoring context, since that's tested in copyJsonObjectValue.sjs
+const content = {
+  "uri": "my-uri",
+  "value": xdmp.toJSON({"hello":"world"})
+};
+
+const copy = flowRunner.copyContentObject(content);
+
+// Modify the original content; in this scenario, we know that a shallow copy of content.value is safe because a JSON 
+// node cannot be modified; a user must first call toObject on it
+content.uri = "modified-uri";
+const objectValue = content.value.toObject();
+objectValue.hello = "modified";
+content.value = objectValue;
+
+const assertions = [
+  test.assertEqual("my-uri", copy.uri),
+  test.assertEqual("world", copy.value.toObject().hello)
+];
+
+assertions

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/flowRunner/copyContentObject/copyJsonObjectValue.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/flowRunner/copyContentObject/copyJsonObjectValue.sjs
@@ -1,0 +1,58 @@
+const flowRunner = require("/data-hub/5/flow/flowRunner.sjs");
+const test = require("/test/test-helper.xqy");
+
+const content = {
+  "uri": "my-uri",
+  "value": {"hello":"world"},
+  "context": {
+    "collections": ["coll1", "coll2"],
+    "originalCollections": ["orig1", "orig2"],
+    "permissions": [xdmp.permission("data-hub-common", "read"), xdmp.permission("data-hub-common-writer", "update")],
+    "metadata": {
+      "meta1": "value1",
+      "meta2": "value2"
+    },
+    "somethingElse": {
+      "child": "value"
+    }
+  },
+  "anotherThing": {
+    "child": "value"
+  }
+};
+
+const copy = flowRunner.copyContentObject(content);
+
+// Now modify the original content and make sure the copy isn't modified - except for ".value"
+content.uri = "modified-uri";
+content.value.hello = "modified";
+content.context.collections = ["modified"];
+content.context.originalCollections = ["also-modified"];
+content.context.permissions = [xdmp.permission("rest-reader", "read"), xdmp.permission("rest-writer", "update")];
+content.context.metadata.meta1 = "modified1";
+content.context.metadata.meta2 = "modified2";
+content.context.somethingElse.child = "modified";
+content.anotherThing.child = "modified";
+
+const assertions = [
+  test.assertEqual("my-uri", copy.uri),
+  test.assertEqual("modified", copy.value.hello, "It's expected that value is modified because copyContentObject is doing a shallow copy; " + 
+    "see the comments on this function for why a deep copy is not yet being done"
+  ),
+  test.assertEqual(2, copy.context.collections.length),
+  test.assertEqual("coll1", copy.context.collections[0]),
+  test.assertEqual("coll2", copy.context.collections[1]),
+  test.assertEqual(2, copy.context.originalCollections.length),
+  test.assertEqual("orig1", copy.context.originalCollections[0]),
+  test.assertEqual("orig2", copy.context.originalCollections[1]),
+  test.assertEqual("data-hub-common", xdmp.roleName(copy.context.permissions[0].roleId)),
+  test.assertEqual("data-hub-common-writer", xdmp.roleName(copy.context.permissions[1].roleId)),
+  test.assertEqual("value1", copy.context.metadata.meta1),
+  test.assertEqual("value2", copy.context.metadata.meta2),
+  test.assertEqual("modified", copy.context.somethingElse.child, "Any unknown property has the same issues as content.value, " + 
+    "where it's not known if a deep copy can be reliably performed. So a shallow copy is expected."),
+  test.assertEqual("modified", copy.anotherThing.child, "Any unknown property has the same issues as content.value, " + 
+    "where it's not known if a deep copy can be reliably performed. So a shallow copy is expected.")
+];
+
+assertions

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/flowRunner/copyContentObject/copyXmlValue.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/flowRunner/copyContentObject/copyXmlValue.sjs
@@ -1,0 +1,22 @@
+const flowRunner = require("/data-hub/5/flow/flowRunner.sjs");
+const test = require("/test/test-helper.xqy");
+
+// Ignoring context, since that's tested in copyJsonObjectValue.sjs
+const content = {
+  "uri": "my-uri",
+  "value": fn.head(xdmp.unquote("<hello>world</hello>"))
+};
+
+const copy = flowRunner.copyContentObject(content);
+
+// Modify the original; note that with an XML document node, a shallow copy works fine because 
+// there's no way to directly modify a document node
+content.uri = "modified-uri";
+content.value = fn.head(xdmp.unquote("<modified>true</modified>"));
+
+const assertions = [
+  test.assertEqual("my-uri", copy.uri),
+  test.assertEqual("world", copy.value.xpath("/hello/fn:string()"))
+];
+
+assertions

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/dontWriteIngestionOrMappingOutput.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/dontWriteIngestionOrMappingOutput.sjs
@@ -1,0 +1,59 @@
+const flowRunner = require("/data-hub/5/flow/flowRunner.sjs");
+const hubTest = require("/test/data-hub-test-helper.sjs");
+const test = require("/test/test-helper.xqy");
+
+const flowName = "ingestAndMap";
+const jobId = sem.uuidString();
+const runtimeOptions = {
+  "stepOptions": {
+    "1": {
+      "writeStepOutput": false,
+      "fullOutput": true
+    },
+    "2": {
+      "writeStepOutput": false,
+      "fullOutput": true
+    }
+  }
+};
+
+const contentArray = [
+  { "uri": "/customer1.json", "value": { "customerId": "1" } },
+  { "uri": "/customer2.json", "value": { "customerId": "2" } }
+];
+
+const assertions = [];
+
+const response = flowRunner.processContentWithFlow(flowName, contentArray, jobId, runtimeOptions);
+
+const ingestResponse = response.stepResponses["1"];
+assertions.push(
+  test.assertEqual("finished", response.jobStatus, "Unexpected status: " + xdmp.toJsonString(response)),
+  test.assertEqual("completed step 1", ingestResponse.status),
+  test.assertEqual(2, ingestResponse.successfulEvents),
+  test.assertEqual(0, ingestResponse.failedEvents),
+  test.assertEqual(1, ingestResponse.successfulBatches),
+  test.assertEqual(2, Object.keys(ingestResponse.fullOutput).length),
+  test.assertEqual("/customer1.json", ingestResponse.fullOutput["/customer1.json"].uri),
+  test.assertEqual("/customer2.json", ingestResponse.fullOutput["/customer2.json"].uri)
+);
+
+const mapResponse = response.stepResponses["2"];
+assertions.push(
+  test.assertEqual("completed step 2", mapResponse.status),
+  test.assertEqual(2, mapResponse.successfulEvents),
+  test.assertEqual(0, mapResponse.failedEvents),
+  test.assertEqual(1, mapResponse.successfulBatches),
+  test.assertEqual(2, Object.keys(mapResponse.fullOutput).length),
+  test.assertEqual("/customer1.json", mapResponse.fullOutput["/customer1.json"].uri),
+  test.assertEqual("/customer2.json", mapResponse.fullOutput["/customer2.json"].uri)
+);
+
+assertions.push(
+  test.assertEqual(false, hubTest.stagingDocumentExists("/customer1.json")),
+  test.assertEqual(false, hubTest.finalDocumentExists("/customer1.json")),
+  test.assertEqual(false, hubTest.stagingDocumentExists("/customer2.json")),
+  test.assertEqual(false, hubTest.finalDocumentExists("/customer2.json"))
+);
+
+assertions;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/dontWriteIngestionOutput.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/dontWriteIngestionOutput.sjs
@@ -1,0 +1,44 @@
+const flowRunner = require("/data-hub/5/flow/flowRunner.sjs");
+const hubTest = require("/test/data-hub-test-helper.sjs");
+const test = require("/test/test-helper.xqy");
+
+const flowName = "ingestAndMap";
+const jobId = sem.uuidString();
+const runtimeOptions = {
+  "stepOptions": {
+    "1": {
+      "writeStepOutput": false
+    }
+  }
+};
+
+const contentArray = [
+  { "uri": "/customer1.json", "value": { "customerId": "1" } }
+];
+
+const assertions = [];
+
+const response = flowRunner.processContentWithFlow(flowName, contentArray, jobId, runtimeOptions);
+
+const ingestResponse = response.stepResponses["1"];
+assertions.push(
+  test.assertEqual("finished", response.jobStatus),
+  test.assertEqual("completed step 1", ingestResponse.status, "The step is still considered to have completed successfully, even though it didn't write anything"),
+  test.assertEqual(1, ingestResponse.successfulEvents),
+  test.assertEqual(0, ingestResponse.failedEvents),
+  test.assertEqual(1, ingestResponse.successfulBatches)
+);
+
+assertions.push(
+  test.assertEqual(false, hubTest.stagingDocumentExists("/customer1.json"), 
+    "Because writeStepOutput=true for the ingestion step, no output should have been persisted")
+);
+
+const mappedCustomer = hubTest.getRecord("/customer1.json");
+assertions.push(
+  test.assertEqual(1, mappedCustomer.document.envelope.instance.Customer.customerId, 
+    "The output of the mapping step should have been written"
+  )
+);
+
+assertions;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/ingestAndMapToStaging.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/ingestAndMapToStaging.sjs
@@ -1,4 +1,3 @@
-const config = require("/com.marklogic.hub/config.sjs");
 const flowRunner = require("/data-hub/5/flow/flowRunner.sjs");
 const hubTest = require("/test/data-hub-test-helper.sjs");
 const test = require("/test/test-helper.xqy");
@@ -30,8 +29,7 @@ const assertions = [
     "should overwrite the one outputted by the ingestion step")
 ];
 
-const isAvailable = fn.head(xdmp.eval("fn.docAvailable('/customer1.json')", {}, { database: xdmp.database(config.FINALDATABASE) }));
-
 assertions.concat(
-  test.assertEqual(false, isAvailable, "The doc should not exist in final since both steps write to staging")
+  test.assertEqual(false, hubTest.finalDocumentExists("/customer1.json"), 
+    "The doc should not exist in final since both steps write to staging")
 )

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/test-data/flows/CustomerByValue.flow.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/test-data/flows/CustomerByValue.flow.json
@@ -7,7 +7,7 @@
     "targetEntity": "Customer",
     "sourceQuery": "cts.values(cts.uriReference())",
     "sourceQueryIsScript": true,
-    "noWrite": true
+    "writeStepOutput": false
   },
   "description": "flow description",
   "steps": {

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/test-data/step-definitions/CustomerByValue.step.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flows/test-data/step-definitions/CustomerByValue.step.json
@@ -11,7 +11,7 @@
     "targetEntity": "Customer",
     "sourceQuery": "cts.values(cts.uriReference())",
     "sourceQueryIsScript": true,
-    "noWrite": true
+    "writeStepOutput": false
   },
   "customHook": {},
   "lang": "zxx",

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping/user-parameters/userModuleThrowsError.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping/user-parameters/userModuleThrowsError.sjs
@@ -16,7 +16,7 @@ const message = "Unexpected response: " + xdmp.toJsonString(response);
 const assertions = [
   test.assertEqual("failed", response.jobStatus, message),
   test.assertEqual(1, response.stepResponses["2"].stepOutput.length, "Expected a single error; " + message),
-  test.assertEqual("Unable to invoke beforeMain on step '2' in flow 'simpleMappingFlow'; " + 
+  test.assertEqual("Unable to invoke beforeMain on step 2 in flow 'simpleMappingFlow'; " + 
     "cause: Throwing error on purpose", response.stepResponses["2"].stepOutput[0], 
     "The error should explain that beforeMain failed, along with the error thrown from beforeMain; " + message)
 ];


### PR DESCRIPTION
### Description

Renamed "noWrite" to "writeStepOutput". Also added support for fullOutput to flowRunner.sjs.

Did some cleanup of fullOutput too - it's now a Map<String, JsonNode> in Java. And WriteStepRunner wasn't doing anything with it, so I removed code from there. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

