### PR TITLE
DHFPROD-7163: Related entity table ordering and deselection issue

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario2.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario2.spec.tsx
@@ -192,7 +192,7 @@ describe("Entity Modeling: Writer Role", () => {
     propertyTable.getProperty("OrderedBy").should("exist");
   });
   it("Delete a property, a structured property and then the entity", () => {
-    //Structured Property 
+    //Structured Property
     propertyTable.getDeleteStructuredPropertyIcon("User3", "Address", "alt_address-streetAlt").click();
     confirmationModal.getDeletePropertyWarnText().should("exist");
     confirmationModal.getYesButton(ConfirmationType.DeletePropertyWarn).click();

--- a/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.tsx
@@ -229,7 +229,7 @@ const CreateEditStep: React.FC<Props>  = (props) => {
       props.updateStepArtifact(getPayload());
     }
     ((props.stepType === StepType.Matching) || (props.stepType === StepType.Merging))? setIsSubmit(true):setIsSubmit(false);
-      /* adding props.stepType !== StepType.Merging below will show the warnings, should be added as a part of DHFPROD-6995*/
+    /* adding props.stepType !== StepType.Merging below will show the warnings, should be added as a part of DHFPROD-6995*/
     if (props.stepType !== StepType.Matching) {
       props.setOpenStepSettings(false);
       props.resetTabs();

--- a/marklogic-data-hub-central/ui/src/components/steps/steps.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/steps/steps.test.tsx
@@ -6,8 +6,6 @@ import mocks from "../../api/__mocks__/mocks.data";
 import data from "../../assets/mock-data/curation/steps.data";
 import StepsConfig from "../../config/steps.config";
 import {ErrorTooltips} from "../../config/tooltips.config";
-import {CurationContext} from "../../util/curation-context";
-import {customerStepWarning} from "../../assets/mock-data/curation/curation-context-mock";
 
 jest.mock("axios");
 
@@ -395,5 +393,5 @@ describe("Steps settings component", () => {
     fireEvent.click(getByText("Custom Hook"));
     expect(getByLabelText("customHook-textarea")).toBeEmpty();
   });
-  
+
 });


### PR DESCRIPTION
### Description

- Fixed issue where deselecting a related entity table caused that table's filter label to drop to the next table.
- Fixed ordering of tables as related entities are selected (related related entities appear below their respective parents now)
- Added styling fix to table row dividers (approved by @jbelonoj)
- Tests are still going to be added as part of this [task](https://project.marklogic.com/jira/browse/DHFPROD-7155)
- NOTE: there are changes to unrelated files due to linting errors that must have been missed in a previous PR.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- N/A Added Tests
  

- ##### Reviewer:

- N/A Reviewed Tests

