### PR TITLE
DHFPROD-5231: Validate and Save ruleset for multiple properties form

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/matching.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/matching.spec.tsx
@@ -6,7 +6,7 @@ import {
   multiSlider,
   confirmYesNo
 } from "../../../support/components/common/index";
-import {matchingStepDetail, rulesetSingleModal, thresholdModal} from "../../../support/components/matching/index";
+import {matchingStepDetail, rulesetSingleModal, thresholdModal, rulesetMultipleModal} from "../../../support/components/matching/index";
 import curatePage from "../../../support/pages/curate";
 import LoginPage from "../../../support/pages/login";
 
@@ -108,7 +108,7 @@ describe("Matching", () => {
     multiSlider.sliderTooltipValue("20");
   });
   it("Add ruleset", () => {
-    matchingStepDetail.addNewRulesetSingle();
+    matchingStepDetail.addNewRuleset();
     matchingStepDetail.getSinglePropertyOption();
     rulesetSingleModal.selectPropertyToMatch("customerId");
     rulesetSingleModal.selectMatchTypeDropdown("exact");
@@ -127,7 +127,7 @@ describe("Matching", () => {
     matchingStepDetail.getPossibleMatchCombinationRuleset("testing", "customerId - Exact").should("be.visible");
   });
   it("Add another ruleset", () => {
-    matchingStepDetail.addNewRulesetSingle();
+    matchingStepDetail.addNewRuleset();
     matchingStepDetail.getSinglePropertyOption();
     rulesetSingleModal.selectPropertyToMatch("email");
     rulesetSingleModal.selectMatchTypeDropdown("exact");
@@ -144,6 +144,26 @@ describe("Matching", () => {
     //Verify the possible match combinations
     matchingStepDetail.getPossibleMatchCombinationRuleset("testing", "email - Exact").trigger("mousemove").should("be.visible");
   });
+  it("Add a ruleset with multiple properties", () => {
+    matchingStepDetail.addNewRuleset();
+    matchingStepDetail.getMultiPropertyOption();
+    rulesetMultipleModal.setRulesetName("customerMultiplePropertyRuleset");
+    rulesetMultipleModal.selectPropertyToMatch("customerId");
+    rulesetMultipleModal.selectMatchTypeDropdown("customerId", "exact");
+    rulesetMultipleModal.saveButton().click();
+    cy.waitForAsyncRequest();
+    cy.waitUntil(() => cy.findByLabelText("customerMultiplePropertyRuleset").should("have.length.gt", 0));
+    multiSlider.getHandleName("customerMultiplePropertyRuleset").should("be.visible");
+  });
+  it("Edit ruleset with multiple properties", () => {
+    multiSlider.editOption("customerMultiplePropertyRuleset");
+    cy.contains("Edit Match Ruleset for Multiple Properties");
+    rulesetMultipleModal.selectPropertyToMatch("name");
+    rulesetMultipleModal.selectMatchTypeDropdown("name", "zip");
+    rulesetMultipleModal.saveButton().click();
+    cy.waitForAsyncRequest();
+    cy.waitUntil(() => cy.findByLabelText("customerMultiplePropertyRuleset").should("have.length.gt", 0));
+  });
   it("Delete a ruleset", () => {
     multiSlider.deleteOption("email");
     matchingStepDetail.getSliderDeleteText().should("be.visible");
@@ -152,6 +172,15 @@ describe("Matching", () => {
     cy.waitUntil(() => cy.findByLabelText("rulesetName-testing-email").should("have.length", 0));
     multiSlider.getHandleName("email").should("not.exist");
     matchingStepDetail.getPossibleMatchCombinationRuleset("testing", "email").should("not.exist");
+  });
+  it("Delete a ruleset with multiple properties", () => {
+    multiSlider.deleteOption("customerMultiplePropertyRuleset");
+    matchingStepDetail.getSliderDeleteText().should("be.visible");
+    matchingStepDetail.confirmSliderOptionDeleteButton().click();
+    cy.waitForAsyncRequest();
+    cy.waitUntil(() => cy.findByLabelText("rulesetName-testing-customerMultiplePropertyRuleset").should("have.length", 0));
+    multiSlider.getHandleName("customerMultiplePropertyRuleset").should("not.exist");
+    matchingStepDetail.getPossibleMatchCombinationRuleset("testing", "customerMultiplePropertyRuleset").should("not.exist");
   });
   it("Delete threshold", () => {
     multiSlider.deleteOption("testing");

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/mastering/e2eMasteringflow.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/mastering/e2eMasteringflow.spec.tsx
@@ -230,7 +230,7 @@ describe("Validate E2E Mastering Flow", () => {
     cy.waitForAsyncRequest();
   });
   it("Add Rulesets", () => {
-    matchingStepDetail.addNewRulesetSingle();
+    matchingStepDetail.addNewRuleset();
     matchingStepDetail.getSinglePropertyOption();
     rulesetSingleModal.selectPropertyToMatch("LastName");
     rulesetSingleModal.selectMatchTypeDropdown("exact");
@@ -240,7 +240,7 @@ describe("Validate E2E Mastering Flow", () => {
     cy.findByTestId("threshold-slider-ticks").find(`div[style*="left: 9.09091%;"]`).trigger("mousemove", {force: true});
     multiSlider.getHandleName("LastName").trigger("mouseup", {force: true});
     cy.waitForAsyncRequest();
-    matchingStepDetail.addNewRulesetSingle();
+    matchingStepDetail.addNewRuleset();
     matchingStepDetail.getSinglePropertyOption();
     rulesetSingleModal.selectPropertyToMatch("SSN");
     rulesetSingleModal.selectMatchTypeDropdown("exact");
@@ -250,7 +250,7 @@ describe("Validate E2E Mastering Flow", () => {
     cy.findByTestId("threshold-slider-ticks").find(`div[style*="left: 19.1919%;"]`).trigger("mousemove", {force: true});
     multiSlider.getHandleName("SSN").trigger("mouseup", {force: true});
     cy.waitForAsyncRequest();
-    matchingStepDetail.addNewRulesetSingle();
+    matchingStepDetail.addNewRuleset();
     matchingStepDetail.getSinglePropertyOption();
     rulesetSingleModal.selectPropertyToMatch("FirstName");
     rulesetSingleModal.selectMatchTypeDropdown("doubleMetaphone");
@@ -262,7 +262,7 @@ describe("Validate E2E Mastering Flow", () => {
     cy.findByTestId("threshold-slider-ticks").find(`div[style*="left: 9.09091%;"]`).trigger("mousemove", {force: true});
     multiSlider.getHandleName("FirstName").trigger("mouseup", {force: true});
     cy.waitForAsyncRequest();
-    matchingStepDetail.addNewRulesetSingle();
+    matchingStepDetail.addNewRuleset();
     matchingStepDetail.getSinglePropertyOption();
     rulesetSingleModal.selectPropertyToMatch("DateOfBirth");
     rulesetSingleModal.selectMatchTypeDropdown("custom");
@@ -275,7 +275,7 @@ describe("Validate E2E Mastering Flow", () => {
     cy.findByTestId("threshold-slider-ticks").find(`div[style*="left: 9.09091%;"]`).trigger("mousemove", {force: true});
     multiSlider.getHandleName("DateOfBirth").trigger("mouseup", {force: true});
     cy.waitForAsyncRequest();
-    matchingStepDetail.addNewRulesetSingle();
+    matchingStepDetail.addNewRuleset();
     matchingStepDetail.getSinglePropertyOption();
     rulesetSingleModal.selectPropertyToMatch("FirstName");
     rulesetSingleModal.selectMatchTypeDropdown("synonym");
@@ -287,7 +287,7 @@ describe("Validate E2E Mastering Flow", () => {
     cy.findByTestId("threshold-slider-ticks").find(`div[style*="left: 9.09091%;"]`).trigger("mousemove", {force: true});
     cy.findAllByTestId("FirstName-active").eq(1).trigger("mouseup", {force: true});
     cy.waitForAsyncRequest();
-    matchingStepDetail.addNewRulesetSingle();
+    matchingStepDetail.addNewRuleset();
     matchingStepDetail.getSinglePropertyOption();
     rulesetSingleModal.selectPropertyToMatch("ZipCode");
     rulesetSingleModal.selectMatchTypeDropdown("zip");
@@ -297,7 +297,7 @@ describe("Validate E2E Mastering Flow", () => {
     cy.findByTestId("threshold-slider-ticks").find(`div[style*="left: 9.09091%;"]`).trigger("mousemove", {force: true});
     multiSlider.getHandleName("ZipCode").trigger("mouseup", {force: true});
     cy.waitForAsyncRequest();
-    matchingStepDetail.addNewRulesetSingle();
+    matchingStepDetail.addNewRuleset();
     matchingStepDetail.getSinglePropertyOption();
     rulesetSingleModal.selectPropertyToMatch("Address");
     rulesetSingleModal.selectMatchTypeDropdown("exact");

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/matching/index.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/matching/index.tsx
@@ -1,9 +1,11 @@
 import matchingStepDetail from "./matching-step-detail";
+import rulesetMultipleModal from "./ruleset-multiple-modal";
 import rulesetSingleModal from "./ruleset-single-modal";
 import thresholdModal from "./threshold-modal";
 
 export {
   matchingStepDetail,
   rulesetSingleModal,
-  thresholdModal
+  thresholdModal,
+  rulesetMultipleModal
 };

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/matching/matching-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/matching/matching-step-detail.tsx
@@ -20,12 +20,16 @@ class MatchingStepDetail {
     return cy.findByLabelText("ruleset-less");
   }
 
-  addNewRulesetSingle() {
+  addNewRuleset() {
     cy.findByLabelText("add-ruleset").click();
   }
 
   getSinglePropertyOption() {
     cy.findByLabelText("singlePropertyRulesetOption").click();
+  }
+
+  getMultiPropertyOption() {
+    cy.findByLabelText("multiPropertyRulesetOption").click();
   }
 
   getSliderDeleteText() {

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/matching/ruleset-multiple-modal.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/matching/ruleset-multiple-modal.tsx
@@ -1,0 +1,31 @@
+class RulesetMultipleModal {
+
+  setRulesetName(str: string) {
+    cy.findByLabelText("rulesetName-input").focus().type(str);
+  }
+
+  selectPropertyToMatch(property: string) {
+    cy.get(`[data-row-key="${property}"] .ant-checkbox-input`).trigger("mouseover").click();
+    cy.waitUntil(() => cy.get(`[data-row-key="${property}"] .ant-checkbox-checked`).should("be.visible"), {timeout: 10000});
+  }
+
+  selectMatchTypeDropdown(property: string, matchType: string) {
+    cy.findByLabelText(`${property}-match-type-dropdown`).should("be.visible", {timeout: 10000}).click({force: true});
+    cy.waitUntil(() => cy.findByLabelText(`${matchType}-option`).should("have.length.gt", 0)).click({force: true});
+  }
+
+  cancelButton() {
+    return cy.findByLabelText("cancel-multiple-ruleset");
+  }
+
+  saveButton() {
+    return cy.findByLabelText("confirm-multiple-ruleset");
+  }
+
+  reduceButton() {
+    return cy.findByLabelText("reduceToggle");
+  }
+}
+
+const rulesetMultipleModal = new RulesetMultipleModal();
+export default rulesetMultipleModal;

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/curation/matching.data.js
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/curation/matching.data.js
@@ -75,6 +75,21 @@ export const matchingStep = {
               "matchType": "exact"
             }
           ]
+        },
+        {
+          "name": "MultipleRuleset-Customer",
+          "weight": 1,
+          "matchRules": [
+            {
+              "entityPropertyPath": "customerId",
+              "matchType": "synonym",
+              "options": {
+                "filter": "",
+                "thesaurusURI": "/thesaurus/uri/input.json"
+              }
+            }],
+          "reduce": true,
+          "rulesetType": "multiple"
         }
       ],
       "thresholds": [

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/matching-step-detail/matching-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/matching-step-detail/matching-step-detail.tsx
@@ -131,13 +131,15 @@ const MatchingStepDetail: React.FC = () => {
   };
 
   const matchRuleSetOptions = matchingStep.matchRulesets && matchingStep.matchRulesets.map((i) => {
+    const rulesetCategory = i.rulesetType && i.rulesetType === "multiple" ? i.rulesetType : "single";
     const firstMatchRule = i.matchRules[0];
     const firstMatchRuleType = firstMatchRule ? firstMatchRule.matchType : "";
     const rulesetType = firstMatchRuleType;
     const matchRuleOptionsObject = {
       props: [{
         prop: i.name.split(" -")[0],
-        type: rulesetType
+        type: rulesetType,
+        rulesetCategory: rulesetCategory
       }],
       value: i.weight
     };
@@ -196,7 +198,11 @@ const MatchingStepDetail: React.FC = () => {
       let editMatchRuleset = updateStepArtifactRulesets[index];
 
       setEditRuleset({...editMatchRuleset, index});
-      toggleShowRulesetSingleModal(true);
+      if (options["rulesetCategory"] === "single") {
+        toggleShowRulesetSingleModal(true);
+      } else {
+        toggleShowRulesetMultipleModal(true);
+      }
     }
   };
 

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/multi-slider/multi-slider.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/multi-slider/multi-slider.tsx
@@ -45,7 +45,7 @@ const MultiSlider = (props) => {
           {activeHandleIdOptions.hasOwnProperty("prop") && options[0].prop === activeHandleIdOptions["prop"] && activeHandleIdOptions.hasOwnProperty("type") && options[0].type === activeHandleIdOptions["type"]? <div className={disabled ? "tooltipDisabled" : "tooltip"}>
             {options.map((opt, i) => (
               <div className={activeHandleIdOptions["index"] === id.split("-")[1] ? "activeTooltipText": "tooltipText"} data-testid={`${options[0].prop}-active-tooltip`} key={i}>
-                <span className="editText" data-testid={`edit-${options[0].prop}`} onClick={() => handleEdit({...options[0], sliderType: props.type, index: id.split("-")[1]})}><span>{opt.prop}</span> {opt.type.length ? `-  ${opt.type}` : ""}</span>
+                <span className="editText" data-testid={`edit-${options[0].prop}`} onClick={() => handleEdit({...options[0], sliderType: props.type, index: id.split("-")[1]})}><span>{opt.prop}</span> {((opt.rulesetCategory && opt.rulesetCategory === "single") || !opt.rulesetCategory) && opt.type.length ? `-  ${opt.type}` : ""}</span>
                 {disabled ? null : <div data-testid={`delete-${options[0].prop}`} className="clearIcon" onClick={() => handleDelete({...options[0], sliderType: props.type, index: id.split("-")[1]})}>X</div>}
               </div>)
             )}
@@ -54,7 +54,7 @@ const MultiSlider = (props) => {
             <div className={disabled ? "tooltipDisabled" : "tooltip"}>
               {options.map((opt, i) => (
                 <div className="tooltipText"  data-testid={`${options[0].prop}-tooltip`} key={i}>
-                  <span className="editText" data-testid={`edit-${options[0].prop}`} onClick={() => handleEdit({...options[0], sliderType: props.type, index: id.split("-")[1]})}><span aria-label={opt.type.length ? `${opt.prop}-${opt.type}`: `${opt.prop}` }>{opt.prop}</span>  {opt.type.length ? `-  ${opt.type}` : ""}</span>
+                  <span className="editText" data-testid={`edit-${options[0].prop}`} onClick={() => handleEdit({...options[0], sliderType: props.type, index: id.split("-")[1]})}><span aria-label={((opt.rulesetCategory && opt.rulesetCategory === "single") || !opt.rulesetCategory) && opt.type.length ? `${opt.prop}-${opt.type}`: `${opt.prop}` }>{opt.prop}</span>  {((opt.rulesetCategory && opt.rulesetCategory === "single") || !opt.rulesetCategory) && opt.type.length ? `-  ${opt.type}` : ""}</span>
                   {disabled ? null : <div data-testid={`delete-${options[0].prop}`} className="clearIcon" onClick={() => handleDelete({...options[0], sliderType: props.type, index: id.split("-")[1]})}><Icon type="close" /></div>}
                 </div>
               ))}

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/ruleset-multiple-modal/ruleset-multiple-modal.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/ruleset-multiple-modal/ruleset-multiple-modal.module.scss
@@ -10,6 +10,16 @@
   }
 }
 
+.noPropertyCheckedErrorMessage {
+  margin-left: 20vw;
+  margin-top: -40px;
+  width: 45em;
+  text-align: center;
+  .exclamationCircle{
+    margin-left: 5em;
+  }
+}
+
 .modalTitleLegend {
   display: flex;
   justify-content: flex-end;

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/ruleset-multiple-modal/ruleset-multiple-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/ruleset-multiple-modal/ruleset-multiple-modal.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect, useContext, CSSProperties} from "react";
-import {Modal, Form, Input, Icon, Switch} from "antd";
+import {Modal, Form, Input, Icon, Switch, Alert} from "antd";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faLayerGroup} from "@fortawesome/free-solid-svg-icons";
 import {MLButton, MLTooltip, MLSelect, MLTable, MLTag} from "@marklogic/design-system";
@@ -10,6 +10,8 @@ import {CurationContext} from "../../../../util/curation-context";
 import {Definition} from "../../../../types/modeling-types";
 import {NewMatchTooltips} from "../../../../config/tooltips.config";
 import ExpandCollapse from "../../../expand-collapse/expand-collapse";
+import {MatchingStep, MatchRule, MatchRuleset} from "../../../../types/curation-types";
+import {updateMatchingArtifact} from "../../../../api/matching";
 
 type Props = {
   editRuleset: any;
@@ -37,7 +39,7 @@ const MATCH_TYPE_OPTIONS = [
 const {MLOption} = MLSelect;
 
 const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
-  const {curationOptions} = useContext(CurationContext);
+  const {curationOptions, updateActiveStepArtifact} = useContext(CurationContext);
 
   const [rulesetName, setRulesetName] = useState("");
   const [rulesetNameErrorMessage, setRulesetNameErrorMessage] = useState("");
@@ -47,9 +49,9 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
 
   const [isPropertyTypeTouched, setIsPropertyTypeTouched] = useState(false);
 
-  const [matchType, setMatchType] = useState<string | undefined>(undefined);
-  const [isMatchTypeTouched, setIsMatchTypeTouched] = useState(false);
   const [matchTypes, setMatchTypes] = useState({});
+  const [matchTypeErrorMessages, setMatchTypeErrorMessages] = useState({});
+  const [isMatchTypeTouched, setIsMatchTypeTouched] = useState(false);
 
   const [thesaurusValues, setThesaurusValues] = useState({});
   const [thesaurusErrorMessages, setThesaurusErrorMessages] = useState({});
@@ -85,6 +87,8 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
   const [selectedRowKeys, setSelectedRowKeys] = useState<any []>([]);
   const [checkTableUpdates, setCheckTableUpdates] = useState("");
 
+  const [saveClicked, setSaveClicked] = useState(false);
+
   useEffect(() => {
     if (props.isVisible && curationOptions.entityDefinitionsArray.length > 0 && curationOptions.activeStep.entityName !== "") {
       let nestedEntityProps = parseDefinitionsToTable(curationOptions.entityDefinitionsArray);
@@ -93,25 +97,57 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
 
     if (Object.keys(props.editRuleset).length !== 0 && props.isVisible) {
       let editRuleset = props.editRuleset;
-      let matchType = editRuleset["matchRules"][0]["matchType"];
       if (editRuleset.reduce) {
         setReduceValue(true);
       }
-      setMatchType(matchType);
-      if (matchType === "custom") {
-        setUriValues(editRuleset["matchRules"][0]["algorithmModulePath"]);
-        setFunctionValues(editRuleset["matchRules"][0]["algorithmModuleFunction"]);
-        setNamespaceValues(editRuleset["matchRules"][0]["algorithmModuleNamespace"]);
 
-      } else if (matchType === "doubleMetaphone") {
-        setDictionaryValues(editRuleset["matchRules"][0]["options"]["dictionaryURI"]);
-        setDistanceThresholdValues(editRuleset["matchRules"][0]["options"]["distanceThreshold"]);
+      if (editRuleset.name) {
+        setRulesetName(editRuleset.name);
+      }
+      let selectedKeys:any = [];
+      let matchTypes = {};
+      let uriValues = {};
+      let functionValues = {};
+      let namespaceValues = {};
+      let dictionaryValues = {};
+      let distanceThresholdValues = {};
+      let thesaurusValues = {};
+      let filterValues = {};
 
-      } else if (matchType === "synonym") {
-        setThesaurusValues(editRuleset["matchRules"][0]["options"]["thesaurusURI"]);
-        setFilterValues(editRuleset["matchRules"][0]["options"]["filter"]);
+      if (editRuleset["matchRules"].length) {
+        editRuleset["matchRules"].forEach(matchRule => {
+          let propertyPath = matchRule["entityPropertyPath"];
+          matchTypes[propertyPath] = matchRule.matchType;
+          if (matchRule.matchType === "custom") {
+            uriValues[propertyPath] = matchRule["algorithmModulePath"];
+            functionValues[propertyPath] = matchRule["algorithmFunction"];
+            namespaceValues[propertyPath] = matchRule["algorithmModuleNamespace"];
+
+          } else if (matchRule.matchType === "doubleMetaphone") {
+            dictionaryValues[propertyPath] = matchRule["options"]["dictionaryURI"];
+            distanceThresholdValues[propertyPath] = matchRule["options"]["distanceThreshold"];
+
+          } else if (matchRule.matchType === "synonym") {
+            thesaurusValues[propertyPath] = matchRule["options"]["thesaurusURI"];
+            filterValues[propertyPath] = matchRule["options"]["filter"];
+          }
+
+          selectedKeys.push(propertyPath);
+        });
 
       }
+
+      setSelectedRowKeys(selectedKeys);
+
+      setMatchTypes(matchTypes);
+      setUriValues(uriValues);
+      setFunctionValues(functionValues);
+      setNamespaceValues(namespaceValues);
+      setDictionaryValues(dictionaryValues);
+      setDistanceThresholdValues(distanceThresholdValues);
+      setThesaurusValues(thesaurusValues);
+      setFilterValues(filterValues);
+
     }
   }, [props.isVisible]);
 
@@ -143,6 +179,7 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
                   key: property.name + "," + index + structIndex + counter,
                   structured: structuredType.name,
                   propertyName: structProperty.name,
+                  propertyPath: getPropertyPath(parentKeysArray, structProperty.name),
                   type: structProperty.datatype === "structured" ? structProperty.ref.split("/").pop() : structProperty.datatype,
                   multiple: structProperty.multiple ? structProperty.name : "",
                   hasChildren: false,
@@ -158,6 +195,7 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
               key: property.name + "," + index + counter,
               structured: structuredType.name,
               propertyName: property.name,
+              propertyPath: hasParent ? getPropertyPath(parentKeysArray, property.name) : property.name,
               multiple: property.multiple ? property.name : "",
               type: property.ref.split("/").pop(),
               children: structuredTypeProperties,
@@ -173,6 +211,7 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
         propertyRow = {
           key: property.name + "," + index,
           propertyName: property.name,
+          propertyPath: property.name,
           type: property.datatype,
           identifier: entityTypeDefinition?.primaryKey === property.name ? property.name : "",
           multiple: property.multiple ? property.name : "",
@@ -184,7 +223,14 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
     });
   };
 
-  const handleInputChange = (event, propertyName) => {
+  const getPropertyPath = (parentKeys: any, propertyName: string) => {
+    let propertyPath = "";
+    parentKeys.forEach(el => !propertyPath.length ? propertyPath = el.split(",")[0] : propertyPath = propertyPath + "." + el.split(",")[0]);
+    propertyPath = propertyPath + "." + propertyName;
+    return propertyPath;
+  };
+
+  const handleInputChange = (event, propertyPath) => {
     switch (event.target.id) {
     case "rulesetName-input":
       if (event.target.value === "") {
@@ -199,66 +245,66 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
     case "thesaurus-uri-input":
       if (event.target.value === "") {
         setIsThesaurusTouched(false);
-        setThesaurusErrorMessages({...thesaurusErrorMessages, [propertyName]: "A thesaurus URI is required"});
+        setThesaurusErrorMessages({...thesaurusErrorMessages, [propertyPath]: "A thesaurus URI is required"});
       } else {
-        setThesaurusErrorMessages({...thesaurusErrorMessages, [propertyName]: ""});
+        setThesaurusErrorMessages({...thesaurusErrorMessages, [propertyPath]: ""});
       }
       setIsThesaurusTouched(true);
-      setThesaurusValues({...thesaurusValues, [propertyName]: event.target.value});
+      setThesaurusValues({...thesaurusValues, [propertyPath]: event.target.value});
       break;
 
     case "filter-input":
       setIsFilterTouched(true);
-      setFilterValues({...filterValues, [propertyName]: event.target.value});
+      setFilterValues({...filterValues, [propertyPath]: event.target.value});
       break;
 
     case "dictionary-uri-input":
       if (event.target.value === "") {
         setIsDictionaryTouched(false);
-        setDictionaryErrorMessages({...dictionaryErrorMessages, [propertyName]: "A dictionary URI is required"});
+        setDictionaryErrorMessages({...dictionaryErrorMessages, [propertyPath]: "A dictionary URI is required"});
       } else {
-        setDictionaryErrorMessages({...dictionaryErrorMessages, [propertyName]: ""});
+        setDictionaryErrorMessages({...dictionaryErrorMessages, [propertyPath]: ""});
       }
       setIsDictionaryTouched(true);
-      setDictionaryValues({...dictionaryValues, [propertyName]: event.target.value});
+      setDictionaryValues({...dictionaryValues, [propertyPath]: event.target.value});
       break;
 
     case "distance-threshold-input":
       if (event.target.value === "") {
         setIsDistanceTouched(false);
-        setDistanceThresholdErrorMessages({...distanceThresholdErrorMessages, [propertyName]: "A distance threshold is required"});
+        setDistanceThresholdErrorMessages({...distanceThresholdErrorMessages, [propertyPath]: "A distance threshold is required"});
       } else {
-        setDistanceThresholdErrorMessages({...distanceThresholdErrorMessages, [propertyName]: ""});
+        setDistanceThresholdErrorMessages({...distanceThresholdErrorMessages, [propertyPath]: ""});
       }
       setIsDistanceTouched(true);
-      setDistanceThresholdValues({...distanceThresholdValues, [propertyName]: event.target.value});
+      setDistanceThresholdValues({...distanceThresholdValues, [propertyPath]: event.target.value});
       break;
 
     case "uri-input":
       if (event.target.value === "") {
         setIsUriTouched(false);
-        setUriErrorMessages({...uriErrorMessages, [propertyName]: "A URI is required"});
+        setUriErrorMessages({...uriErrorMessages, [propertyPath]: "A URI is required"});
       } else {
-        setUriErrorMessages({...uriErrorMessages, [propertyName]: ""});
+        setUriErrorMessages({...uriErrorMessages, [propertyPath]: ""});
       }
       setIsUriTouched(true);
-      setUriValues({...uriValues, [propertyName]: event.target.value});
+      setUriValues({...uriValues, [propertyPath]: event.target.value});
       break;
 
     case "function-input":
       if (event.target.value === "") {
         setIsFunctionTouched(false);
-        setFunctionErrorMessages({...functionErrorMessages, [propertyName]: "A function is required"});
+        setFunctionErrorMessages({...functionErrorMessages, [propertyPath]: "A function is required"});
       } else {
-        setFunctionErrorMessages({...functionErrorMessages, [propertyName]: ""});
+        setFunctionErrorMessages({...functionErrorMessages, [propertyPath]: ""});
       }
       setIsFunctionTouched(true);
-      setFunctionValues({...functionValues, [propertyName]: event.target.value});
+      setFunctionValues({...functionValues, [propertyPath]: event.target.value});
       break;
 
     case "namespace-input":
       setIsNamespaceTouched(true);
-      setNamespaceValues({...namespaceValues, [propertyName]: event.target.value});
+      setNamespaceValues({...namespaceValues, [propertyPath]: event.target.value});
       break;
 
     default:
@@ -278,7 +324,8 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
   const resetModal = () => {
     setRulesetName("");
     setRulesetNameErrorMessage("");
-    setMatchType(undefined);
+    setMatchTypes({});
+    setSelectedRowKeys([]);
     setReduceValue(false);
     setThesaurusValues({});
     setThesaurusErrorMessages({});
@@ -293,6 +340,7 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
     setFunctionErrorMessages({});
     setNamespaceValues({});
     resetTouched();
+    setSaveClicked(false);
   };
 
   const resetTouched = () => {
@@ -310,54 +358,211 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
     setReduceValue(false);
   };
 
-  const onSubmit = (event) => {
-    //Logic to be added later in future stories
+  const updateStepArtifact = async (matchRuleset: MatchRuleset) => {
+    // avoid triggering update of active step prior to persisting the database
+    let updateStep: MatchingStep = {...curationOptions.activeStep.stepArtifact};
+    updateStep.matchRulesets = [...updateStep.matchRulesets];
+    if (Object.keys(props.editRuleset).length !== 0) {
+      // edit match step
+      updateStep.matchRulesets[props.editRuleset["index"]] = matchRuleset;
+    } else {
+      // add match step
+      if (updateStep.matchRulesets) { updateStep.matchRulesets.push(matchRuleset); }
+    }
+    let success = await updateMatchingArtifact(updateStep);
+    if (success) {
+      updateActiveStepArtifact(updateStep);
+    }
   };
 
-  const onMatchTypeSelect = (key: string, value: string) => {
+  const onSubmit = (event) => {
+    event.preventDefault();
+    setSaveClicked(true);
+    let propertyErrorMessage = "";
+    let matchErrorMessage = "";
+    let thesaurusErrorMessage = "";
+    let dictionaryUriErrorMessage = "";
+    let distanceThresholdErrorMessage = "";
+    let uriErrorMessage = "";
+    let functionErrorMessage = "";
+
+    if (rulesetName === "" || rulesetName === undefined) {
+      setRulesetNameErrorMessage("A ruleset name is required");
+    }
+
+    let matchRules: any = [];
+    if (!selectedRowKeys.length) {
+      propertyErrorMessage = "A property to match is required.";
+    } else {
+      selectedRowKeys.forEach(key => {
+        let propertyPath = key;
+        if (!matchTypes[key]) {
+          matchErrorMessage = "A match type is required";
+        }
+        switch (matchTypes[key]) {
+        case "exact":
+        case "zip":
+        {
+          let matchRule: MatchRule = {
+            entityPropertyPath: propertyPath,
+            matchType: matchTypes[key],
+            options: {}
+          };
+          matchRules.push(matchRule);
+          break;
+        }
+        case "synonym":
+        {
+          if (thesaurusValues[key] === "" || thesaurusValues[key] === undefined) {
+            thesaurusErrorMessage = "A thesaurus URI is required";
+          }
+
+          let synonymMatchRule: MatchRule = {
+            entityPropertyPath: propertyPath,
+            matchType: matchTypes[key],
+            options: {
+              thesaurusURI: thesaurusValues[key],
+              filter: filterValues[key]
+            }
+          };
+
+          if (thesaurusErrorMessage === "") {
+            matchRules.push(synonymMatchRule);
+          }
+          setThesaurusErrorMessages({...thesaurusErrorMessages, [key]: thesaurusErrorMessage});
+          break;
+        }
+        case "doubleMetaphone":
+        {
+          if (dictionaryValues[key] === "" || dictionaryValues[key] === undefined) {
+            dictionaryUriErrorMessage = "A dictionary URI is required";
+          }
+
+          if (distanceThresholdValues[key] === "" || distanceThresholdValues[key] === undefined) {
+            distanceThresholdErrorMessage = "A distance threshold is required";
+          }
+
+          let doubleMetaphoneMatchRule: MatchRule = {
+            entityPropertyPath: propertyPath,
+            matchType: matchTypes[key],
+            options: {
+              dictionaryURI: dictionaryValues[key],
+              distanceThreshold: distanceThresholdValues[key]
+            }
+          };
+
+          if (dictionaryUriErrorMessage === "" && distanceThresholdErrorMessage === "") {
+            matchRules.push(doubleMetaphoneMatchRule);
+          }
+          setDictionaryErrorMessages({...dictionaryErrorMessages, [key]: dictionaryUriErrorMessage});
+          setDistanceThresholdErrorMessages({...distanceThresholdErrorMessages, [key]: distanceThresholdErrorMessage});
+          break;
+        }
+        case "custom":
+        {
+          if (uriValues[key] === "" || uriValues[key] === undefined) {
+            uriErrorMessage = "A URI is required";
+          }
+
+          if (functionValues[key] === "" || functionValues[key] === undefined) {
+            functionErrorMessage = "A function is required";
+          }
+
+          let customMatchRule: MatchRule = {
+            entityPropertyPath: propertyPath,
+            matchType: matchTypes[key],
+            algorithmModulePath: uriValues[key],
+            algorithmFunction: functionValues[key],
+            algorithmModuleNamespace: namespaceValues[key],
+            options: {}
+          };
+
+          if (uriErrorMessage === "" && functionErrorMessage === "") {
+            matchRules.push(customMatchRule);
+          }
+          setUriErrorMessages({...uriErrorMessages, [key]: uriErrorMessage});
+          setFunctionErrorMessages({...functionErrorMessages, [key]: functionErrorMessage});
+          break;
+        }
+
+        default:
+          break;
+        }
+        setMatchTypeErrorMessages({...matchTypeErrorMessages, [key]: matchErrorMessage});
+      });
+    }
+
+    let matchRuleset: MatchRuleset = {
+      name: rulesetName,
+      weight: Object.keys(props.editRuleset).length !== 0 ? props.editRuleset["weight"] : 0,
+      ...({reduce: reduceValue}),
+      matchRules: matchRules,
+      rulesetType: "multiple"
+    };
+
+    if (rulesetNameErrorMessage === "") {
+      if (propertyErrorMessage  === "" && matchErrorMessage === "" && thesaurusErrorMessage === "" && dictionaryUriErrorMessage === ""
+         && distanceThresholdErrorMessage === "" && uriErrorMessage === "" && functionErrorMessage === "") {
+        updateStepArtifact(matchRuleset);
+        props.toggleModal(false);
+        resetModal();
+      }
+    }
+  };
+
+  const onMatchTypeSelect = (propertyPath: string, value: string) => {
+    setMatchTypeErrorMessages({...matchTypeErrorMessages, [propertyPath]: ""});
     setIsMatchTypeTouched(true);
-    setMatchTypes({...matchTypes, [key]: value});
+    setMatchTypes({...matchTypes, [propertyPath]: value});
+    if (!selectedRowKeys.includes(propertyPath)) {
+      let selectedKeys = [...selectedRowKeys, propertyPath];
+      setSelectedRowKeys(selectedKeys);
+      // let matchOnTagsArr = getMatchOnTags(selectedKeys);
+      // setMatchOnTags(matchOnTagsArr)
+    }
   };
 
   const hasFormChanged = () => {
-    if (matchType ===  "custom") {
-      let checkCustomValues = hasCustomFormValuesChanged();
-      if (!isRulesetNameTouched
+    for (let key in matchTypes) {
+      if (matchTypes[key] ===  "custom") {
+        let checkCustomValues = hasCustomFormValuesChanged();
+        if (!isRulesetNameTouched
         && !isPropertyTypeTouched
         && !isMatchTypeTouched
         && !checkCustomValues
-      ) {
-        return false;
-      } else {
-        return true;
-      }
-    } else if (matchType === "synonym") {
-      let checkSynonymValues = hasSynonymFormValuesChanged();
-      if (!isRulesetNameTouched
+        ) {
+          return false;
+        } else {
+          return true;
+        }
+      } else if (matchTypes[key] === "synonym") {
+        let checkSynonymValues = hasSynonymFormValuesChanged();
+        if (!isRulesetNameTouched
         && !isPropertyTypeTouched
         && !isMatchTypeTouched
         && !checkSynonymValues
-      ) {
-        return false;
-      } else {
-        return true;
-      }
-    } else if (matchType === "doubleMetaphone") {
-      let checkDoubleMetaphoneValues = hasDoubleMetaphoneFormValuesChanged();
-      if (!isRulesetNameTouched
+        ) {
+          return false;
+        } else {
+          return true;
+        }
+      } else if (matchTypes[key] === "doubleMetaphone") {
+        let checkDoubleMetaphoneValues = hasDoubleMetaphoneFormValuesChanged();
+        if (!isRulesetNameTouched
         && !isPropertyTypeTouched
         && !isMatchTypeTouched
         && !checkDoubleMetaphoneValues
-      ) {
-        return false;
+        ) {
+          return false;
+        } else {
+          return true;
+        }
       } else {
-        return true;
-      }
-    } else {
-      if (!isRulesetNameTouched && !isPropertyTypeTouched && !isMatchTypeTouched) {
-        return false;
-      } else {
-        return true;
+        if (!isRulesetNameTouched && !isPropertyTypeTouched && !isMatchTypeTouched) {
+          return false;
+        } else {
+          return true;
+        }
       }
     }
   };
@@ -409,14 +614,15 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
     onNo={discardCancel}
   />;
 
-  const checkFieldInErrors = (propertyName: string, fieldType: string) => {
+  const checkFieldInErrors = (propertyPath: string, fieldType: string) => {
     let errorCheck = false;
     switch (fieldType) {
-    case "thesaurus-uri-input": { if (thesaurusErrorMessages[propertyName]) { errorCheck = true; } break; }
-    case "dictionary-uri-input" : { if (dictionaryErrorMessages[propertyName]) { errorCheck = true; } break; }
-    case "distance-threshold-input" : { if (distanceThresholdErrorMessages[propertyName]) { errorCheck = true; } break; }
-    case "uri-input" : { if (uriErrorMessages[propertyName]) { errorCheck = true; } break; }
-    case "function-input" : { if (functionErrorMessages[propertyName]) { errorCheck = true; } break; }
+    case "match-type-input": { if (matchTypeErrorMessages[propertyPath]) { errorCheck = true; } break; }
+    case "thesaurus-uri-input": { if (thesaurusErrorMessages[propertyPath]) { errorCheck = true; } break; }
+    case "dictionary-uri-input": { if (dictionaryErrorMessages[propertyPath]) { errorCheck = true; } break; }
+    case "distance-threshold-input": { if (distanceThresholdErrorMessages[propertyPath]) { errorCheck = true; } break; }
+    case "uri-input": { if (uriErrorMessages[propertyPath]) { errorCheck = true; } break; }
+    case "function-input": { if (functionErrorMessages[propertyPath]) { errorCheck = true; } break; }
     default: break;
     }
     return errorCheck;
@@ -426,13 +632,13 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
     return <MLOption key={index} value={matchType.value} aria-label={`${matchType.value}-option`}>{matchType.name}</MLOption>;
   });
 
-  const inputUriStyle = (propName, fieldType) => {
+  const inputUriStyle = (propertyPath, fieldType) => {
     const inputFieldStyle: CSSProperties = {
       width: ["dictionary-uri-input", "thesaurus-uri-input"].includes(fieldType) ? "22vw" : (fieldType === "distance-threshold-input" ? "25vw" : "13vw"),
       marginRight: "5px",
       marginLeft: ["distance-threshold-input", "function-input"].includes(fieldType) ? "15px" : "0px",
       justifyContent: "top",
-      borderColor: checkFieldInErrors(propName, fieldType) ? "red" : ""
+      borderColor: checkFieldInErrors(propertyPath, fieldType) ? "red" : ""
     };
     return inputFieldStyle;
   };
@@ -462,32 +668,32 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
     </span>
   );
 
-  const renderSynonymOptions = (propertyName, propertyKey) => {
+  const renderSynonymOptions = (propertyKey, propertyPath) => {
     return <div className={styles.matchTypeDetailsContainer}>
       <span>
         <span className={styles.mandatoryFieldContainer}>
           <Input
             id="thesaurus-uri-input"
-            aria-label={`${propertyKey}-thesaurus-uri-input`}
+            aria-label={`${propertyPath}-thesaurus-uri-input`}
             placeholder="Enter thesaurus URI"
-            style={inputUriStyle(propertyName, "thesaurus-uri-input")}
-            value={thesaurusValues[propertyName]}
-            onChange={(e) => handleInputChange(e, propertyName)}
-            onBlur={(e) => handleInputChange(e, propertyName)}
+            style={inputUriStyle(propertyPath, "thesaurus-uri-input")}
+            value={thesaurusValues[propertyPath]}
+            onChange={(e) => handleInputChange(e, propertyPath)}
+            onBlur={(e) => handleInputChange(e, propertyPath)}
           />
           {helpIconWithAsterisk(NewMatchTooltips.thesaurusUri)}
         </span>
-        {checkFieldInErrors(propertyName, "thesaurus-uri-input") ? <div id="errorInThesaurusUri" data-testid={propertyName + "-thesaurus-uri-err"} style={validationErrorStyle("thesaurus-uri-input")}>{!thesaurusValues[propertyName] ? "A thesaurus URI is required" : ""}</div> : ""}
+        {checkFieldInErrors(propertyPath, "thesaurus-uri-input") ? <div id="errorInThesaurusUri" data-testid={propertyPath + "-thesaurus-uri-err"} style={validationErrorStyle("thesaurus-uri-input")}>{!thesaurusValues[propertyPath] ? "A thesaurus URI is required" : ""}</div> : ""}
       </span>
       <span>
         <Input
           id="filter-input"
-          aria-label={`${propertyKey}-filter-input`}
+          aria-label={`${propertyPath}-filter-input`}
           placeholder="Enter a node in the thesaurus to use as a filter"
           className={styles.filterInput}
-          value={filterValues[propertyName]}
-          onChange={(e) => handleInputChange(e, propertyName)}
-          onBlur={(e) => handleInputChange(e, propertyName)}
+          value={filterValues[propertyPath]}
+          onChange={(e) => handleInputChange(e, propertyPath)}
+          onBlur={(e) => handleInputChange(e, propertyPath)}
         />
         <MLTooltip title={NewMatchTooltips.filter} placement="bottomLeft">
           <Icon type="question-circle" className={styles.questionCircle} theme="filled" />
@@ -496,83 +702,82 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
     </div>;
   };
 
-  const renderDoubleMetaphoneOptions = (propertyName, propertyKey) => {
+  const renderDoubleMetaphoneOptions = (propertyKey, propertyPath) => {
     return <div className={styles.matchTypeDetailsContainer}>
       <span>
         <span className={styles.mandatoryFieldContainer}>
           <Input
             id="dictionary-uri-input"
-            aria-label={`${propertyKey}-dictionary-uri-input`}
+            aria-label={`${propertyPath}-dictionary-uri-input`}
             placeholder="Enter dictionary URI"
-            style={inputUriStyle(propertyName, "dictionary-uri-input")}
-            value={dictionaryValues[propertyName]}
-            onChange={(e) => handleInputChange(e, propertyName)}
-            onBlur={(e) => handleInputChange(e, propertyName)}
+            style={inputUriStyle(propertyPath, "dictionary-uri-input")}
+            value={dictionaryValues[propertyPath]}
+            onChange={(e) => handleInputChange(e, propertyPath)}
+            onBlur={(e) => handleInputChange(e, propertyPath)}
           />
           {helpIconWithAsterisk(NewMatchTooltips.dictionaryUri)}
         </span>
-        {checkFieldInErrors(propertyName, "dictionary-uri-input") ? <div id="errorInDictionaryUri" data-testid={propertyName + "-dictionary-uri-err"} style={validationErrorStyle("dictionary-uri-input")}>{!dictionaryValues[propertyName] ? "A dictionary URI is required" : ""}</div> : ""}
+        {checkFieldInErrors(propertyPath, "dictionary-uri-input") ? <div id="errorInDictionaryUri" data-testid={propertyPath + "-dictionary-uri-err"} style={validationErrorStyle("dictionary-uri-input")}>{!dictionaryValues[propertyPath] ? "A dictionary URI is required" : ""}</div> : ""}
       </span>
       <span>
         <span className={styles.mandatoryFieldContainer}>
           <Input
             id="distance-threshold-input"
-            aria-label={`${propertyKey}-distance-threshold-input`}
+            aria-label={`${propertyPath}-distance-threshold-input`}
             placeholder="Enter distance threshold"
-            style={inputUriStyle(propertyName, "distance-threshold-input")}
-            value={distanceThresholdValues[propertyName]}
-            onChange={(e) => handleInputChange(e, propertyName)}
-            onBlur={(e) => handleInputChange(e, propertyName)}
+            style={inputUriStyle(propertyPath, "distance-threshold-input")}
+            value={distanceThresholdValues[propertyPath]}
+            onChange={(e) => handleInputChange(e, propertyPath)}
+            onBlur={(e) => handleInputChange(e, propertyPath)}
           />
           {helpIconWithAsterisk(NewMatchTooltips.distanceThreshold)}
         </span>
-        {checkFieldInErrors(propertyName, "distance-threshold-input") ? <div id="errorInDistanceThreshold" data-testid={propertyName + "-distance-threshold-err"} style={validationErrorStyle("distance-threshold-input")}>{!distanceThresholdValues[propertyName] ? "A distance threshold is required" : ""}</div> : ""}
+        {checkFieldInErrors(propertyPath, "distance-threshold-input") ? <div id="errorInDistanceThreshold" data-testid={propertyPath + "-distance-threshold-err"} style={validationErrorStyle("distance-threshold-input")}>{!distanceThresholdValues[propertyPath] ? "A distance threshold is required" : ""}</div> : ""}
       </span>
     </div>;
   };
 
-  const renderCustomOptions = (propertyName, propertyKey) => {
+  const renderCustomOptions = (propertyKey, propertyPath) => {
     return <div className={styles.matchTypeDetailsContainer}>
       <span>
         <span className={styles.mandatoryFieldContainer}>
           <Input
             id="uri-input"
-            aria-label={`${propertyKey}-uri-input`}
+            aria-label={`${propertyPath}-uri-input`}
             placeholder="Enter URI"
-            style={inputUriStyle(propertyName, "uri-input")}
-            value={uriValues[propertyName]}
-            onChange={(e) => handleInputChange(e, propertyName)}
-            onBlur={(e) => handleInputChange(e, propertyName)}
+            style={inputUriStyle(propertyPath, "uri-input")}
+            value={uriValues[propertyPath]}
+            onChange={(e) => handleInputChange(e, propertyPath)}
+            onBlur={(e) => handleInputChange(e, propertyPath)}
           />
           {helpIconWithAsterisk(NewMatchTooltips.uri)}
         </span>
-        {checkFieldInErrors(propertyName, "uri-input") ? <div id="errorInURI" data-testid={propertyName + "-uri-err"} style={validationErrorStyle("uri-input")}>{!uriValues[propertyName] ? "A URI is required" : ""}</div> : ""}
+        {checkFieldInErrors(propertyPath, "uri-input") ? <div id="errorInURI" data-testid={propertyPath + "-uri-err"} style={validationErrorStyle("uri-input")}>{!uriValues[propertyPath] ? "A URI is required" : ""}</div> : ""}
       </span>
       <span>
         <span className={styles.mandatoryFieldContainer}>
           <Input
             id="function-input"
-            aria-label={`${propertyKey}-function-input`}
+            aria-label={`${propertyPath}-function-input`}
             placeholder="Enter a function"
-            //className={styles.functionInput}
-            style={inputUriStyle(propertyName, "function-input")}
-            value={functionValues[propertyName]}
-            onChange={(e) => handleInputChange(e, propertyName)}
-            onBlur={(e) => handleInputChange(e, propertyName)}
+            style={inputUriStyle(propertyPath, "function-input")}
+            value={functionValues[propertyPath]}
+            onChange={(e) => handleInputChange(e, propertyPath)}
+            onBlur={(e) => handleInputChange(e, propertyPath)}
           />
           {helpIconWithAsterisk(NewMatchTooltips.function)}
         </span>
-        {checkFieldInErrors(propertyName, "function-input") ? <div id="errorInFunction" data-testid={propertyName + "-function-err"} style={validationErrorStyle("function-input")}>{!functionValues[propertyName] ? "A function is required" : ""}</div> : ""}
+        {checkFieldInErrors(propertyPath, "function-input") ? <div id="errorInFunction" data-testid={propertyPath + "-function-err"} style={validationErrorStyle("function-input")}>{!functionValues[propertyPath] ? "A function is required" : ""}</div> : ""}
       </span>
       <span>
         <Input
           id="namespace-input"
-          aria-label={`${propertyKey}-namespace-input`}
+          aria-label={`${propertyPath}-namespace-input`}
           placeholder="Enter a namespace"
           className={styles.functionInput}
-          value={namespaceValues[propertyName]}
-          onChange={(e) => handleInputChange(e, propertyName)}
-          onBlur={(e) => handleInputChange(e, propertyName)}
+          value={namespaceValues[propertyPath]}
+          onChange={(e) => handleInputChange(e, propertyPath)}
+          onBlur={(e) => handleInputChange(e, propertyPath)}
         />
         <MLTooltip title={NewMatchTooltips.namespace}>
           <Icon type="question-circle" className={styles.questionCircle} theme="filled" />
@@ -609,17 +814,13 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
     } else {
       setReduceValue(false);
     }
-    //Dummy code to be removed when submitting the form
-    if (reduceValue) {
-      //Remove this block once submit logic is in place.
-    }
   };
 
   const multipleRulesetsTableColumns = [
     {
       title: <span data-testid="nameTitle">Name</span>,
       dataIndex: "propertyName",
-      key: "key",
+      key: "propertyPath",
       width: "17%",
       ellipsis: true,
       render: (text, row) => {
@@ -633,25 +834,27 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
       render: (text, row) => {
         return !row.hasOwnProperty("children") ? <div className={styles.typeContainer}>
           <MLSelect
-            aria-label={`${row.key}-match-type-dropdown`}
+            aria-label={`${row.propertyPath}-match-type-dropdown`}
             className={styles.matchTypeSelect}
             size="default"
             placeholder="Select match type"
-            onSelect={(e) => onMatchTypeSelect(row.key, e)}
-            value={matchTypes[row.key]}
+            onSelect={(e) => onMatchTypeSelect(row.propertyPath, e)}
+            value={matchTypes[row.propertyPath]}
           >
             {renderMatchOptions}
           </MLSelect>
+          {checkFieldInErrors(row.propertyPath, "match-type-input") ? <div id="errorInMatchType" data-testid={row.propertyPath + "-match-type-err"} style={validationErrorStyle("match-type-input")}>{!matchTypes[row.propertyPath] ? "A match type is required" : ""}</div> : ""}
         </div> : null;
       }
     },
     {
       title: <span data-testid="matchTypeDetailsTitle">Match Type Details</span>,
+      width: "68%",
       render: (text, row) => {
-        switch (matchTypes[row.key]) {
-        case "synonym": return renderSynonymOptions(row.propertyName, row.key);
-        case "doubleMetaphone": return renderDoubleMetaphoneOptions(row.propertyName, row.key);
-        case "custom": return renderCustomOptions(row.propertyName, row.key);
+        switch (matchTypes[row.propertyPath]) {
+        case "synonym": return renderSynonymOptions(row.key, row.propertyPath);
+        case "doubleMetaphone": return renderDoubleMetaphoneOptions(row.key, row.propertyPath);
+        case "custom": return renderCustomOptions(row.key, row.propertyPath);
         default:
           break;
         }
@@ -663,6 +866,14 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
     hideCheckboxes();
   }, [multipleRulesetsData, checkTableUpdates]);
 
+  useEffect(() => {
+    let matchOnTagsArr = getMatchOnTags(selectedRowKeys);
+    setMatchOnTags({...matchOnTagsArr});
+    if (saveClicked) {
+      setSaveClicked(false);
+    }
+  }, [selectedRowKeys]);
+
   const hideCheckboxes = () => {
     const checkboxList = document.getElementsByName("hidden");
     checkboxList.forEach((item: any) => {
@@ -670,40 +881,131 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
     });
   };
 
-  const rowSelection = {
+  const getMatchOnTags = (selectedRowKeys) => {
+    let matchTags = {};
+    selectedRowKeys.forEach(key => {
+      let tag = key.split(".").join(" > ");
+      matchTags[`${key}`] = tag;
+    });
+    return matchTags;
+  };
 
-    onChange: (selected, selectedRows) => {
-      let fkeys = selectedRows.map(row =>  row.key);
-      setSelectedRowKeys([...fkeys]);
-    },
-    onSelect: (record, selected, selectedRows) => {
-      if (selected) {
-        let obj = {...matchOnTags, [`${record.key}`]: record.propertyName};
-        setMatchOnTags(obj);
-      } else {
-        let obj = matchOnTags;
-        delete obj[record.key];
-        setMatchOnTags(obj);
+  const resetPropertyErrorsAndValues = (propertyPath, matchType) => {
+    switch (matchType) {
+    case "synonym":
+    {
+      if (propertyPath in thesaurusErrorMessages) {
+        let thesaurusErrorMessagesObj = thesaurusErrorMessages;
+        delete thesaurusErrorMessagesObj[propertyPath];
+        setThesaurusErrorMessages(thesaurusErrorMessagesObj);
       }
-    },
-    selectedRowKeys: selectedRowKeys,
-    getCheckboxProps: record => ({name: record.hasOwnProperty("structured") && record.structured !== "" && record.hasChildren ? "hidden" : record.key}),
-    onSelectAll: (selected, selectedRows, changeRows) => {
-      let matchTags = {};
-      let fkeys = selectedRows.map(row =>  {
-        matchTags = {...matchTags, [`${row.key}`]: row.propertyName};
-        return row.key;
+      if (propertyPath in thesaurusValues) {
+        let thesaurusValuesObj = thesaurusValues;
+        delete thesaurusValuesObj[propertyPath];
+        setThesaurusValues(thesaurusValuesObj);
       }
-      );
-      setSelectedRowKeys([...fkeys]);
-      setMatchOnTags(matchTags);
+      if (propertyPath in filterValues) {
+        let filterValuesObj = filterValues;
+        delete filterValuesObj[propertyPath];
+        setFilterValues(filterValuesObj);
+      }
+      break;
+    }
+    case "doubleMetaphone":
+    {
+      if (propertyPath in dictionaryErrorMessages) {
+        let dictionaryErrorMessagesObj = dictionaryErrorMessages;
+        delete dictionaryErrorMessagesObj[propertyPath];
+        setDictionaryErrorMessages(dictionaryErrorMessagesObj);
+      }
+      if (propertyPath in distanceThresholdErrorMessages) {
+        let distanceThresholdErrorMessagesObj = distanceThresholdErrorMessages;
+        delete distanceThresholdErrorMessagesObj[propertyPath];
+        setDistanceThresholdErrorMessages(distanceThresholdErrorMessagesObj);
+      }
+      if (propertyPath in dictionaryValues) {
+        let dictionaryValuesObj = dictionaryValues;
+        delete dictionaryValuesObj[propertyPath];
+        setDictionaryValues(dictionaryValuesObj);
+      }
+      if (propertyPath in distanceThresholdValues) {
+        let distanceThresholdValuesObj = distanceThresholdValues;
+        delete distanceThresholdValuesObj[propertyPath];
+        setDistanceThresholdValues(distanceThresholdValuesObj);
+      }
+      break;
+    }
+    case "custom":
+    {
+      if (propertyPath in uriErrorMessages) {
+        let uriErrorMessagesObj = uriErrorMessages;
+        delete uriErrorMessagesObj[propertyPath];
+        setUriErrorMessages(uriErrorMessagesObj);
+      }
+      if (propertyPath in functionErrorMessages) {
+        let functionErrorMessagesObj = functionErrorMessages;
+        delete functionErrorMessagesObj[propertyPath];
+        setFunctionErrorMessages(functionErrorMessagesObj);
+      }
+      if (propertyPath in uriValues) {
+        let uriValuesObj = uriValues;
+        delete uriValuesObj[propertyPath];
+        setUriValues(uriValuesObj);
+      }
+      if (propertyPath in functionValues) {
+        let functionValuesObj = functionValues;
+        delete functionValuesObj[propertyPath];
+        setFunctionValues(functionValuesObj);
+      }
+      if (propertyPath in namespaceValues) {
+        let namespaceValuesObj = namespaceValues;
+        delete namespaceValuesObj[propertyPath];
+        setNamespaceValues(namespaceValuesObj);
+      }
+      break;
+    }
+    default:
+      break;
     }
   };
 
-  const handleMatchOnTags = (propertyName) => {
-    const filteredByValue = Object.fromEntries(Object.entries(matchOnTags).filter(([key, value]) => value !== propertyName));
-    setMatchOnTags(filteredByValue);
-    setSelectedRowKeys(Object.keys(filteredByValue));
+  const rowSelection = {
+    onChange: (selected, selectedRows) => {
+      let fkeys = selectedRows.map(row =>  row.propertyPath);
+      setSelectedRowKeys([...fkeys]);
+    },
+    onSelect: (record, selected, selectedRows) => {
+      if (!selected) {
+        if (record.propertyPath in matchTypes) {
+          let obj = matchTypes;
+          let matchType = matchTypes[record.propertyPath];
+          delete obj[record.propertyPath];
+          setMatchTypes(obj);
+          resetPropertyErrorsAndValues(record.propertyPath, matchType);
+        } else {
+          if (record.propertyPath in matchTypeErrorMessages) {
+            let matchTypeErrorMessagesObj = matchTypeErrorMessages;
+            delete matchTypeErrorMessagesObj[record.propertyPath];
+            setMatchTypeErrorMessages(matchTypeErrorMessagesObj);
+          }
+        }
+      }
+    },
+    selectedRowKeys: selectedRowKeys,
+    getCheckboxProps: record => ({name: record.hasOwnProperty("structured") && record.structured !== "" && record.hasChildren ? "hidden" : record.propertyPath}),
+  };
+
+  const handleMatchOnTags = (tag) => {
+    const filteredByValue = Object.fromEntries(Object.entries(matchOnTags).filter(([key, value]) => value !== tag));
+    let rowkeys = Object.keys(filteredByValue);
+    setSelectedRowKeys(rowkeys);
+    let obj = matchTypes;
+    Object.keys(matchTypes).forEach(el => {
+      if (!rowkeys.includes(el)) {
+        delete obj[el];
+      }
+    });
+    setMatchTypes(obj);
   };
 
   const displayMatchOnTags = () => {
@@ -721,6 +1023,21 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
   const handleExpandCollapse = () => {
     //Logic to be added during dedicated story for expand collapse icons
   };
+
+  const onAlertClose = () => {
+    setSaveClicked(false);
+  };
+
+  const noPropertyCheckedErrorMessage = <span id="noPropertyCheckedErrorMessage"><Alert
+    type="error"
+    message="You must select at least one property for the ruleset to be created"
+    aria-label="noPropertyCheckedErrorMessage"
+    className={styles.noPropertyCheckedErrorMessage} showIcon
+    closable
+    onClose={onAlertClose}
+    icon={<Icon type="exclamation-circle" className={styles.exclamationCircle} theme="filled" />} /></span>;
+
+
   return (
     <Modal
       visible={props.isVisible}
@@ -773,6 +1090,7 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
         <Form.Item>
           <span className={styles.matchOnText}>Match on:</span>
           <span className={styles.matchOnTagsContainer}>{displayMatchOnTags()}</span>
+          {!selectedRowKeys.length && saveClicked ? noPropertyCheckedErrorMessage : null}
         </Form.Item>
 
         <div className={styles.modalTitleLegend} aria-label="modalTitleLegend">
@@ -792,7 +1110,7 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
             scroll={{y: "60vh", x: 1000}}
             dataSource={multipleRulesetsData}
             tableLayout="unset"
-            rowKey="key"
+            rowKey="propertyPath"
             getPopupContainer={() => document.getElementById("multipleRulesetsTableContainer") || document.body}
           /></div>
         {modalFooter}

--- a/marklogic-data-hub-central/ui/src/types/curation-types.ts
+++ b/marklogic-data-hub-central/ui/src/types/curation-types.ts
@@ -66,8 +66,9 @@ export interface MatchingStep {
 
 export interface MatchRuleset {
   name: string,
-  weight: number
-  matchRules: MatchRule[]
+  weight: number,
+  matchRules: MatchRule[],
+  rulesetType? : string
 }
 
 export interface MatchRule {


### PR DESCRIPTION
### Description
Below changes are addressed in this PR.
1. The ruleset with multiple properties can be saved now. The result can be seen on the match scale. Cypress tests added for the same.
2. Most of the validation & Integration tests exists in RTL. More scenarios will definitely be added further as we progress with other stories related to individual match types.
3. Saving the ruleset works for all the match types. However, the e2e test cases, if not done here already, will be added in their respective stories. e2e have been added for Zip and Exact match types.

All UI changes are approved by @jbelonoj.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

