### PR TITLE
DHFPROD-7027: Allow structured props to be of related type

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario2.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario2.spec.tsx
@@ -94,6 +94,17 @@ describe("Entity Modeling: Writer Role", () => {
     propertyTable.getPiiIcon("zip").should("not.exist");
     //propertyTable.getWildcardIcon('zip').should('not.exist');
   });
+  it("Add related property to structured type", () => {
+    propertyTable.getAddPropertyToStructureType("Address").click();
+    propertyModal.newPropertyName("OrderedBy");
+    propertyModal.openPropertyDropdown();
+    propertyModal.getTypeFromDropdown("Related Entity").click();
+    propertyModal.getCascadedTypeFromDropdown("Customer").click();
+    propertyModal.openJoinPropertyDropdown();
+    propertyModal.getJoinProperty("nicknames").should("not.be.enabled");
+    propertyModal.getJoinProperty("customerId").click();
+    propertyModal.getSubmitButton().click();
+  });
   it("Add properties to nested structured type", () => {
     propertyTable.getAddPropertyToStructureType("Zip").click();
     propertyModal.getStructuredTypeName().should("have.text", "Address.Zip");

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.tsx
@@ -192,6 +192,7 @@ const PropertyModal: React.FC<Props> = (props) => {
           showJoinProp = true;
           showConfigOptions = false;
           newRadioValues = [ALL_RADIO_DISPLAY_VALUES[1]];
+          structuredLabel = props.structuredTypeOptions.name;
 
         } else if (props.structuredTypeOptions.isStructured) {
           structuredLabel = props.structuredTypeOptions.name;
@@ -567,11 +568,13 @@ const PropertyModal: React.FC<Props> = (props) => {
 
     } else if (props.structuredTypeOptions.isStructured) {
       let structuredDropdown = createStructuredDropdown(structuredDefinitions);
+      let relatedEntityDropdown = createRelatedEntityDropdown();
 
       setDropdownOptions([
         ...COMMON_PROPERTY_TYPES,
         DROPDOWN_PLACEHOLDER("1"),
         structuredDropdown,
+        relatedEntityDropdown,
         DROPDOWN_PLACEHOLDER("2"),
         MORE_STRING_TYPES,
         MORE_NUMBER_TYPES,

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
@@ -493,6 +493,11 @@ const PropertyTable: React.FC<Props> = (props) => {
         newStructuredTypes.isStructured = true;
         newStructuredTypes.name = record.structured;
         newStructuredTypes.propertyName = record.propertyName;
+      } else if (record.joinPropertyType) {
+        propertyType = PropertyType.RelatedEntity;
+        newStructuredTypes.isStructured = true;
+        newStructuredTypes.name = record.structured;
+        newStructuredTypes.propertyName = record.propertyName;
       } else {
         propertyType = PropertyType.Basic;
         newStructuredTypes.isStructured = true;
@@ -718,6 +723,8 @@ const PropertyTable: React.FC<Props> = (props) => {
                   structured: structuredType.name,
                   propertyName: structProperty.name,
                   type: structProperty.datatype === "structured" ? structProperty.ref.split("/").pop() : structProperty.datatype,
+                  joinPropertyName: structProperty.joinPropertyName,
+                  joinPropertyType: structProperty.joinPropertyType,
                   identifier: entityTypeDefinition?.primaryKey === structProperty.name ? structProperty.name : "",
                   multiple: structProperty.multiple ? structProperty.name : "",
                   facetable: structProperty.facetable ? structProperty.name : "",
@@ -745,6 +752,8 @@ const PropertyTable: React.FC<Props> = (props) => {
               facetable: property.facetable ? property.name : "",
               sortable: property.sortable ? property.name : "",
               type: property.ref.split("/").pop(),
+              joinPropertyName: property.joinPropertyName,
+              joinPropertyType: property.joinPropertyType,
               pii: piiValue,
               children: structuredTypeProperties,
               add: addValue,


### PR DESCRIPTION
### Description

User can now add properties of Related Entity type to structured properties, just as they can to regular, non-structured properties. 

Unit test and E2E test added. 

The data-conversion.tsx update is mostly refactoring to make code more concise (avoid long, repeated prop references).

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

