### PR TITLE
DHFPROD-6223: added facet on structured property (hub central) (part 1)

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.test.tsx
@@ -317,8 +317,8 @@ describe("Property Modal Component", () => {
     const piiRadio = screen.getByLabelText("pii-yes");
     fireEvent.change(piiRadio, {target: {value: "yes"}});
     expect(piiRadio["value"]).toBe("yes");
-    expect(queryByLabelText("Sort")).toBeNull();
-    expect(queryByLabelText("Facet")).toBeNull();
+    expect(queryByLabelText("Sort")).toBeInTheDocument();
+    expect(queryByLabelText("Facet")).toBeInTheDocument();
     // const wildcardCheckbox = screen.getByLabelText('Wildcard Search')
     // fireEvent.change(wildcardCheckbox, { target: { checked: true } });
     // expect(wildcardCheckbox).toBeChecked();
@@ -648,8 +648,8 @@ describe("Property Modal Component", () => {
     fireEvent.change(piiRadio, {target: {value: "yes"}});
     expect(piiRadio["value"]).toBe("yes");
 
-    expect(queryByLabelText("Sort")).toBeNull();
-    expect(queryByLabelText("Facet")).toBeNull();
+    expect(queryByLabelText("Sort")).toBeInTheDocument();
+    expect(queryByLabelText("Facet")).toBeInTheDocument();
 
     userEvent.click(getByLabelText("property-modal-submit"));
     expect(editMock).toHaveBeenCalledTimes(1);

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.tsx
@@ -196,7 +196,6 @@ const PropertyModal: React.FC<Props> = (props) => {
         } else if (props.structuredTypeOptions.isStructured) {
           structuredLabel = props.structuredTypeOptions.name;
           newRadioValues = ALL_RADIO_DISPLAY_VALUES.slice(1, 3);
-          showConfigOptions = false;
           if (props.editPropertyOptions.propertyOptions.propertyType === PropertyType.Structured) {
             typeDisplayValue = ["structured", props.editPropertyOptions.propertyOptions.type];
           }
@@ -301,7 +300,7 @@ const PropertyModal: React.FC<Props> = (props) => {
         } else {
           typeValue = value[1];
           setRadioValues(ALL_RADIO_DISPLAY_VALUES.slice(1, 3));
-          toggleShowConfigurationOptions(false);
+          toggleShowConfigurationOptions(true);
         }
         break;
       case "moreStringTypes":
@@ -314,7 +313,7 @@ const PropertyModal: React.FC<Props> = (props) => {
         } else {
           setRadioValues(ALL_RADIO_DISPLAY_VALUES);
         }
-        toggleShowConfigurationOptions(props.structuredTypeOptions.isStructured ? false : true);
+        toggleShowConfigurationOptions(true);
         break;
       default:
         newSelectedPropertyOptions.propertyType = PropertyType.Basic;
@@ -324,7 +323,7 @@ const PropertyModal: React.FC<Props> = (props) => {
         } else {
           setRadioValues(ALL_RADIO_DISPLAY_VALUES);
         }
-        toggleShowConfigurationOptions(props.structuredTypeOptions.isStructured ? false : true);
+        toggleShowConfigurationOptions(true);
         break;
       }
 


### PR DESCRIPTION
### Description
Part 1 of PR.
Enabled faceting on structured properties (parents + children).  Changes to facets on structured properties are saved to underlying server.
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [X] JIRA_ID included in all the commit messages
- [X] PR title is in the format JIRA_ID:Title
- [X] Rebase the branch with upstream
- [X] Squashed all commits into a single commit
- [X] Code passes ESLint tests
- [X] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

