### PR TITLE
DHFPROD-7115: Generate facets for structured properties

### DIFF
--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/generateIndexes.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/generateIndexes.sjs
@@ -232,22 +232,82 @@ function generateIndexConfigWithStructuredProperties() {
       "definitions": {
         "Book": {
           "properties": {
-            "title": {"datatype": "string", "facetable": true, "collation": "http://marklogic.com/collation/"},
-            "authors": {"datatype": "array", "facetable": true, "items": {"datatype": "string"}},
-            "rating": {"datatype": "integer", "facetable": true, "items": {"datatype": "string"}},
-            "id": {"datatype": "string", "facetable": false, "collation": "http://marklogic.com/collation/"},
-            "customer": {"datatype": "array", "items": {"$ref": "#/definitions/Address"}, "facetable": true},
-            "address": {"$ref": "#/definitions/Address", "facetable": true}
+            "title": {
+              "datatype": "string",
+              "facetable": true,
+              "collation": "http://marklogic.com/collation/"
+            },
+            "authors": {
+              "datatype": "array",
+              "facetable": true,
+              "items": {
+                "datatype": "string"
+              }
+            },
+            "rating": {
+              "datatype": "integer",
+              "facetable": true,
+              "items": {
+                "datatype": "string"
+              }
+            },
+            "id": {
+              "datatype": "string",
+              "facetable": false,
+              "collation": "http://marklogic.com/collation/"
+            },
+            "addresses": {
+              "datatype": "array",
+              "items": {
+                "$ref": "#/definitions/Address"
+              }
+            },
+            "address": {
+              "$ref": "#/definitions/Address"
+            }
+          }
+        },
+        "Address": {
+          "properties": {
+            "city": {
+              "datatype": "string",
+              "collation": "http://marklogic.com/collation/codepoint",
+              "facetable": true
+            },
+            "state": {
+              "datatype": "string",
+              "collation": "http://marklogic.com/collation/codepoint"
+            },
+            "zip": {
+              "$ref": "#/definitions/Zip"
+            }
+          }
+        },
+        "Zip": {
+          "properties": {
+            "fiveDigit": {
+              "datatype": "string",
+              "collation": "http://marklogic.com/collation/codepoint",
+              "facetable": true
+            },
+            "plusFour": {
+              "datatype": "string",
+              "collation": "http://marklogic.com/collation/codepoint"
+            }
           }
         }
       }
     }
   ]);
   return [
-    test.assertEqual(3, indexes.length),
+    test.assertEqual(7, indexes.length),
     test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/title", indexes[0]["path-expression"]),
     test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/authors", indexes[1]["path-expression"]),
-    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/rating", indexes[2]["path-expression"])
+    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/rating", indexes[2]["path-expression"]),
+    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/addresses/Address/city", indexes[3]["path-expression"]),
+    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/addresses/Address/zip/Zip/fiveDigit", indexes[4]["path-expression"]),
+    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/address/Address/city", indexes[5]["path-expression"]),
+    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/address/Address/zip/Zip/fiveDigit", indexes[6]["path-expression"])
   ];
 }
 

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/generateSearchOptions.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/impl/hub-entities/generateSearchOptions.sjs
@@ -106,7 +106,14 @@ function generateExplorerWithFacetableAndSortableProperties() {
         "rangeIndex": [ "street" ],
         "properties": {
           "street": {"datatype": "string", "collation": "http://marklogic.com/collation/codepoint"},
-          "city": {"datatype": "string", "collation": "http://marklogic.com/collation/codepoint"}
+          "city": {"datatype": "string", "collation": "http://marklogic.com/collation/codepoint"},
+          "zip": {"$ref": "#/definitions/Zip"}
+        }
+      },
+      "Zip": {
+        "properties": {
+          "fiveDigit": {"datatype": "string", "collation": "http://marklogic.com/collation/codepoint", "facetable": true},
+          "plusFour": {"datatype": "string", "collation": "http://marklogic.com/collation/codepoint"}
         }
       }
     }
@@ -127,6 +134,7 @@ function generateExplorerWithFacetableAndSortableProperties() {
     test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/completedDate", xs.string(fn.head(expOptions.xpath("/*:constraint[contains(@name, 'completedDate')]/*:range/*:path-index/text()")))),
     test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/publishedDate", xs.string(fn.head(expOptions.xpath("/*:constraint[contains(@name, 'publishedDate')]/*:range/*:path-index/text()")))),
     test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Address/street", xs.string(fn.head(expOptions.xpath("/*:constraint[contains(@name, 'street')]/*:range/*:path-index/text()")))),
+    test.assertEqual("/(es:envelope|envelope)/(es:instance|instance)/Book/publishedAtAddress/Address/zip/Zip/fiveDigit", xs.string(fn.head(expOptions.xpath("/*:constraint[contains(@name, 'publishedAtAddress.Address.zip.Zip.fiveDigit')]/*:range/*:path-index/text()")))),
 
     test.assertEqual("true", xs.string(fn.head(expOptions.xpath("/*:constraint[contains(@name, 'title')]/*:range/@facet")))),
     test.assertEqual("false", xs.string(fn.head(expOptions.xpath("/*:constraint[contains(@name, 'authors')]/*:range/@facet")))),
@@ -135,6 +143,7 @@ function generateExplorerWithFacetableAndSortableProperties() {
     test.assertEqual("false", xs.string(fn.head(expOptions.xpath("/*:constraint[contains(@name, 'publishedDate')]/*:range/@facet")))),
     test.assertEqual("true", xs.string(fn.head(expOptions.xpath("/*:constraint[contains(@name, 'street')]/*:range/@facet")))),
     test.assertEqual("true", xs.string(fn.head(expOptions.xpath("/*:constraint[contains(@name, 'city')]/*:range/@facet")))),
+    test.assertEqual("true", xs.string(fn.head(expOptions.xpath("/*:constraint[contains(@name, 'publishedAtAddress.Address.zip.Zip.fiveDigit')]/*:range/@facet")))),
 
     test.assertNotExists(expOptions.xpath("/*:constraint[contains(@name, 'bookId')]/*:range/*:path-index"))
   ];


### PR DESCRIPTION
### Description
- I am storing the range index path for facetable structured properties in the generated primary entity type in the uber-model as a result we can now generate facets for structured properties with the same name in two different entity types as well.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [N/A] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

