### PR TITLE
DHFPROD-7233:Allow users to remove namespace/prefix from an already created entity model

### DIFF
--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/CreateAndUpdateModelTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/CreateAndUpdateModelTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -153,13 +154,14 @@ public class CreateAndUpdateModelTest extends AbstractModelTest {
         assertEquals("ex", loadModel(getHubClient().getFinalClient()).get("definitions").get(MODEL_NAME).get("namespacePrefix").asText());
         assertEquals("Updated description", loadModel(getHubClient().getFinalClient()).get("definitions").get(MODEL_NAME).get("description").asText());
 
+        //Remove namespace and namespacePrefix from entity model
         input.put("description", "Description updated again");
         input.remove("namespace");
         input.remove("namespacePrefix");
         controller.updateModelInfo(MODEL_NAME, input);
         assertEquals("Description updated again", loadModel(getHubClient().getFinalClient()).get("definitions").get(MODEL_NAME).get("description").asText());
-        assertEquals("http://example.org/", loadModel(getHubClient().getFinalClient()).get("definitions").get(MODEL_NAME).get("namespace").asText());
-        assertEquals("ex", loadModel(getHubClient().getFinalClient()).get("definitions").get(MODEL_NAME).get("namespacePrefix").asText());
+        assertNull(loadModel(getHubClient().getFinalClient()).get("definitions").get(MODEL_NAME).get("namespace"));
+        assertNull(loadModel(getHubClient().getFinalClient()).get("definitions").get(MODEL_NAME).get("namespacePrefix"));
     }
 
     private void updateModelEntityTypes() {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelInfo.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/updateModelInfo.sjs
@@ -27,8 +27,8 @@ var name;
 var input = fn.head(xdmp.fromJSON(input));
 
 const description = input.description ? input.description : "";
-const namespace = input.namespace ? input.namespace : null;
-const namespacePrefix = input.namespacePrefix ? input.namespacePrefix : null;
+const namespace = input.namespace;
+const namespacePrefix = input.namespacePrefix;
 
 const uri = entityLib.getModelUri(name);
 if (!fn.docAvailable(uri)) {
@@ -50,10 +50,20 @@ if(namespace || namespacePrefix){
   if(!namespacePrefix){
     httpUtils.throwBadRequest(`Since you entered a namespace, you must specify a prefix.`);
   }
+}
+/*
+If payload doesn't contain namespace and namespacePrefix, entity model didn't have them in the first place or
+user wants to remove the values he had set earlier
+ */
+
+if(!namespace){
+  delete model.definitions[name].namespace;
+  delete model.definitions[name].namespacePrefix;
+}
+else{
   model.definitions[name].namespace = namespace;
   model.definitions[name].namespacePrefix = namespacePrefix;
 }
-
 
 try{
   entityLib.writeModel(name, model);


### PR DESCRIPTION
### Description
@wooldridge found an issue where PUT request with a payload without namespace/prefix doesn't remove them in an already created entity model. This PR addresses that issue.
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

