### PR TITLE
DHFPROD-3754: Add namespace fields to Entity form

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario1.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario1.spec.tsx
@@ -117,8 +117,6 @@ describe("Entity Modeling Senario 1: Writer Role", () => {
     entityTypeModal.newEntityDescription("Description has changed");
     entityTypeModal.getAddButton().click();
     entityTypeModal.getAddButton().should("have.css", "width", "0px");
-    cy.findByLabelText(`Buyer-add-property`).should("not.exist");
-    cy.waitUntil(() => entityTypeTable.getExpandEntityIcon("Buyer")).click();
     propertyTable.editProperty("newId");
     propertyModal.getDeleteIcon("newId").click();
     confirmationModal.getDeletePropertyWarnText().should("exist");

--- a/marklogic-data-hub-central/ui/src/api/modeling.ts
+++ b/marklogic-data-hub-central/ui/src/api/modeling.ts
@@ -5,8 +5,12 @@ export const primaryEntityTypes = async () => {
   return await axios.get(`/api/models/primaryEntityTypes`);
 };
 
-export const updateModelInfo = async (name: string, description: string) => {
-  return await axios.put(`/api/models/${name}/info`, {description});
+export const updateModelInfo = async (name: string, description: string, namespace: string, prefix: string) => {
+  return await axios.put(`/api/models/${name}/info`, {
+    description: description,
+    namespace: namespace,
+    namespacePrefix: prefix
+  });
 };
 
 export const entityReferences = async (entityName: string) => {

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/modeling/modeling.js
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/modeling/modeling.js
@@ -19,6 +19,20 @@ export const createModelErrorResponse = {
   "details": "An entity type already exists with a name of Testing"
 };
 
+export const createModelErrorResponseNamespace = {
+  "code": 400,
+  "message": "Invalid model: Namespace property must be a valid absolute URI. Value is badURI.",
+  "suggestion": "Resend the request in the correct format.",
+  "details": "Invalid model: Namespace property must be a valid absolute URI. Value is badURI."
+};
+
+export const createModelErrorResponsePrefix = {
+  "code": 400,
+  "message": "Invalid model: Namespace prefix xml is not valid. It is a reserved pattern.",
+  "suggestion": "Resend the request in the correct format.",
+  "details": "Invalid model: Namespace prefix xml is not valid. It is a reserved pattern."
+};
+
 export const getEntityTypes = [
   {
     "entityName": "AnotherModel",

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-modal/entity-type-modal.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-modal/entity-type-modal.module.scss
@@ -3,9 +3,17 @@
   margin-left: 7px;
 }
 
+.prefixLabel {
+  display: inline-block; 
+  width: 40px; 
+  line-height: 32px;
+  margin-left: 20px;
+  margin-right: 6px;
+}
+
 .input {
   position: relative;
-  width: 320px;
+  width: 444px;
 }
 
 .icon {
@@ -18,4 +26,11 @@
 
 .asterisk {
   color: #B32424;
+}
+
+.errorServer {
+  color: #B32424;
+  line-height: 20px;
+  margin-top: 10px;
+  margin-bottom: 0;
 }

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-modal/entity-type-modal.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-modal/entity-type-modal.test.tsx
@@ -5,10 +5,33 @@ import userEvent from "@testing-library/user-event";
 
 import EntityTypeModal from "./entity-type-modal";
 import {ModelingTooltips} from "../../../config/tooltips.config";
-import {createModelErrorResponse, createModelResponse} from "../../../assets/mock-data/modeling/modeling";
+import {
+  createModelErrorResponse,
+  createModelErrorResponseNamespace,
+  createModelErrorResponsePrefix,
+  createModelResponse
+} from "../../../assets/mock-data/modeling/modeling";
 
 jest.mock("axios");
 const axiosMock = axios as jest.Mocked<typeof axios>;
+
+const placeholders = {
+  name: "Enter name",
+  description: "Enter description",
+  namespace: "Example: http://example.org/es/gs",
+  namespacePrefix: "Example: esgs"
+};
+
+const defaultModalOptions = {
+  isVisible: true,
+  toggleModal: jest.fn(),
+  updateEntityTypesAndHideModal: jest.fn(),
+  isEditModal: false,
+  name: "",
+  description: "",
+  namespace: "",
+  prefix: ""
+};
 
 describe("EntityTypeModal Component", () => {
   afterEach(() => {
@@ -17,15 +40,8 @@ describe("EntityTypeModal Component", () => {
 
   test("Modal is not visible", () => {
     const {queryByText} = render(
-      <EntityTypeModal
-        isVisible={false}
-        toggleModal={jest.fn()}
-        updateEntityTypesAndHideModal={jest.fn()}
-        isEditModal={false}
-        name={""}
-        description={""}
-      />);
-
+      <EntityTypeModal {...defaultModalOptions} isVisible={false} />
+    );
     expect(queryByText("Add Entity Type")).toBeNull();
   });
 
@@ -33,42 +49,31 @@ describe("EntityTypeModal Component", () => {
     axiosMock.post["mockImplementationOnce"](jest.fn(() => Promise.resolve({status: 201, data: createModelResponse})));
 
     const {getByText, getByPlaceholderText} = render(
-      <EntityTypeModal
-        isVisible={true}
-        toggleModal={jest.fn()}
-        updateEntityTypesAndHideModal={jest.fn()}
-        isEditModal={false}
-        name={""}
-        description={""}
-      />);
+      <EntityTypeModal {...defaultModalOptions} />
+    );
+
+    let url = "/api/models";
+    let payload = {"name": "AnotherModel", "description": "Testing", "namespace": "", "namespacePrefix": ""};
+
     expect(getByText("Add Entity Type")).toBeInTheDocument();
-    userEvent.type(getByPlaceholderText("Enter name"), "AnotherModel");
-    userEvent.type(getByPlaceholderText("Enter description"), "Testing");
+    userEvent.type(getByPlaceholderText(placeholders.name), payload.name);
+    userEvent.type(getByPlaceholderText(placeholders.description), payload.description);
 
     await wait(() => {
       userEvent.click(getByText("Add"));
     });
-
-    let url = "/api/models";
-    let payload = {"name": "AnotherModel", "description": "Testing"};
     expect(axiosMock.post).toHaveBeenCalledWith(url, payload);
     expect(axiosMock.post).toHaveBeenCalledTimes(1);
   });
 
   test("Adding an invalid Entity name shows error message", async () => {
     const {getByText, getByPlaceholderText} = render(
-      <EntityTypeModal
-        isVisible={true}
-        toggleModal={jest.fn()}
-        updateEntityTypesAndHideModal={jest.fn()}
-        isEditModal={false}
-        name={""}
-        description={""}
-      />);
+      <EntityTypeModal {...defaultModalOptions} />
+    );
     expect(getByText(/Add Entity Type/i)).toBeInTheDocument();
 
-    userEvent.type(getByPlaceholderText("Enter name"), "123-Box");
-    userEvent.type(getByPlaceholderText("Enter description"), "Product entity desription");
+    userEvent.type(getByPlaceholderText(placeholders.name), "123-Box");
+    userEvent.type(getByPlaceholderText(placeholders.description), "Product entity description");
 
     await wait(() => {
       userEvent.click(getByText("Add"));
@@ -82,25 +87,19 @@ describe("EntityTypeModal Component", () => {
       Promise.reject({response: {status: 400, data: createModelErrorResponse}})));
 
     const {getByText, getByPlaceholderText} = render(
-      <EntityTypeModal
-        isVisible={true}
-        toggleModal={jest.fn()}
-        updateEntityTypesAndHideModal={jest.fn()}
-        isEditModal={false}
-        name={""}
-        description={""}
-      />);
+      <EntityTypeModal {...defaultModalOptions} />
+    );
     expect(getByText("Add Entity Type")).toBeInTheDocument();
 
-    userEvent.type(getByPlaceholderText("Enter name"), "Testing");
-    userEvent.type(getByPlaceholderText("Enter description"), "");
+    let url = "/api/models";
+    let payload = {"name": "Testing", "description": "", "namespace": "", "namespacePrefix": ""};
+
+    userEvent.type(getByPlaceholderText(placeholders.name), payload.name);
+    userEvent.type(getByPlaceholderText(placeholders.description), payload.description);
 
     await wait(() => {
       userEvent.click(getByText("Add"));
     });
-
-    let url = "/api/models";
-    let payload = {"name": "Testing", "description": ""};
     expect(axiosMock.post).toHaveBeenCalledWith(url, payload);
     expect(axiosMock.post).toHaveBeenCalledTimes(1);
 
@@ -109,28 +108,16 @@ describe("EntityTypeModal Component", () => {
 
   test("Edit modal is not visible", () => {
     const {queryByText} = render(
-      <EntityTypeModal
-        isVisible={false}
-        toggleModal={jest.fn()}
-        updateEntityTypesAndHideModal={jest.fn()}
-        isEditModal={true}
-        name={"ModelName"}
-        description={"Model description"}
-      />);
-
+      <EntityTypeModal {...defaultModalOptions} isVisible={false} isEditModal={true} />
+    );
     expect(queryByText("Edit Entity Type")).toBeNull();
   });
 
   test("Edit modal is visible", () => {
     const {getByText, getByDisplayValue, queryByText} = render(
-      <EntityTypeModal
-        isVisible={true}
-        toggleModal={jest.fn()}
-        updateEntityTypesAndHideModal={jest.fn()}
-        isEditModal={true}
-        name={"ModelName"}
-        description={"Model description"}
-      />);
+      <EntityTypeModal {...defaultModalOptions} isEditModal={true}
+        name={"ModelName"} description={"Model description"} />
+    );
 
     expect(getByText("Edit Entity Type")).toBeInTheDocument();
     expect(queryByText("*")).toBeNull();
@@ -138,30 +125,80 @@ describe("EntityTypeModal Component", () => {
     expect(getByDisplayValue("Model description")).toBeInTheDocument();
   });
 
-  test("Entity description is updated", async () => {
+  test("Entity description, namespace, and prefix are updated", async () => {
     axiosMock.put["mockImplementationOnce"](jest.fn(() => Promise.resolve({status: 200})));
 
     const {getByText, getByPlaceholderText} = render(
-      <EntityTypeModal
-        isVisible={true}
-        toggleModal={jest.fn()}
-        updateEntityTypesAndHideModal={jest.fn()}
-        isEditModal={true}
-        name={"ModelName"}
-        description={"Model description"}
-      />);
+      <EntityTypeModal {...defaultModalOptions} isEditModal={true}
+        name={"ModelName"} description={"Model description"} />
+    );
 
-    userEvent.clear(getByPlaceholderText("Enter description"));
-    userEvent.type(getByPlaceholderText("Enter description"), "Updated Description");
+    let url = "/api/models/ModelName/info";
+    let payload = {"description": "Updated Description", "namespace": "http://example.org/updated", "namespacePrefix": "updated"};
+
+    userEvent.clear(getByPlaceholderText(placeholders.description));
+    userEvent.type(getByPlaceholderText(placeholders.description), payload.description);
+    userEvent.type(getByPlaceholderText(placeholders.namespace), payload.namespace);
+    userEvent.type(getByPlaceholderText(placeholders.namespacePrefix), payload.namespacePrefix);
 
     await wait(() => {
       userEvent.click(getByText("OK"));
     });
-
-    let url = "/api/models/ModelName/info";
-    let payload = {"description": "Updated Description"};
     expect(axiosMock.put).toHaveBeenCalledWith(url, payload);
     expect(axiosMock.put).toHaveBeenCalledTimes(1);
   });
+
+  test("Submitting invalid namespace shows error message", async () => {
+    axiosMock.post["mockImplementationOnce"](jest.fn(() =>
+      Promise.reject({response: {status: 400, data: createModelErrorResponseNamespace}})));
+
+    const {getByText, getByPlaceholderText} = render(
+      <EntityTypeModal {...defaultModalOptions} />
+    );
+    expect(getByText("Add Entity Type")).toBeInTheDocument();
+
+    let url = "/api/models";
+    let payload = {"name": "Testing", "description": "", "namespace": "badURI", "namespacePrefix": "test"};
+
+    userEvent.type(getByPlaceholderText(placeholders.name), payload.name);
+    userEvent.type(getByPlaceholderText(placeholders.description), payload.description);
+    userEvent.type(getByPlaceholderText(placeholders.namespace), payload.namespace);
+    userEvent.type(getByPlaceholderText(placeholders.namespacePrefix), payload.namespacePrefix);
+
+    await wait(() => {
+      userEvent.click(getByText("Add"));
+    });
+    expect(axiosMock.post).toHaveBeenCalledWith(url, payload);
+    expect(axiosMock.post).toHaveBeenCalledTimes(1);
+
+    expect(getByText(createModelErrorResponseNamespace.message)).toBeInTheDocument();
+  });
+
+  test("Submitting invalid namespace prefix shows error message", async () => {
+    axiosMock.post["mockImplementationOnce"](jest.fn(() =>
+      Promise.reject({response: {status: 400, data: createModelErrorResponsePrefix}})));
+
+    const {getByText, getByPlaceholderText} = render(
+      <EntityTypeModal {...defaultModalOptions} />
+    );
+    expect(getByText("Add Entity Type")).toBeInTheDocument();
+
+    let url = "/api/models";
+    let payload = {"name": "Testing", "description": "", "namespace": "http://example.org/test", "namespacePrefix": "xml"};
+
+    userEvent.type(getByPlaceholderText(placeholders.name), payload.name);
+    userEvent.type(getByPlaceholderText(placeholders.description), payload.description);
+    userEvent.type(getByPlaceholderText(placeholders.namespace), payload.namespace);
+    userEvent.type(getByPlaceholderText(placeholders.namespacePrefix), payload.namespacePrefix);
+
+    await wait(() => {
+      userEvent.click(getByText("Add"));
+    });
+    expect(axiosMock.post).toHaveBeenCalledWith(url, payload);
+    expect(axiosMock.post).toHaveBeenCalledTimes(1);
+
+    expect(getByText(createModelErrorResponsePrefix.message)).toBeInTheDocument();
+  });
+
 });
 

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.test.tsx
@@ -101,41 +101,41 @@ describe("EntityTypeModal Component", () => {
     let entityTable = document.querySelectorAll(".ant-table-row-level-0");
 
     //Initial sort should be in descending 'Last Processed' order
-    validateTableRow(entityTable, ["AnotherModel,Testing", "Protein,", "Product,", "Provider,", "TestEntityForMapping,The TestEntityForMapping entity root.", "Order,", "Customer,"]);
+    validateTableRow(entityTable, ["AnotherModel", "Protein", "Product", "Provider", "TestEntityForMapping", "Order", "Customer"]);
     //verify sort by ascending 'Last Processed' order is next and works
     fireEvent.click(getByTestId("lastProcessed"));
     entityTable = document.querySelectorAll(".ant-table-row-level-0");
-    validateTableRow(entityTable, ["Customer,", "Order,", "AnotherModel,Testing", "Protein,", "Product,", "Provider,", "TestEntityForMapping,The TestEntityForMapping entity root."]);
+    validateTableRow(entityTable, ["Customer", "Order", "AnotherModel", "Protein", "Product", "Provider", "TestEntityForMapping"]);
     //verify third click does not return to default, but returns to descending order
     fireEvent.click(getByTestId("lastProcessed"));
     entityTable = document.querySelectorAll(".ant-table-row-level-0");
-    validateTableRow(entityTable, ["AnotherModel,Testing", "Protein,", "Product,", "Provider,", "TestEntityForMapping,The TestEntityForMapping entity root.", "Order,", "Customer,"]);
+    validateTableRow(entityTable, ["AnotherModel", "Protein", "Product", "Provider", "TestEntityForMapping", "Order", "Customer"]);
 
     //verify sort by name alphabetically works in ascending order
     fireEvent.click(getByTestId("entityName"));
     entityTable = document.querySelectorAll(".ant-table-row-level-0");
-    validateTableRow(entityTable, ["AnotherModel,Testing", "Customer,", "Order,", "Product,", "Protein,", "Provider,", "TestEntityForMapping,The TestEntityForMapping entity root."]);
+    validateTableRow(entityTable, ["AnotherModel", "Customer", "Order", "Product", "Protein", "Provider", "TestEntityForMapping"]);
     //verify sort by name alphabetically works in descending order
     fireEvent.click(getByTestId("entityName"));
     entityTable = document.querySelectorAll(".ant-table-row-level-0");
-    validateTableRow(entityTable, ["TestEntityForMapping,The TestEntityForMapping entity root.", "Provider,", "Protein,", "Product,", "Order,", "Customer,", "AnotherModel,Testing"]);
+    validateTableRow(entityTable, ["TestEntityForMapping", "Provider", "Protein", "Product", "Order", "Customer", "AnotherModel"]);
     //verify third click does not return to default, but returns to ascending order
     fireEvent.click(getByTestId("entityName"));
     entityTable = document.querySelectorAll(".ant-table-row-level-0");
-    validateTableRow(entityTable, ["AnotherModel,Testing", "Customer,", "Order,", "Product,", "Protein,", "Provider,", "TestEntityForMapping,The TestEntityForMapping entity root."]);
+    validateTableRow(entityTable, ["AnotherModel", "Customer", "Order", "Product", "Protein", "Provider", "TestEntityForMapping"]);
 
     //verify sort by instances works in ascending order
     fireEvent.click(getByTestId("Instances"));
     entityTable = document.querySelectorAll(".ant-table-row-level-0");
-    validateTableRow(entityTable, ["AnotherModel,Testing", "Protein,", "Product,", "Provider,", "TestEntityForMapping,The TestEntityForMapping entity root.", "Customer,", "Order,"]);
+    validateTableRow(entityTable, ["AnotherModel", "Protein", "Product", "Provider", "TestEntityForMapping", "Customer", "Order"]);
     //verify sort by instances works in descending order
     fireEvent.click(getByTestId("Instances"));
     entityTable = document.querySelectorAll(".ant-table-row-level-0");
-    validateTableRow(entityTable, ["Order,", "Customer,", "AnotherModel,Testing", "Protein,", "Product,", "Provider,", "TestEntityForMapping,The TestEntityForMapping entity root.", "Order,", "Customer,"]);
+    validateTableRow(entityTable, ["Order", "Customer", "AnotherModel", "Protein", "Product", "Provider", "TestEntityForMapping", "Order", "Customer"]);
     //verify third click does not return to default, but returns to ascending order
     fireEvent.click(getByTestId("Instances"));
     entityTable = document.querySelectorAll(".ant-table-row-level-0");
-    validateTableRow(entityTable, ["AnotherModel,Testing", "Protein,", "Product,", "Provider,", "TestEntityForMapping,The TestEntityForMapping entity root.", "Customer,", "Order,"]);
+    validateTableRow(entityTable, ["AnotherModel", "Protein", "Product", "Provider", "TestEntityForMapping", "Customer", "Order"]);
 
   });
 

--- a/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
+++ b/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
@@ -43,6 +43,7 @@ const ModelingTooltips = {
   nameEntityProperty: 'The name of this entity property. ' +
     'Names must start with a letter and can contain letters, numbers, hyphens, and underscores.',  /* intended dupe: all names */
   descriptionEntityProperty: 'A description of this entity property.',
+  namespace: 'Use of entity type namespaces is optional. If you choose to use a namespace, you must specify both a namespace URI and a prefix in your entity type definition.',
 
   /* Form fields */
   joinProperty: 'Structured type properties and arrays cannot be used as join properties.',

--- a/marklogic-data-hub-central/ui/src/pages/Modeling.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Modeling.tsx
@@ -30,6 +30,8 @@ const Modeling: React.FC = () => {
   const [isEditModal, toggleIsEditModal] = useState(false);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
+  const [namespace, setNamespace] = useState("");
+  const [prefix, setPrefix] = useState("");
   const [autoExpand, setAutoExpand] = useState("");
   const [revertAllEntity, toggleRevertAllEntity] = useState(false);
 
@@ -89,18 +91,20 @@ const Modeling: React.FC = () => {
 
   const updateEntityTypesAndHideModal = async (entityName: string, description: string) => {
     if (!isEditModal) {
-      setAutoExpand(entityName + "," + description);
+      setAutoExpand(entityName);
     }
     toggleShowEntityModal(false);
     await setEntityTypesFromServer();
   };
 
-  const editEntityTypeDescription = (entityTypeName: string, entityTypeDescription: string) => {
+  const editEntityTypeDescription = (entityTypeName: string, entityTypeDescription: string, entityTypeNamespace: string, entityTypePrefix: string) => {
     if (canWriteEntityModel) {
       toggleIsEditModal(true);
       toggleShowEntityModal(true);
       setName(entityTypeName);
       setDescription(entityTypeDescription);
+      setNamespace(entityTypeNamespace);
+      setPrefix(entityTypePrefix);
     }
   };
 
@@ -229,6 +233,8 @@ const Modeling: React.FC = () => {
           isEditModal={isEditModal}
           name={name}
           description={description}
+          namespace={namespace}
+          prefix={prefix}
         />
         <EntityTypeTable
           canReadEntityModel={canReadEntityModel}


### PR DESCRIPTION
### Description

Allow users to specify a namespace and namespace prefix for non-structured properties in Modeling.

The backend handles the following errors:

- Namespace and prefix must be defined if either one is defined.
- Prefix cannot be a reserved word (e.g., "xml").
- Namespace needs to be an absolute URI (e.g., "http://example.org/test").
- Entity name cannot be a duplicate of existing entity name (this validation already exists).

Server-side errors are displayed in a common place at the bottom of the form. @jbelonoj has approved the UX.

Tests for this feature are handled with RTL unit tests. 

Entity payload is now handled slightly differently now so relevant tests were updated. Also cleaned up entity-type-modal tests to avoid repetition and hardcoding. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

