### PR TITLE
DHFPROD-4489: Changing mapping step to acceptsBatch=true

### DIFF
--- a/marklogic-data-hub/src/main/resources/hub-internal-artifacts/step-definitions/mapping/marklogic/entity-services-mapping.step.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-artifacts/step-definitions/mapping/marklogic/entity-services-mapping.step.json
@@ -8,6 +8,7 @@
   "batchSize" : 100,
   "threadCount" : 4,
   "options": {
+    "acceptsBatch": true,
     "sourceDatabase": "data-hub-STAGING",
     "targetDatabase": "data-hub-FINAL",
     "sourceQuery": "cts.collectionQuery('default-ingestion')",

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/stepExecutionContext.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/stepExecutionContext.sjs
@@ -166,7 +166,13 @@ class StepExecutionContext {
   }
 
   setCompletedItems(items) {
-    this.completedItems = items;
+    // When a step is run with acceptsBatch=true, the step module may have captured step errors for one or more items.
+    // So we need to deduplicate this with failedItems
+    items.forEach(item => {
+      if (!this.failedItems.includes(item)) {
+        this.completedItems.push(item);
+      }
+    });
   }
 
   setFailedItems(items) {
@@ -241,11 +247,10 @@ class StepExecutionContext {
     return stepError;
   }
 
-  getStepBeforeMainFunction() {
-    const modulePath = this.stepDefinition.modulePath;
-    return new StepDefinition().makeFunction(null, "beforeMain", modulePath);
+  isStopOnError() {
+    return this.combinedOptions.stopOnError === true;
   }
-
+  
   getStepMainFunction() {
     const modulePath = this.stepDefinition.modulePath;
     const stepMainFunction = new StepDefinition().makeFunction(null, "main", modulePath);

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping/user-parameters/userModuleThrowsError.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping/user-parameters/userModuleThrowsError.sjs
@@ -16,9 +16,7 @@ const message = "Unexpected response: " + xdmp.toJsonString(response);
 const assertions = [
   test.assertEqual("failed", response.jobStatus, message),
   test.assertEqual(1, response.stepResponses["2"].stepOutput.length, "Expected a single error; " + message),
-  test.assertEqual("Unable to invoke beforeMain on step 2 in flow 'simpleMappingFlow'; " +
-    "cause: Throwing error on purpose", response.stepResponses["2"].stepOutput[0],
-    "The error should explain that beforeMain failed, along with the error thrown from beforeMain; " + message)
+  test.assertEqual("Throwing error on purpose", response.stepResponses["2"].stepOutput[0])
 ];
 
 // Test that validation fails when the values function throws an error


### PR DESCRIPTION
### Description

This is for user mapping params, and it avoids having to add the new "beforeMain" function. The mapping step main function then iterates over each item. If one throws an error, then it call addStepError and keeps going, unless stopOnError is true. This preserves the existing functionality for a mapping step. 

This is essentially a refactoring, as it doesn't change any tests except a new one, which is now simpler in terms of the error it's checking for. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

