### PR TITLE
DHFPROD-7273: Open all mapped related entity tables by default

### DIFF
--- a/marklogic-data-hub-central/ui/src/assets/mock-data/curation/curation-context-mock.js
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/curation/curation-context-mock.js
@@ -236,3 +236,25 @@ export const personMappingStepWithData = {
   setIsEditing: jest.fn(),
   setStepOpenOptions: jest.fn()
 };
+
+export const personMappingStepWithRelatedEntityData = {
+  curationOptions: {
+    entityDefinitionsArray: personNestedEntityDefArray,
+    activeStep: {
+      stepArtifact: mappingStep.artifacts[1],
+      entityName: mappingStep.entityType,
+      isModified: false
+    }
+  },
+  setActiveStep: jest.fn(),
+  updateActiveStepArtifact: jest.fn(),
+  mappingOptions: {
+    openStepSettings: false,
+    openStep: {},
+    isEditing: false
+  },
+  setOpenStepSettings: jest.fn(),
+  setOpenStep: jest.fn(),
+  setIsEditing: jest.fn(),
+  setStepOpenOptions: jest.fn()
+};

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/curation/mapping.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/curation/mapping.data.ts
@@ -40,6 +40,91 @@ export const mappingStep = {
       },
     },
     {
+      "name": "mapPersonWithRelated",
+      ...mappingArtifactCommonProps,
+      "stepId": "mapPersonWithRelated-mapping",
+      "properties": {
+        propId: {sourcedFrom: "id"},
+        propName: {sourcedFrom: "testNameInExp"},
+        propAttribute: {sourcedFrom: "placeholderAttribute"},
+        items: {
+          sourcedFrom: "",
+          properties: {
+            itemTypes: {sourcedFrom: ""}
+          },
+          targetEntityType: "#/definitions/ItemType"
+        }
+      },
+      relatedEntityMappings: [
+        {
+          relatedEntityMappingId: "Order:Person.items",
+          collections: ["mapPersonWithRelated", "Order"],
+          expressionContext: "/Orders",
+          uriExpression: "concat('/Order/', OrderId)",
+          permissions: "data-hub-common,read,data-hub-common,update",
+          properties: {
+            propId: {sourcedFrom: "id"},
+            propName: {sourcedFrom: "testNameInExp"},
+            propAttribute: {sourcedFrom: "placeholderAttribute"},
+            items: {
+              sourcedFrom: "",
+              properties: {
+                itemTypes: {sourcedFrom: ""}
+              },
+              targetEntityType: "#/definitions/ItemType"
+            }
+          },
+          targetEntityType: "http://example.org/Order-0.0.1/Order"
+        },
+        {
+          relatedEntityMappingId: "BabyRegistry:Person.items",
+          collections: ["mapPersonWithRelated", "BabyRegistry"],
+          permissions: "data-hub-common,read,data-hub-common,update",
+          expressionContext: "BabyRegistry",
+          uriExpression: "concat('/BabyRegistry/', BabyRegistryId)",
+          properties: {
+            propId: {sourcedFrom: "id"},
+            propName: {sourcedFrom: "testNameInExp"},
+            propAttribute: {sourcedFrom: "placeholderAttribute"},
+            items: {
+              sourcedFrom: "",
+              properties: {
+                itemTypes: {sourcedFrom: ""}
+              },
+              targetEntityType: "#/definitions/ItemType"
+            }
+          },
+          targetEntityType: "http://example.org/BabyRegistry-0.0.1/BabyRegistry"
+        },
+        {
+          relatedEntityMappingId: "Product:Order.lineItem.orderIncludes",
+          collections: ["mapPersonWithRelated", "Product"],
+          permissions: "data-hub-common,read,data-hub-common,update",
+          expressionContext: "/Orders/Products",
+          uriExpression: "concat('/Product/', ProductId)",
+          properties: {
+            propId: {sourcedFrom: "id"},
+            propName: {sourcedFrom: "testNameInExp"},
+            propAttribute: {sourcedFrom: "placeholderAttribute"}
+          },
+          targetEntityType: "http://example.org/Product-0.0.1/Product"
+        },
+        {
+          relatedEntityMappingId: "Product:BabyRegistry.hasProduct",
+          collections: ["mapPersonWithRelated", "Product"],
+          permissions: "data-hub-common,read,data-hub-common,update",
+          expressionContext: "/Orders/Products",
+          uriExpression: "concat('/Product/', ProductId)",
+          properties: {
+            propId: {sourcedFrom: "id"},
+            propName: {sourcedFrom: "testNameInExp"},
+            propAttribute: {sourcedFrom: "placeholderAttribute"}
+          },
+          targetEntityType: "http://example.org/Product-0.0.1/Product"
+        }
+      ]
+    },
+    {
       "name": "mapCustomersEmpty",
       "stepId": "mapCustomersEmpty-mapping",
       ...mappingArtifactCommonProps,

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.tsx
@@ -91,8 +91,8 @@ const EntityMapTable: React.FC<Props> = (props) => {
   const [sourceValue, setSourceValue] = useState("");
   const [displaySourceMenu, setDisplaySourceMenu] = useState(false);
   const [displaySourceList, setDisplaySourceList] = useState(false);
-  const [selectedOptions, setSelectedOptions] = useState<any[]>([]);
   const [entityProperties, setEntityProperties] = useState<any[]>(props.entityTypeProperties);
+  const [selectedOptions, setSelectedOptions] = useState<any[]>(["default"]);
 
   let firstRowKeys = new Array(100).fill(0).map((_, i) => i);
 
@@ -145,6 +145,13 @@ const EntityMapTable: React.FC<Props> = (props) => {
       setUpdateContextFlag(false);
     }
   }, [updateContextFlag]);
+
+  useEffect(() => {
+    //when component finishes rendering, set selected options with default entities for filter, necessary to track updates to the filter
+    if (selectedOptions[0] === "default" && props.relatedEntityTypeProperties.length > 0) {
+      setSelectedOptions(getDefaultEntities());
+    }
+  }, [props.relatedEntityTypeProperties]);
 
   const getEntityDataType = (prop) => {
     return prop.startsWith("parent-") ? prop.slice(prop.indexOf("-") + 1) : prop;
@@ -716,16 +723,26 @@ const EntityMapTable: React.FC<Props> = (props) => {
     />
   );
 
+  const getDefaultEntities = () => {
+    let defaultSelected : any = [];
+    let entityTitle = props.isRelatedEntity ? props.entityModel.info.title : props.entityTypeTitle;
+    props.relatedEntitiesSelected.map(entity => {
+      if (/:(.*?)\./.exec(entity["entityMappingId"])![1] === entityTitle) { defaultSelected.push(entity.entityLabel); }
+    });
+    return defaultSelected;
+  };
+
   const relatedEntitiesFilter = (
     <Select
       mode="multiple"
       allowClear
       style={{width: "98%"}}
       placeholder="Select"
+      key={props.relatedEntityTypeProperties.length  > 0 ? "loaded" : "notloaded"}
       id={`${props.entityTypeTitle}-entities-filter`}
       data-testid={`${props.entityTypeTitle}-entities-filter`}
       onChange={value => handleOptionSelect(value)}
-      value={selectedOptions}
+      defaultValue={getDefaultEntities()}
       dropdownClassName={props.isRelatedEntity ? styles.relatedEntityFilterDropdown : styles.entityFilterDropdown}
     >
 

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.test.tsx
@@ -6,7 +6,7 @@ import data from "../../../../assets/mock-data/curation/common.data";
 import {shallow} from "enzyme";
 import {validateMappingTableRow, onClosestTableRow} from "../../../../util/test-utils";
 import {CurationContext} from "../../../../util/curation-context";
-import {personMappingStepEmpty, personMappingStepWithData} from "../../../../assets/mock-data/curation/curation-context-mock";
+import {personMappingStepEmpty, personMappingStepWithData, personMappingStepWithRelatedEntityData} from "../../../../assets/mock-data/curation/curation-context-mock";
 import {updateMappingArtifact, getMappingArtifactByMapName, getMappingFunctions} from "../../../../api/mapping";
 import {mappingStep, mappingStepPerson} from "../../../../assets/mock-data/curation/mapping.data";
 import {getUris, getDoc} from "../../../../util/search-service";
@@ -722,14 +722,14 @@ describe("RTL Source-to-entity map tests", () => {
   });
 
   test("Verify view related entities with selection/deselection in filters", async () => {
-    mockGetMapArtifactByName.mockResolvedValue({status: 200, data: mappingStep.artifacts[0]});
+    mockGetMapArtifactByName.mockResolvedValue({status: 200, data: mappingStep.artifacts[1]});
     mockGetUris.mockResolvedValue({status: 200, data: ["/dummy/uri/person-101.json"]});
     mockGetSourceDoc.mockResolvedValue({status: 200, data: data.jsonSourceDataDefault});
     mockGetNestedEntities.mockResolvedValue({status: 200, data: personRelatedEntityDef});
 
     let getByTestId, getByLabelText, getByText, getAllByText, queryByTestId, getAllByLabelText, queryByLabelText;
     await act(async () => {
-      const renderResults = defaultRender(personMappingStepWithData);
+      const renderResults = defaultRender(personMappingStepWithRelatedEntityData);
       getByTestId = renderResults.getByTestId;
       getByLabelText = renderResults.getByLabelText;
       getByText = renderResults.getByText;
@@ -751,10 +751,27 @@ describe("RTL Source-to-entity map tests", () => {
     expect(entTableTopRow).toHaveTextContent(data.mapProps.entityTypeTitle);
 
     // Verify related entity filter in the first row
-    expect(getByText("Map related entities:").closest("tr")).toBe(entTableTopRow);
+    expect(getAllByText("Map related entities:")[0].closest("tr")).toBe(entTableTopRow);
 
     //Verify entity settings icon also exist in the first row
-    expect(getByLabelText("entitySettings").closest("tr")).toBe(entTableTopRow);
+    expect(getAllByLabelText("entitySettings")[0].closest("tr")).toBe(entTableTopRow);
+
+    //All mapped entity tables should be present on the screen by default
+    expect(getByLabelText("Person-title")).toBeInTheDocument();
+    await wait(() => expect(getByLabelText("Order (orderedBy Person)-title")).toBeInTheDocument());
+    await wait(() => expect(getByLabelText("Product (Order hasProduct)-title")).toBeInTheDocument());
+    await wait(() => expect(getByLabelText("BabyRegistry (ownedBy Person)-title")).toBeInTheDocument());
+    await wait(() => expect(getByLabelText("Product (BabyRegistry hasProduct)-title")).toBeInTheDocument());
+
+    //Clear all the entity tables via clear all button in target entity table filter
+    fireEvent.click(getAllByLabelText("icon: close-circle")[0]);
+
+    //only target entity table (Person) should remain
+    expect(getByLabelText("Person-title")).toBeInTheDocument();
+    await wait(() => expect(queryByLabelText("Order (orderedBy Person)-title")).not.toBeInTheDocument());
+    await wait(() => expect(queryByLabelText("Product (Order hasProduct)-title")).not.toBeInTheDocument());
+    await wait(() => expect(queryByLabelText("BabyRegistry (ownedBy Person)-title")).not.toBeInTheDocument());
+    await wait(() => expect(queryByLabelText("Product (BabyRegistry hasProduct)-title")).not.toBeInTheDocument());
 
     let entitiesFilter = getByText(
       (_content, element) =>

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.tsx
@@ -501,6 +501,17 @@ const MappingStepDetail: React.FC = () => {
           }
         });
       }
+      //set related entities selected to appear by default if their mappings exist
+      let existingRelatedMappings = curationOptions.activeStep.stepArtifact.relatedEntityMappings;
+      let defaultEntitiesToDisplay : any = [];
+      if (existingRelatedMappings) {
+        relatedEntities.map(entity => {
+          if (existingRelatedMappings.findIndex(existingEntity => existingEntity.relatedEntityMappingId === entity.entityMappingId) !== -1) {
+            defaultEntitiesToDisplay.push(entity);
+          }
+        });
+      }
+      setRelatedEntitiesSelected(defaultEntitiesToDisplay);
       setRelatedEntityTypeProperties(relatedEntities);
       setTgtEntityReferences({...tgtRefs});
     }


### PR DESCRIPTION
### Description
- Given an existing step that previously had multiple mappings saved, when we reopen it now, all the mapped entities' respective tables should appear by default. And their filters are populated accordingly with which other tables are opened through them, etc.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

