### PR TITLE
DHFPROD-7288: Handling custom hook errors for 5.5

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/flowRunner.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/flowRunner.sjs
@@ -121,7 +121,7 @@ function normalizeContentArray(contentArray) {
 function processContentWithStep(stepExecutionContext, contentArray, writeQueue) {
   const hookRunner = stepExecutionContext.makeCustomHookRunner(contentArray);
   if (hookRunner && hookRunner.runBefore) {
-    hookRunner.runHook();
+    hookRunner.runHook(contentArray);
   }
 
   const outputContentArray = stepExecutionContext.stepModuleAcceptsBatch() ? 
@@ -136,7 +136,7 @@ function processContentWithStep(stepExecutionContext, contentArray, writeQueue) 
   applyInterceptorsBeforeContentPersisted(outputContentArray, stepExecutionContext);
 
   if (hookRunner && !hookRunner.runBefore) {
-    hookRunner.runHook();
+    hookRunner.runHook(outputContentArray);
   }
 
   if (!stepExecutionContext.stepOutputShouldBeWritten()) {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/RunStepWithCustomHookTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/RunStepWithCustomHookTest.java
@@ -3,6 +3,7 @@ package com.marklogic.hub.flow;
 import com.marklogic.hub.AbstractHubCoreTest;
 import com.marklogic.hub.HubClient;
 import com.marklogic.hub.job.JobStatus;
+import com.marklogic.hub.step.RunStepResponse;
 import com.marklogic.hub.test.ReferenceModelProject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,10 +15,11 @@ public class RunStepWithCustomHookTest extends AbstractHubCoreTest {
     private final static String URI_CREATED_BY_HOOK = "/insertedByHook/customer1.json";
 
     HubClient client;
+    ReferenceModelProject project;
 
     @BeforeEach
     void beforeEach() {
-        ReferenceModelProject project = installReferenceModelProject();
+        project = installReferenceModelProject();
         runAsDataHubOperator();
         client = getHubClient();
         project.createRawCustomer(1, "Jane");
@@ -28,22 +30,86 @@ public class RunStepWithCustomHookTest extends AbstractHubCoreTest {
         RunFlowResponse response = runFlow(new FlowInputs("customHookFlow", "1"));
         assertEquals(JobStatus.FINISHED.toString(), response.getJobStatus());
 
-        assertNotNull(client.getStagingClient().newDocumentManager().exists(URI_CREATED_BY_HOOK));
-        assertNull(client.getFinalClient().newDocumentManager().exists(URI_CREATED_BY_HOOK));
+        assertNotNull(client.getStagingClient().newDocumentManager().exists("/insertedByHook/customer1.json"));
+        assertNull(client.getFinalClient().newDocumentManager().exists("/insertedByHook/customer1.json"));
     }
 
     /**
      * Note that because the hook operation gets the content objects as they were before the step module was executed,
      * the URI of the document inserted by the hook is still based on the URI of the input, not on the content object
      * returned by the step module. That's likely not expected behavior, but that's why custom hooks are being replaced
-     * by step interceptors.
+     * by step interceptors. BUT - in 5.5, this is being fixed so that a custom hook receives the output content array.
+     * This is being done since the expected primary use case for a hook is to attach it to a mapping step to modify
+     * the mapped content objects. Pre 5.5, that worked because a mapping step returns the same content object it
+     * receives. That's no longer the case in 5.5. So we're changing custom hooks to behave the way a user would
+     * likely expect - i.e. that a "before" hook gets the content array before a step processes it, and an "after"
+     * hook gets the content array that a step outputs.
      */
     @Test
     void afterHook() {
         RunFlowResponse response = runFlow(new FlowInputs("customHookFlow", "2"));
         assertEquals(JobStatus.FINISHED.toString(), response.getJobStatus());
 
-        assertNull(client.getStagingClient().newDocumentManager().exists(URI_CREATED_BY_HOOK));
-        assertNotNull(client.getFinalClient().newDocumentManager().exists(URI_CREATED_BY_HOOK));
+        assertNull(client.getStagingClient().newDocumentManager().exists("/insertedByHook/echo/customer1.json"));
+        assertNotNull(client.getFinalClient().newDocumentManager().exists("/insertedByHook/echo/customer1.json"));
+    }
+
+    @Test
+    void beforeHookThrowsErrorAndStopOnErrorIsTrue() {
+        project.createRawCustomer(2, "Janet");
+
+        RunFlowResponse response = runFlow(
+            new FlowInputs("customHookFlow", "1", "2")
+                .withOption("stopOnError", "true")
+                .withOption("throwErrorForStepNumber", "1")
+        );
+
+        assertEquals(JobStatus.STOP_ON_ERROR.toString(), response.getJobStatus());
+        assertEquals("1", response.getLastAttemptedStep());
+        assertEquals("0", response.getLastCompletedStep());
+        assertEquals(1, response.getStepResponses().keySet().size(),
+            "The second step should not have been run since stopOnError=true");
+
+        RunStepResponse stepResponse = response.getStepResponses().get("1");
+        assertEquals("canceled step 1", stepResponse.getStatus());
+        assertEquals(2, stepResponse.getTotalEvents());
+        assertEquals(0, stepResponse.getSuccessfulEvents());
+        assertEquals(2, stepResponse.getFailedEvents(), "Both items are considered to have failed since the " +
+            "entire batch failed due to a custom hook error");
+        assertEquals(0, stepResponse.getSuccessfulBatches());
+        assertEquals(1, stepResponse.getFailedBatches());
+        assertEquals(1, stepResponse.getStepOutput().size());
+        assertTrue(stepResponse.getStepOutput().get(0).contains("Throwing error on purpose for step number"),
+            "Unexpected step error: " + stepResponse.getStepOutput().get(0));
+        assertFalse(stepResponse.isSuccess());
+    }
+
+    @Test
+    void afterHookThrowsErrorAndStopOnErrorIsTrue() {
+        project.createRawCustomer(2, "Janet");
+
+        RunFlowResponse response = runFlow(
+            new FlowInputs("customHookFlow", "2", "1")
+                .withOption("stopOnError", "true")
+                .withOption("throwErrorForStepNumber", "2")
+        );
+
+        assertEquals(JobStatus.STOP_ON_ERROR.toString(), response.getJobStatus());
+        assertEquals("2", response.getLastAttemptedStep());
+        assertEquals("0", response.getLastCompletedStep());
+        assertEquals(1, response.getStepResponses().keySet().size(),
+            "The second step (step 1 in this scenario) should not have been run since stopOnError=true");
+
+        RunStepResponse stepResponse = response.getStepResponses().get("2");
+        assertEquals("canceled step 2", stepResponse.getStatus());
+        assertEquals(2, stepResponse.getTotalEvents());
+        assertEquals(0, stepResponse.getSuccessfulEvents());
+        assertEquals(2, stepResponse.getFailedEvents());
+        assertEquals(0, stepResponse.getSuccessfulBatches());
+        assertEquals(1, stepResponse.getFailedBatches());
+        assertEquals(1, stepResponse.getStepOutput().size());
+        assertTrue(stepResponse.getStepOutput().get(0).contains("Throwing error on purpose for step number"),
+            "Unexpected step error: " + stepResponse.getStepOutput().get(0));
+        assertFalse(stepResponse.isSuccess());
     }
 }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/hooksAndInterceptors/setup.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/hooksAndInterceptors/setup.sjs
@@ -9,7 +9,10 @@ const firstMappingStep = {
   "customHook": {
     "module": "/test/suites/data-hub/5/flow/hooksAndInterceptors/test-data/beforeHook.sjs",
     "runBefore": true
-  },
+  }
+};
+
+const secondMappingStep = {
   "interceptors": [
     {
       "path": "/test/suites/data-hub/5/flow/hooksAndInterceptors/test-data/addHeaders.sjs",
@@ -18,10 +21,7 @@ const firstMappingStep = {
         "headerValueToAdd": "world"
       }
     }
-  ]
-};
-
-const secondMappingStep = {
+  ],
   "customHook": {
     "module": "/test/suites/data-hub/5/flow/hooksAndInterceptors/test-data/afterHook.sjs",
     "runBefore": false

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/hooksAndInterceptors/testHooksAndInterceptors.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/hooksAndInterceptors/testHooksAndInterceptors.sjs
@@ -37,8 +37,9 @@ assertions.push(
 
 const afterHookDoc = hubTest.getRecord("/afterHook/customer1.json", config.FINALDATABASE);
 assertions.push(
-  test.assertEqual("Jane", afterHookDoc.document.envelope.instance.Customer.name, "Verifying that the hook ran; " + 
-    "it should have run against the mapped customer and thus inserted a copy of it")
+  test.assertEqual("world", afterHookDoc.document.envelope.headers.interceptorHeader, 
+    "Starting in 5.5, an 'after' hook receives the output content array from a step instead of the input " + 
+    "content array. So the hook should see the data added by the interceptor.")
 );
 
 assertions;

--- a/marklogic-data-hub/src/test/resources/entity-reference-model/modules/root/custom-modules/custom-hooks/test-hook.sjs
+++ b/marklogic-data-hub/src/test/resources/entity-reference-model/modules/root/custom-modules/custom-hooks/test-hook.sjs
@@ -7,6 +7,11 @@ var flowName;
 var stepNumber;
 var step;
 
-for (const contentObject of content) {
-  xdmp.documentInsert("/insertedByHook" + contentObject.uri, contentObject.value, contentObject.context.permissions);
+if (options.throwErrorForStepNumber === stepNumber) {
+  throw Error("Throwing error on purpose for step number: " + stepNumber);
 }
+
+// Using an array function to verify that an array is passed to the hook
+content.forEach(contentObject => {
+  xdmp.documentInsert("/insertedByHook" + contentObject.uri, contentObject.value, contentObject.context.permissions);
+});


### PR DESCRIPTION
### Description

Doing two things here:

- Ensuring that a Batch doc is written when a hook fails
- Passing the output content array when beforeHook is false

The second thing is being done for two reasons - 1) It's what users likely expected, and 2) It's the behavior users were getting for mapping steps, which is what they were most likely attaching custom hooks to for the purpose of modifying URIs. Mapping steps happened to allow this because they were modifying the input content object instead of returning a new one. But now in 5.5, a mapping step can be returning new content objects since it can return multiple content objects for related entities. So changing this both provides the expected behavior for an "after" hook and also ensures that hooks will continue to work as expected for mapping steps. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

