### PR TITLE
DHFPROD-7197: Avoid throwing an error if job doc not found

### DIFF
--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/JobController.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/controllers/JobController.java
@@ -48,8 +48,9 @@ public class JobController extends BaseController {
     public JsonNode getJob(@PathVariable String jobId) {
         JsonNode jobsJson = JobService.on(getHubClient().getJobsClient()).getJob(jobId);
         if (jobsJson == null) {
-            throw new RuntimeException("Unable to get job document");
+            return null;
         }
+
         return flattenJobsJson(jobsJson);
     }
 

--- a/marklogic-data-hub-central/ui/src/pages/Run.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Run.tsx
@@ -373,6 +373,10 @@ const Run = (props) => {
     let checkStatus = (resolve, reject) => {
       let promise = fn();
       promise.then(function(response) {
+        if (!response.data) {
+          throw new Error("Empty response body received");
+        }
+
         let status = response.data.jobStatus;
         if (status === Statuses.FINISHED || status === Statuses.CANCELED ||
                     status === Statuses.FAILED || status === Statuses.FINISHED_WITH_ERRORS) {


### PR DESCRIPTION
### Description
- Avoids a race condition if the job doc is retrieved before it's written.
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [N/A] Added Tests
  

- ##### Reviewer:

- [N/A] Reviewed Tests

