### PR TITLE
DHFPROD-7288: Batch status is now correct when custom hook fails

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/datahub.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/datahub.sjs
@@ -36,7 +36,7 @@ class DataHub {
 
     this.debug = new Debug(config);
     this.performance = new Perf(config, this);
-    this.flow = new Flow(config, this);
+    this.flow = new Flow(config);
     this.debug = new Debug(config, this);
     if (this.performance.performanceMetricsOn()) {
       this.performance.instrumentDataHub(this);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/flow.sjs
@@ -31,10 +31,9 @@ const cachedFlows = {};
 
 class Flow {
 
-  constructor(config, datahub) {
+  constructor(config) {
     this.config = config;
-    this.datahub = datahub;
-    this.stepDefinition = new StepDefinition(config, datahub);
+    this.stepDefinition = new StepDefinition(config);
 
     // Starting in 5.5, this is needed for backwards compatibility so that scaffolded modules can still
     // refer to datahub.flow.flowUtils .
@@ -88,7 +87,7 @@ class Flow {
         const stepId = flowStep.stepId ? flowStep.stepId : flowStep.name + "-" + flowStep.stepDefinitionType;
         const filteredItems = this.filterItemsAlreadyProcessedByStep(uris, flowName, stepId);
         if (filteredItems.length != uris.length) {
-          xdmp.trace(datahub.consts.TRACE_FLOW, 'excludeAlreadyProcessed filtered out some items; previous count: ' + uris.length + '; new count: ' + filteredItems.length);
+          xdmp.trace(this.consts.TRACE_FLOW, 'excludeAlreadyProcessed filtered out some items; previous count: ' + uris.length + '; new count: ' + filteredItems.length);
         }
         uris = filteredItems;
       }
@@ -151,7 +150,8 @@ class Flow {
    *  class that ideally would be the same as what's produced by flowUtils.makeCombinedOptions, but it's not yet
    * @param stepNumber The number of the step within the given flow to run
    */
-  runFlow(flowName, jobId, contentArray = [], options, stepNumber) {
+  runFlow(flowName, jobId, contentArray, options, stepNumber) {
+    contentArray = contentArray || [];
     const theFlow = this.getFlow(flowName);
     if(!theFlow) {
       throw Error('The flow with the name '+flowName+' could not be found.')
@@ -174,7 +174,6 @@ class Flow {
 
     const flowStep = theFlow.steps[stepNumber];
     if(!flowStep) {
-      this.datahub.debug.log({message: 'Step '+stepNumber+' for the flow: '+flowName+' could not be found.', type: 'error'});
       throw Error('Step '+stepNumber+' for the flow: '+flowName+' could not be found.');
     }
     const stepDefinition = this.stepDefinition.getStepDefinitionByNameAndType(flowStep.stepDefinitionName, flowStep.stepDefinitionType);
@@ -186,6 +185,8 @@ class Flow {
 
     let outputContentArray;
 
+    hubUtils.hubTrace(this.consts.TRACE_FLOW, `Running ${stepExecutionContext.describe()}; content array length: ${batchItems.length}`);
+
     try {
       // No writeQueue is passed in because if we pass in our own, nothing will be added to it if step output is disabled.
       // But this module currently needs everything in the write queue, and then chooses whether or not to persist it later.
@@ -196,6 +197,7 @@ class Flow {
       // Set this based on what's in the writeQueue, which deduplicates URIs to avoid conflicting update errors
       outputContentArray = this.writeQueue.getContentArray(stepExecutionContext.getTargetDatabase());
     } catch (error) {
+      stepExecutionContext.addStepErrorForEntireBatch(error, batchItems);
       this.writeBatchDocumentIfEnabled(stepExecutionContext, jobDoc, batchItems, {});
       throw error;
     }
@@ -228,9 +230,6 @@ class Flow {
     if (combinedOptions.fullOutput) {
       responseHolder.documents = outputContentArray;
     }
-    if (this.datahub.performance.performanceMetricsOn()) {
-      responseHolder.performanceMetrics = this.datahub.performance.stepMetrics;
-    }
 
     this.writeQueue = new WriteQueue();
     return responseHolder;
@@ -251,11 +250,11 @@ class Flow {
         batch.addSingleStepResult(stepExecutionContext, batchItems, writeTransactionInfo);
         batch.persist();
       } else {
-        hubUtils.hubTrace(this.datahub.consts.TRACE_FLOW,
+        hubUtils.hubTrace(this.consts.TRACE_FLOW,
           "Batch document insertion is enabled, but job document is null, so unable to insert a batch document");
       }
-    } else if (xdmp.traceEnabled(this.datahub.consts.TRACE_FLOW)) {
-      hubUtils.hubTrace(this.datahub.consts.TRACE_FLOW, `Batch document insertion is disabled`);
+    } else if (xdmp.traceEnabled(this.consts.TRACE_FLOW)) {
+      hubUtils.hubTrace(this.consts.TRACE_FLOW, `Batch document insertion is disabled`);
     }
   }
 

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/stepDefinition.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/stepDefinition.sjs
@@ -21,13 +21,9 @@ const cachedModules = {};
 
 class StepDefinition {
 
-  constructor(config = null, datahub = null) {
-    if (!datahub) {
-      const Perf = require("/data-hub/5/impl/perf.sjs");
-      this.performance = new Perf(config);
-    } else {
-      this.performance = datahub.performance;
-    }
+  constructor(config = null) {
+    const Perf = require("/data-hub/5/impl/perf.sjs");
+    this.performance = new Perf(config);
   }
 
   getStepDefinitionByNameAndType(name, type = 'custom') {

--- a/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
+++ b/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
@@ -547,6 +547,14 @@ public abstract class AbstractHubTest extends AbstractHubClientTest {
     }
 
     /**
+     * @return the first Batch document, which is often sufficient when you know your test should have only generated
+     * a single Batch doc
+     */
+    protected JsonNode getFirstBatchDoc() {
+        return readJsonObject(getHubClient().getJobsClient().newServerEval().xquery("collection('Batch')[1]").evalAs(String.class));
+    }
+
+    /**
      * @param collection
      * @return the number of documents in the given collection in the Jobs database
      */


### PR DESCRIPTION
### Description

Was missing a call to stepExecutionContext.addBatchErrorForEntireBatch . 

Also, for sanity reasons, removed the datahub instance from flow.sjs, as it had almost no value and created a circular dependency. Removed the code that returned the performance metrics, but that's currently disabled anyway in stepDefinition.sjs. If we find we have a need for that at some point, I think we'll integrate it in a different fashion. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

