### PR TITLE
DHFPROD-7109: Update E2E tests that add step to new flow and run step

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/addMatchStepToFlow.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/addMatchStepToFlow.spec.tsx
@@ -114,26 +114,27 @@ describe("Add Matching step to a flow", () => {
     curatePage.toggleEntityTypeId("Customer");
     curatePage.selectMatchTab("Customer");
   });
-  it("Add the Match step to new flow from card run button and should automatically run", {defaultCommandTimeout: 120000}, () => {
-    curatePage.runStepInCardView(matchStep).click();
-    curatePage.runInNewFlow(matchStep).click();
-    cy.waitForAsyncRequest();
-    cy.findByText("New Flow").should("be.visible");
+  // NOTE Moved testing of a adding step to a new flow and running the step to RTL unit tests
+  // SEE https://project.marklogic.com/jira/browse/DHFPROD-7109
+  it("Add the Match step to new flow", {defaultCommandTimeout: 120000}, () => {
+    // create new flow
+    cy.waitUntil(() => toolbar.getRunToolbarIcon()).click();
+    runPage.createFlowButton().click();
+    runPage.newFlowModal().should("be.visible");
     runPage.setFlowName(flowName2);
     runPage.setFlowDescription(`${flowName2} description`);
     cy.wait(500);
     loadPage.confirmationOptions("Save").click();
+    // add step to that new flow
+    runPage.addStep(flowName2);
+    runPage.addStepToFlow(matchStep);
+    runPage.verifyStepInFlow("Match", matchStep);
     cy.wait(500);
-    cy.waitForAsyncRequest();
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
-    cy.waitUntil(() => runPage.getFlowName(flowName2).should("be.visible"));
-    cy.verifyStepRunResult("success", "Matching", matchStep);
-    tiles.closeRunMessage();
-    cy.verifyStepAddedToFlow("Match", matchStep, flowName2);
   });
   it("Delete the match step and Navigate back to match tab", () => {
     runPage.deleteStep(matchStep).click();
-    loadPage.confirmationOptions("Yes").click();
+    //loadPage.confirmationOptions("Yes").click(); // multiple "Yes" options appearing
+    loadPage.confirmationOptionsAll("Yes").last().click();
     cy.waitForAsyncRequest();
     cy.waitUntil(() => toolbar.getCurateToolbarIcon()).click();
     cy.waitUntil(() => curatePage.getEntityTypePanel("Customer").should("be.visible"));

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/load.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/load.tsx
@@ -159,6 +159,10 @@ class LoadPage {
     return cy.findByLabelText(option);
   }
 
+  confirmationOptionsAll(option: string) {
+    return cy.findAllByLabelText(option);
+  }
+
   saveButton() {
     return cy.findByLabelText("Save");
   }

--- a/marklogic-data-hub-central/ui/src/api/__mocks__/mocks.data.ts
+++ b/marklogic-data-hub-central/ui/src/api/__mocks__/mocks.data.ts
@@ -160,6 +160,10 @@ const runCrudAPI = (axiosMock) => {
     switch (url) {
     case "/api/flows":
       return Promise.resolve({status: 201, data: {}});
+    case `/api/flows/${curateData.flows.data[0].name}/steps`:
+      return Promise.resolve({status: 200, data: {}});
+    case `/api/flows/${curateData.flows.data[0].name}/steps/2`:
+      return Promise.resolve({status: 200, data: {}});
     default:
       return Promise.reject(new Error("not found"));
     }

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/curation/flows.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/curation/flows.data.ts
@@ -658,6 +658,22 @@ const customSteps = {"data": {"stepsWithEntity": [{
 "status": 200
 };
 
+const newStepToFlowOptions = {
+  routeToFlow: true,
+  addingStepToFlow: true,
+  startRunStep: true,
+  flowName: null,
+  newStepName: "Mapping1", // consistent with flows above for testing purposes
+  stepDefinitionType: "mapping",
+  viewMode: "card",
+  pageSize: 10,
+  page: 1,
+  sortOrderInfo: null,
+  targetEntityType: "Person",
+  existingFlow: false, // Opens New Flow dialog
+  flowsDefaultKey: ["-1"]
+};
+
 const flowProps = {
   flows: flows.data,
   deleteFlow: jest.fn(),
@@ -695,8 +711,8 @@ const data = {
   loadsXML: loadsXML,
   loadSettings: loadSettings,
   mappingSettings: mappingSettings,
-  customSteps
-
+  customSteps,
+  newStepToFlowOptions
 };
 
 export default data;

--- a/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
+++ b/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
@@ -191,15 +191,16 @@ const Flows: React.FC<Props> = (props) => {
       }
       //run step after step is added to a new flow
       if (props.newStepToFlowOptions && !props.newStepToFlowOptions.existingFlow && startRun && addedFlowName) {
-        let index = props.flows.findIndex(i => i.name === addedFlowName);
-        if (props.flows[index].steps[0]) {
-          if (props.flows[index].steps[0].stepDefinitionType === "ingestion") {
+        let indexFlow = props.flows.findIndex(i => i.name === addedFlowName);
+        if (props.flows[indexFlow].steps.length > 0) {
+          let indexStep = props.flows[indexFlow].steps.findIndex(s => s.stepName === props.newStepToFlowOptions.newStepName);
+          if (props.flows[indexFlow].steps[indexStep].stepDefinitionType === "ingestion") {
             setShowUploadError(false);
-            setRunningStep(props.flows[index].steps[0]);
+            setRunningStep(props.flows[indexFlow].steps[indexStep]);
             setRunningFlow(addedFlowName);
             openFilePicker();
           } else {
-            props.runStep(addedFlowName, props.flows[index].steps[0]);
+            props.runStep(addedFlowName, props.flows[indexFlow].steps[indexStep]);
             setAddedFlowName("");
             setStartRun(false);
           }

--- a/marklogic-data-hub-central/ui/src/components/flows/new-flow-dialog/new-flow-dialog.tsx
+++ b/marklogic-data-hub-central/ui/src/components/flows/new-flow-dialog/new-flow-dialog.tsx
@@ -85,9 +85,9 @@ const NewFlowDialog = (props) => {
     } else {
       await props.createFlow(dataPayload);
       if (props.createAdd && props.newStepToFlowOptions && props.newStepToFlowOptions.addingStepToFlow) {
+        props.setAddedFlowName(flowName);
         await props.addStepToFlow(props.newStepToFlowOptions.newStepName, flowName, props.newStepToFlowOptions.stepDefinitionType);
         props.setOpenNewFlow(false);
-        props.setAddedFlowName(flowName);
       }
     }
     props.setNewFlow(false);

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.tsx
@@ -234,6 +234,7 @@ const LoadList: React.FC<Props> = (props) => {
       cancelText="Cancel"
       okButtonProps={{style: {display: "none"}}}
       onCancel={() => onCancel()}
+      cancelButtonProps={{"aria-label": "Cancel"}}
       width={650}
       maskClosable={false}
     >


### PR DESCRIPTION
Move some testing from E2E to RTL unit tests to stabilize E2E testing and avoid intermittent failures.

@ngodugu-marklogic reviewed the PR draft and OKed it. 

This PR removes the three "add step to flow" instances in the E2E tests (mentioned in the ticket) and adds RTL unit tests that check when a new flow is added (when adding a step), adding the step, and also running the step.

E2E and unit tests pass on my local environment.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

