### PR TITLE
DHFPROD-7325: Not creating job report if later step fails

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/job/finishStep.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/job/finishStep.sjs
@@ -24,5 +24,5 @@ var stepNumber;
 var stepStatus;
 var runStepResponse = fn.head(xdmp.fromJSON(runStepResponse));
 
-const job = Job.getRequiredJob(jobId).finishStep(stepNumber, runStepResponse, stepStatus, null).update();
+const job = Job.getRequiredJob(jobId).finishStep(stepNumber, runStepResponse, stepStatus, null, null).update();
 job;

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/flowExecutionContext.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/flowExecutionContext.sjs
@@ -79,14 +79,22 @@ class FlowExecutionContext {
     return stepExecutionContext;
   }
 
-  finishStep(stepExecutionContext, stepResponse, batchItems, outputContentArray) {
+  /**
+   * 
+   * @param stepExecutionContext 
+   * @param stepResponse 
+   * @param batchItems 
+   * @param outputContentArray 
+   * @param writeQueue {object} included so that if a step wants to create a job report, it can be added to this instead of being written right away
+   */
+  finishStep(stepExecutionContext, stepResponse, batchItems, outputContentArray, writeQueue) {
     const stepNumber = stepExecutionContext.stepNumber;
     if (stepExecutionContext.wasCompleted()) {
       this.flowResponse.lastCompletedStep = stepNumber;
     }
     this.flowResponse.stepResponses[stepNumber] = stepResponse;
     if (this.jobOutputIsEnabled()) {
-      this.job.finishStep(stepNumber, stepResponse, null, outputContentArray);
+      this.job.finishStep(stepNumber, stepResponse, null, outputContentArray, writeQueue);
       if (stepExecutionContext.batchOutputIsEnabled()) {
         if (this.batch == null) {
           this.batch = new Batch(this.flowResponse.jobId, this.flow.name);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/flowRunner.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/flowRunner.sjs
@@ -61,7 +61,7 @@ function runFlowOnContent(flowName, contentArray, jobId, runtimeOptions, stepNum
       const stepResponse = stepExecutionContext.buildStepResponse();
 
       if (!stepExecutionContext.wasCompleted()) {
-        flowExecutionContext.finishStep(stepExecutionContext, stepResponse, batchItems, currentContentArray);
+        flowExecutionContext.finishStep(stepExecutionContext, stepResponse, batchItems, currentContentArray, writeQueue);
         break;
       }
       else {
@@ -71,7 +71,7 @@ function runFlowOnContent(flowName, contentArray, jobId, runtimeOptions, stepNum
         } else {
           hubUtils.hubTrace(INFO_EVENT, `Provenance is disabled for ${stepExecutionContext.describe()}`);
         }
-        flowExecutionContext.finishStep(stepExecutionContext, stepResponse, batchItems, currentContentArray);  
+        flowExecutionContext.finishStep(stepExecutionContext, stepResponse, batchItems, currentContentArray, writeQueue);  
       }
     } catch (error) {
       // Catches any error thrown by a step, except for an error when an individual item is processed
@@ -84,7 +84,7 @@ function runFlowOnContent(flowName, contentArray, jobId, runtimeOptions, stepNum
         throw error;
       }
       const stepResponse = stepExecutionContext.buildStepResponse();
-      flowExecutionContext.finishStep(stepExecutionContext, stepResponse, batchItems);
+      flowExecutionContext.finishStep(stepExecutionContext, stepResponse, batchItems, writeQueue);
       break;
     }
   }

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/job.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/job.sjs
@@ -70,9 +70,10 @@ class Job {
    * @param stepResponse 
    * @param stepStatus {string} optional; if specified, the status in stepResponse will be ignored
    * @param outputContentArray {array} optional; will be passed along to the jobReport function for the step if one exists
+   * @param writeQueue {object} optional; will be passed along to the jobReport function for the step if one exists
    * @returns 
    */
-  finishStep(stepNumber, stepResponse, stepStatus, outputContentArray) {
+  finishStep(stepNumber, stepResponse, stepStatus, outputContentArray, writeQueue) {
     stepStatus = stepStatus || stepResponse.status;
 
     hubUtils.hubTrace(consts.TRACE_FLOW, `Finishing step '${stepNumber}' of job '${this.data.job.jobId}'; setting job status to '${stepStatus}'`);
@@ -91,7 +92,7 @@ class Job {
       stepResponse.stepEndTime = fn.currentDateTime();
     }
 
-    jobs.createJobReport(this.data.job.jobId, stepNumber, stepResponse, outputContentArray);
+    jobs.createJobReport(this.data.job.jobId, stepNumber, stepResponse, outputContentArray, writeQueue);
 
     this.data.job.stepResponses[stepNumber] = stepResponse;
     return this;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/flowRunner/errorHandling/setup.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/flowRunner/errorHandling/setup.sjs
@@ -10,6 +10,7 @@ hubTestX.loadArtifacts(test.__CALLER_FILE__);
 const customStepOne = {
   "stepDefinitionName": "errorThrowingStep",
   "stepDefinitionType": "custom",
+  "testStepModulePath": "/custom-modules/errorThrowingStepModule.sjs",
   "collections": ["customStepOne"],
   "sourceDatabase": "data-hub-FINAL",
   "targetDatabase": "data-hub-FINAL",
@@ -23,6 +24,7 @@ const customStepOne = {
 const customStepTwo = {
   "stepDefinitionName": "errorThrowingStep",
   "stepDefinitionType": "custom",
+  "testStepModulePath": "/custom-modules/errorThrowingStepModule.sjs",
   "collections": ["customStepTwo"],
   "sourceDatabase": "data-hub-FINAL",
   "targetDatabase": "data-hub-FINAL",

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/flowRunner/errorHandling/test-data/step-definitions/errorThrowingStep.step.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/flowRunner/errorHandling/test-data/step-definitions/errorThrowingStep.step.json
@@ -1,6 +1,0 @@
-{
-  "name" : "errorThrowingStep",
-  "type" : "custom",
-  "lang" : "zxx",
-  "modulePath" : "/custom-modules/errorThrowingStepModule.sjs"
-}

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/flowRunner/ingestMapMaster/dontCreateJobReportOnError.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/flowRunner/ingestMapMaster/dontCreateJobReportOnError.sjs
@@ -1,0 +1,36 @@
+const config = require("/com.marklogic.hub/config.sjs");
+const flowApi = require("/data-hub/public/flow/flow-api.sjs");
+const hubTest = require("/test/data-hub-test-helper.sjs");
+const test = require("/test/test-helper.xqy");
+
+const flowName = "myFlow";
+
+const response = flowApi.runFlowOnContent(flowName,
+  [{
+    "uri": "/incomingCustomer.json",
+    "value": {
+      "envelope": {
+        "instance": {
+          "customerId": 1,
+          "name": "New Jane",
+          "status": "new status"    
+        }
+      }
+    }
+  }]
+);
+
+const assertions = [
+  test.assertEqual("failed", response.jobStatus),
+  test.assertEqual(0, hubTest.getUrisInCollection("sm-Customer-merged", config.FINALDATABASE).length, 
+    "Because the custom step failed, nothing should have been persisted from the merging step"),
+  test.assertEqual(1, hubTest.getUrisInCollection("Job", config.JOBDATABASE).length, 
+    "The Job document should still have been written so the user knows what failed"),
+  test.assertEqual(1, hubTest.getUrisInCollection("Batch", config.JOBDATABASE).length, 
+    "The Batch document should still have been written so the user knows what failed"),
+  test.assertEqual(0, hubTest.getUrisInCollection("JobReport", config.JOBDATABASE).length, 
+    "The merging step should not automatically persist the JobReport; it needs to be added to the writeQueue so that " + 
+    "it can be written after all the steps have completed")
+];
+
+assertions;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/flowRunner/ingestMapMaster/ingestMapMatchMerge.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/flowRunner/ingestMapMaster/ingestMapMatchMerge.sjs
@@ -3,6 +3,7 @@ const hubTest = require("/test/data-hub-test-helper.sjs");
 const test = require("/test/test-helper.xqy");
 
 const flowName = "myFlow";
+const stepNumbersExceptCustomStep = ["1", "2", "3"];
 
 const response = flowApi.runFlowOnContent(flowName,
   [{
@@ -36,7 +37,7 @@ const response = flowApi.runFlowOnContent(flowName,
       }
     }
   }],
-  sem.uuidString(), {}
+  sem.uuidString(), {}, stepNumbersExceptCustomStep
 );
 
 const assertions = [

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/flowRunner/ingestMapMaster/setup.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/flowRunner/ingestMapMaster/setup.sjs
@@ -63,4 +63,15 @@ const mergingStep = {
   }
 };
 
-hubTest.createSimpleProject("myFlow", [mappingStep, matchingStep, mergingStep]);
+const customStepThatThrowsError = {
+  "stepDefinitionName": "errorThrowingStep",
+  "stepDefinitionType": "custom",
+  "testStepModulePath": "/custom-modules/errorThrowingStepModule.sjs",
+  "collections": ["customStepCollection"],
+  "sourceDatabase": "data-hub-FINAL",
+  "targetDatabase": "data-hub-FINAL",
+  "sourceQuery": "cts.collectionQuery('doesnt-matter')",
+  "throwErrorOnPurpose": true
+};
+
+hubTest.createSimpleProject("myFlow", [mappingStep, matchingStep, mergingStep, customStepThatThrowsError]);


### PR DESCRIPTION
### Description

This just involves adding the job report to the writeQueue if a writeQueue exists, as opposed to writing the job report right away - need the former for connected steps, the latter for independent steps. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

