### PR TITLE
DHFPROD-7304: Handle mapping artifact in session storage

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/mappingWithCustomHeader.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/mappingWithCustomHeader.spec.tsx
@@ -127,7 +127,9 @@ describe("Create and verify load steps, map step and flows with a custom header"
     cy.findByText("New Flow").should("be.visible");
     loadPage.confirmationOptions("Cancel").click();
     //should route user back to curate page
+    mappingStepDetail.goBackToCurateHomePage();
     cy.waitUntil(() => curatePage.getEntityTypePanel("Order").should("be.visible"));
+    curatePage.toggleEntityTypeId("Order");
     curatePage.openExistingFlowDropdown("Order", mapStep);
     curatePage.getExistingFlowFromDropdown(flowName).click();
     curatePage.addStepToFlowConfirmationMessage();

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.tsx
@@ -633,9 +633,16 @@ const MappingStepDetail: React.FC = () => {
       <Icon type="close" className={styles.closeIcon} onClick={() => handleCloseEditOption()}/>&nbsp;<Icon type="check" className={styles.checkIcon} onClick={() => handleSubmitUri(sourceURI)}/></span></div>}
   </div> : "";
 
+  // Run when mapping details is opened or returned to
   useEffect(() => {
     if (Object.keys(curationOptions.activeStep.stepArtifact).length !== 0) {
-      const mappingStepArtifact: MappingStep = curationOptions.activeStep.stepArtifact;
+      let mappingStepArtifact: MappingStep;
+      // Use session storage mapping artifact if present, else use artifact from context
+      if (storage.curate?.stepArtifact) {
+        mappingStepArtifact = storage.curate.stepArtifact;
+      } else {
+        mappingStepArtifact = curationOptions.activeStep.stepArtifact;
+      }
       setMappingFunctions();
       setMapData(mappingStepArtifact);
       setSavedMappingArt(mappingStepArtifact);
@@ -1118,9 +1125,19 @@ const MappingStepDetail: React.FC = () => {
     } else {
       setErrorInSaving("error");
     }
-    let mapArt = await getMappingArtifactByMapName(dataPayload.targetEntityType, curationOptions.activeStep.stepArtifact.name);
+    let mapArt: MappingStep = await getMappingArtifactByMapName(dataPayload.targetEntityType, curationOptions.activeStep.stepArtifact.name);
     if (mapArt) {
       await setSavedMappingArt({...mapArt});
+      // On success and if session storage mapping data exists, update it
+      if (storage.curate?.modelDefinition && storage.curate?.entityType) {
+        setViewSettings({...storage,
+          curate: {
+            stepArtifact: mapArt,
+            modelDefinition: {...storage.curate?.modelDefinition},
+            entityType: storage.curate?.entityType
+          }
+        });
+      }
     }
     setMapSaved(mapSavedResult);
   };

--- a/marklogic-data-hub-central/ui/src/pages/Curate.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Curate.tsx
@@ -41,7 +41,6 @@ const Curate: React.FC = () => {
     const storedCurateModel = storage?.curate?.modelDefinition;
     const storedCurateType = storage?.curate?.entityType;
 
-
     if (storedCurateArtifact !== undefined && storedCurateModel !== undefined && storedCurateType !== undefined) {
 
       const stepDefinitionType = storedCurateArtifact["stepDefinitionType"];


### PR DESCRIPTION
- Save mapping artifact in session storage on field change
- Use mapping artifact from session storage if present when viewing mapping UI

To test:

1. Open the details for a mapping step in the Hub Central Curate view.
2. Edit one or more XPath Expression fields, the UI saves these changes on field blur.
3. Go to a different view in Hub Central (Load, Run, Explore...).
4. Return to the Curate view, the details for the previous mapping step will open. 
5. Confirm that the edits made in step 2 are present. (Previously you would see the old values.)

This is a bug fix. Development of tests for updated mapping UI is still in progress, no tests in this PR.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- N/A Added Tests
  

- ##### Reviewer:

- N/A Reviewed Tests

