### PR TITLE
DHFPROD-7131: Handle entities with updated props when building join menu

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario1.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario1.spec.tsx
@@ -55,7 +55,7 @@ describe("Entity Modeling Senario 1: Writer Role", () => {
     propertyModal.openPropertyDropdown();
     propertyModal.getTypeFromDropdown("Related Entity").click();
     propertyModal.getCascadedTypeFromDropdown("Person").click();
-    propertyModal.openJoinPropertyDropdown();
+    propertyModal.toggleJoinPropertyDropdown();
     propertyModal.getJoinProperty("id").click();
     propertyModal.getYesRadio("multiple").click();
     propertyModal.getSubmitButton().click();
@@ -100,7 +100,7 @@ describe("Entity Modeling Senario 1: Writer Role", () => {
     propertyModal.openPropertyDropdown();
     propertyModal.getTypeFromDropdown("Related Entity").click();
     propertyModal.getCascadedTypeFromDropdown("Customer").click();
-    propertyModal.openJoinPropertyDropdown();
+    propertyModal.toggleJoinPropertyDropdown();
     propertyModal.getJoinProperty("customerId").click();
     propertyModal.getYesRadio("idenifier").should("not.exist");
     propertyModal.getYesRadio("multiple").click();
@@ -172,7 +172,7 @@ describe("Entity Modeling Senario 1: Writer Role", () => {
     confirmationModal.getYesButton(ConfirmationType.NavigationWarn).click();
     cy.location("pathname").should("eq", "/");
   });
-  it("Adding property to Order entity", () => {
+  it("Add new property to Order entity", () => {
     LoginPage.postLogin();
     toolbar.getModelToolbarIcon().click();
     entityTypeTable.waitForTableToLoad();
@@ -182,16 +182,26 @@ describe("Entity Modeling Senario 1: Writer Role", () => {
     propertyModal.openPropertyDropdown();
     propertyModal.getTypeFromDropdown("string").should("be.visible").click();
     propertyModal.getNoRadio("identifier").click();
-    propertyModal.getYesRadio("multiple").click();
     propertyModal.getYesRadio("pii").click();
     //propertyModal.clickCheckbox('wildcard');
     propertyModal.getSubmitButton().click();
     modelPage.getEntityModifiedAlert().should("exist");
-    propertyTable.getMultipleIcon("orderID").should("exist");
     propertyTable.getPiiIcon("orderID").should("exist");
     //propertyTable.getWildcardIcon('orderID').should('exist');
   });
-  it("Revert property chanages", () => {
+  it("Add related property to Buyer, check Join Property menu, cancel the addition", () => {
+    entityTypeTable.getExpandEntityIcon("Buyer").click();
+    propertyTable.getAddPropertyButton("Buyer").click();
+    propertyModal.newPropertyName("relProp");
+    propertyModal.openPropertyDropdown();
+    propertyModal.getTypeFromDropdown("Related Entity").click();
+    propertyModal.getCascadedTypeFromDropdown("Order").click();
+    propertyModal.toggleJoinPropertyDropdown();
+    propertyModal.checkJoinPropertyDropdownLength(6); // Check for saved (5) and unsaved (1) Order properties
+    propertyModal.toggleJoinPropertyDropdown();
+    propertyModal.getCancelButton().click();
+  });
+  it("Revert new Order property changes", () => {
     entityTypeTable.getRevertEntityIcon("Order").should("exist");
     entityTypeTable.getRevertEntityIcon("Order").click();
     confirmationModal.getYesButton(ConfirmationType.RevertEntity).click();

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario2.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario2.spec.tsx
@@ -100,7 +100,7 @@ describe("Entity Modeling: Writer Role", () => {
     propertyModal.openPropertyDropdown();
     propertyModal.getTypeFromDropdown("Related Entity").click();
     propertyModal.getCascadedTypeFromDropdown("Customer").click();
-    propertyModal.openJoinPropertyDropdown();
+    propertyModal.toggleJoinPropertyDropdown();
     propertyModal.getJoinProperty("nicknames").should("not.be.enabled");
     propertyModal.getJoinProperty("customerId").click();
     propertyModal.getSubmitButton().click();
@@ -167,7 +167,7 @@ describe("Entity Modeling: Writer Role", () => {
     propertyModal.openPropertyDropdown();
     propertyModal.getTypeFromDropdown("Related Entity").click();
     propertyModal.getCascadedTypeFromDropdown("Person").click();
-    propertyModal.openJoinPropertyDropdown();
+    propertyModal.toggleJoinPropertyDropdown();
     propertyModal.getJoinProperty("Address").click();
     propertyModal.getYesRadio("multiple").click();
     propertyModal.getYesRadio("idenifier").should("not.exist");
@@ -196,7 +196,7 @@ describe("Entity Modeling: Writer Role", () => {
     propertyModal.openPropertyDropdown();
     propertyModal.getTypeFromDropdown("Related Entity").click();
     propertyModal.getCascadedTypeFromDropdown("Customer").click();
-    propertyModal.openJoinPropertyDropdown();
+    propertyModal.toggleJoinPropertyDropdown();
     propertyModal.getJoinProperty("nicknames").should("not.be.enabled");
     propertyModal.getJoinProperty("customerId").click();
     propertyModal.getSubmitButton().click();
@@ -284,7 +284,7 @@ describe("Entity Modeling: Writer Role", () => {
     propertyModal.openPropertyDropdown();
     propertyModal.getTypeFromDropdown("Related Entity").click();
     propertyModal.getCascadedTypeFromDropdown("Order").click();
-    propertyModal.openJoinPropertyDropdown();
+    propertyModal.toggleJoinPropertyDropdown();
     propertyModal.getJoinProperty("orderId").click();
     propertyModal.getYesRadio("multiple").click();
     propertyModal.getSubmitButton().click();
@@ -324,7 +324,7 @@ describe("Entity Modeling: Writer Role", () => {
     propertyModal.openPropertyDropdown();
     propertyModal.getTypeFromDropdown("Related Entity").click();
     propertyModal.getCascadedTypeFromDropdown("Person").click();
-    propertyModal.openJoinPropertyDropdown();
+    propertyModal.toggleJoinPropertyDropdown();
     propertyModal.getJoinProperty("id").click();
     propertyModal.getSubmitButton().click();
     propertyTable.getProperty("personType").should("exist");

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/property-modal.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/property-modal.tsx
@@ -60,13 +60,14 @@ class PropertyModal {
   getJoinPropertyDropdown() {
     return  cy.findByPlaceholderText("Select a join property");
   }
-
-  openJoinPropertyDropdown() {
+  toggleJoinPropertyDropdown() {
     cy.findByLabelText("joinProperty-select").trigger("mouseover").click();
   }
-
   getJoinProperty(propertyName: string) {
     return cy.waitUntil(() => cy.findByLabelText(`${propertyName}-option`));
+  }
+  checkJoinPropertyDropdownLength(len: number) {
+    return cy.get('.ant-select-dropdown-menu').find('li').should('have.length', len);
   }
 }
 

--- a/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
+++ b/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
@@ -46,7 +46,7 @@ const ModelingTooltips = {
   namespace: 'Use of entity type namespaces is optional. If you choose to use a namespace, you must specify both a namespace URI and a prefix in your entity type definition.',
 
   /* Form fields */
-  joinProperty: 'Structured type properties and arrays cannot be used as join properties.',
+  joinProperty: 'Structured type properties, arrays, and unsaved properties cannot be used as join properties.',
 
    /* Foreign key relationship */
    foreignKey: function (relatedEntityName, joinPropertyName, type) {


### PR DESCRIPTION
### Description

Updated properties in entities that have not been saved yet will now show up in the Join Property menu in Modeling.

To test:

1. Create a new property for an entity (e.g. Customer). Do not save the entity.
2. Create a new entity relationship that points from one entity (Order) to the entity with the new property (Customer).
3. Open the Join Property menu to confirm that the new property is included in the list of properties. (Previously, it was not.)

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

