### PR TITLE
DHFPROD-7264: Delete mapping expressions for a related entity

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.module.scss
@@ -24,13 +24,28 @@
 
 .entitySettingsLink {
   display: inline-block;
-  padding-right: 20px;
+  padding-right: 17px;
   font-size: 20px !important;
   color: #44499C;
   cursor: pointer;
   &:hover{
       color: var(--hoverColor);
   }
+}
+
+.deleteEntityLink {
+  display: inline-block;
+  margin-left: -10px;
+  font-size: 20px !important;
+  color: #44499C;
+  cursor: pointer;
+  &:hover{
+      color: var(--hoverColor);
+  }
+}
+
+.deleteTableIcon {
+  padding-right: 10px;
 }
 
 .mapRelatedEntitiesText {


### PR DESCRIPTION
### Description
- Existing related entities that have mappings in the mapping step can now be deleted from the artifact via either the X button on the related entity's table or X button on the related entity's label from the referred entity's filter.
- RTL tests added, will also add more coverage in e2e together once this is started https://project.marklogic.com/jira/browse/DHFPROD-7267

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

