### PR TITLE
DHFPROD-6665: DHF file ingestion now matches MLCP for XML from CSV

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/step/impl/WriteStepRunner.java
@@ -636,7 +636,16 @@ public class WriteStepRunner implements StepRunner {
         ObjectMapper mapper = jacksonHandle.getMapper();
         JsonNode originalContent = jacksonHandle.get();
         ObjectNode node = mapper.createObjectNode();
-        node.set("content",originalContent);
+
+        // Per DHFPROD-6665, this custom file ingester now does the same thing MLCP does when constructing XML from
+        // a delimited file, which is to include a no-namespaced "root" element around the elements that were built
+        // from a particular row
+        if (this.outputFormat != null && this.outputFormat.equalsIgnoreCase("xml")) {
+            node.putObject("content").set("root", originalContent);
+        } else {
+            node.set("content",originalContent);
+        }
+
         node.put("file", file.getAbsolutePath());
         jacksonHandle.set(node);
         try {

--- a/marklogic-data-hub/src/main/resources/ml-modules/transforms/mlRunIngest.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/transforms/mlRunIngest.sjs
@@ -28,7 +28,9 @@ function transform(context, params, content) {
   if(options.inputFileType && options.inputFileType.toLowerCase() === "csv") {
     content = JSON.parse(content);
     options.file = content.file;
-    content = content.content;
+    // Wrap the JSON parsed from the CSV as a document node, as a step's main function expects content.value
+    // to be a node, not an object
+    content = xdmp.toJSON(content.content);
   }
 
   options.writeStepOutput = false;


### PR DESCRIPTION
### Description

A no-namespaced "root" element is now included to match what MLCP does. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

