### PR TITLE
DHFPROD-7348: Fix E2E tests to wait for success Modal

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress.json
+++ b/marklogic-data-hub-central/ui/e2e/cypress.json
@@ -5,6 +5,7 @@
     "viewportHeight": 1050,
     "numTestsKeptInMemory": 1,
     "defaultCommandTimeout": 10000,
+    "ignoreTestFiles": "**/curation/load/defaultIngestionCardView.spec.tsx",
     "reporter": "junit",
     "reporterOptions": {
       "mochaFile": "results/cypress-report[hash].xml",

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/addCustomStepToFlow.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/addCustomStepToFlow.spec.tsx
@@ -61,7 +61,6 @@ describe("Add Custom step to a flow", () => {
     cy.waitForAsyncRequest();
 
     runPage.runStep(stepName);
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", stepType, stepName);
     tiles.closeRunMessage();
   });
@@ -93,7 +92,6 @@ describe("Add Custom step to a flow", () => {
     cy.waitForAsyncRequest();
 
     runPage.runStep(stepName);
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", stepType, stepName);
     tiles.closeRunMessage();
   });

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/addMatchStepToFlow.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/addMatchStepToFlow.spec.tsx
@@ -76,7 +76,6 @@ describe("Add Matching step to a flow", () => {
     cy.verifyStepAddedToFlow("Match", matchStep, flowName1);
     cy.waitForAsyncRequest();
     runPage.runStep(matchStep);
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Matching", matchStep);
     tiles.closeRunMessage();
     cy.waitForAsyncRequest();
@@ -99,7 +98,6 @@ describe("Add Matching step to a flow", () => {
     cy.verifyStepAddedToFlow("Match", matchStep, flowName1);
     cy.waitForAsyncRequest();
     runPage.runStep(matchStep);
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Matching", matchStep);
     tiles.closeRunMessage();
   });
@@ -146,7 +144,6 @@ describe("Add Matching step to a flow", () => {
     curatePage.runStepSelectFlowConfirmation().should("be.visible");
     curatePage.selectFlowToRunIn(flowName2);
     cy.waitForAsyncRequest();
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.waitUntil(() => runPage.getFlowName(flowName2).should("be.visible"));
     cy.verifyStepRunResult("success", "Matching", matchStep);
     tiles.closeRunMessage();
@@ -163,7 +160,6 @@ describe("Add Matching step to a flow", () => {
     curatePage.runStepExistsOneFlowConfirmation().should("be.visible");
     curatePage.confirmContinueRun();
     cy.waitForAsyncRequest();
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.waitUntil(() => runPage.getFlowName(flowName2).should("be.visible"));
     cy.verifyStepRunResult("success", "Matching", matchStep);
     tiles.closeRunMessage();
@@ -195,7 +191,6 @@ describe("Add Matching step to a flow", () => {
     curatePage.selectFlowToRunIn(flowName1);
     cy.waitForAsyncRequest();
     cy.waitUntil(() => runPage.getFlowName(flowName1).should("be.visible"));
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Matching", matchStep);
     tiles.closeRunMessage();
     cy.verifyStepAddedToFlow("Match", matchStep, flowName1);

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/addMergeStepToFlow.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/addMergeStepToFlow.spec.tsx
@@ -80,7 +80,6 @@ describe("Add Merge step to a flow", () => {
     cy.verifyStepAddedToFlow("Merge", mergeStep, flowName1);
     cy.waitForAsyncRequest();
     runPage.runStep(mergeStep);
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Merging", mergeStep);
     tiles.closeRunMessage();
   });
@@ -102,7 +101,6 @@ describe("Add Merge step to a flow", () => {
     cy.verifyStepAddedToFlow("Merge", mergeStep, flowName1);
     cy.waitForAsyncRequest();
     runPage.runStep(mergeStep);
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Merging", mergeStep);
     tiles.closeRunMessage();
   });
@@ -125,7 +123,6 @@ describe("Add Merge step to a flow", () => {
     runPage.setFlowName(flowName2);
     runPage.setFlowDescription(`${flowName2} description`);
     loadPage.confirmationOptions("Save").click();
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.waitForAsyncRequest();
     cy.waitUntil(() => runPage.getFlowName(flowName2).should("be.visible"));
     cy.verifyStepRunResult("success", "Merging", mergeStep);
@@ -146,7 +143,6 @@ describe("Add Merge step to a flow", () => {
     curatePage.runStepSelectFlowConfirmation().should("be.visible");
     curatePage.selectFlowToRunIn(flowName2);
     cy.waitForAsyncRequest();
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.waitUntil(() => runPage.getFlowName(flowName2).should("be.visible"));
     cy.verifyStepRunResult("success", "Merging", mergeStep);
     tiles.closeRunMessage();
@@ -163,7 +159,6 @@ describe("Add Merge step to a flow", () => {
     curatePage.runStepExistsOneFlowConfirmation().should("be.visible");
     curatePage.confirmContinueRun();
     cy.waitForAsyncRequest();
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.waitUntil(() => runPage.getFlowName(flowName2).should("be.visible"));
     cy.verifyStepRunResult("success", "Merging", mergeStep);
     tiles.closeRunMessage();
@@ -194,7 +189,6 @@ describe("Add Merge step to a flow", () => {
     curatePage.runStepExistsMultFlowsConfirmation().should("be.visible");
     curatePage.selectFlowToRunIn(flowName1);
     cy.waitForAsyncRequest();
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.waitUntil(() => runPage.getFlowName(flowName1).should("be.visible"));
     cy.verifyStepRunResult("success", "Merging", mergeStep);
     tiles.closeRunMessage();

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/mappingWithCustomHeader.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/mappingWithCustomHeader.spec.tsx
@@ -74,7 +74,6 @@ describe("Create and verify load steps, map step and flows with a custom header"
     runPage.runStep(loadStep);
     cy.uploadFile("input/10260.json");
     cy.waitForAsyncRequest();
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Ingestion", loadStep);
     tiles.closeRunMessage();
   });
@@ -134,7 +133,6 @@ describe("Create and verify load steps, map step and flows with a custom header"
     curatePage.confirmAddStepToFlow(mapStep, flowName);
     cy.waitForAsyncRequest();
     runPage.runStep(mapStep);
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Mapping", mapStep);
     tiles.closeRunMessage();
     runPage.deleteStep(mapStep).click();
@@ -149,7 +147,6 @@ describe("Create and verify load steps, map step and flows with a custom header"
     curatePage.runStepSelectFlowConfirmation().should("be.visible");
     curatePage.selectFlowToRunIn(flowName);
     //Step should automatically run
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Mapping", mapStep);
     tiles.closeRunMessage();
   });
@@ -172,7 +169,6 @@ describe("Create and verify load steps, map step and flows with a custom header"
     runPage.setFlowDescription(`${flowName} description`);
     loadPage.confirmationOptions("Save").click();
     //Step should automatically run
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Mapping", mapStep);
     tiles.closeRunMessage();
   });
@@ -184,7 +180,6 @@ describe("Create and verify load steps, map step and flows with a custom header"
     curatePage.runStepExistsOneFlowConfirmation().should("be.visible");
     curatePage.confirmContinueRun();
     cy.waitForAsyncRequest();
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.waitUntil(() => runPage.getFlowName(flowName).should("be.visible"));
     cy.verifyStepRunResult("success", "Mapping", mapStep);
     tiles.closeRunMessage();
@@ -212,7 +207,6 @@ describe("Create and verify load steps, map step and flows with a custom header"
     curatePage.runStepExistsMultFlowsConfirmation().should("be.visible");
     curatePage.selectFlowToRunIn(flowName);
     cy.waitForAsyncRequest();
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepAddedToFlow("Map", mapStep, flowName);
     cy.waitUntil(() => runPage.getFlowName(flowName).should("be.visible"));
     cy.verifyStepRunResult("success", "Mapping", mapStep);

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/mappingWithInterceptorsAndCustomHook.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/mappingWithInterceptorsAndCustomHook.spec.tsx
@@ -97,7 +97,6 @@ describe("Create and verify load steps, map step and flows with interceptors & c
     cy.waitForAsyncRequest();
     runPage.runStep(loadStep);
     cy.uploadFile("input/10259.json");
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Ingestion", loadStep);
     tiles.closeRunMessage();
   });
@@ -265,7 +264,6 @@ describe("Create and verify load steps, map step and flows with interceptors & c
     cy.waitForAsyncRequest();
     runPage.runStep(mapStep);
     cy.waitForAsyncRequest();
-    cy.wait('@getJobs',{timeout:120000}).its('response.statusCode').should('eq', 200);
     cy.verifyStepRunResult("success", "Mapping", mapStep);
     runPage.explorerLink().click();
     browsePage.getTableViewSourceIcon().click();

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/customIngestion.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/customIngestion.spec.tsx
@@ -41,7 +41,6 @@ describe("Custom Ingestion", () => {
     runPage.runStep(loadStep);
     cy.uploadFile("input/test-1.json");
     cy.waitForAsyncRequest();
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Ingestion", loadStep);
     tiles.closeRunMessage();
 

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestionCardView.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestionCardView.spec.tsx
@@ -135,7 +135,6 @@ describe("Validate CRUD functionality from card view and run in a flow", () => {
     cy.verifyStepAddedToFlow("Load", stepName, flowName);
     //Upload file to start running, test with invalid input
     cy.uploadFile("input/test-1");
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("failed", "Ingestion", stepName)
       .should("contain.text", "Document is not JSON");
     tiles.closeRunMessage();
@@ -143,7 +142,6 @@ describe("Validate CRUD functionality from card view and run in a flow", () => {
   it("Run the flow with JSON input", {defaultCommandTimeout: 120000}, () => {
     runPage.runStep(stepName);
     cy.uploadFile("input/test-1.json");
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Ingestion", stepName);
     tiles.closeRunMessage();
     runPage.deleteStep(stepName).click();
@@ -171,7 +169,6 @@ describe("Validate CRUD functionality from card view and run in a flow", () => {
     cy.waitForAsyncRequest();
     //Upload file to start running
     cy.uploadFile("input/test-1.json");
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Ingestion", stepName);
     tiles.closeRunMessage();
     cy.verifyStepAddedToFlow("Load", stepName, flowName1);
@@ -186,7 +183,6 @@ describe("Validate CRUD functionality from card view and run in a flow", () => {
     cy.waitForAsyncRequest();
     cy.verifyStepAddedToFlow("Load", stepName, flowName1);
     cy.uploadFile("input/test-1.json");
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Ingestion", stepName);
     tiles.closeRunMessage();
   });
@@ -210,7 +206,6 @@ describe("Validate CRUD functionality from card view and run in a flow", () => {
     cy.waitForAsyncRequest();
     cy.verifyStepAddedToFlow("Load", stepName, flowName1);
     cy.uploadFile("input/test-1.json");
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Ingestion", stepName);
     tiles.closeRunMessage();
   });
@@ -237,7 +232,6 @@ describe("Validate CRUD functionality from card view and run in a flow", () => {
     //Run the flow with TEXT input
     runPage.runLastStepInAFlow(stepName);
     cy.uploadFile("input/test-1.txt");
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Ingestion", stepName);
     tiles.closeRunMessage();
   });

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestionListView.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestionListView.spec.tsx
@@ -152,7 +152,6 @@ describe("Validate CRUD functionality from list view", () => {
     cy.verifyStepAddedToFlow("Load", stepName, flowName);
     //Upload file to start running, test with invalid input
     cy.uploadFile("input/test-1.json");
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Ingestion", stepName);
     tiles.closeRunMessage();
   });
@@ -196,7 +195,6 @@ describe("Validate CRUD functionality from list view", () => {
     cy.waitForAsyncRequest();
     cy.verifyStepAddedToFlow("Load", stepName, flowName);
     cy.uploadFile("input/test-1.json");
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Ingestion", stepName);
     tiles.closeRunMessage();
   });
@@ -220,7 +218,6 @@ describe("Validate CRUD functionality from list view", () => {
     cy.waitForAsyncRequest();
     cy.verifyStepAddedToFlow("Load", stepName, flowName);
     cy.uploadFile("input/test-1.json");
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Ingestion", stepName);
     tiles.closeRunMessage();
   });

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/ingestionForAllFiletypes.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/ingestionForAllFiletypes.spec.tsx
@@ -55,7 +55,6 @@ describe("Verify ingestion for all filetypes", () => {
     runPage.runStep(stepName);
     cy.uploadFile("input/test-1.csv");
     cy.waitForAsyncRequest();
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Ingestion", stepName);
     tiles.closeRunMessage();
   });
@@ -84,7 +83,6 @@ describe("Verify ingestion for all filetypes", () => {
     runPage.runStep(stepName);
     cy.uploadFile("input/test-1.zip");
     cy.waitForAsyncRequest();
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Ingestion", stepName);
     tiles.closeRunMessage();
   });
@@ -115,7 +113,6 @@ describe("Verify ingestion for all filetypes", () => {
     runPage.runStep(stepName);
     cy.uploadFile("input/test-1.xml");
     cy.waitForAsyncRequest();
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Ingestion", stepName);
     //Verify step name appears as a collection facet in explorer
     runPage.explorerLink().click();

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/run/reorderSteps.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/run/reorderSteps.spec.tsx
@@ -60,17 +60,14 @@ describe("Run Tile tests", () => {
 
     //Run map,match and merge step for Person entity using xml documents
     runPage.runStep("mapPersonXML");
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Mapping", "mapPersonXML");
     tiles.closeRunMessage();
     cy.waitForAsyncRequest();
     runPage.runStep("match-xml-person");
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Matching", "match-xml-person");
     tiles.closeRunMessage();
     cy.waitForAsyncRequest();
     runPage.runStep("merge-xml-person");
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Merging", "merge-xml-person");
 
     //Navigate to explorer tile using the explorer link

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/run/runFlow.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/run/runFlow.spec.tsx
@@ -55,17 +55,14 @@ describe("Run Tile tests", () => {
 
     //Run map,match and merge step for Person entity using xml documents
     runPage.runStep("mapPersonXML");
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Mapping", "mapPersonXML");
     tiles.closeRunMessage();
     cy.waitForAsyncRequest();
     runPage.runStep("match-xml-person");
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Matching", "match-xml-person");
     tiles.closeRunMessage();
     cy.waitForAsyncRequest();
     runPage.runStep("merge-xml-person");
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Merging", "merge-xml-person");
 
     //Navigate to explorer tile using the explorer link
@@ -94,7 +91,6 @@ describe("Run Tile tests", () => {
     //run mapping step
     runPage.runStep("mapCustomersWithRelatedEntitiesJSON");
 
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Mapping", "mapCustomersWithRelatedEntitiesJSON");
     cy.waitForAsyncRequest();
 

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explore/jsonOtherValidations.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explore/jsonOtherValidations.tsx
@@ -109,7 +109,6 @@ describe("Verify numeric/date facet can be applied", () => {
     cy.waitUntil(() => runPage.getFlowName("personJSON").should("be.visible"));
     runPage.expandFlow("personJSON");
     runPage.runStep("mapPersonJSON");
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Mapping", "mapPersonJSON");
     runPage.explorerLink().click();
     browsePage.waitForSpinnerToDisappear();

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/mastering/e2eMasteringflow.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/mastering/e2eMasteringflow.spec.tsx
@@ -84,7 +84,6 @@ describe("Validate E2E Mastering Flow", () => {
     cy.waitUntil(() => cy.get("input[type=\"file\"]"));
     cy.get("input[type=\"file\"]").attachFile(["patients/first-name-double-metaphone1.json", "patients/first-name-double-metaphone2.json", "patients/first-name-synonym1.json", "patients/first-name-synonym2.json", "patients/last-name-address-reduce1.json", "patients/last-name-address-reduce2.json", "patients/last-name-dob-custom1.json", "patients/last-name-dob-custom2.json", "patients/last-name-plus-zip-boost1.json", "patients/last-name-plus-zip-boost2.json", "patients/last-name-slight-match1.json", "patients/last-name-slight-match2.json", "patients/ssn-match1.json", "patients/ssn-match2.json"], {force: true});
     cy.waitForAsyncRequest();
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Ingestion", loadStepName);
     //Verify step name appears as a collection facet in explorer
     runPage.explorerLink().click();
@@ -176,7 +175,6 @@ describe("Validate E2E Mastering Flow", () => {
     curatePage.runStepInCardView(mapStep).click();
     curatePage.runStepSelectFlowConfirmation().should("be.visible");
     curatePage.selectFlowToRunIn(flowName);
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Mapping", mapStep);
     //Explore Mapped data
     runPage.explorerLink().click();
@@ -305,7 +303,6 @@ describe("Validate E2E Mastering Flow", () => {
     curatePage.runStepInCardView(matchStep).click();
     curatePage.runStepSelectFlowConfirmation().should("be.visible");
     curatePage.selectFlowToRunIn(flowName);
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Matching", matchStep);
     tiles.closeRunMessage();
   });
@@ -363,7 +360,6 @@ describe("Validate E2E Mastering Flow", () => {
     curatePage.runStepInCardView(mergeStep).click();
     curatePage.runStepSelectFlowConfirmation().should("be.visible");
     curatePage.selectFlowToRunIn(flowName);
-    cy.wait("@getJobs").its("response.statusCode").should("eq", 200);
     cy.verifyStepRunResult("success", "Merging", mergeStep);
     //Verify merged Data
     runPage.explorerLink().click();


### PR DESCRIPTION
### Description
Removing api response wait as it is not polling the response and temporarily disabling defaultIngestionCardView until DHFPROD-7260 is done
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

