### PR TITLE
DHFPROD-7355: Fixing stepStartTime in job doc

### DIFF
--- a/examples/reference-entity-model/steps/merging/merge-customers.step.json
+++ b/examples/reference-entity-model/steps/merging/merge-customers.step.json
@@ -5,7 +5,7 @@
   "sourceQuery" : "cts.collectionQuery('matched-customers')",
   "targetEntityType" : "http://example.org/Customer-0.0.1/Customer",
   "sourceDatabase" : "data-hub-FINAL",
-  "collections" : [ "merged-customer", "merge-customers" ],
+  "collections" : [ "merge-customers" ],
   "targetFormat" : "json",
   "stepId" : "merge-customers-merging",
   "mergeStrategies" : [ ],

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/job.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/flow/job.sjs
@@ -58,20 +58,20 @@ class Job {
     this.data.job.lastAttemptedStep = stepNumber;
     this.data.job.jobStatus = stepStatus;
     this.data.job.stepResponses[stepNumber] = {
-      stepStartTime: fn.currentDateTime(),
+      stepStartTime: fn.currentDateTime().add(xdmp.elapsedTime()),
       status: stepStatus
     };
     return this;
   }
-  
+
   /**
-   * 
-   * @param stepNumber 
-   * @param stepResponse 
+   *
+   * @param stepNumber
+   * @param stepResponse
    * @param stepStatus {string} optional; if specified, the status in stepResponse will be ignored
    * @param outputContentArray {array} optional; will be passed along to the jobReport function for the step if one exists
    * @param writeQueue {object} optional; will be passed along to the jobReport function for the step if one exists
-   * @returns 
+   * @returns
    */
   finishStep(stepNumber, stepResponse, stepStatus, outputContentArray, writeQueue) {
     stepStatus = stepStatus || stepResponse.status;

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/connected/HubFlowRunnerResource.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/connected/HubFlowRunnerResource.java
@@ -24,7 +24,11 @@ public class HubFlowRunnerResource extends ResourceManager {
     }
 
     public RunFlowResponse runFlow(Input input) {
-        JsonNode json = getServices().post(new RequestParameters(), new JacksonHandle(input.getRootNode()), new JacksonHandle()).get();
+        return runFlow(input.getRootNode());
+    }
+
+    public RunFlowResponse runFlow(ObjectNode input) {
+        JsonNode json = getServices().post(new RequestParameters(), new JacksonHandle(input), new JacksonHandle()).get();
         try {
             return new ObjectMapper().readerFor(RunFlowResponse.class).readValue(json);
         } catch (IOException e) {

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/twoJsonDocs.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/flow/ingestAndMapConnected/twoJsonDocs.sjs
@@ -42,7 +42,7 @@ function verifyMapResponse(mapResponse) {
 }
 
 /**
- * This test focuses on the details of the response object, while the one JSON doc test 
+ * This test focuses on the details of the response object, while the one JSON doc test
  * focuses on the details of the documents that are persisted.
  */
 const flowName = "ingestAndMap";
@@ -74,7 +74,11 @@ const assertions = [
   test.assertNotEqual(null, response.timeStarted),
   test.assertNotEqual(null, response.timeEnded),
   test.assertTrue(new Date(response.timeStarted) < new Date(response.timeEnded)),
-  test.assertEqual(2, Object.keys(response.stepResponses).length)
+  test.assertEqual(2, Object.keys(response.stepResponses).length),
+  test.assertTrue(new Date(response.stepResponses["1"].stepStartTime) > new Date(response.timeStarted),
+    "The first step should start after the flow starts"),
+  test.assertTrue(new Date(response.stepResponses["2"].stepStartTime) > new Date(response.stepResponses["1"].stepEndTime),
+    "The second step should start after the first step ends")
 ];
 
 verifyIngestResponse(response.stepResponses["1"]);
@@ -118,7 +122,7 @@ assertions.push(
   test.assertEqual(xdmp.hostName(), batch.hostName),
   test.assertTrue(batch.reqTimeStamp != null),
   test.assertTrue(batch.reqTrnxID != null),
-  test.assertEqual(2, batch.writeTransactions.length, "Because connected steps can result in writes to multiple databases, " + 
+  test.assertEqual(2, batch.writeTransactions.length, "Because connected steps can result in writes to multiple databases, " +
     "we need to capture info about multiple transactions, and hence we need an array"),
   test.assertEqual("data-hub-STAGING", batch.writeTransactions[0].databaseName),
   test.assertTrue(batch.writeTransactions[0].transactionId != null),
@@ -159,7 +163,7 @@ assertions.push(
 );
 
 assertions.push(
-  test.assertEqual(4, hubTest.getProvenanceCount(), 
+  test.assertEqual(4, hubTest.getProvenanceCount(),
     "Expected 2 prov docs for the ingestion step, and 2 for the mapping step, as both have prov enabled")
 );
 


### PR DESCRIPTION
### Description

Also ran into an issue where if the "content" object has no "value", an ingestion step throws an unhelpful error message. Fixed that by throwing a nice error message, and cleaned up the ingestion step module too (no longer depends on the datahub singleton). 

Also, while testing against the reference project, I found the fact that documents processed by the merging step were in both "merged-customer" and "merge-customers" to be confusing, since not every customer was being merged. So I removed "merged-customer". 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

