### PR TITLE
DHFPROD-7354: Fixing scheduled task test on nightly

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubDeveloperTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/security/DataHubDeveloperTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.List;
 
@@ -273,14 +272,18 @@ public class DataHubDeveloperTest extends AbstractSecurityTest {
         task.setTaskRoot("Modules/");
         task.setTaskPeriod(1);
         task.setTaskType("minutely");
-        task.setTaskUser("nobody");
+        
+        // Per DHFPROD-7355, a change in ML nightly has resulted in a user without the "security" role from being able
+        // to assign "nobody" as a user, so the user itself is being used
+        task.setTaskUser(userWithRoleBeingTested.getUserName());
 
         try {
-            task.save();
-            //Modify the task
+            assertDoesNotThrow(() -> task.save(),
+                "A granular privilege on scheduled tasks should allow a data-hub-developer to create tasks");
+
             task.setTaskRoot("newModules/");
             task.setTaskPeriod(2);
-            task.save();
+            assertDoesNotThrow(() -> task.save(), "A data-hub-developer should be able to update tasks");
         } finally {
             new TaskManager(adminUserClient).delete(task.getJson());
         }


### PR DESCRIPTION
### Description

A change in ML nightly prevents a different task user being set

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

