### PR TITLE
DHFPROD-7260: Run load step in new flow sometimes does not run

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress.json
+++ b/marklogic-data-hub-central/ui/e2e/cypress.json
@@ -5,7 +5,6 @@
     "viewportHeight": 1050,
     "numTestsKeptInMemory": 1,
     "defaultCommandTimeout": 10000,
-    "ignoreTestFiles": "**/curation/load/defaultIngestionCardView.spec.tsx",
     "reporter": "junit",
     "reporterOptions": {
       "mochaFile": "results/cypress-report[hash].xml",

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/property-modal.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/property-modal.tsx
@@ -67,7 +67,7 @@ class PropertyModal {
     return cy.waitUntil(() => cy.findByLabelText(`${propertyName}-option`));
   }
   checkJoinPropertyDropdownLength(len: number) {
-    return cy.get('.ant-select-dropdown-menu').find('li').should('have.length', len);
+    return cy.get(".ant-select-dropdown-menu").find("li").should("have.length", len);
   }
 }
 

--- a/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
+++ b/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
@@ -188,29 +188,34 @@ const Flows: React.FC<Props> = (props) => {
             }
           }
         }
-        //run step after step is added to a new flow
-        if (props.newStepToFlowOptions && !props.newStepToFlowOptions.existingFlow && startRun && addedFlowName) {
-          let indexFlow = props.flows.findIndex(i => i.name === addedFlowName);
-          if (indexFlow > -1 && props.flows[indexFlow].steps.length > 0) {
-            let indexStep = props.flows[indexFlow].steps.findIndex(s => s.stepName === props.newStepToFlowOptions.newStepName);
-            if (props.flows[indexFlow].steps[indexStep].stepDefinitionType === "ingestion") {
-              setShowUploadError(false);
-              setRunningStep(props.flows[indexFlow].steps[indexStep]);
-              setRunningFlow(addedFlowName);
-              openFilePicker();
-            } else {
-              props.runStep(addedFlowName, props.flows[indexFlow].steps[indexStep]);
-              setAddedFlowName("");
-              setStartRun(false);
-            }
-          }
-        }
-      }
-      if (activeKeys === undefined) {
-        setActiveKeys([]);
       }
     }
+    if (activeKeys === undefined) {
+      setActiveKeys([]);
+    }
   }, [props.flows]);
+
+
+  useEffect(() => {
+    //run step after step is added to a new flow
+    if (props.newStepToFlowOptions && !props.newStepToFlowOptions.existingFlow && startRun && addedFlowName) {
+      let indexFlow = props.flows?.findIndex(i => i.name === addedFlowName);
+      if (props.flows[indexFlow]?.steps.length > 0) {
+        let indexStep = props.flows[indexFlow].steps.findIndex(s => s.stepName === props.newStepToFlowOptions.newStepName);
+        if (props.flows[indexFlow].steps[indexStep].stepDefinitionType === "ingestion") {
+          setShowUploadError(false);
+          setRunningStep(props.flows[indexFlow].steps[indexStep]);
+          setRunningFlow(addedFlowName);
+          openFilePicker();
+        } else {
+          props.runStep(addedFlowName, props.flows[indexFlow].steps[indexStep]);
+          setAddedFlowName("");
+          setStartRun(false);
+        }
+      }
+    }
+  }, [props.steps]);
+
 
   // Get the latest job info after a step (in a flow) run
   useEffect(() => {


### PR DESCRIPTION
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

- Fix for flaky run load step issue
- To verify: 
- 1. Create a load step and run it in a new flow via the Load tile (file picker should auto appear). 
- 2. Delete the step from the flow, delete the flow, then return to the Load tile
- 3. Run the load step in a new flow again (file picker should still auto appear, previously did not).

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- N/A Added Tests
  

- ##### Reviewer:

- N/A Reviewed Tests

