### PR TITLE
DHFPROD-7194: Add reference dropdown to mapping UI

### DIFF
--- a/marklogic-data-hub-central/ui/src/api/mapping.tsx
+++ b/marklogic-data-hub-central/ui/src/api/mapping.tsx
@@ -73,7 +73,19 @@ export const getMappingFunctions = async () => {
     }
   } catch (error) {
     let message = error;
-    console.error("Error while fetching the functions!", message);
+    console.error("Error getting functions", message);
+  }
+};
+
+export const getMappingRefs = async (stepName) => {
+  try {
+    let response = await axios.get(`/api/steps/mapping/${stepName}/references`);
+    if (response && response.status === 200) {
+      return response;
+    }
+  } catch (error) {
+    let message = error;
+    console.error("Error getting references", message);
   }
 };
 

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/curation/common.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/curation/common.data.ts
@@ -350,6 +350,14 @@ const mapFunctions = [
   {"functionName": "concat", "category": "xpath", "signature": "concat(xs:anyAtomicType?)"}
 ];
 
+const mapReferences = [{
+  name: "$URI",
+  description: "The URI of the source document"
+}, {
+  name: "$ZIP_POINTS",
+  description: "Maps zip codes to points"
+}];
+
 const mapProps = {
   sourceData: jsonSourceData,
   entityTypeProperties: entityTypeProperties,
@@ -634,6 +642,7 @@ const data = {
   flows: flows,
   flowsAdd: flowsAdd,
   loadData: loadData,
+  mapReferences: mapReferences,
   mapProps: mapProps,
   newMap: newMap,
   editMap: editMap,

--- a/marklogic-data-hub-central/ui/src/components/common/dropdown-with-search/dropdownWithSearch.tsx
+++ b/marklogic-data-hub-central/ui/src/components/common/dropdown-with-search/dropdownWithSearch.tsx
@@ -103,7 +103,18 @@ const DropDownWithSearch = (props) => {
         value={null}
         onChange={props.onItemSelect}
       >
-        {props.srcData.map((element, index) => <Select.Option data-testid = {element.value + "-option"} style={optionsStyle(index)} key={element.key}>{formatDropdownText(element.value, index)}{<MLTooltip title = "Multiple"><img data-testid = {element.value + "-optionIcon"} src= {element.struct ? arrayIcon : "" } alt={""}/></MLTooltip>}</Select.Option>)}
+        {props.srcData.map((element, index) =>
+          <Select.Option
+            data-testid = {element.value + "-option"}
+            style={optionsStyle(index)}
+            key={element.key}
+          >
+            {formatDropdownText(element.value, index)}
+            {<MLTooltip title="Multiple">
+              <img data-testid={element.value + "-optionIcon"} src={element.struct ? arrayIcon : "" } alt={""}/>
+            </MLTooltip>}
+          </Select.Option>
+        )}
       </Select>  }
     </div>
   );

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.module.scss
@@ -100,56 +100,24 @@
       margin-bottom:-14px;
       > .typeContext {
           color: #777777;
-          font-size: 12px
+          font-size: 12px;
       }
 
-      >.typeText{
-          margin-top: 10px
+      > .typeText{
+          margin-top: 10px;
       }
-  }
-}
-.listIcon {
-  background: transparent;
-  border: none;
-  color: #394494;
-  display: inline-block;
-  vertical-align: top;
-  margin-top: 4px;
-  font-size: 20px;
-  cursor: pointer;
-  &:hover{
-      color: var(--hoverColor);
   }
 }
 
-.functionIcon {
-  color: #394494;
-  font-size: 14px;
-  width: 22px;
-  height: 18px;
-  border: 1px solid #394494;
-  border-radius: 2px;
-  padding: 0px 0px 0px 0px;
-  cursor: pointer;
-  display: inline-block;
-  vertical-align: top;
-  text-align: center;
-  align-items: center;
-  margin-top: 5px;
-  &:hover{
-      color: var(--hoverColor);
-  }
-}
 .questionCircle {
   font-size: 12px;
   color: #7F86B5;
 }
+
 .mapExpParentContainer {
-  //display: inline;
   margin-top: -12px;
   margin-bottom: -12px;
-
-  >.validationErrors {
+  > .validationErrors {
       width: 23vw;
       line-height: normal;
       padding-top: 6px;
@@ -157,7 +125,6 @@
       padding-bottom: 4px;
       color: #DB4f59;
       word-break: break-all;
-
   }
 }
 
@@ -166,6 +133,53 @@
   display: inline-flex;
   vertical-align: top;
   align-items: flex-start;
+}
+
+.mapExpressionContainer > span > i, 
+.mapExpressionContainer > span > button {
+  display: inline-block;
+  cursor: pointer;
+  margin-left: 6px;
+}
+
+.listIcon {
+  color: #394494;
+  background: transparent;
+  border: none;
+  margin-top: 5px;
+  font-size: 20px;
+  &:hover{
+    color: var(--hoverColor);
+  }
+}
+
+.functionIcon {
+  color: #394494;
+  font-size: 14px;
+  width: 22px;
+  height: 20px;
+  border: 1px solid #394494;
+  border-radius: 2px;
+  padding: 0;
+  text-align: center;
+  margin-top: 5px;
+  &:hover{
+    color: var(--hoverColor);
+  }
+}
+
+.refIcon {
+  color: #e2e0e6;
+  background: #394494;
+  width: 21px !important;
+  height: 20px;
+  border: 1px solid #394494;
+  border-radius: 2px;
+  padding: 5px 1px 3px 1px;
+  margin-top: 5px;
+  &:hover{
+    color: var(--hoverColor);
+  }
 }
 
 .mapValue {

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.tsx
@@ -19,7 +19,7 @@ import {xmlParserForMapping} from "../../../../util/record-parser";
 import {CurationContext} from "../../../../util/curation-context";
 import {AuthoritiesContext} from "../../../../util/authorities";
 import {MappingStep, StepType} from "../../../../types/curation-types";
-import {getMappingArtifactByMapName, updateMappingArtifact, getMappingFunctions} from "../../../../api/mapping";
+import {getMappingArtifactByMapName, updateMappingArtifact, getMappingFunctions, getMappingRefs} from "../../../../api/mapping";
 import Steps from "../../../steps/steps";
 import {AdvMapTooltips} from "../../../../config/tooltips.config";
 import arrayIcon from "../../../../assets/icon_array.png";
@@ -86,21 +86,24 @@ const MappingStepDetail: React.FC = () => {
   const [mapSaved, setMapSaved] = useState(false); // eslint-disable-line @typescript-eslint/no-unused-vars
   const [errorInSaving, setErrorInSaving] = useState("");
 
-  //For storing  mapping functions
+  // For storing mapping functions
   const [mapFunctions, setMapFunctions] = useState<any>([]);
 
-  //For source dropdown search menu
+  // For reference dropdown search menu
+  const [mapRefs, setMapRefs] = useState<any>([]);
+
+  // For source dropdown search menu
   const [flatArray, setFlatArray]   = useState<any[]>([]);
 
-  //For TEST and Clear buttons
+  // For Test and Clear buttons
   const [mapResp, setMapResp] = useState({});
   const [isTestClicked, setIsTestClicked] = useState(false);
   const [savedMappingArt, setSavedMappingArt] = useState<any>(DEFAULT_MAPPING_STEP);
 
-  //Navigate URI buttons
+  // Navigate URI buttons
   const [uriIndex, setUriIndex] = useState(0);
 
-  //For Collapse all-Expand All buttons
+  // For Collapse all-Expand All buttons
   const [entityExpandedKeys, setEntityExpandedKeys] = useState<any[]>([]);
   const [sourceExpandedKeys, setSourceExpandedKeys] = useState<any[]>([]);
   const [expandedEntityFlag, setExpandedEntityFlag] = useState(false);
@@ -111,7 +114,7 @@ const MappingStepDetail: React.FC = () => {
   const [allEntityKeys, setAllEntityKeys] = useState<any []>([]);
   const [allRelatedEntitiesKeys, setAllRelatedEntitiesKeys] = useState<any[]>([]);
 
-  //For Entity table
+  // For Entity table
   const [tgtEntityReferences, setTgtEntityReferences] = useState({});
   let EntityTableKeyIndex = 100;
   let sourceTableKeyIndex = 0;
@@ -123,13 +126,13 @@ const MappingStepDetail: React.FC = () => {
   const previousSelected : any = usePrevious(relatedEntitiesSelected);
   const [targetRelatedMappings, setTargetRelatedMappings] = useState<any[]>([]);
   const [labelRemoved, setLabelRemoved] = useState("");
-  //For Entity table filtering
+  // For Entity table filtering
   const [filterStr, setFilterStr] = useState("");
 
-  //For storing docURIs
+  // For storing docURIs
   const [docUris, setDocUris] = useState<any[]>([]);
 
-  //For storing namespaces
+  // For storing namespaces
   const [namespaces, setNamespaces] = useState({});
   let nmspaces: any = {};
   let namespaceString = "";
@@ -143,7 +146,7 @@ const MappingStepDetail: React.FC = () => {
 
   const tableColors = ["#e4f1f4", "#f0f9f5", "#fae9d3", "#f6e2e9", "#edecf5", "#f0e8ed", "#e0e1ea", "#e6eff6", "#f0f6d9", "#fff5d7", "#ecfaf7", "#ecfae2", "#dcebf3", "#f3dbd8", "#f1eef5", "#dee2ed", "#effadd", "#fae3df", "#f6f7f8"];
 
-  //For Column Option dropdown checkboxes
+  // For Column Option dropdown checkboxes
   const [checkedEntityColumns, setCheckedEntityColumns] = useState({
     "name": true,
     "type": true,
@@ -263,6 +266,13 @@ const MappingStepDetail: React.FC = () => {
     }
   };
 
+  const setMappingRefs = async (stepName) => {
+    let mappingRefsResponse = await getMappingRefs(stepName);
+    if (mappingRefsResponse) {
+      setMapRefs(mappingRefsResponse.data);
+    }
+  };
+
   const updateMappingWithNamespaces = async (mapDataLocal) => {
     let {lastUpdated, ...dataPayload} = mapDataLocal;
     dataPayload["namespaces"] = nmspaces;
@@ -275,7 +285,7 @@ const MappingStepDetail: React.FC = () => {
     return namespace.slice(ind);
   };
 
-  //Generate namespaces for source properties
+  // Generate namespaces for source properties
   const getNamespace = (key, val, parentNamespacePrefix, defaultNamespace = "") => {
     let objWithNmspace = "";
     let keyParts = key.split(":");
@@ -340,7 +350,7 @@ const MappingStepDetail: React.FC = () => {
     };
   };
 
-  //Generate property object to push into deeply nested source data
+  // Generate property object to push into deeply nested source data
   const getPropertyObject = (key, obj) => {
     let propty: any;
     if (obj.hasOwnProperty("#text")) {
@@ -644,6 +654,7 @@ const MappingStepDetail: React.FC = () => {
         mappingStepArtifact = curationOptions.activeStep.stepArtifact;
       }
       setMappingFunctions();
+      setMappingRefs(mappingStepArtifact.name);
       setMapData(mappingStepArtifact);
       setSavedMappingArt(mappingStepArtifact);
       setMappingStepDetailPageData(mappingStepArtifact);
@@ -1435,6 +1446,7 @@ const MappingStepDetail: React.FC = () => {
                 allRelatedEntitiesKeys={allRelatedEntitiesKeys}
                 setAllRelatedEntitiesKeys={setAllRelatedEntitiesKeys}
                 mapFunctions = {mapFunctions}
+                mapRefs = {mapRefs}
                 savedMappingArt = {savedMappingArt}
                 deleteRelatedEntity = {deleteRelatedEntity}
                 labelRemoved = {labelRemoved}
@@ -1475,6 +1487,7 @@ const MappingStepDetail: React.FC = () => {
                   allRelatedEntitiesKeys={allRelatedEntitiesKeys}
                   setAllRelatedEntitiesKeys={setAllRelatedEntitiesKeys}
                   mapFunctions = {mapFunctions}
+                  mapRefs = {mapRefs}
                   savedMappingArt = {savedMappingArt}
                   deleteRelatedEntity = {deleteRelatedEntity}
                   labelRemoved = {labelRemoved}

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-navigation/source-navigation.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-navigation/source-navigation.module.scss
@@ -1,5 +1,5 @@
 .navigate_source_uris{
-  width: 115px;
+  width: 110px;
   display: flex;
   align-content: center ;
   vertical-align: bottom;
@@ -10,10 +10,12 @@
   white-space: nowrap;
 }
 
-.navigate_uris_left {
+.navigate_uris_left,
+.navigate_uris_right {
   user-select: none;
   cursor: pointer;
-  width: 2vw;
+  width: 32px;
+  height: 32px;
   text-align: center;
   align-content: center ;
   justify-content: center;
@@ -21,9 +23,11 @@
   outline: none !important;
   > .navigateIcon {
       display: block;
-      margin-left: -6px;
+      margin-left: -1px;
+      margin-top: 1px;
   }
 }
+
 .URI_Index{
   > p {
   border: 1px solid #7F86B5;
@@ -33,24 +37,6 @@
   width: 32px;
   height: 32px;
   padding-top: 4px;
-
   font-size: 15px;
-
-  }
-}
-
-.navigate_uris_right {
-  user-select: none;
-  cursor: pointer;
-  width: 2vw;
-  background:none;
-  outline: none !important;
-  text-align: center;
-  outline: none;
-  align-content: center ;
-  justify-content: center;
-  > .navigateIcon {
-      display: block;
-      margin-left: -6px;
   }
 }


### PR DESCRIPTION
### Description

- Add new dropdown menu for inserting reference values into the XPath Expression field in the mapping UI. Works similarly to the property and function menus that are already there.
- Refactor some of the mapping logic and CSS to make it more DRY.
- Fix the function menu bug so that the mapping UI auto-saves after function insertion. (Property and reference insertion also have auto-save.)
- Note that this PR doesn't include description information in the dropdown menu, that feature has been pushed to a separate ticket. This Jira ticket has been updated to note all this.
- Added tests for the reference menu and updated tests for the function menu.

To test, open mapping details for a step and use the new references menu (should appear next to all fields except Context). Selecting should add the menu item to the expression field.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

