### PR TITLE
DHFPROD-7194: Fix saving issue for mapping menu values

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.tsx
@@ -614,18 +614,17 @@ const EntityMapTable: React.FC<Props> = (props) => {
       mapExp[propName] = "";
     }
     if (propName === "URI" && !selectedRow.isProperty) {
-      insertedContext = uriExpression.substr(0, caretPosition) + content +
+      insertedUri = uriExpression.substr(0, caretPosition) + content +
         uriExpression.substr(caretPosition, uriExpression.length);
-      setUriExpression(insertedContext);
-      await setMapExp({...mapExp});
-      tempMapExp = Object.assign({}, mapExp);
+      setUriExpression(insertedUri);
+      tempMapExp = mapExp;
     } else {
       let newExp = mapExp[propName].substr(0, caretPosition) + content +
         mapExp[propName].substr(caretPosition, mapExp[propName].length);
-      await setMapExp({...mapExp, [propName]: newExp});
-      tempMapExp = Object.assign({}, mapExp);
+      let newMapExp = {...mapExp, [propName]: newExp};
+      setMapExp(newMapExp);
+      tempMapExp = Object.assign({}, newMapExp);
     }
-
     await props.saveMapping(tempMapExp, props.entityMappingId, insertedContext, insertedUri, props.entityModel);
     setDisplaySelectList(prev => false);
     setDisplayFuncMenu(prev => false);


### PR DESCRIPTION
Updated mapping menu insertion logic to fix save issues:
- Cannot rely on hook values being avail at time of save. Make sure tempMapExp is saved correctly (for reference and function vals).
- Also set insertedUri (not insertedContext) for URI field case.

To test, check reference (and function) menus when inserting content into URI and regular property fields in mapping UI. 

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- N/A Added Tests
  

- ##### Reviewer:

- N/A Reviewed Tests

