### PR TITLE
DHFPROD-7420:Ensure 'additionalCollections' setting works for related entity mapping

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/main.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/main.sjs
@@ -166,6 +166,9 @@ function createContextForRelatedEntityInstance(relatedEntityMapping, content){
   let entityContext = {};
   let relatedEntityPermissions = fn.string(relatedEntityMapping.permissions);
   let relatedEntityCollections = relatedEntityMapping.collections;
+  if(relatedEntityMapping.additionalCollections){
+    relatedEntityCollections = relatedEntityCollections.concat(relatedEntityMapping.additionalCollections);
+  }
   entityContext["permissions"] = hubUtils.parsePermissions(relatedEntityPermissions);
   entityContext["collections"] = relatedEntityCollections;
   if(content.context && content.context.originalCollections){

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping/map-multiple-entities/runFlowWithRelatedEntityMapping.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping/map-multiple-entities/runFlowWithRelatedEntityMapping.sjs
@@ -17,6 +17,7 @@ function runJSONMapping(){
   let results = datahub.flow.runFlow('customerFlow', 'test-job', content, {outputFormat: 'json', mapping:{name:'mapCustomersJSON'}}, 1);
   let customerUris = hubTest.getUrisInCollection("Customer");
   let orderUris = hubTest.getUrisInCollection("Order").sort();
+  let userOrderUris = hubTest.getUrisInCollection("UserOrder").sort();
   let productUris = hubTest.getUrisInCollection("Product").sort();
   let orderDocPermissions = hubTest.getRecord(orderUris[0], "data-hub-FINAL");
   let productDocPermissions = hubTest.getRecord(productUris[0], "data-hub-FINAL")
@@ -28,6 +29,7 @@ function runJSONMapping(){
     test.assertEqual(1, customerUris.length),
     test.assertEqual("/mapped/content/customerInfo.json", customerUris[0]),
     test.assertEqualJson(["/Order/2002.json", "/Order/2012.json"], orderUris),
+    test.assertEqualJson(["/Order/2002.json", "/Order/2012.json"], userOrderUris),
     test.assertEqualJson(["/Product/10.json", "/Product/30.json", "/Product/40.json"], productUris),
     /* Not checking for permissions of the main entity instance since we have tests for it and also permissions passed through options
     won't get applied before runFlow() is called. */

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping/map-multiple-entities/test-data/steps/mapping/mapCustomersJSON.step.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping/map-multiple-entities/test-data/steps/mapping/mapCustomersJSON.step.json
@@ -44,6 +44,7 @@
     {
       "relatedEntityMappingId": "Customer.customerId:Order",
       "collections": ["mapCustomersJSON", "Order"],
+      "additionalCollections": ["UserOrder"],
       "expressionContext": "/Orders",
       "uriExpression": "concat('/Order/', OrderId)",
       "permissions": "data-hub-common,read,data-hub-common,update",


### PR DESCRIPTION
### Description
Ensure 'additionalCollections' setting works for related entity mapping
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

