### PR TITLE
DHFPROD-7441: Join property field still displays after changing prope…

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.test.tsx
@@ -182,9 +182,35 @@ describe("Property Modal Component", () => {
     expect(screen.queryByLabelText("Facet")).toBeNull();
     //expect(screen.queryByLabelText('Wildcard Search')).toBeNull();
 
+    expect(getByLabelText("joinProperty-select")).toBeInTheDocument();
+    //Join property select field should disappear after selecting a different property type like string
+    userEvent.click(getByLabelText("icon: close-circle")); //clear "Customer" from property field
+    userEvent.click(getByPlaceholderText("Select the property type"));
+    userEvent.click(getByText("string"));
+    expect(screen.queryByLabelText("joinProperty-select")).toBeNull();
+
+    //Try selection of a structured type after selecting related entity type again, join property select should disappear
+    userEvent.click(getByLabelText("icon: close-circle")); //clear "string" from property field
+    userEvent.click(getByPlaceholderText("Select the property type"));
+    userEvent.click(getByText("Related Entity"));
+    userEvent.click(getAllByText("Customer")[1]);
+    expect(getByLabelText("joinProperty-select")).toBeInTheDocument();
+
+    userEvent.click(getByLabelText("icon: close-circle")); //clear "Customer" from property field
+    userEvent.click(getByPlaceholderText("Select the property type"));
+    userEvent.click(getByText("Structured"));
+    userEvent.click(getByText("Address"));
+    expect(screen.queryByLabelText("joinProperty-select")).toBeNull();
+
+    //Now go back to related entity type to populate
+    userEvent.click(getByLabelText("icon: close-circle")); //clear "Address" from property field
+    userEvent.click(getByPlaceholderText("Select the property type"));
+    userEvent.click(getByText("Related Entity"));
+    userEvent.click(getAllByText("Customer")[1]);
+
     // Choose join property after menu is populated
     userEvent.click(getByLabelText("joinProperty-select"));
-    expect(mockPrimaryEntityTypes).toBeCalledTimes(1);
+    expect(mockPrimaryEntityTypes).toBeCalledTimes(3);
     await wait(() => userEvent.click(getByText("customerId")));
 
     const multipleRadio = screen.getByLabelText("multiple-no");
@@ -328,7 +354,7 @@ describe("Property Modal Component", () => {
     expect(mockGetSystemInfo).toBeCalledTimes(1);
   });
 
-  test.only("Add a Property with relationship type to a structured type definition", async () => {
+  test("Add a Property with relationship type to a structured type definition", async () => {
     mockGetSystemInfo.mockResolvedValueOnce({status: 200, data: {}});
     // Mock population of Join Property menu
     mockPrimaryEntityTypes.mockResolvedValue({status: 200, data: curateData.primaryEntityTypes.data});

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.tsx
@@ -295,6 +295,7 @@ const PropertyModal: React.FC<Props> = (props) => {
       case "structured":
         newSelectedPropertyOptions.propertyType = PropertyType.Structured;
         newSelectedPropertyOptions.identifier = "";
+        toggleShowJoinProperty(false);
         //newSelectedPropertyOptions.wildcard = false;
         if (value[1] === "newPropertyType") {
           toggleStructuredTypeModal(true);
@@ -314,6 +315,7 @@ const PropertyModal: React.FC<Props> = (props) => {
         } else {
           setRadioValues(ALL_RADIO_DISPLAY_VALUES);
         }
+        toggleShowJoinProperty(false);
         toggleShowConfigurationOptions(true);
         break;
       default:
@@ -324,6 +326,7 @@ const PropertyModal: React.FC<Props> = (props) => {
         } else {
           setRadioValues(ALL_RADIO_DISPLAY_VALUES);
         }
+        toggleShowJoinProperty(false);
         toggleShowConfigurationOptions(true);
         break;
       }


### PR DESCRIPTION
…rty type to non-related entity type

### Description

- Fixed the bug where the required join property name still appears when selecting a related entity property type in Modeling and then backtracking to select a different property type.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

