### PR TITLE
DHFPROD-7439: Fix MLCP related tests

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub_integration/EndToEndFlowTests.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub_integration/EndToEndFlowTests.java
@@ -800,16 +800,10 @@ public class EndToEndFlowTests extends AbstractHubCoreTest {
         LegacyFlow flow = flowManager.getFlow(ENTITY, flowName, FlowType.INPUT);
         String inputPath = getResourceFile("e2e-test/input/input" + fileSuffix + "." + dataFormat.toString()).getAbsolutePath();
         String basePath = getResourceFile("e2e-test/input").getAbsolutePath();
-        String OS = System.getProperty("os.name").toLowerCase();
         String optionString;
         JsonNode mlcpOptions;
         try {
-        	if (OS.indexOf("win") >= 0) {
-        		optionString = toJsonString(options).replace("\"", "\\\\\\\"");
-        	}
-        	else {
-        		optionString = toJsonString(options).replace("\"", "\\\"");
-        	}
+            optionString = toJsonString(options).replace("\"", "\\\"");
             String optionsJson =
                 "{" +
                     "\"input_file_path\":\"" + inputPath.replace("\\", "\\\\\\\\") + "\"," +


### PR DESCRIPTION
### Description
We don't need to escape strings anymore after this change: https://github.com/marklogic/marklogic-data-hub/pull/5751

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [ ] JIRA_ID included in all the commit messages
- [ ] PR title is in the format JIRA_ID:Title
- [ ] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [N/A] Code passes ESLint tests
- [N/A] Added Tests
  

- ##### Reviewer:

- [N/A] Reviewed Tests

