### PR TITLE
DHFPROD-7421: Use Date instead of interval for calculating timeout

### DIFF
--- a/marklogic-data-hub-central/src/main/resources/application.properties
+++ b/marklogic-data-hub-central/src/main/resources/application.properties
@@ -14,7 +14,7 @@ mlHost=localhost
 server.servlet.session.persistent=false
 
 # Specify time in seconds
-server.servlet.session.timeout=600
+server.servlet.session.timeout=1200
 
 # Using special value '-1' causing the browser to keep sending the cookie for the duration of the "browser session".
 server.servlet.session.cookie.max-age=-1

--- a/marklogic-data-hub-central/ui/src/config/application.config.js
+++ b/marklogic-data-hub-central/ui/src/config/application.config.js
@@ -4,4 +4,4 @@ export const Application = {
 
 // Time when session warning pop up shows up
 export const SESSION_WARNING_COUNTDOWN = 30;
-export const MAX_SESSION_TIME = 600;
+export const MAX_SESSION_TIME = 1200;


### PR DESCRIPTION
### Description

Still needs extensive testing, but I believe getting away from the setInterval to track the timeout and using a Date instead will provide us with more accurate timing.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

