### PR TITLE
DHFPROD-7453: Not including mappingStep in getParameterValues

### DIFF
--- a/examples/reference-entity-model/README.md
+++ b/examples/reference-entity-model/README.md
@@ -69,7 +69,7 @@ object has a unique "name" property and an optional "description" property. This
 is loaded or saved in MarkLogic.
 1. getParameterValues is called each time the mapping step processes a batch of documents, which includes when the "Test" button 
 is used in the Hub Central mapping editor. This function receives a sequence of content objects that encapsulate the documents
-being processed and the mapping step. It must return a JSON object whose keys match the parameter "names" defined by getParameterDefinitions. 
+being processed. It must return a JSON object whose keys match the parameter "names" defined by getParameterDefinitions. 
 
 Typically, the value of each key in the JSON object returned by getParameterValues will be an object itself and will represent some 
 mapping between keys and values. In this example project, the getParameterValues function uses the content sequence to construct a mapping of

--- a/examples/reference-entity-model/src/main/ml-modules/root/custom-modules/mapping-params/example-mapping-params.sjs
+++ b/examples/reference-entity-model/src/main/ml-modules/root/custom-modules/mapping-params/example-mapping-params.sjs
@@ -1,20 +1,20 @@
 /**
- * This module is an example of a valid module for use in a mapping step as the value of the "mappingParametersModulePath" property.
+ * This module is an example of a valid module for use in a mapping step as the value of the "mappingParametersModulePath" property. 
  * It is referenced by the mapCustomersJSON.step.json mapping step.
- *
+ * 
  * A mapping parameters module must define the two functions shown below.
  */
 
 /**
- * This function must return an array of JSON objects, one for each parameter to be made available to the mapping expressions via the
- * "$" symbol. Each JSON object must define a "name" property, which is the name of the parameter that will be used in mapping expressions.
+ * This function must return an array of JSON objects, one for each parameter to be made available to the mapping expressions via the 
+ * "$" symbol. Each JSON object must define a "name" property, which is the name of the parameter that will be used in mapping expressions. 
  * Each object may also define an optional "description" property to provide a description of what this parameter represents.
- *
- * This function is called when a mapping step is loaded or saved in MarkLogic, and thus the mapping step is passed as an argument in case
- * a developer needs any information from it.
- *
- * @param mappingStep
- * @returns
+ * 
+ * This function is called when a mapping step is loaded or saved in MarkLogic, and thus the mapping step is passed as an argument in case 
+ * a developer needs any information from it. 
+ * 
+ * @param mappingStep 
+ * @returns 
  */
 function getParameterDefinitions(mappingStep) {
   return [
@@ -26,25 +26,24 @@ function getParameterDefinitions(mappingStep) {
 }
 
 /**
- * This function must return a JSON object that defines the parameter names and values based on the given sequence of content. The content sequence
- * represents the batch of documents being processed by the given mapping step. When using the "Test" feature in the Hub Central mapping editor, the content
- * sequence will consist of the source document against which the mapping is being tested.
- *
- * The reason the content sequence is included is so that a developer can optimize any queries that involve looking up data from MarkLogic indexes or
- * other documents. For example, in this project, the code below builds a JSON object for the "ZIP_POINTS" parameter that is based on values in two
- * MarkLogic indexes. Given that there are over 33,000 zip code documents in the staging database, it would be inefficient to retrieve all of the values.
- * But it would also be inefficient to call this code in a custom mapping function, once per document. For a batch of 100 documents, a custom mapping function
+ * This function must return a JSON object that defines the parameter names and values based on the given sequence of content. The content sequence 
+ * represents the batch of documents being processed by a mapping step. When using the "Test" feature in the Hub Central mapping editor, the content 
+ * sequence will consist of the source document against which the mapping is being tested. 
+ * 
+ * The reason the content sequence is included is so that a developer can optimize any queries that involve looking up data from MarkLogic indexes or 
+ * other documents. For example, in this project, the code below builds a JSON object for the "ZIP_POINTS" parameter that is based on values in two 
+ * MarkLogic indexes. Given that there are over 33,000 zip code documents in the staging database, it would be inefficient to retrieve all of the values. 
+ * But it would also be inefficient to call this code in a custom mapping function, once per document. For a batch of 100 documents, a custom mapping function 
  * would result in 100 queries. With the approach below, a single query is performed to find only the needed zipCode and geoPoint values based on the content
  * sequence.
- *
+ * 
  * While this code shows range indexes being used, a developer is free to implement any code desired. However, the only keys in the returned JSON object that will
- * be available for use in mapping expressions are those that are also defined by the getParameterDefinitions function above.
- *
+ * be available for use in mapping expressions are those that are also defined by the getParameterDefinitions function above. 
+ * 
  * @param contentSequence
- * @param mappingStep
- * @returns
+ * @returns 
  */
-function getParameterValues(contentSequence, mappingStep) {
+function getParameterValues(contentSequence) {
   const zipCodes = [];
   for (var contentObject of contentSequence) {
     contentObject.value.xpath("//Postal").toArray().forEach(code => {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/lib.sjs
@@ -388,7 +388,7 @@ function validateAndTestMapping(mapping, uri) {
       const contentSequence = Sequence.from([{"uri": uri, "value": sourceDocument}]);
       const moduleLib = require(modulePath);
       userParameterNames = moduleLib["getParameterDefinitions"](mapping).map(def => def.name);
-      userParameterMap = moduleLib["getParameterValues"](contentSequence, mapping);
+      userParameterMap = moduleLib["getParameterValues"](contentSequence);
     }
   } catch (error) {
     // Need to throw an HTTP error so that the testMapping endpoint returns a proper error

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/main.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/builtins/steps/mapping/entity-services/main.sjs
@@ -145,7 +145,7 @@ function buildUri(entityInstance, entityName, outputFormat){
 function getUserMappingParameterMap(stepExecutionContext, contentSequence) {
   if (stepExecutionContext != null) {
     const path = stepExecutionContext.flowStep.options.mappingParametersModulePath;
-    return path ? require(path)["getParameterValues"](contentSequence, stepExecutionContext.flowStep) : {};
+    return path ? require(path)["getParameterValues"](contentSequence) : {};
   }
   return {};
 }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping/user-parameters/test-data/bad-get-parameter-values.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping/user-parameters/test-data/bad-get-parameter-values.sjs
@@ -6,7 +6,7 @@ function getParameterDefinitions(mappingStep) {
   ];
 }
 
-function getParameterValues(contentSequence, mappingStep) {
+function getParameterValues(contentSequence) {
   throw Error("Throwing error on purpose");
 }
 

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping/user-parameters/test-data/user-params.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping/user-parameters/test-data/user-params.sjs
@@ -13,11 +13,7 @@ function getParameterDefinitions(mappingStep) {
   ];
 }
 
-function getParameterValues(contentSequence, mappingStep) {
-  if (!mappingStep) {
-    throw Error("A mappingStep should be included when getParameterValues is called");
-  }
-
+function getParameterValues(contentSequence) {
   // Just verifying that we can iterate over the sequence
   for (var ignore of contentSequence) {
   }


### PR DESCRIPTION
### Description

The problem is that the structure of mappingStep differs based on whether the "Test" GUI button is used or when the mapping step is run. Something to resolve later when we're not about to release. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

