### PR TITLE
DHFPROD-7397: Make it clear custom hooks are deprecated in Hub Central

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.module.scss
@@ -175,3 +175,12 @@ span.readOnlyLabel {
 .alertMessage {
     font-weight: bold;
 }
+
+.deprecatedLabel {
+    font-size: 9px;
+    color: #B32424;
+    border: 1px solid #B32424;
+    border-radius: 4px;
+    margin-left: 0.5vw;
+    padding: 3px;
+}

--- a/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.scss
+++ b/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.scss
@@ -7,3 +7,7 @@
     width: 173px;
     margin-left: 450px;
 }
+
+.ant-form-item-label {
+    overflow: inherit;
+}

--- a/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.test.tsx
@@ -57,6 +57,8 @@ describe("Advanced step settings", () => {
 
     fireEvent.click(getByText("Custom Hook"));
     expect(getByText("{ \"hook\": true }")).toBeInTheDocument();
+    fireEvent.mouseOver(getByText("DEPRECATED"));
+    await wait(() =>  expect(getByText(AdvancedSettingsTooltips.customHookDeprecated)).toBeInTheDocument());
 
   });
 
@@ -95,6 +97,8 @@ describe("Advanced step settings", () => {
 
     fireEvent.click(getByText("Custom Hook"));
     expect(getByText("{ \"hook\": true }")).toBeInTheDocument();
+    fireEvent.mouseOver(getByText("DEPRECATED"));
+    await wait(() =>  expect(getByText(AdvancedSettingsTooltips.customHookDeprecated)).toBeInTheDocument());
 
     expect(getByPlaceholderText("Please enter additional settings")).toBeInTheDocument();
     expect(getByPlaceholderText("Please enter additional settings")).toBeEnabled();
@@ -143,6 +147,8 @@ describe("Advanced step settings", () => {
 
     fireEvent.click(getByText("Custom Hook"));
     expect(getByText("{ \"hook\": true }")).toBeInTheDocument();
+    fireEvent.mouseOver(getByText("DEPRECATED"));
+    await wait(() =>  expect(getByText(AdvancedSettingsTooltips.customHookDeprecated)).toBeInTheDocument());
 
   });
 
@@ -169,12 +175,16 @@ describe("Advanced step settings", () => {
 
     expect(getByText("Interceptors")).toBeInTheDocument();
     expect(getByText("Custom Hook")).toBeInTheDocument();
+    fireEvent.mouseOver(getByText("DEPRECATED"));
+    await wait(() =>  expect(getByText(AdvancedSettingsTooltips.customHookDeprecated)).toBeInTheDocument());
 
     fireEvent.click(getByText("Interceptors"));
     expect((await(waitForElement(() => getByText("{ \"interceptor\": true }"))))).toBeInTheDocument();
 
     fireEvent.click(getByText("Custom Hook"));
     expect(getByText("{ \"hook\": true }")).toBeInTheDocument();
+    fireEvent.mouseOver(getByText("DEPRECATED"));
+    await wait(() =>  expect(getByText(AdvancedSettingsTooltips.customHookDeprecated)).toBeInTheDocument());
 
   });
 
@@ -247,6 +257,8 @@ describe("Advanced step settings", () => {
 
     fireEvent.click(getByText("Custom Hook"));
     expect(getByText("{ \"hook\": true }")).toBeInTheDocument();
+    fireEvent.mouseOver(getByText("DEPRECATED"));
+    await wait(() =>  expect(getByText(AdvancedSettingsTooltips.customHookDeprecated)).toBeInTheDocument());
 
   });
 
@@ -338,6 +350,8 @@ describe("Advanced step settings", () => {
     fireEvent.click(getByText("Custom Hook"));
     fireEvent.change(getByLabelText("customHook-textarea"), {target: {value: "hook-changed"}});
     expect(getByLabelText("customHook-textarea")).toHaveValue("hook-changed");
+    fireEvent.mouseOver(getByText("DEPRECATED"));
+    await wait(() =>  expect(getByText(AdvancedSettingsTooltips.customHookDeprecated)).toBeInTheDocument());
 
   });
 

--- a/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.tsx
+++ b/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.tsx
@@ -869,6 +869,7 @@ const AdvancedSettings: React.FC<Props> = (props) => {
               rotate={customHookExpanded ? 90 : 0}
             />
             <span className={styles.expandLabel} onClick={() => setCustomHookExpanded(!customHookExpanded)}>Custom Hook</span>
+            <MLTooltip title={tooltips.customHookDeprecated} placement={"right"}><span className={styles.deprecatedLabel}>DEPRECATED</span></MLTooltip>
           </span>}
           labelAlign="left"
           className={styles.formItem}

--- a/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
+++ b/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
@@ -484,6 +484,7 @@ const AdvancedSettingsTooltips = {
   options: 'Key-value pairs to pass as parameters to the custom module.',
   customModuleURI: 'The path to your custom step module.',
   batchSize : 'The maximum number of items to process in a batch.',
+  customHookDeprecated: 'Custom hooks are deprecated and will be removed in a future version. Please use interceptors instead.',
 
   /* TO BE DEPRECATED. Please use SecurityTooltips.missingPermission. */
   missingPermission: 'Contact your security administrator for access.',


### PR DESCRIPTION
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

