### PR TITLE
DHFPROD-7454: Default Merge Strategies in Hub Central

### DIFF
--- a/marklogic-data-hub-central/ui/src/assets/mock-data/curation/merging.data.ts
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/curation/merging.data.ts
@@ -54,6 +54,7 @@ export const mergingStep = {
         },
         {
           strategyName: "testMerge",
+          default: true,
           mergeModulePath: "/custom/merge/strategy.sjs",
           mergeModuleFunction: "testMergeFunction",
           mergeModuleNamespace: "",

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merge-strategy-dialog/merge-strategy-dialog.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merge-strategy-dialog/merge-strategy-dialog.module.scss
@@ -3,6 +3,7 @@
     font-size :24px;
     font-weight: 500;
 }
+
 .submitButtonsForm {
     margin-top: 20px;
     display: flex;

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merge-strategy-dialog/merge-strategy-dialog.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merge-strategy-dialog/merge-strategy-dialog.test.tsx
@@ -66,6 +66,7 @@ describe("Merge Strategy Dialog component", () => {
       <CurationContext.Provider value={customerMergingStep}>
         <MergeStrategyDialog
           {...data.mergeStrategyDataProps}
+          isEditStrategy={false}
         />
       </CurationContext.Provider>
     );
@@ -74,6 +75,51 @@ describe("Merge Strategy Dialog component", () => {
     expect(screen.queryByLabelText("confirm-body")).toBeNull();
     expect(data.mergeStrategyDataProps.setOpenEditMergeStrategyDialog).toHaveBeenCalledTimes(1);
     expect(mockMergingUpdate).toHaveBeenCalledTimes(0);
+  });
+
+  it("Verify Add/Edit Merge Strategy dialog shows default strategy and error message ", async () => {
+    mockMergingUpdate.mockResolvedValueOnce({status: 200, data: {}});
+    const {getByText, getByLabelText, queryByLabelText, rerender} = render(
+      <CurationContext.Provider value={customerMergingStep}>
+        <MergeStrategyDialog
+          {...data.mergeStrategyDataProps}
+          isEditStrategy={false}
+        />
+      </CurationContext.Provider>
+    );
+
+    //testing Add strategy scenario
+    expect(getByText("Add Strategy")).toBeInTheDocument();
+
+    expect(getByText("Default Strategy?")).toBeInTheDocument();
+    //default strategy radio button should be set to "No" by default
+    let radio = getByLabelText("No");
+    expect(radio["value"]).toBe("2");
+
+    expect(queryByLabelText("default-strategy-error")).not.toBeInTheDocument();
+    //selecting "Yes" when there is an existing default strategy should prompt error message
+    fireEvent.click(getByLabelText("Yes"));
+    expect(getByLabelText("default-strategy-error")).toBeInTheDocument();
+
+    //rerender to test edit scenario
+    rerender(<CurationContext.Provider value={customerMergingStep}>
+      <MergeStrategyDialog
+        {...data.mergeStrategyDataProps}
+        strategyName={"myFavouriteSource"}
+      />
+    </CurationContext.Provider>);
+
+    expect(getByText("Edit Strategy")).toBeInTheDocument();
+
+    expect(getByText("Default Strategy?")).toBeInTheDocument();
+    //default strategy radio button should be set to "No" by default
+    radio = getByLabelText("No");
+    expect(radio["value"]).toBe("2");
+
+    //selecting "Yes" when there is an existing default strategy should prompt error message
+    fireEvent.click(getByLabelText("Yes"));
+    expect(getByLabelText("default-strategy-error")).toBeInTheDocument();
+
   });
 
   it("Verify Edit Merge Strategy dialog renders correctly with priority order options", () => {

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.module.scss
@@ -62,6 +62,12 @@
     cursor: not-allowed;
 }
 
+.defaultIcon{
+    color: green;
+    margin-left: 15px;
+    font-size: 20px;
+}
+
 .enabledDeleteIcon{
     color:#B32424
 }

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.test.tsx
@@ -48,7 +48,7 @@ describe("Merging Step Detail view component", () => {
 
   it("can render merging step with merge strategies and rulesets", async () => {
 
-    const {getByText, getAllByText, getByLabelText, getByTestId} = render(
+    const {getByText, getAllByText, getByLabelText, getByTestId, queryByTestId} = render(
       <CurationContext.Provider value={customerMergingStep}>
         <MergingStepDetail />
       </CurationContext.Provider>
@@ -77,10 +77,15 @@ describe("Merging Step Detail view component", () => {
     expect((await(waitForElement(() => getByText(multiSliderTooltips.viewOnlyTooltip))))).toBeInTheDocument();
 
     //Verify merge rules table is rendered with data
-    // Check table column headers are rendered
+    //Check table column headers are rendered
     expect(getByText("Property")).toBeInTheDocument();
     expect(getByText("Merge Type")).toBeInTheDocument();
     expect(getByText("Strategy")).toBeInTheDocument();
+    expect(getByText("Default")).toBeInTheDocument();
+
+    //Verify default icon is rendered for only default strategy
+    expect(getByTestId("default-testMerge-icon")).toBeInTheDocument();
+    expect(queryByTestId("default-customMergeStrategy-icon")).not.toBeInTheDocument();
 
     //check table data is rendered correctly
     expect(getByText("name")).toBeInTheDocument();

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../../../types/curation-types";
 import {MergeStrategyTooltips, MergingStepDetailText, multiSliderTooltips} from "../../../../config/tooltips.config";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faTrashAlt} from "@fortawesome/free-solid-svg-icons";
+import {faTrashAlt, faCheck} from "@fortawesome/free-solid-svg-icons";
 import MultiSlider from "../../matching/multi-slider/multi-slider";
 import MergeStrategyDialog from "../merge-strategy-dialog/merge-strategy-dialog";
 import MergeRuleDialog from "../add-merge-rule/merge-rule-dialog";
@@ -148,6 +148,18 @@ const MergingStepDetail: React.FC = () => {
       width: 200,
     },
     {
+      title: "Default",
+      dataIndex: "default",
+      key: "default",
+      sortDirections: ["ascend", "descend", "ascend"],
+      sorter: (a, b) => {
+        a = a.maxSources || "";
+        b = b.maxSources || "";
+        return a.localeCompare(b);
+      },
+      width: 200,
+    },
+    {
       title: "Delete",
       dataIndex: "delete",
       key: "delete",
@@ -228,6 +240,7 @@ const MergingStepDetail: React.FC = () => {
         strategyName: i["strategyName"],
         maxValues: i["maxValues"],
         maxSources: i["maxSources"],
+        default: i["default"] === true ? <FontAwesomeIcon className={styles.defaultIcon} icon={faCheck} data-testid={"default-" + i["strategyName"] + "-icon"} /> : null,
         priorityOrder: i.hasOwnProperty("priorityOrder") ? true : false,
         delete: <MLTooltip title={commonStrategyNames.indexOf(i["strategyName"]) !==-1 ? MergeStrategyTooltips.delete : ""}>
           <FontAwesomeIcon


### PR DESCRIPTION
### Description

- UI support for ability to set a merge strategy as "default", with error messages if there is already an existing default strategy
- New column in step details that shows which strategy is currently the default one with a check mark
- Functionality: https://drive.google.com/file/d/121e4uv-toQgrLkxLEoVVfYAiJUJJ9U_C/view

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

