### PR TITLE
DHFPROD-7511: Added pom stuff for marklogic-data-hub-junit5

### DIFF
--- a/marklogic-data-hub-junit5/build.gradle
+++ b/marklogic-data-hub-junit5/build.gradle
@@ -39,10 +39,56 @@ task sourcesJar(type: Jar, dependsOn: classes) {
     from sourceSets.main.allJava
 }
 
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    archiveClassifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+Node pomCustomizations = new NodeBuilder().project {
+    name 'marklogic-data-hub-junit5'
+    packaging 'jar'
+    textdescription 'Supports testing Data Hub applications via JUnit5'
+    url 'https://github.com/marklogic/marklogic-data-hub'
+    scm {
+        url 'git@github.com:marklogic/marklogic-data-hub.git'
+        connection 'scm:git@github.com:marklogic/marklogic-data-hub.git'
+        developerConnection 'scm:git@github.com:marklogic/marklogic-data-hub.git'
+    }
+    licenses {
+        license {
+            name 'The Apache Software License, Version 2.0'
+            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+        }
+    }
+    developers {
+        developer {
+            name 'MarkLogic'
+            email 'java-sig@marklogic.com'
+            organization 'MarkLogic'
+            organizationUrl 'https://www.marklogic.com'
+        }
+        developer {
+            name 'MarkLogic Github Contributors'
+            email 'general@developer.marklogic.com'
+            organization 'Github Contributors'
+            organizationUrl 'https://github.com/marklogic/marklogic-data-hub/graphs/contributors'
+        }
+    }
+}
+
 publishing {
     publications {
         mainJava(MavenPublication) {
             from components.java
+            pom.withXml {
+                asNode().appendNode('description', pomCustomizations.textdescription.text())
+                asNode().append(pomCustomizations.developers)
+                asNode().append(pomCustomizations.name)
+                asNode().append(pomCustomizations.packaging)
+                asNode().append(pomCustomizations.url)
+                asNode().append(pomCustomizations.scm)
+                asNode().append(pomCustomizations.licenses)
+            }
         }
         sourcesJava(MavenPublication) {
             from components.java


### PR DESCRIPTION
### Description

This is just porting the fix to the develop branch. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
 