### PR TITLE
DHFPROD-7449: Scroll to respective tables when pagination is applied

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/relatedEntityMapping.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/relatedEntityMapping.spec.tsx
@@ -245,4 +245,16 @@ describe("Mapping", () => {
     //Related entity does not exist after reopening step
     mappingStepDetail.entityTitle("Relation (relatedTo Person)").should("not.exist");
   });
+
+  it("Verify page automically scrolls to top of table after pagination", () => {
+    cy.waitUntil(() => mappingStepDetail.relatedFilterMenu("Person")).click();
+    cy.waitUntil(() => mappingStepDetail.getRelatedEntityFromList("Relation (relatedTo Person)")).click();
+    cy.get("#entityContainer").scrollTo("bottom",  {ensureScrollable: false});
+    mappingStepDetail.entityTitle("Person").should("not.be.visible");
+    browsePage.getPaginationPageSizeOptions().then(attr => {
+      attr[1].click();
+    });
+    browsePage.getPageSizeOption("10 / page").click();
+    mappingStepDetail.entityTitle("Person").should("be.visible");
+  });
 });

--- a/marklogic-data-hub-central/ui/package-lock.json
+++ b/marklogic-data-hub-central/ui/package-lock.json
@@ -17562,6 +17562,11 @@
         "dequal": "^1.0.0"
       }
     },
+    "use-dynamic-refs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/use-dynamic-refs/-/use-dynamic-refs-1.0.0.tgz",
+      "integrity": "sha512-1Ky+Jaj6MIpTRz6NTaCLVm/iDXfRNwUMH9X7BkLtgSL2RCXHQhK2p9SVhut8jZPDfxLDtOIYNM3txsiLXd4yVQ=="
+    },
     "use-sidecar": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.2.tgz",

--- a/marklogic-data-hub-central/ui/package.json
+++ b/marklogic-data-hub-central/ui/package.json
@@ -55,6 +55,7 @@
     "stompjs": "^2.3.3",
     "typescript": "^3.8.0",
     "use-deep-compare-effect": "^1.3.1",
+    "use-dynamic-refs": "^1.0.0",
     "xml-formatter": "^2.4.0"
   },
   "scripts": {

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.tsx
@@ -12,11 +12,13 @@ import {faKey, faLayerGroup} from "@fortawesome/free-solid-svg-icons";
 import arrayIcon from "../../../../assets/icon_array.png";
 import {css} from "@emotion/css";
 import {getParentKey, getKeys, deepCopy} from "../../../../util/data-conversion";
-import {paginationOptions} from "../../../../config/mapping.config";
+import {paginationMapping} from "../../../../config/mapping.config";
 import {ModelingTooltips, MappingDetailsTooltips} from "../../../../config/tooltips.config";
 import StepsConfig from "../../../../config/steps.config";
 
 interface Props {
+  setScrollRef: any;
+  executeScroll: any;
   mapResp: any;
   mapData: any;
   setMapResp: any;
@@ -208,6 +210,17 @@ const EntityMapTable: React.FC<Props> = (props) => {
 
   /*  The source context is updated when mapping is saved/loaded, this function does a level order traversal of entity
      json and updates the sourceContext for every entity property */
+
+  const paginationFunction = {
+    defaultCurrent: paginationMapping.defaultCurrent,
+    defaultPageSize: paginationMapping.defaultPageSize,
+    hideOnSinglePage: paginationMapping.hideOnSinglePage,
+    pageSizeOptions: paginationMapping.pageSizeOptions,
+    showSizeChanger: paginationMapping.showSizeChanger,
+    size: paginationMapping.size,
+    onChange: (e) => { props.executeScroll(`${props.entityMappingId}-ref`); },
+    onShowSizeChange: (e) => { props.executeScroll(`${props.entityMappingId}-ref`); }
+  };
 
   const updateSourceContext = (mapExp, entityTable) => {
 
@@ -1365,7 +1378,7 @@ const EntityMapTable: React.FC<Props> = (props) => {
   });
 
   return (props.entityLoaded ? (props.entityMappingId || !props.isRelatedEntity) ? (<div id={props.isRelatedEntity? "entityTableContainer" : "rootTableContainer"} data-testid={props.entityTypeTitle.split(" ")[0].toLowerCase() + "-table"}>
-    <div id={entityProperties.length > 0 ? "upperTable" : "upperTableEmptyProps"}>
+    <div id={entityProperties.length > 0 ? "upperTable" : "upperTableEmptyProps"} ref={props.setScrollRef(`${props.entityMappingId}-ref`)}>
       <Table
         pagination={false}
         className={tableCSS}
@@ -1387,7 +1400,7 @@ const EntityMapTable: React.FC<Props> = (props) => {
     {entityProperties.length > 0 ?
       <div id="lowerTable">
         <Table
-          pagination={paginationOptions}
+          pagination={paginationFunction}
           className={tableCSS}
           expandIcon={(props) => customExpandIcon(props)}
           onExpand={(expanded, record) => toggleRowExpanded(expanded, record, "key")}

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.test.tsx
@@ -1646,6 +1646,7 @@ describe("RTL Source-to-entity map tests", () => {
     mockGetUris.mockResolvedValue({status: 200, data: ["/dummy/uri/person-101.json"]});
     mockGetSourceDoc.mockResolvedValue({status: 200, data: data.jsonSourceDataLargeDataset});
     mockGetNestedEntities.mockResolvedValue({status: 200, data: personRelatedEntityDefLargePropSet});
+    window.HTMLElement.prototype.scrollIntoView = function() {};
 
     let getByText, queryByText, getByTestId, getByTitle, getAllByTitle, queryByTitle, getByLabelText, queryByTestId, getAllByText;
     await act(async () => {

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.tsx
@@ -26,7 +26,8 @@ import arrayIcon from "../../../../assets/icon_array.png";
 import relatedEntityIcon from "../../../../assets/icon_related_entities.png";
 import CustomPageHeader from "../../page-header/page-header";
 import {clearSessionStorageOnRefresh, getViewSettings, setViewSettings} from "../../../../util/user-context";
-import {paginationOptions, mappingColors} from "../../../../config/mapping.config";
+import {paginationMapping, mappingColors} from "../../../../config/mapping.config";
+import useDynamicRefs from "use-dynamic-refs";
 
 const DEFAULT_MAPPING_STEP: MappingStep = {
   name: "",
@@ -145,6 +146,14 @@ const MappingStepDetail: React.FC = () => {
   const [sourceFormat, setSourceFormat] = useState("");
   const [docNotFound, setDocNotFound] = useState(false);
   const [mapData, setMapData] = useState<any>(DEFAULT_MAPPING_STEP);
+  const [getRef, setRef] =  useDynamicRefs();
+
+  const executeScroll = (refId) => {
+    const scrollToRef : any = getRef(refId);
+    if (scrollToRef && scrollToRef.current) {
+      scrollToRef.current.scrollIntoView();
+    }
+  };
 
   let tableColors = [...mappingColors];
 
@@ -1399,7 +1408,7 @@ const MappingStepDetail: React.FC = () => {
                       <span className={styles.sourceCollapseButtons}><ExpandCollapse handleSelection={(id) => handleSourceExpandCollapse(id)} currentSelection={""} /></span>
                     </div>
                     <Table
-                      pagination={paginationOptions}
+                      pagination={paginationMapping}
                       expandIcon={(props) => customExpandIcon(props)}
                       onExpand={(expanded, record) => toggleSourceRowExpanded(expanded, record, "rowKey")}
                       expandedRowKeys={sourceExpandedKeys}
@@ -1431,6 +1440,8 @@ const MappingStepDetail: React.FC = () => {
                 <span className={styles.columnOptionsSelector}>{columnOptionsSelector}</span>
               </div>
               <EntityMapTable
+                setScrollRef = {setRef}
+                executeScroll = {executeScroll}
                 mapResp={mapResp}
                 mapData={mapData}
                 setMapResp={setMapResp}
@@ -1471,8 +1482,10 @@ const MappingStepDetail: React.FC = () => {
                 labelRemoved = {labelRemoved}
                 entityLoaded = {entityLoaded}
               />
-              {relatedEntityTypeProperties.map(entity => relatedEntitiesSelected.map(selectedEntity => selectedEntity.entityMappingId).includes(entity.entityMappingId) ?
+              {relatedEntityTypeProperties.map((entity, i) => relatedEntitiesSelected.map(selectedEntity => selectedEntity.entityMappingId).includes(entity.entityMappingId) ?
                 <EntityMapTable
+                  setScrollRef = {setRef}
+                  executeScroll = {executeScroll}
                   mapResp={mapResp}
                   mapData={mapData}
                   setMapResp={setMapResp}

--- a/marklogic-data-hub-central/ui/src/config/mapping.config.js
+++ b/marklogic-data-hub-central/ui/src/config/mapping.config.js
@@ -1,4 +1,4 @@
-export const paginationOptions = {
+export const paginationMapping = {
   defaultCurrent: 1,
   defaultPageSize: 20,
   hideOnSinglePage: false,


### PR DESCRIPTION
### Description
- Automatic scrolling to the top of the respective table that had pagination applied to it (fixes issues where sometimes tables would be out of sight due to page size changing and scrollbar not following)
- Added dynamic refs library to dynamically create and assign specific refs to scroll to on each table.
- Demo here: https://drive.google.com/file/d/1gQoLP-Cy9FctItmNU6_AlgLmJCpUc6jv/view
- Will create a second PR for 5.5-develop branch once this is merged.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

