### PR TITLE
DHFPROD-7434: View entity type from entity model graph view

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/reader.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/reader.spec.tsx
@@ -4,6 +4,8 @@ import modelPage from "../../support/pages/model";
 import {
   entityTypeModal,
   entityTypeTable,
+  graphView,
+  graphViewSidePanel,
   propertyModal,
   propertyTable,
 } from "../../support/components/model/index";
@@ -88,5 +90,25 @@ describe("Entity Modeling: Reader Role", () => {
 
     propertyTable.getDeleteStructuredPropertyIcon("Customer", "Zip", "zip-fiveDigit").click({force: true});
     confirmationModal.getDeletePropertyStepWarnText().should("not.exist");
+  });
+
+  it("can navigate to graph view from table view", () => {
+    // Should be updated once the dummy entity links are replaced by actual graph nodes.
+    entityTypeTable.viewEntityInGraphView("Customer").click({force: true});
+    graphView.getFilterInput().should("be.visible");
+    graphView.getAddEntityButton().should("be.visible");
+    graphView.getPublishToDatabaseButton().should("be.visible");
+    graphView.getExportGraphIcon().should("be.visible");
+    graphViewSidePanel.getSelectedEntityHeading("Customer").should("be.visible");
+    graphViewSidePanel.getPropertiesTab().should("be.visible");
+    graphViewSidePanel.getEntityTypeTab().should("be.visible");
+    graphViewSidePanel.getDeleteIcon("Customer").should("be.visible");
+
+    graphViewSidePanel.closeSidePanel();
+    graphViewSidePanel.getSelectedEntityHeading("Customer").should("not.exist");
+
+    modelPage.selectView("table");
+    entityTypeTable.viewEntityInGraphView("Person").click({force: true});
+    graphViewSidePanel.getSelectedEntityHeading("Person").should("be.visible");
   });
 });

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/entity-type-table.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/entity-type-table.tsx
@@ -48,6 +48,10 @@ class EntityTypeTable {
   waitForTableToLoad() {
     cy.waitUntil(() => cy.get(".ant-table-row").should("have.length.gt", 0));
   }
+
+  viewEntityInGraphView(entityName: string) {
+    return cy.findByTestId(`${entityName}-graphView-icon`);
+  }
 }
 
 const entityTypeTable = new EntityTypeTable();

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/graph-view-side-panel.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/graph-view-side-panel.tsx
@@ -1,0 +1,24 @@
+class GraphViewSidePanel {
+  getSelectedEntityHeading(entityName: string) {
+    return cy.findByLabelText(`${entityName}-selectedEntity`);
+  }
+
+  getDeleteIcon(entityName: string) {
+    return cy.findByTestId(`${entityName}-delete`);
+  }
+
+  closeSidePanel() {
+    return cy.findByLabelText("closeGraphViewSidePanel").trigger("mouseover").click();
+  }
+
+  getPropertiesTab() {
+    return cy.findByLabelText("propertiesTabInSidePanel");
+  }
+
+  getEntityTypeTab() {
+    return cy.findByLabelText("entityTypeTabInSidePanel");
+  }
+}
+
+const graphViewSidePanel = new GraphViewSidePanel();
+export default graphViewSidePanel;

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/graph-view.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/graph-view.tsx
@@ -1,0 +1,20 @@
+class GraphView {
+  getFilterInput() {
+    return cy.findByLabelText("graph-view-filter-input");
+  }
+
+  getAddEntityButton() {
+    return cy.findByLabelText("add-entity-type-relationship");
+  }
+
+  getPublishToDatabaseButton() {
+    return cy.findByLabelText("publish-to-database");
+  }
+
+  getExportGraphIcon() {
+    return cy.findByLabelText("graph-export");
+  }
+}
+
+const graphView = new GraphView();
+export default graphView;

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/index.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/index.tsx
@@ -3,6 +3,8 @@ import entityTypeTable from "./entity-type-table";
 import propertyModal from "./property-modal";
 import propertyTable from "./property-table";
 import structuredTypeModal from "./structured-type-modal";
+import graphViewSidePanel from "./graph-view-side-panel";
+import graphView from "./graph-view";
 
 
 export {
@@ -10,5 +12,7 @@ export {
   entityTypeTable,
   propertyModal,
   propertyTable,
-  structuredTypeModal
+  structuredTypeModal,
+  graphView,
+  graphViewSidePanel
 };

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/modeling/modeling-context-mock.js
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/modeling/modeling-context-mock.js
@@ -35,13 +35,68 @@ export const isModified = {
           }
         }
       }
-    ]
+    ],
+    view: "graph",
+    selectedEntity: "Order"
   },
   toggleIsModified: jest.fn(),
   setEntityTypeNamesArray: jest.fn(),
   updateEntityModified: jest.fn(),
   removeEntityModified: jest.fn(),
-  clearEntityModified: jest.fn()
+  clearEntityModified: jest.fn(),
+  setView: jest.fn(),
+  setSelectedEntity: jest.fn(),
+  setGraphViewOptions: jest.fn()
+};
+
+export const isModifiedTableView = {
+  modelingOptions: {
+    isModified: true,
+    entityTypeNamesArray: ["Order"],
+    modifiedEntitiesArray: [
+      {
+        "entityName": "Order",
+        "modelDefinition": {
+          "Order": {
+            "required": [],
+            "pii": [
+              "someProperty"
+            ],
+            "elementRangeIndex": [
+              "someProperty"
+            ],
+            "rangeIndex": [
+              "someOtherProperty"
+            ],
+            "properties": {
+              "someProperty": {
+                "datatype": "string",
+                "collation": "http://marklogic.com/collation/codepoint"
+              },
+              "someOtherProperty": {
+                "datatype": "string",
+                "collation": "http://marklogic.com/collation/codepoint"
+              },
+              "zip": {
+                "datatype": "string",
+                "collation": "http://marklogic.com/collation/codepoint"
+              }
+            }
+          }
+        }
+      }
+    ],
+    view: "table",
+    selectedEntity: "Order"
+  },
+  toggleIsModified: jest.fn(),
+  setEntityTypeNamesArray: jest.fn(),
+  updateEntityModified: jest.fn(),
+  removeEntityModified: jest.fn(),
+  clearEntityModified: jest.fn(),
+  setView: jest.fn(),
+  setSelectedEntity: jest.fn(),
+  setGraphViewOptions: jest.fn()
 };
 
 export const notModified = {
@@ -50,7 +105,23 @@ export const notModified = {
   },
   clearEntityModified: jest.fn(),
   toggleIsModified: jest.fn(),
-  setEntityTypeNamesArray: jest.fn()
+  setEntityTypeNamesArray: jest.fn(),
+  setView: jest.fn(),
+  setSelectedEntity: jest.fn(),
+  setGraphViewOptions: jest.fn()
+};
+
+export const notModifiedTableView = {
+  modelingOptions: {
+    isModified: false,
+    view: "table"
+  },
+  clearEntityModified: jest.fn(),
+  toggleIsModified: jest.fn(),
+  setEntityTypeNamesArray: jest.fn(),
+  setView: jest.fn(),
+  setSelectedEntity: jest.fn(),
+  setGraphViewOptions: jest.fn()
 };
 
 export const entityNamesArray = {

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.module.scss
@@ -1,5 +1,5 @@
 
-.iconRevert, .iconTrash {
+.iconRevert, .iconTrash, .iconViewGraph {
   font-size: 21px;
   cursor: pointer;
   margin-right: 8px;

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.test.tsx
@@ -461,6 +461,37 @@ describe("EntityTypeModal Component", () => {
     expect(container.querySelector(".ant-pagination")).toBeNull();
   });
 
+  test("can mock navigation to graph view", async () => {
+    mockEntityReferences.mockResolvedValueOnce({status: 200, data: referencePayloadEmpty});
+    mockDeleteEntity.mockResolvedValueOnce({status: 200});
+
+    const updateMock = jest.fn();
+
+    const {getByTestId} =  render(
+      <ModelingContext.Provider value={isModified}>
+        <Router>
+          <EntityTypeTable
+            allEntityTypesData={getEntityTypes}
+            canReadEntityModel={true}
+            canWriteEntityModel={true}
+            autoExpand=""
+            editEntityTypeDescription={jest.fn()}
+            updateEntities={updateMock}
+            revertAllEntity={false}
+            toggleRevertAllEntity={jest.fn()}
+            updateSavedEntity={jest.fn()}
+          />
+        </Router>
+      </ModelingContext.Provider>
+    );
+
+    // check if graph view icon tooltip appears
+    fireEvent.mouseOver(getByTestId("Order-graphView-icon"));
+    await wait(() => expect(screen.getByText(ModelingTooltips.viewGraph)).toBeInTheDocument());
+
+    userEvent.click(getByTestId("Order-graphView-icon"));
+    expect(isModified.setGraphViewOptions).toBeCalledWith({view: "graph", selectedEntity: "Order"});
+  });
 
 });
 

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useEffect, useContext} from "react";
 import {Link} from "react-router-dom";
 import {MLTable, MLTooltip} from "@marklogic/design-system";
-import {faUndo, faTrashAlt, faSave} from "@fortawesome/free-solid-svg-icons";
+import {faUndo, faTrashAlt, faSave, faProjectDiagram} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import styles from "./entity-type-table.module.scss";
 
@@ -33,7 +33,7 @@ const EntityTypeTable: React.FC<Props> = (props) => {
   const expandedRowStorage = storage?.model?.entityExpandedRows;
 
   const {handleError} = useContext(UserContext);
-  const {modelingOptions, removeEntityModified, clearEntityModified} = useContext(ModelingContext);
+  const {modelingOptions, removeEntityModified, clearEntityModified, setGraphViewOptions} = useContext(ModelingContext);
   const [expandedRows, setExpandedRows] = useState<string[]>(expandedRowStorage ? expandedRowStorage : []);
   const [allEntityTypes, setAllEntityTypes] = useState<any[]>([]);
 
@@ -225,6 +225,10 @@ const EntityTypeTable: React.FC<Props> = (props) => {
     }
   };
 
+  const navigateToGraphView = (entityName) => {
+    setGraphViewOptions({view: "graph", selectedEntity: entityName});
+  };
+
   const columns = [
     {
       title: <span data-testid="entityName">Name</span>,
@@ -372,6 +376,14 @@ const EntityTypeTable: React.FC<Props> = (props) => {
                   }
                 }}
                 size="2x"
+              />
+            </MLTooltip>
+            <MLTooltip title={ModelingTooltips.viewGraph} overlayStyle={{maxWidth: "225px"}}>
+              <FontAwesomeIcon
+                data-testid={text + "-graphView-icon"}
+                className={styles.iconViewGraph}
+                icon={faProjectDiagram}
+                onClick={() => navigateToGraphView(text)}
               />
             </MLTooltip>
             <MLTooltip title={props.canWriteEntityModel ? ModelingTooltips.deleteIcon : "Delete Entity: " + SecurityTooltips.missingPermission} overlayStyle={{maxWidth: "225px"}}>

--- a/marklogic-data-hub-central/ui/src/components/modeling/graph-view/graph-view.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/modeling/graph-view/graph-view.module.scss
@@ -1,5 +1,5 @@
 .graphViewContainer {
-    padding: 10px 0px 0px 0px;
+    padding: 10px 10px 0px 0px;
 
     .graphHeader {
         display: flex;
@@ -58,3 +58,26 @@
         color: #bfbfbf;
     }
 }
+
+.resizerStyle {
+  border: 1px solid rgba(1, 22, 39, 0.21);
+  cursor: col-resize;
+  height: auto;
+  margin-top: 10px;
+  min-height: 60vh;
+};
+
+.resizerStyle::before {
+  content: '| |';
+  position: absolute;
+  top: 50%;
+  padding: 0 8px;
+  transform: translate(-50%, -50%);
+  background-color: transparent;
+  color: #CCCCCC;
+  line-height: 16px;
+  font-size: 16px;
+  letter-spacing: 0px;
+  display: inline-block;
+}
+

--- a/marklogic-data-hub-central/ui/src/components/modeling/graph-view/graph-view.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/graph-view/graph-view.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import {render, screen, wait, cleanup} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import GraphView from "./graph-view";
+import {ModelingContext} from "../../../util/modeling-context";
+import {ModelingTooltips} from "../../../config/tooltips.config";
+import {getEntityTypes} from "../../../assets/mock-data/modeling/modeling";
+import {isModified} from "../../../assets/mock-data/modeling/modeling-context-mock";
+
+jest.mock("../../../api/modeling");
+jest.mock("../../../api/environment");
+
+describe("Graph View Component", () => {
+  window.scrollTo = jest.fn();
+  afterEach(() => {
+    jest.clearAllMocks();
+    cleanup();
+  });
+
+  const withEntityAs = (entityName) => {
+    let isModifiedUpdated = {...isModified, modelingOptions: {... isModified.modelingOptions, selectedEntity: entityName}};
+    return (<ModelingContext.Provider value={isModifiedUpdated}>
+      <GraphView
+        entityTypes={getEntityTypes}
+      />
+    </ModelingContext.Provider>
+    );
+  };
+
+  test("can view and close side panel for a selected entity within graph view", async () => {
+
+    const {getByTestId, getByLabelText, queryByLabelText, queryByTestId, rerender} =  render(
+      <ModelingContext.Provider value={isModified}>
+        <GraphView
+          entityTypes={getEntityTypes}
+        />
+      </ModelingContext.Provider>
+    );
+    let productEntity = getByTestId("Product-entityNode");
+
+    expect(queryByLabelText("Product-selectedEntity")).not.toBeInTheDocument();
+    userEvent.click(productEntity);
+    expect(isModified.setSelectedEntity).toBeCalledWith("Product");
+    rerender(withEntityAs("Product"));
+
+    //Verify side panel content
+    expect(getByLabelText("Product-selectedEntity")).toBeInTheDocument();
+
+    userEvent.hover(getByTestId("Product-delete"));
+    await wait(() => expect(screen.getByText(ModelingTooltips.deleteIcon)).toBeInTheDocument());
+
+    expect(getByLabelText("closeGraphViewSidePanel")).toBeInTheDocument();
+    expect(getByLabelText("propertiesTabInSidePanel")).toBeInTheDocument();
+    expect(getByLabelText("entityTypeTabInSidePanel")).toBeInTheDocument();
+
+    //Closing side panel
+    userEvent.click(getByLabelText("closeGraphViewSidePanel"));
+    expect(queryByLabelText("Product-selectedEntity")).not.toBeInTheDocument();
+    expect(queryByTestId("Product-delete")).not.toBeInTheDocument();
+    expect(queryByLabelText("closeGraphViewSidePanel")).not.toBeInTheDocument();
+    expect(queryByLabelText("propertiesTabInSidePanel")).not.toBeInTheDocument();
+    expect(queryByLabelText("entityTypeTabInSidePanel")).not.toBeInTheDocument();
+  });
+});

--- a/marklogic-data-hub-central/ui/src/components/modeling/graph-view/graph-view.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/graph-view/graph-view.tsx
@@ -1,4 +1,4 @@
-import React, {CSSProperties} from "react";
+import React, {CSSProperties, useContext, useEffect, useState} from "react";
 import {AutoComplete, Dropdown, Icon, Menu} from "antd";
 import styles from "./graph-view.module.scss";
 import {ModelingTooltips} from "../../../config/tooltips.config";
@@ -7,12 +7,27 @@ import {DownOutlined} from "@ant-design/icons";
 import PublishToDatabaseIcon from "../../../assets/publish-to-database-icon";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faFileExport} from "@fortawesome/free-solid-svg-icons";
+import SplitPane from "react-split-pane";
+import GraphViewSidePanel from "./side-panel/side-panel";
+import {ModelingContext} from "../../../util/modeling-context";
+import {defaultModelingView} from "../../../config/modeling.config";
 
 type Props = {
   entityTypes: any;
 };
 
 const GraphView: React.FC<Props> = (props) => {
+
+  const [viewSidePanel, setViewSidePanel] = useState(false);
+  const {modelingOptions, setSelectedEntity} = useContext(ModelingContext);
+
+  useEffect(() => {
+    if (modelingOptions.view === defaultModelingView && modelingOptions.selectedEntity) {
+      if (!viewSidePanel) {
+        setViewSidePanel(true);
+      }
+    }
+  }, [modelingOptions.selectedEntity]);
 
   const publishIconStyle: CSSProperties = {
     width: "20px",
@@ -51,7 +66,7 @@ const GraphView: React.FC<Props> = (props) => {
         <div className={styles.addButtonContainer}>
           <MLButton aria-label="add-entity-type-relationship" size="default" type="primary">
             <span className={styles.addButtonText}>Add</span>
-            <DownOutlined className={styles.downArrowIcon}/>
+            <DownOutlined className={styles.downArrowIcon} />
           </MLButton>
         </div>
       </Dropdown>
@@ -59,7 +74,7 @@ const GraphView: React.FC<Props> = (props) => {
     <MLTooltip title={ModelingTooltips.publish}>
       <MLButton aria-label="publish-to-database" size="default" type="secondary">
         <span className={styles.publishButtonContainer}>
-          <PublishToDatabaseIcon style={publishIconStyle}/>
+          <PublishToDatabaseIcon style={publishIconStyle} />
           <span className={styles.publishButtonText}>Publish</span>
         </span>
       </MLButton>
@@ -69,21 +84,65 @@ const GraphView: React.FC<Props> = (props) => {
     </MLTooltip>
   </span>;
 
-  return (
+  const splitPaneStyles = {
+    pane1: {minWidth: "150px"},
+    pane2: {minWidth: "140px", maxWidth: "90%"},
+    pane: {overflow: "hidden"},
+  };
 
-    <div className={styles.graphViewContainer}>
-      <div className={styles.graphHeader}>
-        {filter}
-        {headerButtons}
-      </div>
+  const splitStyle: CSSProperties = {
+    position: "relative",
+    height: "none",
+  };
 
+  const handleEntitySelection = (entityName) => {
+    setSelectedEntity(entityName);
+  };
+
+  const onCloseSidePanel = () => {
+    setViewSidePanel(false);
+    setSelectedEntity(undefined);
+  };
+
+  const deleteEntityClicked = (selectedEntity) => {
+    //Logic will be added here for deletion of entity.
+  };
+
+  const graphViewMainPanel =
+  <div className={styles.graphViewContainer}>
+    <div className={styles.graphHeader}>
+      {filter}
+      {headerButtons}
+    </div>
+    <div>
       {//Just a placeholder for actual graph view. Below code should be removed.
-        <ul>{props.entityTypes && props.entityTypes?.map((el) => <li key={el.entityName} style={{color: "blue"}}>{el.entityName}</li>)}
+        <ul>{props.entityTypes && props.entityTypes?.map((el) => <li data-testid={`${el.entityName}-entityNode`} key={el.entityName} style={{color: "blue", cursor: "pointer"}} onClick={(e) => handleEntitySelection(el.entityName)}>{el.entityName}</li>)}
         </ul>
         //--------------//
       }
     </div>
+  </div>;
 
+  return (
+    !viewSidePanel ? graphViewMainPanel :
+      <SplitPane
+        style={splitStyle}
+        paneStyle={splitPaneStyles.pane}
+        allowResize={true}
+        resizerClassName={styles.resizerStyle}
+        pane1Style={splitPaneStyles.pane1}
+        pane2Style={splitPaneStyles.pane2}
+        split="vertical"
+        primary="first"
+        defaultSize="70%"
+      >
+        {graphViewMainPanel}
+        <GraphViewSidePanel
+          entityTypes={props.entityTypes}
+          onCloseSidePanel={onCloseSidePanel}
+          deleteEntityClicked={deleteEntityClicked}
+        />
+      </SplitPane>
   );
 };
 

--- a/marklogic-data-hub-central/ui/src/components/modeling/graph-view/side-panel/side-panel.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/modeling/graph-view/side-panel/side-panel.module.scss
@@ -1,0 +1,34 @@
+.sidePanel {
+    padding: 10px 10px;
+  
+    .selectedEntityHeading{
+      font-size: 22px;
+      color: #333333;
+      padding-right: 10px;
+    }
+  
+    .deleteIcon {
+      color: #5B69AF;
+      font-size: 24px;
+    }
+  
+    .deleteIcon:hover{
+      color: var(--hoverColor);
+      cursor: pointer;
+    }
+  
+    .close {
+      position: relative;
+      float: right;
+      font-size: 20px;
+      height: 28px;
+      cursor: pointer;
+    }
+  
+    .tabs {
+      padding: 10px 0px 10px 0px;
+      .sidePanelTabLabel {
+        font-size: 18px;
+      }
+    }
+  }

--- a/marklogic-data-hub-central/ui/src/components/modeling/graph-view/side-panel/side-panel.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/graph-view/side-panel/side-panel.tsx
@@ -1,0 +1,61 @@
+import React, {useContext, useState} from "react";
+import styles from "./side-panel.module.scss";
+import {MLTooltip} from "@marklogic/design-system";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faTrashAlt} from "@fortawesome/free-solid-svg-icons";
+import {ModelingTooltips} from "../../../../config/tooltips.config";
+import {CloseOutlined} from "@ant-design/icons";
+import {Menu} from "antd";
+import {ModelingContext} from "../../../../util/modeling-context";
+
+type Props = {
+  entityTypes: any;
+  onCloseSidePanel: () => void;
+  deleteEntityClicked: (selectedEntity) => void;
+};
+
+const DEFAULT_TAB = "properties";
+
+const GraphViewSidePanel: React.FC<Props> = (props) => {
+
+  const [currentTab, setCurrentTab] = useState(DEFAULT_TAB);
+  const {modelingOptions} = useContext(ModelingContext);
+
+  const handleTabChange = (item) => {
+    setCurrentTab(item.key);
+  };
+
+  const displayPanelContent = () => {
+    return currentTab === "entityType" ? <div>Dummy content for Entity Type tab.</div> : <div>Dummy content for Properties tab.</div>;
+  };
+
+  return (
+    <div id="sidePanel" className={styles.sidePanel}>
+      <div>
+        <span className={styles.selectedEntityHeading} aria-label={`${modelingOptions.selectedEntity}-selectedEntity`}>{modelingOptions.selectedEntity}</span>
+        <span><MLTooltip title={ModelingTooltips.deleteIcon} placement="top">
+          <i key="last" role="delete-entity button" data-testid={modelingOptions.selectedEntity + "-delete"} onClick={() => props.deleteEntityClicked(modelingOptions.selectedEntity)}>
+            <FontAwesomeIcon icon={faTrashAlt} className={styles.deleteIcon} size="lg" />
+          </i>
+        </MLTooltip></span>
+        <span><i className={styles.close} aria-label={"closeGraphViewSidePanel"}
+          onClick={props.onCloseSidePanel}>
+          <CloseOutlined />
+        </i></span>
+      </div>
+      <div className={styles.tabs}>
+        <Menu mode="horizontal" defaultSelectedKeys={[DEFAULT_TAB]} selectedKeys={[currentTab]} onClick={handleTabChange}>
+          <Menu.Item key="properties" aria-label="propertiesTabInSidePanel">
+            {<span className={styles.sidePanelTabLabel}>Properties</span>}
+          </Menu.Item>
+          <Menu.Item key="entityType" aria-label="entityTypeTabInSidePanel">
+            {<span className={styles.sidePanelTabLabel}>Entity Type</span>}
+          </Menu.Item>
+        </Menu>
+      </div>
+      {displayPanelContent()}
+    </div>
+  );
+};
+
+export default GraphViewSidePanel;

--- a/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
+++ b/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
@@ -23,6 +23,7 @@ const ModelingTooltips = {
   saveIcon: 'Save changes to this entity type.',
   revertIcon: 'Discard unsaved changes to this entity type.',
   deleteIcon: 'Delete this entity type.',
+  viewGraph: 'View entity in graph view.',
 
   /* Icons for entity properties */
   addStructuredProperty: 'Add a property to this structured property.',

--- a/marklogic-data-hub-central/ui/src/pages/Modeling.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Modeling.tsx
@@ -25,8 +25,7 @@ import {defaultModelingView} from "../config/modeling.config";
 
 const Modeling: React.FC = () => {
   const {handleError} = useContext(UserContext);
-  const {modelingOptions, setEntityTypeNamesArray, clearEntityModified} = useContext(ModelingContext);
-  const [view, setView] = useState(defaultModelingView);
+  const {modelingOptions, setEntityTypeNamesArray, clearEntityModified, setView} = useContext(ModelingContext);
   const [entityTypes, setEntityTypes] = useState<any[]>([]);
   const [showEntityModal, toggleShowEntityModal] = useState(false);
   const [isEditModal, toggleIsEditModal] = useState(false);
@@ -186,17 +185,17 @@ const Modeling: React.FC = () => {
     <MLRadio.MLGroup
       buttonStyle="outline"
       className={"radioGroupView"}
-      defaultValue={view}
+      defaultValue={modelingOptions.view}
       name="radiogroup"
       onChange={e => handleViewChange(e.target.value)}
       size="large"
       style={mlRadioStyle}
       tabIndex={0}
     >
-      <MLRadio.MLButton aria-label="switch-view-graph" value={"graph"} checked={view === "graph"}>
+      <MLRadio.MLButton aria-label="switch-view-graph" value={"graph"} checked={modelingOptions.view === "graph"}>
         <i>{<FontAwesomeIcon icon={faProjectDiagram} />}</i>
       </MLRadio.MLButton>
-      <MLRadio.MLButton aria-label="switch-view-table" value={"table"} checked={view === "table"}>
+      <MLRadio.MLButton aria-label="switch-view-table" value={"table"} checked={modelingOptions.view === "table"}>
         <i>{<FontAwesomeIcon icon={faTable} />}</i>
       </MLRadio.MLButton>
     </MLRadio.MLGroup>
@@ -212,7 +211,7 @@ const Modeling: React.FC = () => {
         { modelingOptions.isModified && (
           <MLAlert type="info" aria-label="entity-modified-alert" showIcon message={ModelingTooltips.entityEditedAlert}/>
         )}
-        {view === "table" ? <div>
+        {modelingOptions.view === "table" ? <div>
           <div className={styles.header}>
             <h1>Entity Types</h1>
             <div className={styles.buttonContainer}>
@@ -291,8 +290,6 @@ const Modeling: React.FC = () => {
           namespace={namespace}
           prefix={prefix}
         />
-
-
       </div>
     );
   } else {

--- a/marklogic-data-hub-central/ui/src/types/modeling-types.ts
+++ b/marklogic-data-hub-central/ui/src/types/modeling-types.ts
@@ -6,13 +6,18 @@ export interface ModelingContextInterface {
   removeEntityModified: (entityModified: EntityModified) => void;
   clearEntityModified: () => void;
   setEntityPropertiesNamesArray: (entityDefinitionsArray: any[]) => void;
+  setView: (view: string) => void;
+  setSelectedEntity: (entityName: string | undefined) => void;
+  setGraphViewOptions: (graphViewOptions: graphViewOptions) => void;
 }
 
 export interface ModelingOptionsInterface {
   entityTypeNamesArray: any[],
   isModified: boolean,
   modifiedEntitiesArray:  any[],
-  entityPropertiesNamesArray: string[]
+  entityPropertiesNamesArray: string[],
+  view: string,
+  selectedEntity?: string
 }
 
 export interface Definition {
@@ -82,4 +87,9 @@ export enum PropertyType {
 export interface EntityModified {
   entityName: string,
   modelDefinition: any
+}
+
+export interface graphViewOptions {
+  view: string,
+  selectedEntity: string
 }

--- a/marklogic-data-hub-central/ui/src/util/modeling-context.tsx
+++ b/marklogic-data-hub-central/ui/src/util/modeling-context.tsx
@@ -1,15 +1,19 @@
 import React, {useState} from "react";
+import {defaultModelingView} from "../config/modeling.config";
 import {
   ModelingOptionsInterface,
   ModelingContextInterface,
-  EntityModified
+  EntityModified,
+  graphViewOptions
 } from "../types/modeling-types";
 
 const DEFAULT_MODELING_OPTIONS = {
   entityTypeNamesArray: [],
   isModified: false,
   modifiedEntitiesArray: [],
-  entityPropertiesNamesArray: []
+  entityPropertiesNamesArray: [],
+  view: defaultModelingView,
+  selectedEntity: undefined
 };
 
 export const ModelingContext = React.createContext<ModelingContextInterface>({
@@ -19,7 +23,10 @@ export const ModelingContext = React.createContext<ModelingContextInterface>({
   updateEntityModified: () => {},
   removeEntityModified: () => {},
   clearEntityModified: () => {},
-  setEntityPropertiesNamesArray: () => {}
+  setEntityPropertiesNamesArray: () => {},
+  setView: () => {},
+  setSelectedEntity: () => {},
+  setGraphViewOptions: () => {}
 });
 
 const ModelingProvider: React.FC<{ children: any }> = ({children}) => {
@@ -71,6 +78,22 @@ const ModelingProvider: React.FC<{ children: any }> = ({children}) => {
     setModelingOptions({...modelingOptions, entityPropertiesNamesArray});
   };
 
+  const setView = (view: string) => {
+    setModelingOptions({...modelingOptions, view: view});
+  };
+
+  const setSelectedEntity = (selectedEntity: string | undefined) => {
+    setModelingOptions({...modelingOptions, selectedEntity: selectedEntity});
+  };
+
+  const setGraphViewOptions = (graphViewOptions: graphViewOptions) => {
+    setModelingOptions({
+      ...modelingOptions,
+      view: graphViewOptions.view,
+      selectedEntity: graphViewOptions.selectedEntity
+    });
+  };
+
   return (
     <ModelingContext.Provider value={{
       modelingOptions,
@@ -79,7 +102,10 @@ const ModelingProvider: React.FC<{ children: any }> = ({children}) => {
       updateEntityModified,
       removeEntityModified,
       clearEntityModified,
-      setEntityPropertiesNamesArray
+      setEntityPropertiesNamesArray,
+      setView,
+      setSelectedEntity,
+      setGraphViewOptions
     }}>
       {children}
     </ModelingContext.Provider>


### PR DESCRIPTION
### Description
We can now open the side panel on graph view by selecting the dummy entity type links in graph view or the new graph view navigation icon in table view.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

