### PR TITLE
DHFPROD-7450: Take horizontal scrolling out of entity tables

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.module.scss
@@ -128,6 +128,21 @@
   }
 }
 
+.relatedMapExpParentContainer {
+  margin-left: 9px;
+  margin-top: -12px;
+  margin-bottom: -12px;
+  > .validationErrors {
+      width: 23vw;
+      line-height: normal;
+      padding-top: 6px;
+      padding-left: 2px;
+      padding-bottom: 4px;
+      color: #DB4f59;
+      word-break: break-all;
+  }
+}
+
 .mapExpressionContainer {
   width: 100%;
   display: inline-flex;

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.tsx
@@ -118,6 +118,8 @@ const EntityMapTable: React.FC<Props> = (props) => {
   const [entitiesReferencing, setEntitiesReferencing] = useState<any>([]);
   const [pendingOptions, setPendingOptions] = useState<any>([]);
 
+  let directRelation = props.isRelatedEntity ? ("(" + props.entityMappingId.split(".")[0]) === props.entityTypeTitle.split(" ")[1] ? true : false : null;
+
   let firstRowKeys = new Array(100).fill(0).map((_, i) => i);
   //Documentation links for using Xpath expressions
   const xPathDocLinks = <div className={styles.xpathDoc}><span id="doc">Documentation:</span>
@@ -1280,7 +1282,7 @@ const EntityMapTable: React.FC<Props> = (props) => {
       render: (text, row, index) => {
         if (row.key > 100 && row.name !== "more" && row.name !== "less") {
           if (row.name === "Context" && !row.isProperty) {
-            return {children: <div className={styles.mapExpParentContainer}><div className={styles.mapExpressionContainer}>
+            return {children: <div className={!directRelation ? styles.relatedMapExpParentContainer: styles.mapExpParentContainer}><div className={styles.mapExpressionContainer}>
               <TextArea
                 id={"mapexpression"+row.name.split("/").pop()}
                 data-testid={`${props.entityTypeTitle}-` + row.name.split("/").pop()+`-mapexpression`}
@@ -1295,7 +1297,7 @@ const EntityMapTable: React.FC<Props> = (props) => {
             </div>
             {checkFieldInErrors(row.name, false) ? <div id="errorInExp" data-testid={row.name+"-expErr"} className={styles.validationErrors}>{displayResp(row.name, false)}</div> : ""}</div>, props: {colSpan: 1}};
           } else if (row.name === "URI" && !row.isProperty) {
-            return {children: <div className={styles.mapExpParentContainer}><div className={styles.mapExpressionContainer}>
+            return {children: <div className={props.isRelatedEntity && !directRelation ? styles.relatedMapExpParentContainer : styles.mapExpParentContainer}><div className={styles.mapExpressionContainer}>
               <TextArea
                 id={"mapexpression"+row.name.split("/").pop()}
                 data-testid={`${props.entityTypeTitle}-` + row.name.split("/").pop()+`-mapexpression`}
@@ -1358,6 +1360,7 @@ const EntityMapTable: React.FC<Props> = (props) => {
   ];
 
   const tableCSS = css({
+    minWidth: "1000px",
     "& thead > tr > th": {
       backgroundColor: props.tableColor,
       paddingTop: "12px",
@@ -1388,7 +1391,6 @@ const EntityMapTable: React.FC<Props> = (props) => {
         onExpand={(expanded, record) => toggleRowExpanded(expanded, record, "key")}
         expandedRowKeys={props.entityExpandedKeys}
         columns={getColumnsForEntityTable()}
-        scroll={{x: 1000}}
         dataSource={filterApplied ? [{key: props.firstRowTableKeyIndex, name: topRowDetails, type: "", parentVal: ""}] : entityProperties.length > 1 ? props.isRelatedEntity? [{key: props.firstRowTableKeyIndex, name: topRowDetails, type: "", parentVal: ""}, entityProperties[0], entityProperties[1]] : [{key: props.firstRowTableKeyIndex, name: topRowDetails, type: "", parentVal: ""}, entityProperties[0]]: [{key: props.firstRowTableKeyIndex, name: topRowDetails, type: "", parentVal: ""}]}
         tableLayout="unset"
         rowKey={(record: any) => record.key}
@@ -1408,7 +1410,6 @@ const EntityMapTable: React.FC<Props> = (props) => {
           indentSize={28}
           //defaultExpandAllRows={true}
           columns={getColumnsForEntityTable()}
-          scroll={{x: 1000}}
           dataSource={filterApplied ? entityProperties : props.isRelatedEntity ? entityProperties.slice(2, entityProperties.length) : entityProperties.slice(1, entityProperties.length)}
           tableLayout="unset"
           rowKey={(record: any) => record.key}

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.module.scss
@@ -93,7 +93,7 @@
 }
 
 .entityContainer{
-    width: auto;
+    width: 100%;
     flex: 9;
     display: flex;
     flex-direction: column;
@@ -117,6 +117,7 @@
 
     > .columnOptionsSelectorContainer {
         display: inline-block;
+        min-width: 1000px;
         margin-bottom: 10px;
 
         > .columnOptionsSelector{


### PR DESCRIPTION
### Description
- Unified all entity table horizontal scrollbars under one scroll when the page width is shrunk.
- Previously each table had separate horizontal scrollbars within
- Designed reviewed by @jbelonoj 
- Will make secondary PR for 5.5-develop branch once this is merged
- No tests needed for css changes

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- N/A Added Tests
  

- ##### Reviewer:

- N/A Reviewed Tests

