### PR TITLE
DHFPROD-7443:Handle wrong number of arguments for "fn:" function error in mapping step(5.5.1)

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/mapping/mapping-lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/mapping/mapping-lib.sjs
@@ -34,6 +34,10 @@ function extractFriendlyErrorMessage(e){
     case "XSLT-BADXPATH":
       errorMessage = extractBadXPathError(e);
       break;
+    case "XDMP-TOOFEWARGS":
+    case "XDMP-TOOMANYARGS":
+      errorMessage = extractIncorrectNumberOfArgumentsError(e);
+      break;
     default:
       errorMessage = null;
   }
@@ -79,6 +83,17 @@ function extractInvalidLexicalValueError(e) {
 function extractErrorMessageForMappingUI(e){
   let errorMessage = extractFriendlyErrorMessage(e);
   return errorMessage ? errorMessage : hubUtils.getErrorMessage(e);
+}
+
+function extractIncorrectNumberOfArgumentsError(e) {
+  const error = new Error(e);
+  let errorMessage = error.message;
+  const regex = /^(XDMP-TOOMANYARGS|XDMP-TOOFEWARGS): \(err:XPST0017\) fn:(.+) -- Too (many|few) args, expected (\d+) but got (\d+)$/;
+  const extractedError = errorMessage.match(regex);
+  if(extractedError){
+    errorMessage = `Wrong number of arguments: '${extractedError[2]}'. Cause: Requires ${extractedError[4]} arguments but received ${extractedError[5]}.`;
+  }
+  return errorMessage;
 }
 
 module.exports = {

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping/mapping-errors/incorrectNumberOfArgumentsError.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping/mapping-errors/incorrectNumberOfArgumentsError.sjs
@@ -1,0 +1,29 @@
+const test = require("/test/test-helper.xqy");
+const lib = require("lib/lib.sjs")
+let assertions = [];
+
+const runTooFewArgsMappingOutput = lib.runMappingStep("tooFewArgsMapping", 8);
+const testTooFewArgsMappingOutput = lib.validateAndTestMapping("tooFewArgsMapping");
+
+assertions = assertions.concat([
+  test.assertEqual("Wrong number of arguments: 'upper-case()'. Cause: Requires 1 arguments but received 0."
+    , testTooFewArgsMappingOutput.properties.name.errorMessage),
+
+  test.assertEqual("Wrong number of arguments: 'upper-case()'. Cause: Requires 1 arguments but received 0."
+    , runTooFewArgsMappingOutput.errors[0].message),
+  test.assertEqual("/content/customer.json", runTooFewArgsMappingOutput.failedItems[0]),
+]);
+
+const runTooManyArgsMappingOutput = lib.runMappingStep("tooManyArgsMapping", 9);
+const testTooManyArgsMappingOutput = lib.validateAndTestMapping("tooManyArgsMapping");
+
+assertions = assertions.concat([
+  test.assertEqual("Wrong number of arguments: 'lower-case(\"a\", \"b\")'. Cause: Requires 1 arguments but received 2."
+    , testTooManyArgsMappingOutput.properties.name.errorMessage),
+
+  test.assertEqual("Wrong number of arguments: 'lower-case(\"a\", \"b\")'. Cause: Requires 1 arguments but received 2."
+    , runTooManyArgsMappingOutput.errors[0].message),
+  test.assertEqual("/content/customer.json", runTooManyArgsMappingOutput.failedItems[0]),
+]);
+
+assertions;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping/mapping-errors/setup.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/mapping/mapping-errors/setup.sjs
@@ -63,6 +63,20 @@ hubTest.createSimpleMappingProject( [
       {
         "name": {"sourcedFrom": "upper-case('a)" }
       }
+  },
+  {
+    "name":"tooFewArgsMapping",
+    "properties":
+      {
+        "name": {"sourcedFrom": "upper-case()" }
+      }
+  },
+  {
+    "name":"tooManyArgsMapping",
+    "properties":
+      {
+        "name": {"sourcedFrom": "lower-case('a','b')" }
+      }
   }
 ]
 );


### PR DESCRIPTION
### Description
Handle wrong number of arguments for "fn:" function error in mapping step
#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

