### PR TITLE
DHFPROD-7409: HC UI inconsistent load "settings" access

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestionListView.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestionListView.spec.tsx
@@ -57,7 +57,7 @@ describe("Validate CRUD functionality from list view", () => {
     cy.findByText(stepName).should("be.visible");
   });
   it("Verify Edit", () => {
-    loadPage.stepName(stepName).click();
+    loadPage.editStepInCardView(stepName).click();
     loadPage.stepNameInput().should("be.disabled");
     loadPage.stepDescriptionInput().clear().type("UPDATED");
     loadPage.saveButton().click();
@@ -65,7 +65,7 @@ describe("Validate CRUD functionality from list view", () => {
     cy.findByText("UPDATED").should("be.visible");
   });
   it("Verify Advanced Settings and Error validations", () => {
-    loadPage.stepName(stepName).click();
+    loadPage.editStepInCardView(stepName).click();
     loadPage.switchEditAdvanced().click();  // Advanced tab
     loadPage.selectTargetDB("FINAL");
     loadPage.targetCollectionInput().type("e2eTestCollection{enter}test1{enter}test2{enter}");
@@ -95,29 +95,29 @@ describe("Validate CRUD functionality from list view", () => {
     loadPage.confirmationOptions("No").click();
     cy.waitUntil(() => loadPage.saveSettings(stepName)).click({force: true});
     cy.waitForAsyncRequest();
-    loadPage.stepName(stepName).should("be.visible");
+    loadPage.editStepInCardView(stepName).should("be.visible");
   });
   it("Open settings, change setting, switch tabs, save", () => {
-    loadPage.stepName(stepName).click();
+    loadPage.editStepInCardView(stepName).click();
     loadPage.stepDescriptionInput().clear().type("UPDATE2");
     loadPage.switchEditAdvanced().click();
     cy.waitUntil(() => loadPage.saveSettings(stepName)).click({force: true});
     cy.waitForAsyncRequest();
   });
   it("Verify that change was saved", () => {
-    loadPage.stepName(stepName).click();
+    loadPage.editStepInCardView(stepName).click();
     loadPage.stepDescription("UPDATE2").should("be.visible");
     loadPage.cancelButton().click();
   });
   it("Open settings, change setting, switch tabs, cancel, discard changes", () => {
-    loadPage.stepName(stepName).click();
+    loadPage.editStepInCardView(stepName).click();
     loadPage.stepDescriptionInput().clear().type("DISCARD");
     loadPage.switchEditAdvanced().click();
     cy.findByTestId(`${stepName}-cancel-settings`).click();
     cy.findByText("Discard changes?").should("be.visible");
     loadPage.confirmationOptions("Yes").click();
     // Verify that change was NOT saved.
-    loadPage.stepName(stepName).click();
+    loadPage.editStepInCardView(stepName).click();
     loadPage.stepDescription("UPDATE2").should("be.visible");
     loadPage.stepDescription("DISCARD").should("not.exist");
     loadPage.cancelButton().click();
@@ -200,8 +200,8 @@ describe("Validate CRUD functionality from list view", () => {
   });
   it("Add step to a new flow and Verify Run Load step where step exists in multiple flows", {defaultCommandTimeout: 120000}, () => {
     cy.waitUntil(() => toolbar.getLoadToolbarIcon()).click();
-    loadPage.loadView("table").click();
-    loadPage.addStepToNewFlowListView(stepName);
+    loadPage.loadView("th-large").click();
+    loadPage.addStepToNewFlow(stepName);
     cy.waitForAsyncRequest();
     cy.findByText("New Flow").should("be.visible");
     runPage.setFlowName(flowName2);
@@ -239,10 +239,10 @@ describe("Validate CRUD functionality from list view", () => {
     loadPage.deleteStep(stepName).click();
     loadPage.confirmationOptions("No").click();
     cy.waitForAsyncRequest();
-    loadPage.stepName(stepName).should("be.visible");
+    loadPage.editStepInCardView(stepName).should("be.visible");
     loadPage.deleteStep(stepName).click();
     cy.waitUntil(() => loadPage.confirmationOptions("Yes")).click();
     cy.waitForAsyncRequest();
-    loadPage.stepName(stepName).should("not.exist");
+    loadPage.editStepInCardView(stepName).should("not.exist");
   });
 });

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/login/authorization.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/login/authorization.spec.tsx
@@ -88,7 +88,6 @@ describe("login", () => {
     });
 
     toolbar.getModelToolbarIcon().click();
-    cy.wait(2000);
     tiles.getModelTile().should("exist");
     modelPage.getAddEntityButton().should("be.disabled");
   });
@@ -119,7 +118,7 @@ describe("login", () => {
     loadPage.loadView("table").click();
     tiles.waitForTableToLoad();
     loadPage.addToFlowDisabled(stepName).should("exist");
-    loadPage.stepName(stepName).click();
+    loadPage.editStepInCardView(stepName).click();
     loadPage.saveButton().should("be.disabled");
     loadPage.cancelButton().click();
     loadPage.deleteStepDisabled(stepName).should("exist");

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/load.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/load.tsx
@@ -2,15 +2,15 @@ class LoadPage {
 
   //Load tile list view page objects
   /**
-     * @param type - accepts `table` for list-view or `th-large` for card-view
-     */
+       * @param type - accepts `table` for list-view or `th-large` for card-view
+       */
   loadView(type: string) {
     return cy.get(`[data-icon="${type}"]`);
   }
 
   /**
-     * @param type - accepts `list` or `card`
-     */
+       * @param type - accepts `list` or `card`
+       */
   addNewButton(type: string) {
     return cy.findByLabelText(`add-new-${type}`);
   }
@@ -44,15 +44,15 @@ class LoadPage {
   }
 
   /**
-     * add to flow icon in load table view
-     * @param stepName
-     */
+       * add to flow icon in load table view
+       * @param stepName
+       */
   addToFlow(stepName: string) {
-    return cy.findByLabelText(`${stepName}-add-icon`);
+    return cy.findByLabelText(`${stepName}-run`);
   }
 
   addToFlowDisabled(stepName: string) {
-    return cy.findByLabelText(`${stepName}-disabled-add-icon`);
+    return cy.findByTestId(`${stepName}-disabled-run`);
   }
 
   switchEditAdvanced() {
@@ -114,8 +114,8 @@ class LoadPage {
   }
 
   /**
-     * @param text - a string that matches any button by its label
-     */
+       * @param text - a string that matches any button by its label
+       */
   findByButtonText(text: string) {
     return cy.findByLabelText(text);
   }
@@ -168,17 +168,17 @@ class LoadPage {
   }
 
   /**
-     * Clicks on a database option
-     * @param db - accepts `STAGING` or `FINAL`
-     */
+       * Clicks on a database option
+       * @param db - accepts `STAGING` or `FINAL`
+       */
   selectTargetDB(db: string) {
     cy.waitUntil(() => cy.findByLabelText("targetDatabase-select")).click();
     cy.waitUntil(() => cy.findByTestId(`targetDbOptions-data-hub-${db}`)).click({force: true});
   }
 
   /**
-     * This input field takes multiple values with special character sequences for keyboard events
-     */
+       * This input field takes multiple values with special character sequences for keyboard events
+       */
   targetCollectionInput() {
     return cy.findByLabelText("additionalColl-select");
   }
@@ -188,19 +188,19 @@ class LoadPage {
   }
 
   /**
-     * Overwrite the existing default permissions
-     * @param permissions - accepts a comma separated text of roles and capabilities alternately
-     * @example role1,cap1,role2,cap2
-     */
+       * Overwrite the existing default permissions
+       * @param permissions - accepts a comma separated text of roles and capabilities alternately
+       * @example role1,cap1,role2,cap2
+       */
   setTargetPermissions(permissions: string) {
     return cy.get("#targetPermissions").clear().type(permissions);
   }
 
   /**
-     * Add to the existing default permissions
-     * @param permissions - accepts a comma separated text of roles and capabilities alternately
-     * @example role1,cap1,role2,cap2
-     */
+       * Add to the existing default permissions
+       * @param permissions - accepts a comma separated text of roles and capabilities alternately
+       * @example role1,cap1,role2,cap2
+       */
   appendTargetPermissions(permissions: string) {
     return cy.get("#targetPermissions").type(`,${permissions}`);
   }
@@ -215,10 +215,10 @@ class LoadPage {
   }
 
   /**
-     * Textarea that takes a file path in fixtures and pastes the json object {} in the text area
-     * @param fixturePath - file path to headerContent json config file
-     * @see https://docs.cypress.io/api/commands/type.html#Key-Combinations
-     */
+       * Textarea that takes a file path in fixtures and pastes the json object {} in the text area
+       * @param fixturePath - file path to headerContent json config file
+       * @see https://docs.cypress.io/api/commands/type.html#Key-Combinations
+       */
   setHeaderContent(fixturePath: string) {
     cy.fixture(fixturePath).then(content => {
       cy.get("#headers").clear().type(JSON.stringify(content), {parseSpecialCharSequences: false});
@@ -226,10 +226,10 @@ class LoadPage {
   }
 
   /**
-     * Textarea that takes a file path in fixtures and pastes the json array object [] in the text area
-     * @param fixturePath - file path to stepInterceptor json config file
-     * @see https://docs.cypress.io/api/commands/type.html#Key-Combinations
-     */
+       * Textarea that takes a file path in fixtures and pastes the json array object [] in the text area
+       * @param fixturePath - file path to stepInterceptor json config file
+       * @see https://docs.cypress.io/api/commands/type.html#Key-Combinations
+       */
   setStepInterceptor(fixturePath: string) {
     cy.findByText("Interceptors").click();
     if (fixturePath === "") { return cy.get("#interceptors").clear(); } else {
@@ -240,10 +240,10 @@ class LoadPage {
   }
 
   /**
-     * Textarea that takes a file path in fixtures and pastes the json object {} in the text area
-     * @param fixturePath - file path to customHook json config file
-     * @see https://docs.cypress.io/api/commands/type.html#Key-Combinations
-     */
+       * Textarea that takes a file path in fixtures and pastes the json object {} in the text area
+       * @param fixturePath - file path to customHook json config file
+       * @see https://docs.cypress.io/api/commands/type.html#Key-Combinations
+       */
   setCustomHook(fixturePath: string) {
     cy.findByText("Custom Hook").click();
     if (fixturePath === "") { return cy.get("#customHook").clear(); } else {
@@ -296,8 +296,8 @@ class LoadPage {
   }
 
   addStepToNewFlowListView(stepName: string) {
-    cy.findByLabelText(`${stepName}-add-icon`).click();
-    this.addToNewFlow(stepName).click({force: true});
+    cy.findByTestId(`${stepName}-run`).click();
+    this.runInNewFlow(stepName).click({force: true});
     cy.waitForAsyncRequest();
   }
 

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.module.scss
@@ -27,6 +27,17 @@
     }
 }
 
+.editIcon{
+    font-size: 21px;
+    color: #5B69AF;
+    cursor: pointer;
+    padding-right: 9px;
+    padding-left: 3px;
+    &:hover{
+        color: var(--hoverColor) !important;
+    }
+}
+
 .popover {
     color: #FF8C00;
     align-items: flex-start;
@@ -79,8 +90,8 @@
 .deleteIcon {
     color: #B32424;
     font-size: 21px;
-    align-items: flex-start;
     cursor: pointer;
+    margin-bottom: 2px;
     padding-bottom: 2px;
     &:hover{
         color: var(--hoverColor) !important;

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {render, fireEvent, wait, within, cleanup, waitForElement} from "@testing-library/react";
+import {render, fireEvent, wait, within, cleanup} from "@testing-library/react";
 import LoadList from "./load-list";
 import data from "../../assets/mock-data/curation/common.data";
 import axiosMock from "axios";
@@ -138,7 +138,7 @@ describe("Load data component", () => {
 
     // Click name to open default Basic settings
     await wait(() => {
-      fireEvent.click(getByText(data.loadData.data[0].name));
+      fireEvent.click(getByTestId("testLoad-edit"));
     });
     expect(getByText("Basic").closest("div")).toHaveClass("ant-tabs-tab-active");
     expect(getByText("Advanced").closest("div")).not.toHaveClass("ant-tabs-tab-active");
@@ -199,83 +199,6 @@ describe("Load data component", () => {
     expect(targetPermissions).toHaveValue("role1,read");
     fireEvent.blur(targetPermissions);
     expect(getByTestId("validationError")).toHaveTextContent("");
-
-  });
-
-  test("Load List - Add step to an existing flow where step DOES NOT exist", async () => {
-    const authorityService = new AuthoritiesService();
-    authorityService.setAuthorities(["readIngestion", "writeIngestion", "writeFlow"]);
-    const {getByText, getByLabelText, getByTestId} = render(
-      <MemoryRouter>
-        <AuthoritiesContext.Provider value={authorityService}>
-          <LoadList
-            {...data.loadData}
-            flows={data.flowsAdd}
-            canWriteFlow={true}
-            addStepToFlow={jest.fn()}
-            addStepToNew={jest.fn()} />
-        </AuthoritiesContext.Provider>
-      </MemoryRouter>
-    );
-
-    //Check if the list is rendered properly
-    expect(getByText("testLoadXML")).toBeInTheDocument();
-
-    fireEvent.click(getByLabelText("testLoadXML-add-icon")); // Click the Add to Flow Icon to get more options
-
-    //Verify if the flow related options are availble on click
-    await waitForElement(() => expect(getByTestId(`testLoadXML-toNewFlow`))); // check if option 'Add to a new Flow' is visible
-    await waitForElement(() => expect(getByTestId(`testLoadXML-toExistingFlow`))); // check if option 'Add to an existing Flow' is visible
-
-    //Click on the select field to open the list of existing flows.
-    fireEvent.click(getByTestId("testLoadXML-flowsList"));
-
-    //Choose FlowStepNoExist from the dropdown
-    fireEvent.click(getByText("FlowStepNoExist"));
-
-    //Dialog appears, click 'Yes' button
-    expect(getByLabelText("step-not-in-flow")).toBeInTheDocument();
-    fireEvent.click(getByLabelText("Yes"));
-
-    //Check if the /tiles/run/add route has been called
-    wait(() => {
-      expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/add");
-    });
-    //TODO- E2E test to check if the Run tile is loaded or not.
-
-  });
-
-  test("Load List - Add step to an existing flow where step DOES exist", async () => {
-    const authorityService = new AuthoritiesService();
-    authorityService.setAuthorities(["readIngestion", "writeIngestion", "writeFlow"]);
-    const {getByText, getByLabelText, getByTestId} = render(
-      <MemoryRouter>
-        <AuthoritiesContext.Provider value={authorityService}>
-          <LoadList
-            {...data.loadData}
-            flows={data.flowsAdd}
-            canWriteFlow={true}
-            addStepToFlow={jest.fn()}
-            addStepToNew={jest.fn()} />
-        </AuthoritiesContext.Provider>
-      </MemoryRouter>
-    );
-
-    fireEvent.click(getByLabelText("testLoadXML-add-icon")); // Clik over the Add to Flow Icon to get more options
-
-    //Verify if the flow related options are availble on click
-    await waitForElement(() => expect(getByTestId(`testLoadXML-toNewFlow`))); // check if option 'Add to a new Flow' is visible
-    await waitForElement(() => expect(getByTestId(`testLoadXML-toExistingFlow`))); // check if option 'Add to an existing Flow' is visible
-
-    //Click on the select field to open the list of existing flows.
-    fireEvent.click(getByTestId("testLoadXML-flowsList"));
-
-    //Choose FlowStepExist from the dropdown
-    fireEvent.click(getByText("FlowStepExist"));
-
-    //Dialog appears, click 'Yes' button
-    expect(getByLabelText("step-in-flow")).toBeInTheDocument();
-    fireEvent.click(getByLabelText("Yes"));
 
   });
 
@@ -371,96 +294,6 @@ describe("Load data component", () => {
     wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/add-run"); });
   });
 
-  test("Load List - Add step to an new Flow", async () => {
-    const authorityService = new AuthoritiesService();
-    authorityService.setAuthorities(["readIngestion", "writeIngestion", "writeFlow"]);
-    const {getByText, getByLabelText, getByTestId} = render(
-      <MemoryRouter>
-        <AuthoritiesContext.Provider value={authorityService}>
-          <LoadList
-            {...data.loadData}
-            flows={data.flows}
-            canWriteFlow={true}
-            addStepToFlow={jest.fn()}
-            addStepToNew={jest.fn()} />
-        </AuthoritiesContext.Provider>
-      </MemoryRouter>
-    );
-
-    //Check if the list is rendered properly
-    expect(getByText("testLoadXML")).toBeInTheDocument();
-
-    fireEvent.click(getByLabelText("testLoadXML-add-icon")); // Click over the Add to Flow Icon to get more options
-
-    //Verify if the flow related options are availble on mouseOver
-    await waitForElement(() => expect(getByTestId(`testLoadXML-toNewFlow`))); // check if option 'Add to a new Flow' is visible
-    await waitForElement(() => expect(getByTestId(`testLoadXML-toExistingFlow`))); // check if option 'Add to an existing Flow' is visible
-
-    //Click on the select field to open the list of existing flows.
-    fireEvent.click(getByTestId("testLoadXML-toNewFlow"));
-
-    //Check if the /tiles/run/add route has been called
-    wait(() => {
-      expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/add");
-    });
-    //TODO- E2E test to check if the Run tile is loaded or not.
-
-
-    //Verify run step in a new flow
-
-    //Click play button 'Run' icon
-    fireEvent.click(getByTestId("testLoadXML-run"));
-
-    //Modal with option to add and run in a new flow should appear
-    expect(getByLabelText("step-in-no-flows-confirmation")).toBeInTheDocument();
-
-    //Select "New Flow" option to add and run in a new flow
-    fireEvent.click(getByTestId("testLoadXML-run-toNewFlow"));
-
-    //Check if the /tiles/run/add-run route has been called
-    wait(() => { expect(mockHistoryPush).toHaveBeenCalledWith("/tiles/run/add-run"); });
-
-  });
-
-  test("Verify Load list allows step to be added to flow with writeFlow authority", async () => {
-    const authorityService = new AuthoritiesService();
-    authorityService.setAuthorities(["readIngestion", "writeFlow"]);
-    const mockAddStepToFlow = jest.fn();
-    const mockAddStepToNew = jest.fn();
-    const mockCreateLoadArtifact = jest.fn();
-    const mockDeleteLoadArtifact = jest.fn();
-    const {getByText, getByLabelText, getByTestId} = render(<MemoryRouter><AuthoritiesContext.Provider value={authorityService}><LoadList
-      addStepToFlow={mockAddStepToFlow}
-      addStepToNew={mockAddStepToNew}
-      canReadOnly={authorityService.canReadLoad()}
-      canReadWrite={authorityService.canWriteLoad()}
-      canWriteFlow={authorityService.canWriteFlow()}
-      createLoadArtifact={mockCreateLoadArtifact}
-      data={data.loadData.data}
-      deleteLoadArtifact={mockDeleteLoadArtifact}
-      flows={data.flows}/>
-    </AuthoritiesContext.Provider></MemoryRouter>);
-
-    const loadStepName = data.loadData.data[0].name;
-
-    fireEvent.click(getByLabelText("testLoad-add-icon"));
-
-    //verify components and text appear on click
-    await waitForElement(() => expect(getByTestId(`${loadStepName}-toNewFlow`)));
-    await waitForElement(() => expect(getByTestId(`${loadStepName}-toExistingFlow`)));
-    await waitForElement(() => expect(getByTestId(`${loadStepName}-flowsList`)));
-    await waitForElement(() => expect(getByText("Add step to a new flow")));
-    await waitForElement(() => expect(getByText("Add step to an existing flow")));
-
-    // test adding to existing flow
-    fireEvent.click(getByTestId(`${loadStepName}-flowsList`));
-    fireEvent.click(getByText(data.flows[0].name));
-    fireEvent.click(getByText("Yes"));
-    expect(mockAddStepToFlow).toBeCalledTimes(1);
-
-    //TODO: Mock addStepToNew not implemented yet
-  });
-
   test("Verify Load list does not allow a step to be added to flow or run in a flow with readFlow authority only", async () => {
     const authorityService = new AuthoritiesService();
     authorityService.setAuthorities(["readIngestion", "readFlow"]);
@@ -468,7 +301,7 @@ describe("Load data component", () => {
     const mockAddStepToNew = jest.fn();
     const mockCreateLoadArtifact = jest.fn();
     const mockDeleteLoadArtifact = jest.fn();
-    const {getByText, queryByTestId, getByLabelText, getByTestId, queryByText} = render(<MemoryRouter><AuthoritiesContext.Provider value={authorityService}><LoadList
+    const {getByText, queryByTestId, getByTestId, queryByText} = render(<MemoryRouter><AuthoritiesContext.Provider value={authorityService}><LoadList
       addStepToFlow={mockAddStepToFlow}
       addStepToNew={mockAddStepToNew}
       canReadOnly={authorityService.canReadLoad()}
@@ -480,9 +313,6 @@ describe("Load data component", () => {
       flows={data.flows}/>
     </AuthoritiesContext.Provider></MemoryRouter>);
     const loadStepName = data.loadData.data[0].name;
-    // adding to new flow icon is disabled and shows correct tooltip
-    fireEvent.mouseOver(getByLabelText(`${loadStepName}-disabled-add-icon`));
-    await wait(() => expect(getByText("Add to Flow: " + SecurityTooltips.missingPermission)).toBeInTheDocument());
 
 
     // test adding to existing flow option does not appear
@@ -594,6 +424,3 @@ describe("Load data component", () => {
     expect(container.querySelector(".ant-pagination")).toBeNull();
   });
 });
-
-
-

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.tsx
@@ -2,7 +2,7 @@ import React, {useState, useEffect, useContext} from "react";
 import {Link, useLocation, useHistory} from "react-router-dom";
 import styles from "./load-list.module.scss";
 import "./load-list.scss";
-import {Table, Icon, Modal, Menu, Select, Row, Col, Divider, Dropdown} from "antd";
+import {Table, Icon, Modal, Menu, Select, Row, Col, Divider} from "antd";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faTrashAlt} from "@fortawesome/free-regular-svg-icons";
 import {MLButton} from "@marklogic/design-system";
@@ -13,6 +13,7 @@ import {AdvLoadTooltips, SecurityTooltips} from "../../config/tooltips.config";
 import {MLTooltip} from "@marklogic/design-system";
 import {LoadingContext} from "../../util/loading-context";
 import {getViewSettings, setViewSettings} from "../../util/user-context";
+import {faCog} from "@fortawesome/free-solid-svg-icons";
 
 const {Option} = Select;
 
@@ -310,6 +311,7 @@ const LoadList: React.FC<Props> = (props) => {
     </Modal>
   );
 
+  // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
   const menu = (name) => (
     <Menu className={styles.dropdownMenu}>
       <Menu.Item key="0">
@@ -368,9 +370,6 @@ const LoadList: React.FC<Props> = (props) => {
       title: <span data-testid="loadTableName">Name</span>,
       dataIndex: "name",
       key: "name",
-      render: (text: any, record: any) => (
-        <span><span onClick={() => OpenStepSettings(record)} className={styles.editLoadConfig}>{text}</span> </span>
-      ),
       sortDirections: ["ascend", "descend", "ascend"],
       sorter: (a: any, b: any) => a.name.localeCompare(b.name),
       sortOrder: (sortedInfo && sortedInfo.columnKey === "name") ? sortedInfo.order : "",
@@ -424,11 +423,7 @@ const LoadList: React.FC<Props> = (props) => {
       render: (text, row) => (
         <span>
           {props.canReadWrite ? <MLTooltip title={"Run"} placement="bottom"><i aria-label="icon: run"><Icon type="play-circle" theme="filled" className={styles.runIcon} data-testid={row.name + "-run"} onClick={() => handleStepRun(row.name)} /></i></MLTooltip> : <MLTooltip title={"Run: " + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: "200px"}}><i role="disabled-run-load-list button" data-testid={row.name + "-disabled-run"}><Icon type="play-circle" theme="filled" onClick={(event) => event.preventDefault()} className={styles.disabledRunIcon} /></i></MLTooltip>}
-          <Dropdown data-testid={`${row.name}-dropdown`} overlay={menu(row.name)} trigger={["click"]} disabled={!props.canWriteFlow} placement="bottomCenter">
-            {props.canWriteFlow ? <MLTooltip title={"Add to Flow"} placement="bottom"><span className={"AddToFlowIcon"} aria-label={row.name + "-add-icon"}></span></MLTooltip> : <MLTooltip title={"Add to Flow: " + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: "225px"}}><span aria-label={row.name + "-disabled-add-icon"} className={"disabledAddToFlowIcon"}></span></MLTooltip>}
-          </Dropdown>
-          {/* <MLTooltip title={'Settings'} placement="bottom"><Icon type="setting" data-testid={row.name+'-settings'} onClick={() => OpenLoadSettingsDialog(row)} className={styles.settingsIcon} /></MLTooltip> */}
-                    &nbsp;
+          <MLTooltip title={"Step Settings"} placement="bottom"><i key="edit" className={styles.editIcon}><FontAwesomeIcon icon={faCog} data-testid={row.name + "-edit"} onClick={() => OpenStepSettings(row)}/></i></MLTooltip>
           {props.canReadWrite ? <MLTooltip title={"Delete"} placement="bottom"><i aria-label="icon: delete"><FontAwesomeIcon icon={faTrashAlt} data-testid={row.name + "-delete"} onClick={() => { showDeleteConfirm(row.name); }} className={styles.deleteIcon} size="lg" /></i></MLTooltip> :
             <MLTooltip title={"Delete: " + SecurityTooltips.missingPermission} placement="bottom" overlayStyle={{maxWidth: "200px"}}><i aria-label="icon: delete"><FontAwesomeIcon icon={faTrashAlt} data-testid={row.name + "-disabled-delete"} onClick={(event) => event.preventDefault()} className={styles.disabledDeleteIcon} size="lg" /></i></MLTooltip>}
         </span>

--- a/marklogic-data-hub-central/ui/src/pages/Load.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Load.test.tsx
@@ -45,7 +45,7 @@ describe("Load component", () => {
 
     // Open settings
     await act(async () => {
-      await fireEvent.click(getByText("testLoad"));
+      await fireEvent.click(getByTestId("testLoad-edit"));
     });
     expect(getByText("Loading Step Settings")).toBeInTheDocument();
     expect(getByText("Basic").closest("div")).toHaveClass("ant-tabs-tab-active");
@@ -109,7 +109,7 @@ describe("Load component", () => {
 
     // Open settings
     await act(async () => {
-      await fireEvent.click(getByText("testLoad"));
+      await fireEvent.click(getByTestId("testLoad-edit"));
     });
     expect(getByText("Loading Step Settings")).toBeInTheDocument();
     expect(getByText("Basic").closest("div")).toHaveClass("ant-tabs-tab-active");


### PR DESCRIPTION
### Description
This PR removes the flow icon from load list view and adds a settings icon, making it consistent with table view. The link to settings via the load name was removed. Tests were edited and removed due to changed functionality.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests

