### PR TITLE
DHFPROD-6478:Margin size mismatch between Map/Match tab vs Merge tab in Curate tile

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merging-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merging-card.tsx
@@ -366,7 +366,7 @@ const MergingCard: React.FC<Props> = (props) => {
   };
 
   return (
-    <div className={styles.mergeContainer}>
+    <div className={styles.mergingContainer}>
       <Row gutter={16} type="flex">
         {props.canWriteMatchMerge ? (
           <Col>


### PR DESCRIPTION
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests

