### PR TITLE
DHFPROD-7448: Add legend to Properties tab in Graph View

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/modeling/graph-view/properties-tab/properties-tab.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/modeling/graph-view/properties-tab/properties-tab.module.scss
@@ -1,0 +1,34 @@
+.legend {
+  display: flex;
+  justify-content: flex-start;
+  margin-top: 5px;
+  margin-bottom: 15px;
+  flex-wrap: wrap;
+
+  .legendText {
+    font-size: 14px;
+    margin-right: 18px;
+    img, svg {
+      margin-right: 2px;
+    }
+  }
+
+  .foreignKeyLegendText {
+    font-size: 14px;
+    margin-right: 18px;
+  }
+
+  .foreignKeyIcon {
+    color: #37AA6C;
+    font-size: 14px;
+  }
+
+  .structuredIcon {
+    color: #5B69AF;
+    font-size: 14px;
+  }
+
+  .arrayImage {
+    margin-bottom: 4px
+  }
+}

--- a/marklogic-data-hub-central/ui/src/components/modeling/graph-view/properties-tab/properties-tab.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/graph-view/properties-tab/properties-tab.test.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import {BrowserRouter as Router} from "react-router-dom";
+import {render, fireEvent} from "@testing-library/react";
+import PropertiesTab from "./properties-tab";
+
+import {
+  getEntityTypes,
+} from "../../../../assets/mock-data/modeling/modeling";
+
+describe("Graph Modeling Properties Tab Component", () => {
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("Verify Show/Hide Legend functionality", () => {
+    const {getByTestId, queryByTestId} =  render(
+      <Router>
+        <PropertiesTab
+          entityTypeData={getEntityTypes[0]}
+          canWriteEntityModel={true}
+          canReadEntityModel={true}
+        />
+      </Router>);
+
+    //Legend should be hidden by default with "Show Legend >>" link visible
+    expect(getByTestId("showLegendLink")).toBeInTheDocument();
+
+    expect(queryByTestId("foreignKeyIconLegend")).not.toBeInTheDocument();
+    expect(queryByTestId("multipleIconLegend")).not.toBeInTheDocument();
+    expect(queryByTestId("structuredIconLegend")).not.toBeInTheDocument();
+    expect(queryByTestId("hideLegendLink")).not.toBeInTheDocument();
+
+    //toggle link to show legend
+    fireEvent.click(getByTestId("showLegendLink"));
+    expect(getByTestId("hideLegendLink")).toBeInTheDocument();
+    expect(queryByTestId("showLegendLink")).not.toBeInTheDocument();
+
+    expect(getByTestId("foreignKeyIconLegend")).toBeInTheDocument();
+    expect(getByTestId("multipleIconLegend")).toBeInTheDocument();
+    expect(getByTestId("structuredIconLegend")).toBeInTheDocument();
+    expect(getByTestId("hideLegendLink")).toBeInTheDocument();
+
+  });
+});

--- a/marklogic-data-hub-central/ui/src/components/modeling/graph-view/properties-tab/properties-tab.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/graph-view/properties-tab/properties-tab.tsx
@@ -1,5 +1,9 @@
-import React from "react";
+import React, {useState} from "react";
 import PropertyTable from "../../property-table/property-table";
+import styles from "./properties-tab.module.scss";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faLayerGroup, faKey} from "@fortawesome/free-solid-svg-icons";
+import arrayIcon from "../../../../assets/icon_array.png";
 
 interface Props {
   entityTypeData: any;
@@ -7,16 +11,49 @@ interface Props {
   canReadEntityModel: any;
 }
 
+
 const PropertiesTab: React.FC<Props> = (props) => {
+  const [showLegend, setShowLegend] = useState(false);
+
+  const toggleLegend = () => {
+    if (showLegend) {
+      setShowLegend(false);
+    } else {
+      setShowLegend(true);
+    }
+  };
+
+  const LegendShowHide =
+    <div>
+      {showLegend ?
+        <div className={styles.legend}>
+          <div data-testid="foreignKeyIconLegend" className={styles.foreignKeyLegendText}>
+            <FontAwesomeIcon className={styles.foreignKeyIcon} icon={faKey}/> Foreign Key Relationship
+          </div>
+          <div data-testid="multipleIconLegend" className={styles.legendText}>
+            <img className={styles.arrayImage} src={arrayIcon} alt={""}/> Multiple
+          </div>
+          <div data-testid="structuredIconLegend" className={styles.legendText}>
+            <FontAwesomeIcon className={styles.structuredIcon} icon={faLayerGroup}/> Structured Type
+          </div>
+          <a data-testid="hideLegendLink" onClick={() => toggleLegend()}>Hide Legend &lt;&lt;</a>
+        </div>
+        :
+        <a data-testid="showLegendLink" onClick={() => toggleLegend()}>Show Legend &gt;&gt;</a>
+      }
+    </div>;
 
   return (
-    <PropertyTable
-      entityName={props.entityTypeData?.entityName}
-      definitions={props.entityTypeData?.model.definitions}
-      canReadEntityModel={props.canReadEntityModel}
-      canWriteEntityModel={props.canWriteEntityModel}
-      sidePanelView={true}
-    />
+    <div>
+      {LegendShowHide}
+      <PropertyTable
+        entityName={props.entityTypeData?.entityName}
+        definitions={props.entityTypeData?.model.definitions}
+        canReadEntityModel={props.canReadEntityModel}
+        canWriteEntityModel={props.canWriteEntityModel}
+        sidePanelView={true}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
### Description
- https://drive.google.com/file/d/1eZL6L0IBE8NbZpahMbrU2tDZy_sZoKiy/view
- When legend is shown, the legend + "Hide Legend <<" text is set to wrap to a new line depending on the width of the side panel, as discussed with Jamie. 
- Design approved by Jamie

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

