### PR TITLE
DHFPROD-7630: Attempt to fix E2E flow tests on Windows

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub_integration/EndToEndFlowTests.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub_integration/EndToEndFlowTests.java
@@ -846,9 +846,12 @@ public class EndToEndFlowTests extends AbstractHubCoreTest {
         }
         logger.error(mlcpRunner.getProcessOutput());
 
+        final DatabaseClient stagingClient = getHubClient().getStagingClient();
+
         for (int i = 0; i < 10; i++) {
             Thread.sleep(1000);
-            if (getStagingDocCount() == finalCounts.stagingCount + existingStagingCount) {
+            String count = stagingClient.newServerEval().javascript("cts.estimate(cts.trueQuery())").evalAs(String.class);
+            if (Integer.parseInt(count) == finalCounts.stagingCount + existingStagingCount) {
                 break;
             }
         }
@@ -871,7 +874,7 @@ public class EndToEndFlowTests extends AbstractHubCoreTest {
             	}
             }
 
-            GenericDocumentManager stagingDocMgr = getHubClient().getStagingClient().newDocumentManager();
+            GenericDocumentManager stagingDocMgr = stagingClient.newDocumentManager();
             if (dataFormat.equals(DataFormat.JSON)) {
                 String expected = getResource("e2e-test/" + filename + "." + dataFormat.toString());
                 String actual = stagingDocMgr.read("/input" + fileSuffix + "." + dataFormat.toString()).next().getContent(new StringHandle()).get();


### PR DESCRIPTION
### Description

Using the same DB client to get the count of staging docs, and thus hoping that means the read succeeds as well. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit

- ##### Reviewer:

- [x] Reviewed Tests

