### PR TITLE
DHFPROD-7133: Run flows success and error messages

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/run/runFlow.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/run/runFlow.spec.tsx
@@ -59,7 +59,9 @@ describe("Run Tile tests", () => {
     cy.get("#merge-xml-person").click();
     cy.get("#master-person").click();
     runPage.runFlow("testPersonXML");
-    tiles.closeRunMessage();
+    runPage.verifyFlowModalRunning("testPersonXML");
+    cy.waitForAsyncRequest();
+    runPage.getFlowStatusModal().type("{esc}");
     runPage.clickSuccessCircleIcon("mapPersonXML");
     cy.verifyStepRunResult("success", "Mapping", "mapPersonXML");
     tiles.closeRunMessage();
@@ -69,17 +71,24 @@ describe("Run Tile tests", () => {
     runPage.clickSuccessCircleIcon("merge-xml-person");
     cy.verifyStepRunResult("success", "Merging", "merge-xml-person");
     tiles.closeRunMessage();
+    runPage.openFlowStatusModal("testPersonXML");
+    runPage.verifyFlowModalCompleted("testPersonXML");
+    runPage.getFlowStatusModal().type("{esc}");
 
     //Verify if no step is selected in run flow dropdown; all steps are executed
     runPage.expandFlow("testCustomFlow");
     runPage.runFlow("testCustomFlow");
     cy.uploadFile("input/test-1.zip");
     cy.waitForAsyncRequest();
-    tiles.closeRunMessage();
+    runPage.verifyFlowModalRunning("testCustomFlow");
+    runPage.getFlowStatusModal().type("{esc}");
     runPage.expandFlow("testCustomFlow");
     runPage.clickSuccessCircleIcon("mapping-step");
     cy.verifyStepRunResult("success", "Custom", "mapping-step");
     tiles.closeRunMessage();
+    runPage.openFlowStatusModal("testCustomFlow");
+    runPage.verifyFlowModalCompleted("testCustomFlow");
+    runPage.getFlowStatusModal().type("{esc}");
 
     //Run map,match and merge step for Person entity using xml documents
     runPage.runStep("mapPersonXML");

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/run.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/run.tsx
@@ -48,6 +48,26 @@ class RunPage {
     cy.findAllByText(stepName).first().should("be.visible");
   }
 
+  getFlowStatusModal() {
+    return cy.get("[data-testid=job-response-modal]");
+  }
+
+  verifyFlowModalRunning(flowName: string) {
+    cy.findByLabelText(`${flowName}-running`).should("be.visible");
+  }
+
+  verifyFlowModalCompleted(flowName: string) {
+    cy.findByLabelText(`${flowName}-completed`).should("be.visible");
+  }
+
+  openFlowStatusModal(flowName: string) {
+    cy.findByTestId(`${flowName}-StatusIcon`).click();
+  }
+
+  closeFlowStatusModal() {
+    return cy.get("[aria-label=\"icon: close\"]").click();
+  }
+
   runStep(stepName: string) {
     cy.waitUntil(() => cy.findByLabelText(`runStep-${stepName}`)).click({force: true});
     cy.waitForAsyncRequest();

--- a/marklogic-data-hub-central/ui/src/components/flows/flows.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/flows/flows.module.scss
@@ -31,6 +31,16 @@
     color: var(--hoverColor);
   }
 
+
+  .infoIcon {
+    vertical-align: middle;
+    margin-left: 8px;
+    color: #7F86B5;
+    cursor: pointer;
+    &:hover {
+      color: var(--hoverColor);
+    }  }
+
   .disabledDeleteIcon {
     color: rgba(0, 0, 0, 0.65);
     opacity: 0.5;

--- a/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
+++ b/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
@@ -44,8 +44,9 @@ interface Props {
   flowsDefaultActiveKey: any;
   showStepRunResponse: any;
   runEnded: any;
-  onReorderFlow: (flowIndex: number, newSteps: Array<any>) => void;
-  isStepRunning: boolean
+  onReorderFlow: (flowIndex: number, newSteps: Array<any>) => void
+  setJobId: any;
+  setOpenJobResponse: any;
 }
 
 const StepDefinitionTypeTitles = {
@@ -147,9 +148,8 @@ const Flows: React.FC<Props> = (props) => {
       return;
     }
 
-    // Shows job data for steps in a flow that is expanded in session storage
-    Array.from(openFlows).forEach(flowKey => {
-      getFlowWithJobInfo(Number(flowKey));
+    props.flows.map((flow, i) => {
+      getFlowWithJobInfo(i);
     });
 
     setHasQueriedInitialJobData(true);
@@ -237,7 +237,6 @@ const Flows: React.FC<Props> = (props) => {
       setStartRun(true);
     }
   }, [props.newStepToFlowOptions]);
-
 
   // For role-based privileges
   const authorityService = useContext(AuthoritiesContext);
@@ -650,12 +649,30 @@ const Flows: React.FC<Props> = (props) => {
   );
 
   const flowHeader = (name, index) => (
-    <MLTooltip title={props.canWriteFlow ? "Edit Flow" : "Flow Details"} placement="right">
-      <span className={styles.flowName} onClick={(e) => OpenEditFlowDialog(e, index)}>
-        {name}
-      </span>
-    </MLTooltip>
+    <span>
+      <MLTooltip title={props.canWriteFlow ? "Edit Flow" : "Flow Details"} placement="bottom">
+        <span className={styles.flowName} onClick={(e) => OpenEditFlowDialog(e, index)}>
+          {name}
+        </span>
+      </MLTooltip>
+      {latestJobData && latestJobData[name] && latestJobData[name].find(step => step.jobId) ?
+        <MLTooltip title={"Flow Status"} placement="bottom">
+          <span onClick={(e) => OpenFlowJobStatus(e, index, name)} className={styles.infoIcon}>
+            <Icon type="info-circle" theme="filled" data-testid={name + "-StatusIcon"} />
+          </span>
+        </MLTooltip>
+        : ""
+      }
+    </span>
   );
+
+  const OpenFlowJobStatus = (e, index, name) => {
+    e.stopPropagation();
+    e.preventDefault();
+    let jobIdIndex = latestJobData[name].findIndex(step => step.hasOwnProperty("jobId"));
+    props.setJobId(latestJobData[name][jobIdIndex].jobId);
+    props.setOpenJobResponse(true);
+  };
 
   const OpenEditFlowDialog = (e, index) => {
     e.stopPropagation();

--- a/marklogic-data-hub-central/ui/src/components/job-response/job-response.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/job-response/job-response.module.scss
@@ -33,13 +33,57 @@
   }
 
   .stepResponse {
+    width: 35%;
     padding-right: 15px;
     padding-left: 1px;
-    padding-bottom: 15px;
-
+    // padding-bottom: 15px;
+    
     .stepName {
       vertical-align: center;
     }
+  }
+
+  .errorStepResponse {
+    width: 100%;
+    padding-right: 15px;
+    padding-left: 1px;
+    // padding-bottom: 15px;
+    
+    .stepName {
+      vertical-align: center;
+    }
+  }
+
+
+  .divider {
+    margin: 10px 0px !important;
+  }
+
+  .stepRow{
+    display: flex;
+    flex-direction: row;
+  }
+
+  .headerRow {
+    display: flex;
+    flex-direction: row;
+    padding-top: 25px;
+    margin-left: 25px;
+  }
+
+  .headerItem {
+    width: 25%;
+    margin-right: 75px;
+    padding-left: 1px;
+    text-align: left;
+  }
+
+  .documentsWritten {
+    width: 25%;
+    padding-right: 15px;
+    text-align: left;
+    margin-right: 12%;
+    margin-left: 8%;
   }
 
   .running {
@@ -87,6 +131,20 @@
   format('truetype');
 }
 
+.exploreActionIcon:before {
+  content: "\68";
+  font-family: ExploreIcon;
+  font-size: 15px;
+  padding-right: 6px;
+  vertical-align: middle;
+  color: #ffffff;
+}
+
+.exploreActionText{
+  font-size: 15px;
+  padding-right: 5px;
+}
+
 .exploreDataContainer {
   margin: auto;
   width: 50%;
@@ -102,7 +160,7 @@
   cursor: pointer;
   border-radius: 4px;
   padding: 0px 7px;
-  margin-right: -3px;
+  margin-right: 12%;
 }
 
 .exploreText{

--- a/marklogic-data-hub-central/ui/src/components/job-response/job-response.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/job-response/job-response.test.tsx
@@ -9,6 +9,15 @@ import {curationContextMock} from "../../assets/mock-data/curation/curation-cont
 
 jest.mock("axios");
 
+const getSubElements=(content, node, title) => {
+  const hasText = node => node.textContent === title;
+  const nodeHasText = hasText(node);
+  const childrenDontHaveText = Array.from(node.children).every(
+    child => !hasText(child)
+  );
+  return nodeHasText && childrenDontHaveText;
+};
+
 describe("Job response modal", () => {
 
   beforeEach(() => {
@@ -37,8 +46,16 @@ describe("Job response modal", () => {
       ));
     });
 
-    // check that
-    await (waitForElement(() => (getByText("testFlow"))));
+    // verify modal text and headers
+    expect(await(waitForElement(() => getByText((content, node) => {
+      return getSubElements(content, node, "The flow testFlow completed");
+    })))).toBeInTheDocument();
+
+    expect(getByText("Job ID:")).toBeInTheDocument();
+    expect(getByText("Start Time:")).toBeInTheDocument();
+    expect(getByText("Duration:")).toBeInTheDocument();
+
+    expect(getByText("e4590649-8c4b-419c-b6a1-473069186592")).toBeInTheDocument();
     expect(getByText("2020-04-24 14:05")).toBeInTheDocument();
     expect(getByText("0s 702ms")).toBeInTheDocument();
 
@@ -48,9 +65,6 @@ describe("Job response modal", () => {
     expect(getByText("merge-customer")).toBeInTheDocument();
     expect(getByText("master-customer")).toBeInTheDocument();
     expect(getByText("Ingestion1")).toBeInTheDocument();
-
-    expect(getByText("Close")).toBeInTheDocument();
-
   });
 
   test("Verify failed job response information displays", async () => {


### PR DESCRIPTION
### Description

- Added flow status modal upon running multiple steps in a flow in the Run tile
- When a flow has been run, its status modal can be opened via the info icon next to the flow name
- Out of scope: automatic updating of the status modal, so re-visit page to see changes at the moment
- Out of scope: Explore data button on the status modal.
- https://drive.google.com/file/d/1GHPRTM8E88LJP_Lnqw7RwVWhwCb1UXt3/view

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [x] Run UI tests
  

- ##### Reviewer:

- [x] Reviewed Tests

