### PR TITLE
DHFPROD-7668: No longer logging confusing error when metadata is null

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/entities/entity-search-lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/entities/entity-search-lib.sjs
@@ -390,12 +390,13 @@ function addEntitySpecificProperties(result, entityInfo, selectedPropertyMetadat
     result.entityProperties.push(getPropertyValues(parentProperty, entityInstance));
   });
   addPrimaryKeyToResult(result, entityInstance, entityDef);
-  try {
-    result.createdOn = xdmp.documentGetMetadata(result.uri).datahubCreatedOn;
-    result.createdBy = xdmp.documentGetMetadata(result.uri).datahubCreatedBy;
-  } catch (error) {
-    console.log(`Unable to obtain document with URI '${result.uri}'; will not add document metadata to its search result`);
+
+  const metadata = xdmp.documentGetMetadata(result.uri);
+  if (metadata) {
+    result.createdOn = metadata.datahubCreatedOn;
+    result.createdBy = metadata.datahubCreatedBy;
   }
+
   result.entityInstance = entityInstance;
   result.sources = getEntitySources(result.uri);
   result.entityName = entityTitle;


### PR DESCRIPTION
### Description

No test needed or possible, as verification is done by looking at logging

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
