### PR TITLE
DHFPROD-7695: Removed jcenter references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ Gradle plugin:
   buildscript {
     repositories {
       mavenLocal()
-      jcenter()
+      mavenCentral()
     }
     dependencies {
       classpath "com.marklogic:ml-data-hub:(the version number you chose)"
@@ -143,7 +143,7 @@ Gradle plugin:
   plugins {
      ...
      // comment out this line. It pulls the version from the cloud
-     // id 'com.marklogic.ml-data-hub' version '4.0.0'
+     // id 'com.marklogic.ml-data-hub' version '5.5.0'
   }
 
   // this tells gradle to apply the plugin you included above in the buildscript section

--- a/examples/dh-5-example/README.md
+++ b/examples/dh-5-example/README.md
@@ -74,7 +74,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {

--- a/examples/dhs-example/build.gradle
+++ b/examples/dhs-example/build.gradle
@@ -2,11 +2,11 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url "https://plugins.gradle.org/m2/" }
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         if (project.hasProperty("testing")) {
-            classpath "com.marklogic:ml-data-hub:5.2-SNAPSHOT"
+            classpath "com.marklogic:ml-data-hub:5.5-SNAPSHOT"
         } else {
             classpath "com.marklogic:ml-data-hub:5.5.0"
         }

--- a/examples/reference-entity-model/README.md
+++ b/examples/reference-entity-model/README.md
@@ -98,7 +98,7 @@ library available in the DHF 5.5.0 release. This support is enabled via the foll
 build.gradle file:
 
 - The "java" plugin is applied so that Gradle's support for compiling and running JUnit5 tests can be used
-- In the "repositories" block, mavenCentral() and jcenter() are both included to satisfy the dependencies for test support
+- In the "repositories" block, mavenCentral() is included to satisfy the dependencies for test support
 - In the "dependencies" block, marklogic-unit-test-modules is included so that the modules associated with this library will be 
 loaded into the modules database, and marklogic-data-hub-junit5 is included to support JUnit5 testing
 - The "test" block includes "useJUnitPlatform()" to tell Gradle to use the platform support in JUnit5

--- a/marklogic-data-hub-spark-connector/spark-test-project/build.gradle
+++ b/marklogic-data-hub-spark-connector/spark-test-project/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 sourceCompatibility = "8"

--- a/performance-tests/projects/commoncrawl/build.gradle
+++ b/performance-tests/projects/commoncrawl/build.gradle
@@ -2,14 +2,14 @@ buildscript {
 	repositories {
 		mavenLocal()
 		maven { url "https://plugins.gradle.org/m2/" }
-		jcenter()
+		mavenCentral()
 	}
 	dependencies {
 		if (project.hasProperty("testing")) {
 			classpath "com.marklogic:ml-data-hub:5.5-SNAPSHOT"
 
 		} else {
-			classpath "com.marklogic:ml-data-hub:5.4.0"
+			classpath "com.marklogic:ml-data-hub:5.5.0"
 		}
 	}
 }
@@ -41,11 +41,11 @@ task clearFinalDatabase(type: com.marklogic.gradle.task.databases.ClearDatabaseT
 }
 
 repositories {
-    jcenter()
-    maven { url "http://developer.marklogic.com/maven2/" }
+    mavenCentral()
+    maven { url "https://developer.marklogic.com/maven2/" }
 }
 dependencies {
-    mlcp "com.marklogic:mlcp:10.0.5"
+    mlcp "com.marklogic:mlcp:10.0.6.2"
     mlcp files("lib")
 }
 
@@ -86,7 +86,7 @@ task loadIpViaMlcp(type: com.marklogic.gradle.task.MlcpTask) {
 task runMapping (type: com.marklogic.gradle.task.RunFlowTask) {
     description = "Run mapping step"
     flowName = "mapping"
-    showOptions = "true"                    
+    showOptions = "true"
 }
 
 task runMastering (type: com.marklogic.gradle.task.RunFlowTask) {

--- a/performance-tests/projects/commoncrawl/gradle/wrapper/gradle-wrapper.properties
+++ b/performance-tests/projects/commoncrawl/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Description

Replaced with mavenCentral() where appropriate. Did not modify any of the dhf4 example projects, as those depend on older versions of DHF and ml-gradle whose dependencies only exist in jcenter. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
