### PR TITLE
DHFPROD-7698: Refactored some of Explore into custom constraints

### DIFF
--- a/marklogic-data-hub-api/src/main/java/com/marklogic/hub/HubClientConfig.java
+++ b/marklogic-data-hub-api/src/main/java/com/marklogic/hub/HubClientConfig.java
@@ -90,10 +90,36 @@ public class HubClientConfig {
     // Defines functions for consuming properties from a PropertySource
     private Map<String, Consumer<String>> propertyConsumerMap;
 
+    /**
+     * Constructor that applies this class's default property values, though that notably does not include values for
+     * username and password.
+     */
     public HubClientConfig() {
         applyDefaultPropertyValues();
     }
 
+    /**
+     * Convenience constructor for the common scenario of connecting to a DHF instance that requires a username and
+     * password for authentication.
+     *
+     * @param host
+     * @param username
+     * @param password
+     */
+    public HubClientConfig(String host, String username, String password) {
+        this();
+        Properties props = new Properties();
+        if (host != null) {
+            props.setProperty("mlHost", host);
+        }
+        props.setProperty("mlUsername", username);
+        props.setProperty("mlPassword", password);
+        applyProperties(props);
+    }
+
+    /**
+     * @param props defines a set of properties that will override that default values of this class's properties
+     */
     public HubClientConfig(Properties props) {
         this();
         applyProperties(props);

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/models/DocSearchQueryInfo.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/entities/search/models/DocSearchQueryInfo.java
@@ -16,135 +16,175 @@
  */
 package com.marklogic.hub.central.entities.search.models;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class DocSearchQueryInfo {
 
-  private boolean hideHubArtifacts;
-  private String searchText;
-  private List<String> entityTypeIds;
-  private Map<String, FacetData> selectedFacets;
+    private boolean hideHubArtifacts;
 
-  public DocSearchQueryInfo() {
-    this.hideHubArtifacts = true;
-    this.searchText = "";
-    this.entityTypeIds = new ArrayList<>();
-    this.selectedFacets = new HashMap<>();
-  }
+    // Note that this is the user-provided search text and not the complete criteria string
+    private String searchText;
+
+    // This is a misnomer; these are expected to be types, not type IDs; a type ID is e.g.
+    // http://example.org/MyEntity-1.0/MyEntity, whereas a type is "MyEntity" .
+    // This cannot easily be changed in the DHF 5.x timeframe due to saved queries using this name.
+    private List<String> entityTypeIds;
+
+    private Map<String, FacetData> selectedFacets;
+
+    public DocSearchQueryInfo() {
+        this.hideHubArtifacts = true;
+        this.searchText = "";
+        this.entityTypeIds = new ArrayList<>();
+        this.selectedFacets = new HashMap<>();
+    }
 
     /**
-     * @return an array of non-empty entityTypeIds; this is used to handle empty strings being passed in by the UI,
+     * @return combination of user's search text and custom constraints based on other properties of this class
+     */
+    public String calculateSearchCriteria() {
+        StringBuilder builder = new StringBuilder(searchText != null ? searchText : "");
+
+        final List<String> selectedEntityTypes = this.getSelectedEntityTypes();
+        if (!selectedEntityTypes.isEmpty()) {
+            // The string-concatenated list of entity types is enclosed in double quotes. Based on the current validation
+            // rules for entity types, this isn't necessary to do; this is primarily for future-proofing in case those
+            // rules were to change and allow characters like double quotes.
+            builder.append(" entityType:\"")
+                .append(selectedEntityTypes.stream().collect(Collectors.joining(",")))
+                .append("\"");
+        }
+
+        if (isHideHubArtifacts()) {
+            builder.append(" hideHubArtifacts:true");
+        }
+
+        return StringUtils.trim(builder.toString());
+    }
+
+    /**
+     * @return a single entity type if one and only one entity type has been selected
+     */
+    public String getSingleSelectedEntityType() {
+        return entityTypeIds != null && entityTypeIds.size() == 1 ? entityTypeIds.get(0) : null;
+    }
+
+    /**
+     * @return an array of non-empty entity types; this is used to handle empty strings being passed in by the UI,
      * which seems like a bug, but we don't want it to cause a problem
      */
-  public String[] getEntityTypeCollections() {
-      if (entityTypeIds != null && !entityTypeIds.isEmpty()) {
-          List<String> filteredTypes = new ArrayList<>();
-          entityTypeIds.forEach(type -> {
-              if (type != null && type.trim().length() > 0) {
-                  filteredTypes.add(type);
-              }
-          });
-          return filteredTypes.toArray(new String[]{});
-      }
-      return null;
-  }
-
-  public boolean isHideHubArtifacts() {
-    return hideHubArtifacts;
-  }
-
-  public void setHideHubArtifacts(boolean hideHubArtifacts) {
-    this.hideHubArtifacts = hideHubArtifacts;
-  }
-
-  public String getSearchText() {
-    return searchText;
-  }
-
-  public void setSearchText(String searchText) {
-    this.searchText = searchText;
-  }
-
-  public List<String> getEntityTypeIds() {
-    return entityTypeIds;
-  }
-
-  public void setEntityTypeIds(List<String> entityTypeIds) {
-    this.entityTypeIds = entityTypeIds;
-  }
-
-  public Map<String, FacetData> getSelectedFacets() {
-    return selectedFacets;
-  }
-
-  public void setSelectedFacets(Map<String, FacetData> selectedFacets) {
-    this.selectedFacets = selectedFacets;
-  }
-
-  public final static class FacetData {
-
-    private String dataType;
-    private List<String> stringValues;
-    private RangeValues rangeValues;
-
-    public FacetData() {
-      this.dataType = "";
-      this.stringValues = new ArrayList<>();
-      this.rangeValues = new RangeValues();
+    public List<String> getSelectedEntityTypes() {
+        return entityTypeIds != null ?
+            entityTypeIds.stream().filter(type -> StringUtils.isNotBlank(type)).collect(Collectors.toList()) :
+            new ArrayList<>();
     }
 
-    public String getDataType() {
-      return dataType;
+    public void addSelectedEntityType(String entityType) {
+        if (entityTypeIds == null) {
+            entityTypeIds = new ArrayList<>();
+        }
+        entityTypeIds.add(entityType);
     }
 
-    public void setDataType(String dataType) {
-      this.dataType = dataType;
+    public boolean isHideHubArtifacts() {
+        return hideHubArtifacts;
     }
 
-    public List<String> getStringValues() {
-      return stringValues;
+    public void setHideHubArtifacts(boolean hideHubArtifacts) {
+        this.hideHubArtifacts = hideHubArtifacts;
     }
 
-    public void setStringValues(List<String> stringValues) {
-      this.stringValues = stringValues;
+    public String getSearchText() {
+        return searchText;
     }
 
-    public RangeValues getRangeValues() {
-      return rangeValues;
+    public void setSearchText(String searchText) {
+        this.searchText = searchText;
     }
 
-    public void setRangeValues(RangeValues rangeValues) {
-      this.rangeValues = rangeValues;
-    }
-  }
-
-  public final static class RangeValues {
-
-    private String lowerBound;
-    private String upperBound;
-
-    public RangeValues() {
-      this.lowerBound = "";
-      this.upperBound = "";
+    public List<String> getEntityTypeIds() {
+        return entityTypeIds;
     }
 
-    public String getLowerBound() {
-      return lowerBound;
+    public void setEntityTypeIds(List<String> entityTypeIds) {
+        this.entityTypeIds = entityTypeIds;
     }
 
-    public void setLowerBound(String lowerBound) {
-      this.lowerBound = lowerBound;
+    public Map<String, FacetData> getSelectedFacets() {
+        return selectedFacets;
     }
 
-    public String getUpperBound() {
-      return upperBound;
+    public void setSelectedFacets(Map<String, FacetData> selectedFacets) {
+        this.selectedFacets = selectedFacets;
     }
 
-    public void setUpperBound(String upperBound) {
-      this.upperBound = upperBound;
+    public final static class FacetData {
+
+        private String dataType;
+        private List<String> stringValues;
+        private RangeValues rangeValues;
+
+        public FacetData() {
+            this.dataType = "";
+            this.stringValues = new ArrayList<>();
+            this.rangeValues = new RangeValues();
+        }
+
+        public String getDataType() {
+            return dataType;
+        }
+
+        public void setDataType(String dataType) {
+            this.dataType = dataType;
+        }
+
+        public List<String> getStringValues() {
+            return stringValues;
+        }
+
+        public void setStringValues(List<String> stringValues) {
+            this.stringValues = stringValues;
+        }
+
+        public RangeValues getRangeValues() {
+            return rangeValues;
+        }
+
+        public void setRangeValues(RangeValues rangeValues) {
+            this.rangeValues = rangeValues;
+        }
     }
-  }
+
+    public final static class RangeValues {
+
+        private String lowerBound;
+        private String upperBound;
+
+        public RangeValues() {
+            this.lowerBound = "";
+            this.upperBound = "";
+        }
+
+        public String getLowerBound() {
+            return lowerBound;
+        }
+
+        public void setLowerBound(String lowerBound) {
+            this.lowerBound = lowerBound;
+        }
+
+        public String getUpperBound() {
+            return upperBound;
+        }
+
+        public void setUpperBound(String upperBound) {
+            this.upperBound = upperBound;
+        }
+    }
 }

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/EntitySearchManagerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/EntitySearchManagerTest.java
@@ -103,56 +103,6 @@ public class EntitySearchManagerTest extends AbstractHubCentralTest {
         assertNull(new EntitySearchManager(getHubClient()).search(searchQuery), "Entity Model with name Some-entityType doesn't exist ");
     }
 
-    @Test
-    public void testSortCriteria() {
-        EntitySearchManager entitySearchManager = new EntitySearchManager(getHubClient());
-        SearchQuery query = new SearchQuery();
-        DocSearchQueryInfo info = new DocSearchQueryInfo();
-        info.setEntityTypeIds(Arrays.asList("Customer"));
-        query.setQuery(info);
-
-        SearchQuery.SortOrder sortOrder = new SearchQuery.SortOrder();
-        sortOrder.setPropertyName("customerId");
-        sortOrder.setSortDirection("ascending");
-        List<SearchQuery.SortOrder> sortOrderList = new ArrayList<>();
-        sortOrderList.add(sortOrder);
-        query.setSortOrder(sortOrderList);
-
-        entitySearchManager.buildSearchTextWithSortOperator(query);
-        assertEquals("sort:Customer_customerIdAscending", query.getQuery().getSearchText());
-
-        query.getQuery().setSearchText("");
-        sortOrderList.get(0).setSortDirection("descending");
-        entitySearchManager.buildSearchTextWithSortOperator(query);
-        assertEquals("sort:Customer_customerIdDescending", query.getQuery().getSearchText());
-
-        query.getQuery().setSearchText("Jane");
-        sortOrderList.get(0).setSortDirection("descending");
-        entitySearchManager.buildSearchTextWithSortOperator(query);
-        assertEquals("Jane sort:Customer_customerIdDescending", query.getQuery().getSearchText());
-
-        query.getQuery().setSearchText("Jane");
-        sortOrderList.get(0).setSortDirection("someOtherValue");
-        entitySearchManager.buildSearchTextWithSortOperator(query);
-        assertEquals("Jane sort:Customer_customerIdDescending", query.getQuery().getSearchText());
-
-        query.getQuery().setSearchText("Jane");
-        sortOrderList.get(0).setSortDirection("descending");
-        sortOrder = new SearchQuery.SortOrder();
-        sortOrder.setPropertyName("customerId");
-        sortOrder.setSortDirection("ascending");
-        sortOrderList.add(sortOrder);
-        entitySearchManager.buildSearchTextWithSortOperator(query);
-        assertEquals("Jane sort:Customer_customerIdDescending sort:Customer_customerIdAscending", query.getQuery().getSearchText());
-
-        info.setEntityTypeIds(null);
-        query.getQuery().setSearchText("Jane");
-        entitySearchManager.buildSearchTextWithSortOperator(query);
-        assertEquals("Jane sort:_customerIdDescending sort:_customerIdAscending", query.getQuery().getSearchText(),
-            "If there's somehow no entity type specified, then an error shouldn't be thrown; we should just have sort " +
-                "state names that don't correspond to actual states, which will result in no error but no sorting either");
-    }
-
     /**
      * This is using XML instances with namespaces to ensure that path expressions in sort operator states work
      * correctly. Will soon add a JSON test once we have sort operators that are entity-type-specific.

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/models/CalculateSearchCriteriaTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/models/CalculateSearchCriteriaTest.java
@@ -1,0 +1,55 @@
+package com.marklogic.hub.central.entities.search.models;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CalculateSearchCriteriaTest {
+
+    DocSearchQueryInfo info = new DocSearchQueryInfo();
+
+    @Test
+    void noUserInput() {
+        assertEquals("hideHubArtifacts:true", calculate(), "hub artifacts are excluded by default");
+    }
+
+    @Test
+    void entityTypeNoUserSearchText() {
+        info.setEntityTypeIds(Arrays.asList("A", "", null, "B", null));
+        assertEquals("entityType:\"A,B\" hideHubArtifacts:true", calculate());
+    }
+
+    @Test
+    void entityTypeWithUserSearchText() {
+        info.setSearchText("hello world");
+        info.setEntityTypeIds(Arrays.asList("A", "", null, "B", null));
+        assertEquals("hello world entityType:\"A,B\" hideHubArtifacts:true", calculate());
+    }
+
+    @Test
+    void dontHideHubArtifacts() {
+        info.setSearchText("hi   ");
+        info.setHideHubArtifacts(false);
+        assertEquals("hi", calculate(), "hideHubArtifacts should be omitted when set to false");
+    }
+
+    @Test
+    void nullSearchText() {
+        info.setSearchText(null);
+        info.setEntityTypeIds(Arrays.asList("A", "B"));
+        assertEquals("entityType:\"A,B\" hideHubArtifacts:true", calculate());
+    }
+
+    @Test
+    void emptySearchText() {
+        info.setSearchText(" ");
+        info.setEntityTypeIds(Arrays.asList("A"));
+        assertEquals("entityType:\"A\" hideHubArtifacts:true", calculate());
+    }
+
+    private String calculate() {
+        return info.calculateSearchCriteria();
+    }
+}

--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/models/CalculateSearchCriteriaWithSortOrderTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/entities/search/models/CalculateSearchCriteriaWithSortOrderTest.java
@@ -1,0 +1,55 @@
+package com.marklogic.hub.central.entities.search.models;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CalculateSearchCriteriaWithSortOrderTest {
+
+    SearchQuery searchQuery = new SearchQuery();
+
+    @Test
+    void ascending() {
+        searchQuery.getQuery().setSearchText("user text");
+        searchQuery.getQuery().addSelectedEntityType("Customer");
+        searchQuery.addSortOrder("customerId", "ascending");
+        assertEquals("user text entityType:\"Customer\" hideHubArtifacts:true sort:Customer_customerIdAscending", calculate());
+    }
+
+    @Test
+    void descending() {
+        searchQuery.getQuery().addSelectedEntityType("Customer");
+        searchQuery.addSortOrder("customerId", "descending");
+        assertEquals("entityType:\"Customer\" hideHubArtifacts:true sort:Customer_customerIdDescending", calculate());
+    }
+
+    @Test
+    void invalidDirection() {
+        searchQuery.getQuery().addSelectedEntityType("Customer");
+        searchQuery.addSortOrder("customerId", "invalid");
+        assertEquals("entityType:\"Customer\" hideHubArtifacts:true sort:Customer_customerIdDescending", calculate(),
+            "If the sort direction isn't recognized, it defaults to descending");
+    }
+
+    @Test
+    void multipleSortOrders() {
+        searchQuery.getQuery().addSelectedEntityType("Customer");
+        searchQuery.addSortOrder("customerId", "descending");
+        searchQuery.addSortOrder("name", "ascending");
+        assertEquals("entityType:\"Customer\" hideHubArtifacts:true sort:Customer_customerIdDescending sort:Customer_nameAscending", calculate());
+
+    }
+
+    @Test
+    void noSelectedEntityTypes() {
+        searchQuery.getQuery().setSearchText("hello");
+        searchQuery.addSortOrder("customerId", "descending");
+        assertEquals("hello hideHubArtifacts:true", calculate(),
+            "If no entity type is selected, then no sort operators should be added to the calculate search text, as sort " +
+                "operators are only generated for entity properties with sortable=true");
+    }
+
+    private String calculate() {
+        return searchQuery.calculateSearchCriteriaWithSortOperator();
+    }
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/entities/constraint/entityType.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/entities/constraint/entityType.xqy
@@ -1,0 +1,53 @@
+(:
+  Copyright (c) 2021 MarkLogic Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+:)
+xquery version "1.0-ml";
+
+module namespace ns = "http://marklogic.com/data-hub/entities/constraint/entityType";
+
+declare namespace search = "http://marklogic.com/appservices/search";
+
+(:
+Supports constraint on collections specific to entity types while also excluding mastering-specific
+collections that contain documents that are not considered to be entity instances.
+:)
+declare function parse(
+  $constraint-qtext as xs:string,
+  $right as schema-element(cts:query)
+) as schema-element(cts:query)
+{
+  let $entity-types :=
+    for $token in fn:tokenize($right//cts:text, ",")
+    let $token := fn:normalize-space($token)
+    where fn:not($token = "")
+    return $token
+
+  let $query := <x>{
+    cts:and-not-query(
+      cts:collection-query($entity-types),
+      cts:collection-query((
+        "mdm-auditing",
+        for $entity-type in $entity-types
+        return ("auditing", "notification") ! fn:concat("sm-", $entity-type, "-", .)
+      ))
+    )
+  }</x>/element()
+
+  return element { fn:node-name($query) } {
+    attribute qtextconst { fn:concat($constraint-qtext, fn:string($right//cts:text)) },
+    $query/@*,
+    $query/node()
+  }
+};

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/entities/constraint/hideHubArtifacts.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/entities/constraint/hideHubArtifacts.xqy
@@ -1,0 +1,48 @@
+(:
+  Copyright (c) 2021 MarkLogic Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+:)
+xquery version "1.0-ml";
+
+module namespace ns = "http://marklogic.com/data-hub/entities/constraint/hideHubArtifacts";
+
+declare namespace search = "http://marklogic.com/appservices/search";
+
+(:
+Supports hiding hub artifacts from an "all data" search, the assumption being that by default, users do not
+want to see these documents in their search results.
+:)
+declare function parse(
+  $constraint-qtext as xs:string,
+  $right as schema-element(cts:query)
+) as schema-element(cts:query)
+{
+  let $query :=
+    if ("true" = fn:lower-case($right//cts:text/text())) then
+      <x>{cts:not-query(cts:collection-query((
+        "http://marklogic.com/data-hub/flow",
+        "http://marklogic.com/data-hub/mappings",
+        "http://marklogic.com/data-hub/step-definition",
+        "http://marklogic.com/data-hub/steps",
+        "http://marklogic.com/entity-services/models"
+      )))}</x>/*
+    else
+      <x>{cts:true-query()}</x>/*
+
+  return element {fn:node-name($query)} {
+    attribute qtextconst { fn:concat($constraint-qtext, fn:string($right//cts:text)) },
+    $query/@*,
+    $query/node()
+  }
+};

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-entities.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/hub-entities.xqy
@@ -238,64 +238,77 @@ declare function is-explorer-constraint-name($name as xs:string) as xs:boolean
 (:
 Defined in a separate function so that these can be referenced when validating entity names.
 :)
-declare private function build-static-explorer-constraints()
+declare private function build-static-explorer-constraints() as element(search:constraint)+
 {
-  (
-    <search:constraint name="Collection">
-      <search:collection>
-        <search:facet-option>limit=25</search:facet-option>
-        <search:facet-option>frequency-order</search:facet-option>
-        <search:facet-option>descending</search:facet-option>
-      </search:collection>
-    </search:constraint>,
-    <search:constraint name="createdByJob">
-      <search:range facet="false">
-        <search:field name="datahubCreatedByJob"/>
-      </search:range>
-    </search:constraint>,
-    <search:constraint name="createdByStep">
-      <search:range>
-        <search:field name="datahubCreatedByStep"/>
-        <search:facet-option>limit=25</search:facet-option>
-        <search:facet-option>frequency-order</search:facet-option>
-        <search:facet-option>descending</search:facet-option>
-      </search:range>
-    </search:constraint>,
-    <search:constraint name="createdByJobWord">
-      <search:word>
-        <search:field name="datahubCreatedByJob"/>
-      </search:word>
-    </search:constraint>,
-    <search:constraint name="createdOnRange">
-      <search:range facet="false">
-        <search:field name="datahubCreatedOn"/>
-      </search:range>
-    </search:constraint>,
-    <search:constraint name="createdInFlowRange">
-      <search:range>
-        <search:field name="datahubCreatedInFlow"/>
-        <search:facet-option>limit=25</search:facet-option>
-        <search:facet-option>frequency-order</search:facet-option>
-        <search:facet-option>descending</search:facet-option>
-      </search:range>
-    </search:constraint>,
-    <search:constraint name="sourceName">
-      <search:range>
-        <search:field name="datahubSourceName"/>
-        <search:facet-option>limit=25</search:facet-option>
-        <search:facet-option>frequency-order</search:facet-option>
-        <search:facet-option>descending</search:facet-option>
-      </search:range>
-    </search:constraint>,
-    <search:constraint name="sourceType">
-      <search:range>
-        <search:field name="datahubSourceType"/>
-        <search:facet-option>limit=25</search:facet-option>
-        <search:facet-option>frequency-order</search:facet-option>
-        <search:facet-option>descending</search:facet-option>
-      </search:range>
-    </search:constraint>
-  )
+  (: This wrapper element is used to avoid repeating the "search:" prefix over and over :)
+  <wrapper xmlns="http://marklogic.com/appservices/search">
+    <constraint name="Collection">
+      <collection>
+        <facet-option>limit=25</facet-option>
+        <facet-option>frequency-order</facet-option>
+        <facet-option>descending</facet-option>
+      </collection>
+    </constraint>
+    <constraint name="entityType">
+      <custom facet="false">
+        <parse apply="parse" ns="http://marklogic.com/data-hub/entities/constraint/entityType"
+          at="/data-hub/5/entities/constraint/entityType.xqy" />
+      </custom>
+    </constraint>
+    <constraint name="hideHubArtifacts">
+      <custom facet="false">
+        <parse apply="parse" ns="http://marklogic.com/data-hub/entities/constraint/hideHubArtifacts"
+          at="/data-hub/5/entities/constraint/hideHubArtifacts.xqy" />
+      </custom>
+    </constraint>
+    <constraint name="createdByJob">
+      <range facet="false">
+        <field name="datahubCreatedByJob"/>
+      </range>
+    </constraint>
+    <constraint name="createdByStep">
+      <range>
+        <field name="datahubCreatedByStep"/>
+        <facet-option>limit=25</facet-option>
+        <facet-option>frequency-order</facet-option>
+        <facet-option>descending</facet-option>
+      </range>
+    </constraint>
+    <constraint name="createdByJobWord">
+      <word>
+        <field name="datahubCreatedByJob"/>
+      </word>
+    </constraint>
+    <constraint name="createdOnRange">
+      <range facet="false">
+        <field name="datahubCreatedOn"/>
+      </range>
+    </constraint>
+    <constraint name="createdInFlowRange">
+      <range>
+        <field name="datahubCreatedInFlow"/>
+        <facet-option>limit=25</facet-option>
+        <facet-option>frequency-order</facet-option>
+        <facet-option>descending</facet-option>
+      </range>
+    </constraint>
+    <constraint name="sourceName">
+      <range>
+        <field name="datahubSourceName"/>
+        <facet-option>limit=25</facet-option>
+        <facet-option>frequency-order</facet-option>
+        <facet-option>descending</facet-option>
+      </range>
+    </constraint>
+    <constraint name="sourceType">
+      <range>
+        <field name="datahubSourceType"/>
+        <facet-option>limit=25</facet-option>
+        <facet-option>frequency-order</facet-option>
+        <facet-option>descending</facet-option>
+      </range>
+    </constraint>
+  </wrapper>/element()
 };
 
 declare %private function hent:build-sort-operator(


### PR DESCRIPTION
### Description

entityType and hideHubArtifacts are both ML custom constraints now instead of being in Java code, which will allow overriding the behavior of entityType possible via custom search options

Also reworked some tests in EntitySearchManagerTest to be plain JUnit tests, as the logic is now in SearchQuery and DocSearchQueryInfo instead of in EntitySearchManager

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests

