### PR TITLE
DHFPROD-7718: Can now customize how database indexes are built

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/services/mlDbConfigs.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/services/mlDbConfigs.xqy
@@ -26,28 +26,17 @@ import module namespace hent = "http://marklogic.com/data-hub/hub-entities"
 import module namespace perf = "http://marklogic.com/data-hub/perflog-lib"
   at "/data-hub/4/impl/perflog-lib.xqy";
 
-declare namespace rapi = "http://marklogic.com/rest-api";
-
-declare namespace hub = "http://marklogic.com/data-hub";
-
 declare option xdmp:mapping "false";
 
-(:~
- : Entry point for java to get entity(s).
- :
- : if the "entity-name" param is given then return a entity. Otherwise
- : return all entities.
- :
- :)
 declare function post(
   $context as map:map,
   $params  as map:map,
   $input   as document-node()*
   ) as document-node()*
 {
-  debug:dump-env("GET ENTITY(s)"),
+  debug:dump-env("Build indexes"),
 
-  perf:log('/v1/resources/entity:get', function() {
+  perf:log('/v1/resources/mlDbConfigs', function() {
     document {
       hent:dump-indexes($input)
     }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/customdata/ExploreCustomEntityInstancesTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/customdata/ExploreCustomEntityInstancesTest.java
@@ -1,39 +1,63 @@
 package com.marklogic.hub.customdata;
 
+import com.marklogic.appdeployer.command.databases.DeployOtherDatabasesCommand;
 import com.marklogic.client.io.SearchHandle;
+import com.marklogic.client.query.FacetResult;
 import com.marklogic.client.query.QueryDefinition;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.hub.AbstractHubCoreTest;
+import com.marklogic.hub.EntityManager;
+import com.marklogic.hub.deploy.commands.HubDeployDatabaseCommandFactory;
+import com.marklogic.hub.impl.EntityManagerImpl;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ExploreCustomEntityInstancesTest extends AbstractHubCoreTest {
 
+    // Using an alternate convention for entity type collections, which allows us to verify that DHF supports
+    // modifying the entityType constraint to match how the data is persisted
+    private final static String ENTITY_COLLECTION = "entity-Person";
+
+    @AfterEach
+    void afterEach() {
+        // Gotta reset the indexes because we changed them during this test
+        runAsAdmin();
+        applyDatabasePropertiesForTests(getHubConfig());
+    }
+
     @Test
     void test() {
-        installProjectInFolder("test-projects/custom-data", true);
+        installProjectInFolder("test-projects/custom-data");
+        saveAndDeployIndexesAndQueryOptions();
 
-        // Using an alternate convention for entity type collections, which allows us to verify that DHF supports
-        // modifying the entityType constraint to match how the data is persisted
-        final String entityCollection = "entity-Person";
-        writeFinalJsonDoc("/person1.json", "{\n" +
-            "  \"customEnvelope\": {\n" +
-            "    \"Person\": {\n" +
-            "      \"name\": {\n" +
-            "        \"value\": \"Jane\",\n" +
-            "        \"confirmed\": true\n" +
-            "      }\n" +
-            "    }\n" +
-            "  }\n" +
-            "}", entityCollection);
+        runAsDataHubOperator();
+        insertPersonBornIn1990();
+        insertPersonBornIn1991();
 
-        SearchHandle response = searchWithCriteria("entityType:Person");
-        assertEquals(1, response.getTotalResults(), "The entityType constraint in the options should have been " +
+        SearchHandle response = searchWithCriteria("entityType:Person sort:Person_birthYearAscending");
+        assertEquals(2, response.getTotalResults(), "The entityType constraint in the options should have been " +
             "modified so that a custom module is used that expects entity instances to be in a collection matching " +
             "the lower-case representation of the entity type name, as opposed to the DHF default of the collection " +
             "being the same value as the entity type name");
-        assertEquals("/person1.json", response.getMatchResults()[0].getUri());
+        assertEquals("/person1990.json", response.getMatchResults()[0].getUri());
+        assertEquals("/person1991.json", response.getMatchResults()[1].getUri());
+
+        FacetResult statusFacet = response.getFacetResult("Person.status");
+        assertEquals("Person.status", statusFacet.getName());
+        assertEquals(1, statusFacet.getFacetValues().length, "Expecting the status value to be returned; this ensures " +
+            "that both the database indexes and the range constraints were modified to conform to the project-specific path " +
+            "of /customEnvelope/Person/status/value instead of assuming the ES-specific path");
+        assertEquals("Active", statusFacet.getFacetValues()[0].getName());
+        assertEquals(2, statusFacet.getFacetValues()[0].getCount());
+
+        response = searchWithCriteria("entityType:Person sort:Person_birthYearDescending");
+        assertEquals(2, response.getTotalResults());
+        assertEquals("/person1991.json", response.getMatchResults()[0].getUri());
+        assertEquals("/person1990.json", response.getMatchResults()[1].getUri());
 
         assertEquals(1, searchWithCriteria("entityType:Person Jane").getTotalResults());
         assertEquals(0, searchWithCriteria("entityType:Person aTermThatDoesntMatchAnything").getTotalResults());
@@ -47,4 +71,54 @@ public class ExploreCustomEntityInstancesTest extends AbstractHubCoreTest {
         return mgr.search(query, new SearchHandle());
     }
 
+    private void insertPersonBornIn1990() {
+        writeFinalJsonDoc("/person1990.json", "{\n" +
+            "  \"customEnvelope\": {\n" +
+            "    \"Person\": {\n" +
+            "      \"name\": {\n" +
+            "        \"value\": \"Jane\",\n" +
+            "        \"confirmed\": true\n" +
+            "      },\n" +
+            "      \"status\": {\n" +
+            "        \"value\": \"Active\"\n" +
+            "      },\n" +
+            "      \"birthYear\": {\n" +
+            "        \"value\": \"1990\"\n" +
+            "      }\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ENTITY_COLLECTION);
+    }
+
+    private void insertPersonBornIn1991() {
+        writeFinalJsonDoc("/person1991.json", "{\n" +
+            "  \"customEnvelope\": {\n" +
+            "    \"Person\": {\n" +
+            "      \"name\": {\n" +
+            "        \"value\": \"Janet\",\n" +
+            "        \"confirmed\": true\n" +
+            "      },\n" +
+            "      \"status\": {\n" +
+            "        \"value\": \"Active\"\n" +
+            "      },\n" +
+            "      \"birthYear\": {\n" +
+            "        \"value\": \"1991\"\n" +
+            "      }\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ENTITY_COLLECTION);
+    }
+
+    private void saveAndDeployIndexesAndQueryOptions() {
+        EntityManager mgr = new EntityManagerImpl(getHubConfig());
+        mgr.saveDbIndexes();
+
+        runAsAdmin();
+        DeployOtherDatabasesCommand command = new DeployOtherDatabasesCommand();
+        command.setResourceFilenamesIncludePattern(Pattern.compile("final-database.json"));
+        command.setDeployDatabaseCommandFactory(new HubDeployDatabaseCommandFactory(getHubConfig()));
+        command.execute(newCommandContext());
+
+        mgr.deployQueryOptions();
+    }
 }

--- a/marklogic-data-hub/src/test/resources/test-projects/custom-data/entities/Person.entity.json
+++ b/marklogic-data-hub/src/test/resources/test-projects/custom-data/entities/Person.entity.json
@@ -3,7 +3,8 @@
     "title": "Person",
     "version": "0.0.1",
     "baseUri": "http://example.org/",
-    "searchOptionsPostProcessor": "/custom-data-modules/my-options-post-processor.xqy"
+    "searchOptionsPostProcessor": "/custom-data-modules/my-options-post-processor.xqy",
+    "databaseIndexesPostProcessor": "/custom-data-modules/my-indexes-post-processor.sjs"
   },
   "definitions": {
     "Person": {
@@ -11,6 +12,15 @@
         "name": {
           "datatype": "string",
           "collation": "http://marklogic.com/collation/codepoint"
+        },
+        "status": {
+          "datatype": "string",
+          "collation": "http://marklogic.com/collation/codepoint",
+          "facetable": true
+        },
+        "birthYear": {
+          "datatype": "integer",
+          "sortable": true
         }
       }
     }

--- a/marklogic-data-hub/src/test/resources/test-projects/custom-data/modules/root/custom-data-modules/my-indexes-post-processor.sjs
+++ b/marklogic-data-hub/src/test/resources/test-projects/custom-data/modules/root/custom-data-modules/my-indexes-post-processor.sjs
@@ -1,0 +1,17 @@
+var config;
+
+// config is a document-node, so must call toObject() first in order to modify it
+config = config.toObject();
+
+if (config["range-path-index"]) {
+  config["range-path-index"].forEach(index => {
+    let expr = index["path-expression"];
+    const tokens = expr.split("/").slice(-2);
+    const entityName = tokens[0];
+    const propertyName = tokens[1];
+    index["path-expression"] = "/customEnvelope/" + entityName + "/" + propertyName + "/value";
+  })
+}
+
+// Must return a document-node
+xdmp.toJSON(config);

--- a/marklogic-data-hub/src/test/resources/test-projects/custom-data/modules/root/custom-data-modules/my-options-post-processor.xqy
+++ b/marklogic-data-hub/src/test/resources/test-projects/custom-data/modules/root/custom-data-modules/my-options-post-processor.xqy
@@ -19,15 +19,42 @@ declare namespace search = "http://marklogic.com/appservices/search";
 
 declare variable $options as element(search:options) external;
 
+
+(: Recursive function for rewriting an element with a search:path-index somewhere in it :)
+declare function local:rewrite($el as element()) as element()
+{
+  element {fn:node-name($el)} {
+    $el/@*,
+    for $kid in $el/node()
+    return
+      if ($kid instance of element()) then
+        if ($kid[self::search:path-index]) then
+          element search:path-index {local:convert-path($kid/text())}
+        else local:rewrite($kid)
+      else $kid
+  }
+};
+
+declare function local:convert-path($path as xs:string) as xs:string
+{
+  let $property-name := fn:tokenize($path, "/")[fn:last()]
+  return  "/customEnvelope/Person/" || $property-name || "/value"
+};
+
 element search:options {
   $options/@*,
+
   for $el in $options/element()
   return
+
     if ($el[self::search:constraint and @name = "entityType"]) then
       <constraint name="entityType" xmlns="http://marklogic.com/appservices/search">
         <custom facet="false">
           <parse apply="parse" ns="org:example" at="/custom-data-modules/my-entity-type-constraint.xqy"/>
         </custom>
       </constraint>
+
+    else if ($el//search:path-index) then local:rewrite($el)
+
     else $el
 }


### PR DESCRIPTION
### Description

This allows for a project, like TZ, to customize the DHF-generated indexes so that they conform to the project's data format. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests

