### PR TITLE
DHFPROD-7712: Center the entity type

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/graphValidations.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/graphValidations.spec.tsx
@@ -143,4 +143,22 @@ describe("Graph Validations", () => {
     cy.waitForAsyncRequest();
     relationshipModal.getModalHeader().should("not.exist");
   });
+
+  it("can center on entity type in graph view", () => {
+    modelPage.selectView("project-diagram");
+    graphVis.getPositionsOfNodes("Person").then((nodePositions: any) => {
+      let orderCoordinates: any = nodePositions["Person"];
+      graphVis.getGraphVisCanvas().rightclick(orderCoordinates.x, orderCoordinates.y);
+      graphVis.getCenterOnEntityTypeOption("Person").trigger("mouseover").click();
+
+      //Clicking on center of the canvas, should click on Person entity node.
+      graphVis.getGraphVisCanvas().click();
+
+      //Verify the side panel content for selected entity
+      graphViewSidePanel.getSelectedEntityHeading("Person").should("be.visible");
+      graphViewSidePanel.getPropertiesTab().should("be.visible");
+      graphViewSidePanel.getEntityTypeTab().should("be.visible");
+      graphViewSidePanel.getDeleteIcon("Person").should("be.visible");
+    });
+  });
 });

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/graph-vis.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/graph-vis.tsx
@@ -69,6 +69,10 @@ class GraphVis {
       return coordinatesInDOM;
     })));
   }
+
+  getCenterOnEntityTypeOption(entityName: string) {
+    return cy.findByTestId(`centerOnEntityType-${entityName}`);
+  }
 }
 
 const graphVis = new GraphVis();


### PR DESCRIPTION
### Description
Right click menu is available now for entity nodes, with only one option so far, using which user can bring focus on any specific node so that the node is in center of the canvas.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [x] Run UI tests
  

- ##### Reviewer:

- [x] Reviewed Tests

