### PR TITLE
DHFPROD-7807: Not ignoring entity-config/databases 

### DIFF
--- a/examples/dhf5-custom-hook/.gitignore
+++ b/examples/dhf5-custom-hook/.gitignore
@@ -2,4 +2,4 @@ src/main/ml-config/*
 src/main/ml-config/security/query-rolesets
 !src/main/ml-config/security/
 gradle*.properties
-src/main/entity-config
+src/main/entity-config/*.xml

--- a/examples/dhs-example/.gitignore
+++ b/examples/dhs-example/.gitignore
@@ -1,2 +1,2 @@
-src/main/entity-config
+src/main/entity-config/*.xml
 

--- a/examples/insurance/.gitignore
+++ b/examples/insurance/.gitignore
@@ -1,4 +1,4 @@
 src/main/ml-config
-src/main/entity-config
+src/main/entity-config/*.xml
 
 

--- a/examples/mapping-example/.gitignore
+++ b/examples/mapping-example/.gitignore
@@ -1,5 +1,5 @@
 build
 src/main/hub-internal-config
 src/main/ml-config
-src/main/entity-config
+src/main/entity-config/*.xml
 pharmaData

--- a/examples/patient-hub/.gitignore
+++ b/examples/patient-hub/.gitignore
@@ -1,2 +1,2 @@
 src/main/ml-config
-src/main/entity-config
+src/main/entity-config/*.xml

--- a/examples/reference-entity-model/.gitignore
+++ b/examples/reference-entity-model/.gitignore
@@ -5,4 +5,6 @@ src/main/hub-internal-config
 src/main/ml-config/database-fields
 src/main/ml-config/databases
 src/main/ml-config/servers
-src/main/entity-config
+
+# Can't ignore the entity-config/databases files as those won't be generated when mlDeploy is run
+src/main/entity-config/*.xml

--- a/examples/reference-entity-model/src/main/entity-config/databases/final-database.json
+++ b/examples/reference-entity-model/src/main/entity-config/databases/final-database.json
@@ -1,0 +1,39 @@
+{
+  "lang" : "zxx",
+  "path-namespace" : [ {
+    "prefix" : "oex",
+    "namespace-uri" : "http://example.org/"
+  }, {
+    "prefix" : "es",
+    "namespace-uri" : "http://marklogic.com/entity-services"
+  } ],
+  "range-path-index" : [ {
+    "invalid-values" : "reject",
+    "path-expression" : "/(es:envelope|envelope)/(es:instance|instance)/Customer/customerId",
+    "range-value-positions" : false,
+    "scalar-type" : "decimal"
+  }, {
+    "invalid-values" : "reject",
+    "path-expression" : "/(es:envelope|envelope)/(es:instance|instance)/Customer/birthDate",
+    "range-value-positions" : false,
+    "scalar-type" : "date"
+  }, {
+    "invalid-values" : "reject",
+    "path-expression" : "/(es:envelope|envelope)/(es:instance|instance)/Customer/status",
+    "range-value-positions" : false,
+    "scalar-type" : "string",
+    "collation" : "http://marklogic.com/collation/"
+  }, {
+    "invalid-values" : "reject",
+    "path-expression" : "/es:envelope/es:instance/oex:NamespacedCustomer/oex:customerIdentifier",
+    "range-value-positions" : false,
+    "scalar-type" : "decimal"
+  }, {
+    "invalid-values" : "reject",
+    "path-expression" : "/es:envelope/es:instance/oex:NamespacedCustomer/oex:status",
+    "range-value-positions" : false,
+    "scalar-type" : "string",
+    "collation" : "http://marklogic.com/collation/"
+  } ],
+  "database-name" : "%%mlFinalDbName%%"
+}

--- a/examples/reference-entity-model/src/main/entity-config/databases/staging-database.json
+++ b/examples/reference-entity-model/src/main/entity-config/databases/staging-database.json
@@ -1,0 +1,39 @@
+{
+  "lang" : "zxx",
+  "path-namespace" : [ {
+    "prefix" : "oex",
+    "namespace-uri" : "http://example.org/"
+  }, {
+    "prefix" : "es",
+    "namespace-uri" : "http://marklogic.com/entity-services"
+  } ],
+  "range-path-index" : [ {
+    "invalid-values" : "reject",
+    "path-expression" : "/(es:envelope|envelope)/(es:instance|instance)/Customer/customerId",
+    "range-value-positions" : false,
+    "scalar-type" : "decimal"
+  }, {
+    "invalid-values" : "reject",
+    "path-expression" : "/(es:envelope|envelope)/(es:instance|instance)/Customer/birthDate",
+    "range-value-positions" : false,
+    "scalar-type" : "date"
+  }, {
+    "invalid-values" : "reject",
+    "path-expression" : "/(es:envelope|envelope)/(es:instance|instance)/Customer/status",
+    "range-value-positions" : false,
+    "scalar-type" : "string",
+    "collation" : "http://marklogic.com/collation/"
+  }, {
+    "invalid-values" : "reject",
+    "path-expression" : "/es:envelope/es:instance/oex:NamespacedCustomer/oex:customerIdentifier",
+    "range-value-positions" : false,
+    "scalar-type" : "decimal"
+  }, {
+    "invalid-values" : "reject",
+    "path-expression" : "/es:envelope/es:instance/oex:NamespacedCustomer/oex:status",
+    "range-value-positions" : false,
+    "scalar-type" : "string",
+    "collation" : "http://marklogic.com/collation/"
+  } ],
+  "database-name" : "%%mlStagingDbName%%"
+}

--- a/examples/smart-mastering-complete/.gitignore
+++ b/examples/smart-mastering-complete/.gitignore
@@ -1,3 +1,3 @@
 src/main/hub-internal-config
 src/main/ml-config
-src/main/entity-config
+src/main/entity-config/*.xml

--- a/examples/step-interceptors/.gitignore
+++ b/examples/step-interceptors/.gitignore
@@ -1,7 +1,7 @@
 build
 src/main/hub-internal-config
 src/main/ml-config
-src/main/entity-config
+src/main/entity-config/*.xml
 gradle
 gradlew
 gradlew.bat


### PR DESCRIPTION
### Description

This ensures that the databases files will be accounted for when mlDeploy is run. Without this, a user must run "mlDeploy hubDeployAsDeveloper", as the latter does generate index files while the former does not. One reason that the former does not is a chicken-and-egg problem - generating the indexes file requires first loading the DHF modules, but the databases/indexes are deployed before DHF modules are loaded. This can be solved, but the easiest solution is just to not gitignore src/main/entity-config/databases. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
