### PR TITLE
DHFPROD-7805: Fixing instance count in modeling tile 

### DIFF
--- a/marklogic-data-hub-central/src/test/resources/logback.xml
+++ b/marklogic-data-hub-central/src/test/resources/logback.xml
@@ -27,7 +27,7 @@
   <logger name="com.marklogic.hub.impl.HubProjectImpl" level="WARN" additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="com.marklogic.hub.deploy.commands.LoadUserArtifactsCommand" level="WARN" additivity="false">
+  <logger name="com.marklogic.hub.deploy" level="WARN" additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/marklogic-data-hub-central/src/test/resources/test-projects/custom-data/modules/root/data-hub/public/extensions/entity/build-entity-query.xqy
+++ b/marklogic-data-hub-central/src/test/resources/test-projects/custom-data/modules/root/data-hub/public/extensions/entity/build-entity-query.xqy
@@ -15,27 +15,14 @@
 :)
 xquery version "1.0-ml";
 
-module namespace ns = "org:example";
+module namespace ext = "http://marklogic.com/data-hub/extensions/entity";
 
-declare function parse(
-  $constraint-qtext as xs:string,
-  $right as schema-element(cts:query)
-) as schema-element(cts:query)
+declare function build-entity-query($entity-type-names as xs:string*) as cts:query
 {
   (: Adds "entity-" as a prefix, which is the convention for collections in this example project :)
-  let $entity-types :=
-    for $token in fn:tokenize($right//cts:text, ",")
-    let $token := fn:normalize-space($token)
-    where fn:not($token = "")
-    return "entity-" || $token
-
-  let $query :=
-    if ($entity-types) then <x>{cts:collection-query($entity-types)}</x>/*
-    else <x>{cts:false-query()}</x>/*
-
-  return element {fn:node-name($query)} {
-    attribute qtextconst {fn:concat($constraint-qtext, fn:string($right//cts:text))},
-    $query/@*,
-    $query/node()
-  }
+  cts:collection-query(
+    for $name in $entity-type-names
+    return "entity-" || $name
+  )
 };
+

--- a/marklogic-data-hub-central/src/test/resources/test-projects/custom-data/modules/root/data-hub/public/extensions/entity/post-process-search-options.xqy
+++ b/marklogic-data-hub-central/src/test/resources/test-projects/custom-data/modules/root/data-hub/public/extensions/entity/post-process-search-options.xqy
@@ -26,16 +26,7 @@ declare function post-process-search-options($options as element(search:options)
 
     for $el in $options/element()
     return
-
-      if ($el[self::search:constraint and @name = "entityType"]) then
-        <constraint name="entityType" xmlns="http://marklogic.com/appservices/search">
-          <custom facet="false">
-            <parse apply="parse" ns="org:example" at="/custom-data-modules/my-entity-type-constraint.xqy"/>
-          </custom>
-        </constraint>
-
-      else if ($el//search:path-index) then rewrite($el)
-
+      if ($el//search:path-index) then rewrite($el)
       else $el
   }
 };

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/getPrimaryEntityTypes.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/getPrimaryEntityTypes.sjs
@@ -18,6 +18,7 @@
 xdmp.securityAssert("http://marklogic.com/data-hub/privileges/read-entity-model", "execute");
 
 const entityLib = require("/data-hub/5/impl/entity-lib.sjs");
+const ext = require("/data-hub/public/extensions/entity/build-entity-query.xqy");
 
 let modelResponseArr = fn.collection(entityLib.getModelCollection()).toArray().map(model => {
   model = model.toObject();
@@ -26,7 +27,7 @@ let modelResponseArr = fn.collection(entityLib.getModelCollection()).toArray().m
   const response = {
     entityName: entityName,
     entityTypeId: entityLib.getEntityTypeId(model, entityName),
-    entityInstanceCount: cts.estimate(cts.collectionQuery(entityName)),
+    entityInstanceCount: cts.estimate(ext.buildEntityQuery(entityName)),
     model: model
   };
   return Object.assign(response, jobData);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/public/extensions/entity/build-entity-query.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/public/extensions/entity/build-entity-query.xqy
@@ -1,0 +1,29 @@
+(:
+  Copyright (c) 2021 MarkLogic Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+:)
+xquery version "1.0-ml";
+
+module namespace ext = "http://marklogic.com/data-hub/extensions/entity";
+
+(:
+Invoked when DHF needs to build a query that constrains on documents for one or more entity types.
+By default, DHF assumes that entity documents are in a collection with a name matching that of the
+associated entity type.
+:)
+declare function build-entity-query($entity-type-names as xs:string*) as cts:query
+{
+  cts:collection-query($entity-type-names)
+};
+


### PR DESCRIPTION
### Description

This applies when a project uses a different technique for identifying entity instance documents; getPrimaryEntityTypes.sjs now supports that technique via the build-entity-query.xqy extension point. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests  

- ##### Reviewer:

- [x] Reviewed Tests

