### PR TITLE
DHFPROD-7806: Path reference construction can now be overridden

### DIFF
--- a/marklogic-data-hub-central/src/test/resources/test-projects/custom-data/entities/Person.entity.json
+++ b/marklogic-data-hub-central/src/test/resources/test-projects/custom-data/entities/Person.entity.json
@@ -18,7 +18,8 @@
         },
         "birthYear": {
           "datatype": "integer",
-          "sortable": true
+          "sortable": true,
+          "facetable": true
         }
       }
     }

--- a/marklogic-data-hub-central/src/test/resources/test-projects/custom-data/modules/root/data-hub/public/extensions/entity/build-property-path-reference.sjs
+++ b/marklogic-data-hub-central/src/test/resources/test-projects/custom-data/modules/root/data-hub/public/extensions/entity/build-property-path-reference.sjs
@@ -1,0 +1,25 @@
+/**
+ Copyright (c) 2021 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+'use strict';
+
+function buildPropertyPathReference(entityTypeId, propertyPath) {
+  // Hardcoded for test purposes; a real impl would be a bit more dynamic
+  return cts.pathReference(`/customEnvelope/Person/${propertyPath}/value`);
+}
+
+module.exports = {
+  buildPropertyPathReference
+}

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/entitySearch/getMatchingPropertyValues.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/entitySearch/getMatchingPropertyValues.sjs
@@ -17,8 +17,8 @@
 
 xdmp.securityAssert("http://marklogic.com/data-hub/privileges/read-entity-model", "execute");
 
+const ext = require("/data-hub/public/extensions/entity/build-property-path-reference.sjs");
 const httpUtils = require("/data-hub/5/impl/http-utils.sjs");
-const lib = require('/data-hub/5/impl/hub-es.sjs');
 
 var facetValuesSearchQuery;
 if(facetValuesSearchQuery == null) {
@@ -70,8 +70,7 @@ if(referenceType === 'element') {
 } else if(referenceType === 'collection') {
   query = cts.collectionReference();
 } else {
-  const result = lib.buildPathReferenceParts(entityTypeId, propertyPath);
-  query = cts.pathReference(result.pathExpression, null, result.namespaces);
+  query = ext.buildPropertyPathReference(entityTypeId, propertyPath);
 }
 
 var facetValues = cts.valueMatch(query, pattern + "*",

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/public/extensions/entity/build-property-path-reference.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/public/extensions/entity/build-property-path-reference.sjs
@@ -1,0 +1,36 @@
+/**
+ Copyright (c) 2021 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+ 'use strict';
+
+const hubEs = require('/data-hub/5/impl/hub-es.sjs');
+
+/**
+ * Invoked when DHF needs to build a path reference based on a given entity type and property path; the path reference
+ * is then used to retrieve values from an index. By default, this assumes an entity document will conform to the ES
+ * envelope and the path expression is thus built off this assumption.
+ *
+ * @param {string} entityTypeId full entity type identifier; e.g. http://example.org/Person-1.0/Person
+ * @param {string} propertyPath dot-separated path to a property in the entity model; e.g. "shipping.zip.code"
+ * @returns a cts.pathReference instance
+ */
+function buildPropertyPathReference(entityTypeId, propertyPath) {
+  const result = hubEs.buildPathReferenceParts(entityTypeId, propertyPath);
+  return cts.pathReference(result.pathExpression, null, result.namespaces);
+}
+
+module.exports = {
+  buildPropertyPathReference
+}


### PR DESCRIPTION
### Description

Added build-property-path-reference.sjs extension to allow for a user to override how a cts.pathReference is constructed in case there entity documents do not conform to the ES format. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests

