### PR TITLE
DHFPROD-7528: Persist entity node coordinates for graph

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/graph.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/graph.spec.tsx
@@ -7,6 +7,7 @@ import {
   graphView,
   graphViewSidePanel,
 } from "../../support/components/model/index";
+import graphVis from "../../support/components/model/graph-vis";
 import {toolbar} from "../../support/components/common/index";
 import {Application} from "../../support/application.config";
 import LoginPage from "../../support/pages/login";
@@ -36,7 +37,21 @@ describe("Entity Modeling: Graph View", () => {
     cy.resetTestUser();
     cy.waitForAsyncRequest();
   });
-  it.only("can create a new entity in graph view, showing its details in side panel", () => {
+  it("can view graph view and select a node", () => {
+    cy.loginAsDeveloper().withRequest();
+    entityTypeTable.viewEntityInGraphView("Person");
+    // Allow graph to stabilize
+    cy.wait(3000);
+
+    // Click entity node
+    graphVis.getPositionsOfNodes("Person").then((nodePositions: any) => {
+      graphVis.getGraphVisCanvas().click(nodePositions["Person"].x, nodePositions["Person"].y);
+    });
+    // Verify entity is shown in side panel
+    graphViewSidePanel.getSelectedEntityHeading("Person").should("be.visible");
+
+  });
+  it("can create a new entity in graph view, showing its details in side panel", () => {
     cy.loginAsDeveloper().withRequest();
     entityTypeTable.viewEntityInGraphView("Person");
 

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/graphValidations.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/graphValidations.spec.tsx
@@ -161,4 +161,50 @@ describe("Graph Validations", () => {
       graphViewSidePanel.getDeleteIcon("Person").should("be.visible");
     });
   });
+
+  it("can select all available nodes in graph view, locations persist", () => {
+    let ids = ["BabyRegistry", "Client", "Customer", "Order", "Person"];
+    let savedCoords: any = {};
+    modelPage.selectView("project-diagram");
+
+    // Select each entity node using retrieved coords
+    ids.forEach(id => {
+      graphVis.getPositionsOfNodes(id).then((nodePositions: any) => {
+        let coords: any = nodePositions[id];
+        savedCoords[id] = {x: coords.x, y: coords.y};
+        graphVis.getGraphVisCanvas().click(coords.x, coords.y);
+      });
+      // Verify entity is shown in side panel and close
+      graphViewSidePanel.getSelectedEntityHeading(id).should("be.visible");
+      graphViewSidePanel.closeSidePanel();
+    });
+
+    // Exit graph view and return
+    cy.waitUntil(() => toolbar.getCurateToolbarIcon()).click();
+    cy.waitUntil(() => toolbar.getModelToolbarIcon()).click();
+    modelPage.selectView("project-diagram");
+
+    // Select entity nodes using previously saved coords
+    ids.forEach(id => {
+      // TODO getPositionsOfNodes not necessary here for positions, but necessary for async behavior in tests
+      graphVis.getPositionsOfNodes(id).then(() => {
+        graphVis.getGraphVisCanvas().click(savedCoords[id].x, savedCoords[id].y);
+      });
+      // Verify entity is shown in side panel and close
+      graphViewSidePanel.getSelectedEntityHeading(id).should("be.visible");
+      graphViewSidePanel.closeSidePanel();
+    });
+
+    // TODO rearrange nodes in graph view, test selection and persistence of changed positions
+
+    // NOTE The following does not work, the node is selected but no dragging occurs
+    // graphVis.getPositionsOfNodes().then((nodePositions: any) => {
+    //   let clientCoords: any = nodePositions["Client"];
+    //   graphVis.getGraphVisCanvas().trigger("pointerdown", clientCoords.x, clientCoords.y, {button: 0});
+    //   graphVis.getGraphVisCanvas().trigger("pointermove", clientCoords.x+10, clientCoords.y+10, {button: 0});
+    //   graphVis.getGraphVisCanvas().trigger("pointerup", clientCoords.x+20, clientCoords.y+20, {button: 0});
+    // });
+
+  });
+
 });

--- a/marklogic-data-hub-central/ui/src/api/modeling.ts
+++ b/marklogic-data-hub-central/ui/src/api/modeling.ts
@@ -5,12 +5,23 @@ export const primaryEntityTypes = async () => {
   return await axios.get(`/api/models/primaryEntityTypes`);
 };
 
-export const updateModelInfo = async (name: string, description: string, namespace: string, prefix: string) => {
-  return await axios.put(`/api/models/${name}/info`, {
+export const updateModelInfo = async (name: string, description: string,
+  namespace: string, prefix: string, graphX?: number, graphY?: number) => {
+  let payload = {
     description: description,
     namespace: namespace,
-    namespacePrefix: prefix
-  });
+    namespacePrefix: prefix,
+    hubCentral: {
+      modeling: {}
+    }
+  };
+  if (graphX && graphY) {
+    payload.hubCentral.modeling = {
+      graphX: graphX,
+      graphY: graphY
+    };
+  }
+  return await axios.put(`/api/models/${name}/info`, payload);
 };
 
 export const entityReferences = async (entityName: string, propertyName?: string) => {

--- a/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
+++ b/marklogic-data-hub-central/ui/src/components/flows/flows.tsx
@@ -133,7 +133,7 @@ const Flows: React.FC<Props> = (props) => {
       setAddFlowDirty({...addFlowDirty, [flowName]: currentFlow?.steps?.length});
     } else {
       // if step is added from external view
-      const {state = {}} = location;
+      let state: any = location.state || {};
       const externalDirty = (state ? state["addFlowDirty"] : false) && addExternalFlowDirty;
       const thisFlow = state ? state["flowName"] : null;
       if (externalDirty) {

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-modal/entity-type-modal.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-modal/entity-type-modal.test.tsx
@@ -134,7 +134,7 @@ describe("EntityTypeModal Component", () => {
     );
 
     let url = "/api/models/ModelName/info";
-    let payload = {"description": "Updated Description", "namespace": "http://example.org/updated", "namespacePrefix": "updated"};
+    let payload = {"description": "Updated Description", "hubCentral": {"modeling": {}}, "namespace": "http://example.org/updated", "namespacePrefix": "updated"};
 
     userEvent.clear(getByPlaceholderText(placeholders.description));
     userEvent.type(getByPlaceholderText(placeholders.description), payload.description);

--- a/marklogic-data-hub-central/ui/src/components/modeling/graph-view/graph-view.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/graph-view/graph-view.test.tsx
@@ -34,6 +34,7 @@ describe("Graph View Component", () => {
         relationshipModalVisible={false}
         toggleRelationshipModal={jest.fn()}
         updateSavedEntity={jest.fn()}
+        setEntityTypesFromServer={jest.fn()}
       />
     </ModelingContext.Provider>
     );
@@ -53,6 +54,7 @@ describe("Graph View Component", () => {
           relationshipModalVisible={false}
           toggleRelationshipModal={jest.fn()}
           updateSavedEntity={jest.fn()}
+          setEntityTypesFromServer={jest.fn()}
         />
       </ModelingContext.Provider>
     );

--- a/marklogic-data-hub-central/ui/src/config/graph-vis.config.ts
+++ b/marklogic-data-hub-central/ui/src/config/graph-vis.config.ts
@@ -61,10 +61,69 @@ const customEdgeSVG: any = {
   oneToOneHover: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTMiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxMyAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGxpbmUgeDE9IjEiIHkxPSI5LjUiIHgyPSIxMiIgeTI9IjkuNSIgc3Ryb2tlPSIjN0ZBREUzIi8+Cjwvc3ZnPgo="
 }
 
+// TODO temp hardcoded node data, remove when retrieved from db
+let sampleMetadata = {
+  BabyRegistry: {
+    color: "#e3ebbc",
+    instances: 5,
+    x: 10,
+    y: -100
+  },
+  Customer: {
+    color: "#ecf7fd",
+    instances: 63,
+    x: 10,
+    y: 50
+  },
+  Product: {
+    color: "#ded2da",
+    instances: 252,
+    x: -10,
+    y: -100
+  },
+  Order: {
+    color: "#cfe3e8",
+    instances: 50123,
+    x: -300,
+    y: 50
+  },
+  NamespacedCustomer: {
+    color: "#dfe2ec",
+    instances: 75,
+    x: -600,
+    y: -100
+  },
+  Person: {
+    color: "#dfe2ec",
+    instances: 75,
+    x: -150,
+    y: -100
+  },
+  Client: {
+    color: "#dfe2ec",
+    instances: 75,
+    x: -300,
+    y: -100
+  },
+  Relation: {
+    color: "#ded2da",
+    instances: 75,
+    x: -400,
+    y: -100
+  },
+  Concept: {
+    color: "#ded2da",
+    instances: 75,
+    x: -300,
+    y: -200
+  }
+};
+
 export default {
     defaultOptions,
     defaultNodeProps,
     defaultEdgeProps,
     nodeStyles,
-    customEdgeSVG
+    customEdgeSVG,
+    sampleMetadata
 };

--- a/marklogic-data-hub-central/ui/src/pages/Modeling.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Modeling.tsx
@@ -417,6 +417,7 @@ const Modeling: React.FC = () => {
               toggleRelationshipModal={toggleRelationshipModal}
               toggleShowEntityModal={toggleShowEntityModal}
               toggleIsEditModal={toggleIsEditModal}
+              setEntityTypesFromServer={setEntityTypesFromServer}
             />
           </>
         }


### PR DESCRIPTION
### Description

Nodes have physics applied initially to determine initial coordinates. 

(Position persistence during and immediately after stabilization may be buggy and can use some review by the team. For example: Select a node during stabilization or immediately after stabilization.)

Clicking and dragging a node updates the coordinates for the node in the local state and in the database (user can leave graph view and return and the position is retained).

Position changes due to panning the entire graph set and zooming are not supported yet and have been described in bug tickets: DHFPROD-7838, DHFPROD-7839

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [x] Run UI tests
  

- ##### Reviewer:

- [x] Reviewed Tests

