### PR TITLE
DHFPROD-7947: Making Detail view its own tile

### DIFF
--- a/marklogic-data-hub-central/ui/src/App.tsx
+++ b/marklogic-data-hub-central/ui/src/App.tsx
@@ -143,7 +143,7 @@ const App: React.FC<Props> = ({history, location}) => {
                         <TilesView id="explore"/>
                       </PrivateRoute>
                       <PrivateRoute path="/tiles/explore/detail">
-                        <TilesView id="explore"/>
+                        <TilesView id="detail"/>
                       </PrivateRoute>
                       <PrivateRoute path="/tiles/monitor">
                         <TilesView id="monitor"/>

--- a/marklogic-data-hub-central/ui/src/components/tiles/toolbar.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/tiles/toolbar.test.tsx
@@ -12,9 +12,16 @@ import tiles from "../../config/tiles.config";
 describe("Toolbar component", () => {
 
   it("renders with clickable tools", () => {
-    const tools = Object.keys(tiles);
-    const {getByLabelText} = render(<Router history={history}><Toolbar tiles={tiles} enabled={tools}/></Router>);
+    let tools: string[] = [];
 
+    // Only add items that should appear in toolbar
+    for (let key of Object.keys(tiles)) {
+      if (tiles[key].toolbar) {
+        tools.push(key);
+      }
+    }
+
+    const {getByLabelText} = render(<Router history={history}><Toolbar tiles={tiles} enabled={tools}/></Router>);
     expect(getByLabelText("toolbar")).toBeInTheDocument();
 
     tools.forEach((tool, i) => {

--- a/marklogic-data-hub-central/ui/src/components/tiles/toolbar.tsx
+++ b/marklogic-data-hub-central/ui/src/components/tiles/toolbar.tsx
@@ -17,7 +17,14 @@ interface Props {
 
 const Toolbar: React.FC<Props> = (props) => {
 
-  const tiles = props.tiles; // config/tiles.config.ts
+  const allTiles = props.tiles; // config/tiles.config.ts
+  const tiles: any = {};
+  // Filter out tiles that should not be displayed in the toolbar.
+  for (let key of Object.keys(allTiles)) {
+    if (allTiles[key].toolbar) {
+      tiles[key] = allTiles[key];
+    }
+  }
 
   // array of references used to set focus
   let tileRefs : any[] = [];
@@ -158,7 +165,8 @@ const Toolbar: React.FC<Props> = (props) => {
             </div>
           );
         }
-      })}
+      }
+      )}
       <ConfirmationModal
         isVisible={showConfirmModal}
         type={ConfirmationType.NavigationWarn}

--- a/marklogic-data-hub-central/ui/src/config/tiles.config.ts
+++ b/marklogic-data-hub-central/ui/src/config/tiles.config.ts
@@ -1,6 +1,6 @@
 import { faLongArrowAltRight, faCube, faCubes, faObjectUngroup, faProjectDiagram } from "@fortawesome/free-solid-svg-icons";
 
-export type TileId =  'load' | 'model' | 'curate' | 'run' | 'explore' | 'monitor';;
+export type TileId =  'load' | 'model' | 'curate' | 'run' | 'explore' | 'monitor' | 'detail';
 export type IconType = 'fa' | 'custom';
 export type ControlType = 'menu' | 'newTab' | 'maximize' | 'minimize' | 'close';
 
@@ -13,7 +13,8 @@ interface TileItem {
     border: string;
     controlColor: string;
     controls: ControlType[];
-    intro: string;
+    intro?: string;
+    toolbar: boolean;
 }
 
 const tiles: Record<TileId, TileItem>  = {
@@ -27,6 +28,7 @@ const tiles: Record<TileId, TileItem>  = {
         controlColor: '#777',
         controls: ['close'],
         intro: 'Create and configure steps that ingest raw data from multiple sources.',
+        toolbar: true
     },
     model: {
         title: 'Model',
@@ -38,6 +40,7 @@ const tiles: Record<TileId, TileItem>  = {
         controlColor: '#777',
         controls: ['close'],
         intro: 'Define the entity models that describe and standardize your data. You need these entity models to curate your data.',
+        toolbar: true
     },
     curate: {
         title: 'Curate',
@@ -49,6 +52,7 @@ const tiles: Record<TileId, TileItem>  = {
         controlColor: '#777',
         controls: ['close'],
         intro: 'Create and configure steps that curate and refine your data. The Mapping step associates a field in your raw data with a property in your entity model. The Matching step identifies possible duplicate documents. The Merging step combines identified duplicates or performs other actions.',
+        toolbar: true
     },
     run: {
         title: 'Run',
@@ -60,6 +64,7 @@ const tiles: Record<TileId, TileItem>  = {
         controlColor: '#777',
         controls: ['close'],
         intro: 'Create flows, add your existing steps to flows, and run them.',
+        toolbar: true
     },
     explore: {
         title: 'Explore',
@@ -71,6 +76,7 @@ const tiles: Record<TileId, TileItem>  = {
         controlColor: '#777',
         controls: ['menu', 'close'],
         intro: 'Search, filter, review, and export your data.',
+        toolbar: true
     },
     monitor: {
         title: 'Monitor',
@@ -82,6 +88,18 @@ const tiles: Record<TileId, TileItem>  = {
         controlColor: '#777',
         controls: ['menu', 'close'],
         intro: 'Monitor Flows and Steps',
+        toolbar: true
+    },
+    detail: {
+        title: 'Explore',
+        iconType: 'custom',
+        icon: 'exploreIcon',
+        color: '#376F63',
+        bgColor: '#F4F6F8',
+        border: '#BFBFBF',
+        controlColor: '#777',
+        controls: ['menu', 'close'],
+        toolbar: false
     }
 };
 

--- a/marklogic-data-hub-central/ui/src/pages/Detail.module.scss
+++ b/marklogic-data-hub-central/ui/src/pages/Detail.module.scss
@@ -59,14 +59,14 @@
   justify-content: space-between;
 
   .backButtonHeader {
-    //border: 1px solid red; 
+    //border: 1px solid red;
     margin-right: 30px;
     display: flex;
     //width: 60%;
   }
 
   .documentMetadataContainer {
-    display: flex; 
+    display: flex;
     align-items: center;
 
     > .metadataCollapseIcon {
@@ -77,10 +77,10 @@
         border-radius: 5px 0px 0px 5px;
         cursor: pointer;
       }
-    
+
       .collapseExpandIcons{
         font-size: 16px;
-        color: #000; 
+        color: #000;
       }
     }
   }
@@ -126,6 +126,5 @@
 }
 
 .documentContainer{
-  max-height: 57vh;
   overflow: auto;
  }

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.test.tsx
@@ -60,7 +60,8 @@ describe("Tiles View component tests for Developer user", () => {
   });
 
   test("Verify tiles can be closed", () => {
-    const tools = Object.keys(tiles);
+    // Only check tiles with toolbar buttons
+    const tools: String[] = Object.keys(tiles).filter(key => tiles[key].toolbar);
     const {getByLabelText} = render(<Router history={history}>
       <AuthoritiesContext.Provider value={mockDevRolesService}>
         <TilesView/>

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.tsx
@@ -21,7 +21,7 @@ import MergingStepDetail from "../components/entities/merging/merging-step-detai
 import {ConfigProvider} from "antd";
 import MappingStepDetail from "../components/entities/mapping/mapping-step-detail/mapping-step-detail";
 
-export type TileId = "load" | "model" | "curate" | "run" | "explore" | "monitor";
+export type TileId = "load" | "model" | "curate" | "run" | "explore" | "monitor" | "detail";
 export type IconType = "fa" | "custom";
 interface TileItem {
     title: string;
@@ -59,7 +59,8 @@ const TilesView = (props) => {
     model: <Modeling />,
     curate: setCurateView(),
     run: <Run />,
-    explore: location.pathname.startsWith("/tiles/explore/detail") ? <Detail /> : <Browse/>,
+    explore: <Browse/>,
+    detail: <Detail />,
     monitor: <Monitor />
   };
 
@@ -88,6 +89,7 @@ const TilesView = (props) => {
     curate: auth.canReadMapping() || auth.canWriteMapping() || auth.canReadMatchMerge() || auth.canWriteMatchMerge() || auth.canReadCustom(),
     run: auth.canReadFlow() || auth.canWriteFlow(),
     explore: true,
+    detail: true,
     monitor: auth.canAccessMonitor()
     // TODO - Needs to be updated if there are any changes in authorities for Explorer
     // explore: auth.canReadFlow() || auth.canWriteFlow(),


### PR DESCRIPTION
### Description

The detail view shared the same options as the explore tile view. This caused issues with CSS that was targeting the Explore view to hide contents on the detail page.  This change set addresses this by making a detail view its own TileView.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [x] Run UI tests
  

- ##### Reviewer:

- [x] Reviewed Tests

