### PR TITLE
DHFPROD-7690: Component Replacement: Tabs

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.scss
+++ b/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.scss
@@ -1,13 +1,3 @@
-.ant-tabs {
-    width: 100%;
-}
-
-.ant-tabs-top-bar {
-    text-align: right;
-    width: 173px;
-    margin-left: 450px;
-}
-
 .ant-form-item-label {
     overflow: inherit;
 }

--- a/marklogic-data-hub-central/ui/src/components/entities/custom/custom-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/custom/custom-card.test.tsx
@@ -109,8 +109,8 @@ describe("Custom Card component", () => {
     });
 
     expect(getByText("Custom Step Settings")).toBeInTheDocument();
-    expect(getByText("Basic").closest("div")).toHaveClass("ant-tabs-tab-active");
-    expect(getByText("Advanced").closest("div")).not.toHaveClass("ant-tabs-tab-active");
+    expect(getByText("Basic").closest("button")).toHaveClass("nav-link active");
+    expect(getByText("Advanced").closest("button")).not.toHaveClass("nav-link active");
 
     // Basic settings values
     expect(getByPlaceholderText("Enter name")).toHaveValue("customJSON");
@@ -124,8 +124,8 @@ describe("Custom Card component", () => {
     await wait(() => {
       fireEvent.click(getByText("Advanced"));
     });
-    expect(getByText("Basic").closest("div")).not.toHaveClass("ant-tabs-tab-active");
-    expect(getByText("Advanced").closest("div")).toHaveClass("ant-tabs-tab-active");
+    expect(getByText("Basic").closest("button")).not.toHaveClass("nav-link active");
+    expect(getByText("Advanced").closest("button")).toHaveClass("nav-link active");
 
     // Advanced settings values
     expect(getByText("Source Database:")).toBeInTheDocument();
@@ -174,8 +174,8 @@ describe("Custom Card component", () => {
     });
 
     expect(getByText("Custom Step Settings")).toBeInTheDocument();
-    expect(getByText("Basic").closest("div")).toHaveClass("ant-tabs-tab-active");
-    expect(getByText("Advanced").closest("div")).not.toHaveClass("ant-tabs-tab-active");
+    expect(getByText("Basic").closest("button")).toHaveClass("nav-link active");
+    expect(getByText("Advanced").closest("button")).not.toHaveClass("nav-link active");
 
     // Basic settings values
     expect(getByPlaceholderText("Enter name")).toHaveValue("customJSON");
@@ -189,8 +189,8 @@ describe("Custom Card component", () => {
     await wait(() => {
       fireEvent.click(getByText("Advanced"));
     });
-    expect(getByText("Basic").closest("div")).not.toHaveClass("ant-tabs-tab-active");
-    expect(getByText("Advanced").closest("div")).toHaveClass("ant-tabs-tab-active");
+    expect(getByText("Basic").closest("button")).not.toHaveClass("nav-link active");
+    expect(getByText("Advanced").closest("button")).toHaveClass("nav-link active");
 
     // Advanced settings values
     expect(getByText("Source Database:")).toBeInTheDocument();

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
@@ -176,8 +176,8 @@ describe("Mapping Card component", () => {
     });
     wait(async () => {
       expect(screen.getByText("Mapping Step Settings")).toBeInTheDocument();
-      expect(getByText("Basic").closest("div")).toHaveClass("ant-tabs-tab-active");
-      expect(getByText("Advanced").closest("div")).not.toHaveClass("ant-tabs-tab-active");
+      expect(getByText("Basic").closest("button")).toHaveClass("nav-link active");
+      expect(getByText("Advanced").closest("button")).not.toHaveClass("nav-link active");
 
       // Basic settings values
       expect(getByPlaceholderText("Enter name")).toHaveValue("Mapping1");
@@ -195,8 +195,8 @@ describe("Mapping Card component", () => {
       await wait(() => {
         fireEvent.click(getByText("Advanced"));
       });
-      expect(getByText("Basic").closest("div")).not.toHaveClass("ant-tabs-tab-active");
-      expect(getByText("Advanced").closest("div")).toHaveClass("ant-tabs-tab-active");
+      expect(getByText("Basic").closest("button")).not.toHaveClass("nav-link active");
+      expect(getByText("Advanced").closest("button")).toHaveClass("nav-link active");
 
       // Advanced settings values
       expect(getByText("Source Database")).toBeInTheDocument();

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.test.tsx
@@ -140,8 +140,8 @@ describe("Load data component", () => {
     await wait(() => {
       fireEvent.click(getByText(data.loadData.data[0].name));
     });
-    expect(getByText("Basic").closest("div")).toHaveClass("ant-tabs-tab-active");
-    expect(getByText("Advanced").closest("div")).not.toHaveClass("ant-tabs-tab-active");
+    expect(getByText("Basic").closest("button")).toHaveClass("nav-link active");
+    expect(getByText("Advanced").closest("div")).not.toHaveClass("nav-link active");
 
     // Basic settings values
     expect(getAllByText("testLoad")[0]).toBeInTheDocument();
@@ -154,8 +154,8 @@ describe("Load data component", () => {
     await wait(() => {
       fireEvent.click(getByText("Advanced"));
     });
-    expect(getByText("Basic").closest("div")).not.toHaveClass("ant-tabs-tab-active");
-    expect(getByText("Advanced").closest("div")).toHaveClass("ant-tabs-tab-active");
+    expect(getByText("Basic").closest("button")).not.toHaveClass("nav-link active");
+    expect(getByText("Advanced").closest("button")).toHaveClass("nav-link active");
     let saveButton = getAllByText("Save"); // Each tab has a Save button
     expect(saveButton.length > 0);
     let stepName = loadData.loads.data[0].name;

--- a/marklogic-data-hub-central/ui/src/components/steps/steps.scss
+++ b/marklogic-data-hub-central/ui/src/components/steps/steps.scss
@@ -1,12 +1,45 @@
-.ant-tabs .ant-tabs-content {
-    margin-top: 30px;
-}
-
-.ant-tabs-top-bar {
-    width: 190px;
-    margin-left: 430px;
-}
+@import "../../HCTheme.scss";
 
 .basicTooltip, .advTooltip {
     max-width: 100%;
-  }
+}
+
+.nav-tabs {
+    width: 173px;
+    margin-left: 430px;
+    justify-content: space-around;
+
+    .nav-link, .nav-item.show .nav-link {
+        border: none !important;
+        border-bottom: #e8e8e8;
+        color: $text-color !important;
+        font-size: 16px;
+        padding: 16px;     
+
+        &.active {
+            color: $info !important;
+            border-bottom: 2px solid $info !important;
+            font-weight: 500;
+        }
+        &:not(.active) {
+            margin-left: -7px !important;
+        }
+    }
+
+    .nav-item:last-child .nav-link {
+        margin-left: 1px !important;
+    }
+}
+
+.nav-link.disabled {
+    color: #ccc !important;
+    cursor: not-allowed !important;
+    pointer-events: initial !important;
+}
+
+.tab-content {
+    .active {
+        margin-left: inherit !important;
+        padding-top: 30px;
+    }
+}

--- a/marklogic-data-hub-central/ui/src/components/steps/steps.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/steps/steps.test.tsx
@@ -29,8 +29,8 @@ describe("Steps settings component", () => {
     expect(getByLabelText("Close")).toBeInTheDocument();
 
     // Default Basic tab
-    expect(getByText("Basic").closest("div")).toHaveClass("ant-tabs-tab-active");
-    expect(getByText("Advanced").closest("div")).not.toHaveClass("ant-tabs-tab-active");
+    expect(getByText("Basic").closest("button")).toHaveClass("nav-link active");
+    expect(getByText("Advanced").closest("button")).not.toHaveClass("nav-link active");
     expect(baseElement.querySelector("#name")).toHaveValue("AdvancedLoad");
     // Other Basic settings details tested in create-edit-*.test.tsx
 
@@ -38,8 +38,8 @@ describe("Steps settings component", () => {
     await wait(() => {
       fireEvent.click(getByText("Advanced"));
     });
-    expect(getByText("Basic").closest("div")).not.toHaveClass("ant-tabs-tab-active");
-    expect(getByText("Advanced").closest("div")).toHaveClass("ant-tabs-tab-active");
+    expect(getByText("Basic").closest("button")).not.toHaveClass("nav-link active");
+    expect(getByText("Advanced").closest("button")).toHaveClass("nav-link active");
     expect(getByPlaceholderText("Please enter target permissions")).toHaveValue("data-hub-common,read,data-hub-common,update");
     // Other Advanced settings details tested in advanced-settings.test.tsx
 
@@ -53,8 +53,8 @@ describe("Steps settings component", () => {
     await wait(() => {
       fireEvent.click(getByText("Basic"));
     });
-    expect(getByText("Basic").closest("div")).toHaveClass("ant-tabs-tab-active");
-    expect(getByText("Advanced").closest("div")).not.toHaveClass("ant-tabs-tab-active");
+    expect(getByText("Basic").closest("button")).toHaveClass("nav-link active");
+    expect(getByText("Advanced").closest("button")).not.toHaveClass("nav-link active");
 
     fireEvent.click(getAllByLabelText("Cancel")[0]);
 
@@ -99,8 +99,8 @@ describe("Steps settings component", () => {
     expect(detailsLink.onclick).toHaveBeenCalledTimes(1);
 
     // Default Basic tab
-    expect(getByText("Basic").closest("div")).toHaveClass("ant-tabs-tab-active");
-    expect(getByText("Advanced").closest("div")).not.toHaveClass("ant-tabs-tab-active");
+    expect(getByText("Basic").closest("button")).toHaveClass("nav-link active");
+    expect(getByText("Advanced").closest("button")).not.toHaveClass("nav-link active");
 
     // Switch to Advanced tab, create error, verify other tab disabled
     await wait(() => {
@@ -114,7 +114,7 @@ describe("Steps settings component", () => {
     //TODO: Test with reference rather than hardcoded string.
     expect(getByTestId("validationError")).toHaveTextContent("The format of the string is incorrect. The required format is role,capability,role,capability,....");
 
-    expect(getByText("Basic").closest("div")).toHaveClass("ant-tabs-tab-disabled");
+    expect(getByText("Basic").closest("button")).toHaveClass("nav-link disabled");
     fireEvent.mouseOver(getByText("Basic"));
     wait(() => expect(screen.getByText(ErrorTooltips.disabledTab)).toBeInTheDocument());
 
@@ -125,7 +125,7 @@ describe("Steps settings component", () => {
     getByPlaceholderText("Please enter target permissions").blur();
     expect(getByTestId("validationError")).toHaveTextContent("");
 
-    expect(getByText("Basic").closest("div")).not.toHaveClass("ant-tabs-tab-disabled");
+    expect(getByText("Basic").closest("button")).not.toHaveClass("nav-link disabled");
 
     // Close dialog, verify discard changes confirm dialog
     await wait(() => {
@@ -208,8 +208,8 @@ describe("Steps settings component", () => {
     expect(getByLabelText("Close")).toBeInTheDocument();
 
     // Advanced tab disabled since Basic tab has empty required fields
-    expect(getByText("Basic").closest("div")).toHaveClass("ant-tabs-tab-active");
-    expect(getByText("Advanced").closest("div")).toHaveClass("ant-tabs-tab-disabled");
+    expect(getByText("Basic").closest("button")).toHaveClass("nav-link active");
+    expect(getByText("Advanced").closest("button")).toHaveClass("nav-link disabled");
 
     // Enter required name
     const nameField = getByPlaceholderText("Enter name");
@@ -257,8 +257,8 @@ describe("Steps settings component", () => {
     expect(getByLabelText("Close")).toBeInTheDocument();
 
     // Advanced tab disabled since Basic tab has empty required fields
-    expect(getByText("Basic").closest("div")).toHaveClass("ant-tabs-tab-active");
-    expect(getByText("Advanced").closest("div")).toHaveClass("ant-tabs-tab-disabled");
+    expect(getByText("Basic").closest("button")).toHaveClass("nav-link active");
+    expect(getByText("Advanced").closest("button")).toHaveClass("nav-link disabled");
 
     // Enter required name
     const nameField = getByPlaceholderText("Enter name");
@@ -312,8 +312,8 @@ describe("Steps settings component", () => {
     expect(getByLabelText("Close")).toBeInTheDocument();
 
     // Advanced tab disabled since Basic tab has empty required fields
-    expect(getByText("Basic").closest("div")).toHaveClass("ant-tabs-tab-active");
-    expect(getByText("Advanced").closest("div")).toHaveClass("ant-tabs-tab-disabled");
+    expect(getByText("Basic").closest("button")).toHaveClass("nav-link active");
+    expect(getByText("Advanced").closest("button")).toHaveClass("nav-link disabled");
 
     // Enter required name
     const nameField = getByPlaceholderText("Enter name");
@@ -361,8 +361,8 @@ describe("Steps settings component", () => {
     expect(getByLabelText("Close")).toBeInTheDocument();
 
     // Advanced tab disabled since Basic tab has empty required fields
-    expect(getByText("Basic").closest("div")).toHaveClass("ant-tabs-tab-active");
-    expect(getByText("Advanced").closest("div")).toHaveClass("ant-tabs-tab-disabled");
+    expect(getByText("Basic").closest("button")).toHaveClass("nav-link active");
+    expect(getByText("Advanced").closest("button")).toHaveClass("nav-link disabled");
 
     // Enter required name
     const nameField = getByPlaceholderText("Enter name");

--- a/marklogic-data-hub-central/ui/src/components/steps/steps.tsx
+++ b/marklogic-data-hub-central/ui/src/components/steps/steps.tsx
@@ -1,5 +1,8 @@
 import React, {useState, useEffect} from "react";
-import {Modal, Tabs} from "antd";
+import {Modal} from "antd";
+import Tabs from "react-bootstrap/Tabs";
+import Tab from "react-bootstrap/Tab";
+import TabPane from "react-bootstrap/TabContainer";
 import CreateEditLoad from "../load/create-edit-load/create-edit-load";
 import CreateEditStep from "../entities/create-edit-step/create-edit-step";
 import AdvancedSettings from "../advanced-settings/advanced-settings";
@@ -11,8 +14,6 @@ import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faPencilAlt} from "@fortawesome/free-solid-svg-icons";
 import {ErrorTooltips} from "../../config/tooltips.config";
 import HCTooltip from "../common/hc-tooltip/hc-tooltip";
-
-const {TabPane} = Tabs;
 
 interface Props {
     isEditing: boolean;
@@ -231,36 +232,39 @@ const Steps: React.FC<Props> = (props) => {
         <div className={styles.title}>{getTitle()}</div>
       </header>
       <div className={styles.tabs}>
-        <Tabs activeKey={currentTab} defaultActiveKey={DEFAULT_TAB} size={"large"} onTabClick={handleTabChange} animated={false} tabBarGutter={10}>
-
-          <TabPane tab={(
+        <Tabs activeKey={currentTab} defaultActiveKey={DEFAULT_TAB} onSelect={handleTabChange}>
+          <Tab title={(
             <HCTooltip text={(!isValid && currentTab !== "1") ? ErrorTooltips.disabledTab : ""} id="basic-tooltip" placement="bottom"><span>Basic</span></HCTooltip>
-          )} key="1" disabled={!isValid && currentTab !== "1"}>
-            {getCreateEditStep(props.activityType)}
-          </TabPane>
-          <TabPane tab={(
-            <HCTooltip text={(!isValid && currentTab !== "2") ? ErrorTooltips.disabledTab : ""} id="basic-tooltip" placement="bottom"><span>Advanced</span></HCTooltip>
-          )} key="2" disabled={!isValid && currentTab !== "2"} forceRender={true}>
-            <AdvancedSettings
-              tabKey="2"
-              tooltipsData={props.tooltipsData}
-              isEditing={props.isEditing}
-              openStepSettings={props.openStepSettings}
-              setOpenStepSettings={props.setOpenStepSettings}
-              stepData={props.stepData}
-              updateStep={updateStep}
-              activityType={props.activityType}
-              canWrite={props.canWrite}
-              currentTab={currentTab}
-              setIsValid={setIsValid}
-              resetTabs={resetTabs}
-              setHasChanged={setHasAdvancedChanged}
-              setPayload={setAdvancedPayload}
-              createStep={createStep}
-              onCancel={onCancel}
-              defaultCollections={defaultCollections}
-            />
-          </TabPane>
+          )} key="1" eventKey="1" disabled={!isValid && currentTab !== "1"}>
+            <TabPane mountOnEnter={false}>
+              {getCreateEditStep(props.activityType)}
+            </TabPane>
+          </Tab>
+          <Tab title={(
+            <HCTooltip text={(!isValid && currentTab !== "2") ? ErrorTooltips.disabledTab : ""} id="advanced-tooltip" placement="bottom"><span>Advanced</span></HCTooltip>
+          )} key="2" eventKey="2" disabled={!isValid && currentTab !== "2"}>
+            <TabPane>
+              <AdvancedSettings
+                tabKey="2"
+                tooltipsData={props.tooltipsData}
+                isEditing={props.isEditing}
+                openStepSettings={props.openStepSettings}
+                setOpenStepSettings={props.setOpenStepSettings}
+                stepData={props.stepData}
+                updateStep={updateStep}
+                activityType={props.activityType}
+                canWrite={props.canWrite}
+                currentTab={currentTab}
+                setIsValid={setIsValid}
+                resetTabs={resetTabs}
+                setHasChanged={setHasAdvancedChanged}
+                setPayload={setAdvancedPayload}
+                createStep={createStep}
+                onCancel={onCancel}
+                defaultCollections={defaultCollections}
+              />
+            </TabPane>
+          </Tab>
         </Tabs>
       </div>
       {/* Step Details link for Mapping steps */}

--- a/marklogic-data-hub-central/ui/src/pages/Load.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Load.test.tsx
@@ -48,8 +48,8 @@ describe("Load component", () => {
       await fireEvent.click(getByText("testLoad"));
     });
     expect(getByText("Loading Step Settings")).toBeInTheDocument();
-    expect(getByText("Basic").closest("div")).toHaveClass("ant-tabs-tab-active");
-    expect(getByText("Advanced").closest("div")).not.toHaveClass("ant-tabs-tab-active");
+    expect(getByText("Basic").closest("button")).toHaveClass("nav-link active");
+    expect(getByText("Advanced").closest("button")).not.toHaveClass("nav-link active");
 
     // Basic settings
     expect(getByPlaceholderText("Enter name")).toHaveValue("testLoad");
@@ -63,8 +63,8 @@ describe("Load component", () => {
     await wait(() => {
       fireEvent.click(getByText("Advanced"));
     });
-    expect(getByText("Basic").closest("div")).not.toHaveClass("ant-tabs-tab-active");
-    expect(getByText("Advanced").closest("div")).toHaveClass("ant-tabs-tab-active");
+    expect(getByText("Basic").closest("button")).not.toHaveClass("nav-link active");
+    expect(getByText("Advanced").closest("button")).toHaveClass("nav-link active");
 
     expect(await(waitForElement(() => getByText("Target Database:")))).toBeInTheDocument();
     expect(getByLabelText("headers-textarea")).toBeDisabled();
@@ -112,8 +112,8 @@ describe("Load component", () => {
       await fireEvent.click(getByText("testLoad"));
     });
     expect(getByText("Loading Step Settings")).toBeInTheDocument();
-    expect(getByText("Basic").closest("div")).toHaveClass("ant-tabs-tab-active");
-    expect(getByText("Advanced").closest("div")).not.toHaveClass("ant-tabs-tab-active");
+    expect(getByText("Basic").closest("button")).toHaveClass("nav-link active");
+    expect(getByText("Advanced").closest("button")).not.toHaveClass("nav-link active");
 
     // Basic settings
     expect(getByPlaceholderText("Enter name")).toHaveValue("testLoad");
@@ -127,8 +127,8 @@ describe("Load component", () => {
     await wait(() => {
       fireEvent.click(getByText("Advanced"));
     });
-    expect(getByText("Basic").closest("div")).not.toHaveClass("ant-tabs-tab-active");
-    expect(getByText("Advanced").closest("div")).toHaveClass("ant-tabs-tab-active");
+    expect(getByText("Basic").closest("button")).not.toHaveClass("nav-link active");
+    expect(getByText("Advanced").closest("button")).toHaveClass("nav-link active");
     expect(getByLabelText("headers-textarea")).not.toBeDisabled();
     fireEvent.click(getByText("Interceptors"));
     expect(getByLabelText("interceptors-textarea")).not.toBeDisabled();


### PR DESCRIPTION
### Description
Replaces `antd` Tabs component with `react-bootstrap` Tabs (and its utility components).

![image](https://user-images.githubusercontent.com/88854466/136286924-914fe81d-7002-4b0c-82f9-fdabf75a054e.png)

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [x] Run UI tests
  

- ##### Reviewer:

- [x] Reviewed Tests

