### PR TITLE
DHFPROD-7898: Change name of relationship and structured type selections

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/reader.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/reader.spec.tsx
@@ -131,6 +131,20 @@ describe("Entity Modeling: Reader Role", () => {
     graphViewSidePanel.getPropertyTypeIcon("structured", "shipping");
     graphViewSidePanel.getIconTooltip("Structured Type");
 
+    //To verify cannot edit Entity Type tab without permissions (except color)
+    graphViewSidePanel.getEntityTypeTab().click();
+    graphViewSidePanel.getPersonEntityDescription().should("be.disabled");
+    graphViewSidePanel.getPersonEntityNamespace().should("be.disabled");
+    graphViewSidePanel.getPersonEntityPrefix().should("be.disabled");
+    graphViewSidePanel.getEditEntityTypeColor().click();
+    graphViewSidePanel.selectColorFromPicker("#D5D3DD").click();
+    if (Cypress.isBrowser("!firefox")) {
+      graphViewSidePanel.getEntityTypeColor("Customer").should("have.css", "background", "rgb(213, 211, 221) none repeat scroll 0% 0% / auto padding-box border-box");
+    }
+    if (Cypress.isBrowser("firefox")) {
+      graphViewSidePanel.getEntityTypeColor("Customer").should("have.css", "background-color", "rgb(213, 211, 221)");
+    }
+
     graphViewSidePanel.closeSidePanel();
     graphViewSidePanel.getSelectedEntityHeading("Customer").should("not.exist");
 

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario1.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario1.spec.tsx
@@ -201,6 +201,7 @@ describe("Entity Modeling Senario 1: Writer Role", () => {
     propertyModal.toggleForeignKeyDropdown();
     propertyModal.getCancelButton();
   });
+
   it("Adding property to Person entity", () => {
     entityTypeTable.getExpandEntityIcon("Person");
     propertyTable.getAddPropertyButton("Person").click();

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario2.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario2.spec.tsx
@@ -492,7 +492,7 @@ describe("Entity Modeling: Writer Role", () => {
     entityTypeTable.getExpandEntityIcon("Person");
     propertyTable.editProperty("purchased");
     propertyModal.getYesRadio("multiple").should("be.checked");
-    propertyModal.verifyPropertyType("Order");
+    propertyModal.verifyPropertyType("Relationship: Order");
     propertyModal.verifyForeignKeyPlaceholder();
     propertyModal.getCancelButton();
 
@@ -570,7 +570,7 @@ describe("Entity Modeling: Writer Role", () => {
     entityTypeTable.waitForTableToLoad();
     propertyTable.editProperty("referredBy");
     propertyModal.getYesRadio("multiple").should("be.checked");
-    propertyModal.verifyPropertyType("Client");
+    propertyModal.verifyPropertyType("Relationship: Client");
     propertyModal.verifyForeignKey("firstname");
     propertyModal.getCancelButton();
 

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/entity-map-table/entity-map-table.tsx
@@ -412,7 +412,7 @@ const EntityMapTable: React.FC<Props> = (props) => {
           placeholder={`Search name`}
           value={selectedKeys[0]}
           onChange={e => setSelectedKeys(e.target.value ? [e.target.value] : [])}
-          onPressEnter={() => handleColSearch(selectedKeys, confirm, dataIndex)}
+          onPressEnter={() => selectedKeys?.length > 0 ? handleColSearch(selectedKeys, confirm, dataIndex) : false}
           className={styles.searchInput}
         />
         <MLButton data-testid={`ResetSearch-${dataIndex}`} onClick={() => handleSearchReset(clearFilters, dataIndex)} size="small" className={styles.resetButton}>
@@ -421,7 +421,7 @@ const EntityMapTable: React.FC<Props> = (props) => {
         <MLButton
           data-testid={`submitSearch-${dataIndex}`}
           type="primary"
-          onClick={() => handleColSearch(selectedKeys, confirm, dataIndex)}
+          onClick={() => selectedKeys?.length > 0 ? handleColSearch(selectedKeys, confirm, dataIndex) : false}
           size="small"
           className={styles.searchSubmitButton}
         >

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.module.scss
@@ -386,14 +386,21 @@ hr {
     color: #394494;
 }
 
+.uriHoverContainer {
+    display: flex;
+    flex-direction: row;
+}
+
 .editIcon{
-    font-Size: 27px;
+    display: relative;
+    justify-content: flex-end;
+    font-Size: 24px;
     color: #394494;
     background-color: #b9daed;
     padding: 5px 3px 5px 3px;
-    margin-right: -3px;
+    margin-left: 5px;
+    margin-right: -6px;
     margin-top: -4px;
-    margin-left: 13.75%;
     cursor: pointer;
 }
 

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.tsx
@@ -699,7 +699,7 @@ const MappingStepDetail: React.FC = () => {
         {!showEditURIOption ?
           <span data-testid={"uri-edit"} className={styles.notShowingEditContainer}>URI: <span className={styles.URItext}>{sourceURI}</span></span>
           :
-          <div><span data-testid={"uri-edit"} className={styles.showingEditContainer}>URI: <span className={styles.showingEditIcon}>{sourceURI}</span></span><i><FontAwesomeIcon icon={faPencilAlt} size="lg" onClick={handleEditIconClick} className={styles.editIcon} data-testid={"pencil-icon"}/></i></div>}
+          <div className={styles.uriHoverContainer}><span data-testid={"uri-edit"} className={styles.showingEditContainer}>URI: <span className={styles.showingEditIcon}>{sourceURI}<i><FontAwesomeIcon icon={faPencilAlt} size="lg" onClick={handleEditIconClick} className={styles.editIcon} data-testid={"pencil-icon"}/></i></span></span></div>}
       </div>
       :
       <div className={styles.inputURIContainer}>URI:
@@ -891,14 +891,14 @@ const MappingStepDetail: React.FC = () => {
           placeholder={`Search name`}
           value={selectedKeys[0]}
           onChange={e => setSelectedKeys(e.target.value ? [e.target.value] : [])}
-          onPressEnter={() => handleColSearch(selectedKeys, confirm, dataIndex)}
+          onPressEnter={() => selectedKeys?.length > 0 ? handleColSearch(selectedKeys, confirm, dataIndex) : false}
           className={styles.searchInput}
         />
         <MLButton data-testid={`ResetSearch-${dataIndex}`} onClick={() => handleSourceSearchReset(clearFilters, dataIndex)} size="small" className={styles.resetButton}>Reset</MLButton>
         <MLButton
           data-testid={`submitSearch-${dataIndex}`}
           type="primary"
-          onClick={() => handleColSearch(selectedKeys, confirm, dataIndex)}
+          onClick={() => selectedKeys?.length > 0 ? handleColSearch(selectedKeys, confirm, dataIndex) : false}
           size="small"
           className={styles.searchSubmitButton}
         >

--- a/marklogic-data-hub-central/ui/src/components/modeling/graph-view/side-panel/side-panel.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/graph-view/side-panel/side-panel.tsx
@@ -258,6 +258,7 @@ const GraphViewSidePanel: React.FC<Props> = (props) => {
           id="description"
           data-testid="description"
           placeholder="Enter description"
+          disabled={props.canReadEntityModel && !props.canWriteEntityModel}
           className={styles.descriptionInput}
           value={selectedEntityDescription}
           onChange={handlePropertyChange}
@@ -281,6 +282,7 @@ const GraphViewSidePanel: React.FC<Props> = (props) => {
             id="namespace"
             data-testid="namespace"
             placeholder="Example: http://example.org/es/gs"
+            disabled={props.canReadEntityModel && !props.canWriteEntityModel}
             className={styles.input}
             value={selectedEntityNamespace}
             onChange={handlePropertyChange}
@@ -299,6 +301,7 @@ const GraphViewSidePanel: React.FC<Props> = (props) => {
               id="prefix"
               data-testid="prefix"
               placeholder="Example: esgs"
+              disabled={props.canReadEntityModel && !props.canWriteEntityModel}
               className={styles.prefixInput}
               value={selectedEntityNamespacePrefix}
               onChange={handlePropertyChange}
@@ -319,21 +322,12 @@ const GraphViewSidePanel: React.FC<Props> = (props) => {
       >
         <div className={styles.colorContainer}>
           <div data-testid={`${modelingOptions.selectedEntity}-color`} style={{width: "26px", height: "26px", background: colorSelected, marginTop: "4px"}}></div>
-          {!props.canWriteEntityModel && props.canReadEntityModel ?
-            <div>
-              <span className={styles.editIconContainer}><MLTooltip title={SecurityTooltips.missingPermission} placement={"top"}><FontAwesomeIcon icon={faPencilAlt} size="sm" className={styles.editIconReadOnly} data-testid={"edit-color-icon-disabled"}/></MLTooltip></span>
-              <MLTooltip title={<span>Select a color to associate it with the <b>{modelingOptions.selectedEntity}</b> entity type throughout your project.</span>} placement={"right"}>
-                <Icon type="question-circle" className={styles.questionCircle} theme="filled"/>
-              </MLTooltip>
-            </div>
-            :
-            <div>
-              <span className={styles.editIconContainer}><FontAwesomeIcon icon={faPencilAlt} size="sm" onClick={handleEditColorMenu} className={styles.editIcon} data-testid={"edit-color-icon"}/></span>
-              <MLTooltip title={<span>Select a color to associate it with the <b>{modelingOptions.selectedEntity}</b> entity type throughout your project.</span>} placement={"right"}>
-                <Icon type="question-circle" className={styles.questionCircle} theme="filled"/>
-              </MLTooltip>
-            </div>
-          }
+          <div>
+            <span className={styles.editIconContainer}><FontAwesomeIcon icon={faPencilAlt} size="sm" onClick={handleEditColorMenu} className={styles.editIcon} data-testid={"edit-color-icon"}/></span>
+            <MLTooltip title={<span>Select a color to associate it with the <b>{modelingOptions.selectedEntity}</b> entity type throughout your project.</span>} placement={"right"}>
+              <Icon type="question-circle" className={styles.questionCircle} theme="filled"/>
+            </MLTooltip>
+          </div>
         </div>
       </Form.Item>
     </div>

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.test.tsx
@@ -446,7 +446,7 @@ describe("Property Modal Component", () => {
 
     fireEvent.submit(screen.getByLabelText("structured-input-name"));
 
-    expect(getByText("Product")).toBeInTheDocument();
+    expect(getByText("Structured: Product")).toBeInTheDocument();
 
     const multipleRadio = screen.getByLabelText("multiple-yes");
     fireEvent.change(multipleRadio, {target: {value: "yes"}});
@@ -637,6 +637,7 @@ describe("Property Modal Component", () => {
     expect(queryByText("Hide Steps...")).toBeNull();
 
     expect(getByText("Edit Property")).toBeInTheDocument();
+    expect(getByText("Relationship: Customer")).toBeInTheDocument();
 
     // Change Join Property
     expect(getByText("You can select the foreign key now or later:")).toBeInTheDocument();

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.tsx
@@ -881,7 +881,19 @@ const PropertyModal: React.FC<Props> = (props) => {
             aria-label="type-dropdown"
             placeholder="Select the property type"
             options={dropdownOptions}
-            displayRender={ label => { return label[label.length-1]; } }
+            displayRender={ label => {
+              if (label[label.length - 1]) {
+                if (label[0] === "Related Entity") {
+                  return "Relationship: " + label[label.length - 1];
+                } else if (label[0] === "Structured") {
+                  return "Structured: " + label[label.length - 1];
+                } else {
+                  return label[label.length - 1];
+                }
+              } else {
+                return label[label.length - 1];
+              }
+            }}
             onChange={onPropertyTypeChange}
             value={typeDisplayValue}
           />

--- a/marklogic-data-hub-central/ui/src/util/data-conversion.tsx
+++ b/marklogic-data-hub-central/ui/src/util/data-conversion.tsx
@@ -370,7 +370,6 @@ export const definitionsParser = (definitions: any): Definition[] => {
             // Handle join props if present
             property.relatedEntityType = defProp["relatedEntityType"];
             property.joinPropertyName = defProp["joinPropertyName"];
-
             if (defProp["relatedEntityType"]) {
               // Parse type from relatedEntityType URI
               let typeSplit = defProp["relatedEntityType"].split("/");


### PR DESCRIPTION
### Description
- Added "Relationship: " and "Structured: " labels to selections
- Fixed edit URI icon alignment [issue](https://project.marklogic.com/jira/browse/DHFPROD-7927) in mapping 
- Included read-only [fix](https://project.marklogic.com/jira/browse/DHFPROD-7840) to prevent Description and Namespace from being edited.
- Removed role restrictions from edit color in graph view.
- Included @MSBrignoni 's fix for the UI breaking when searching on an empty string in source and entity mapping tables.

-------------------------------------------------------------------------------------------------------------------
<img width="682" alt="Screen Shot 2021-10-08 at 11 08 57 AM" src="https://user-images.githubusercontent.com/18374593/136602994-c0edf9e3-3c5f-437c-ba3d-48c18c76cefa.png">

<img width="678" alt="Screen Shot 2021-10-08 at 11 08 39 AM" src="https://user-images.githubusercontent.com/18374593/136603020-27da2819-a786-4809-a383-432159746038.png">

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [x] Run UI tests
  

- ##### Reviewer:

- [x] Reviewed Tests

