### PR TITLE
DHFPROD-7908: Add color picker hover styles

### DIFF
--- a/marklogic-data-hub-central/ui/src/App.scss
+++ b/marklogic-data-hub-central/ui/src/App.scss
@@ -461,3 +461,8 @@ ul.ant-cascader-menu:nth-child(2) {
 #entitySettings .ant-popover-arrow {
   display: none !important;
 }
+
+/* hover style for color picker */
+.twitter-picker div:nth-child(3) span div:hover {
+  border: solid #5B69AF 2px;
+}

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-modal/entity-type-modal.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-modal/entity-type-modal.module.scss
@@ -34,6 +34,10 @@
   cursor: pointer;
 }
 
+.editIcon:hover {
+  color: #7FADE3;
+}
+
 .questionCircle {
 font-size: 12px;
 vertical-align: top;

--- a/marklogic-data-hub-central/ui/src/components/modeling/graph-view/side-panel/side-panel.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/modeling/graph-view/side-panel/side-panel.module.scss
@@ -76,6 +76,10 @@
     cursor: pointer;
 }
 
+.editIcon:hover {
+    color: #7FADE3;
+}
+
 .questionCircle {
   font-size: 12px;
   vertical-align: top;


### PR DESCRIPTION
### Description

CSS update that adds a color border on mouseover of the colors in the entity color picker, screencast:

https://watch.screencastify.com/v/V6uhIAEMu9f3oQM6Rvcm

Edit pencil icon hover style also added (for both graph and table views), for example: https://watch.screencastify.com/v/fN24PWIEa24czzYJ9Oo1

No test updates needed.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [x] Run UI tests
  

- ##### Reviewer:

- [x] Reviewed Tests

