### PR TITLE
DHFPROD-7786: Make datetime tests work for other timezones

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
@@ -10,6 +10,7 @@ import mocks from "../../../api/__mocks__/mocks.data";
 import {SecurityTooltips} from "../../../config/tooltips.config";
 import {CurationContext} from "../../../util/curation-context";
 import {customerMappingStep} from "../../../assets/mock-data/curation/curation-context-mock";
+import moment from "moment";
 
 jest.mock("axios");
 
@@ -245,9 +246,13 @@ describe("Mapping Card component", () => {
     // Check if the card is rendered properly
     expect(getByText("Add New")).toBeInTheDocument();
     expect(getByText("Mapping1")).toBeInTheDocument();
-    expect(getByText("Last Updated: 04/24/2020 1:21PM")).toBeInTheDocument();
+    let ts: string = mapping[0].lastUpdated; // "2020-04-24T13:21:00.169198-07:00"
+    let tsExpected: string = moment(ts).format("MM/DD/YYYY h:mmA");
+    expect(getByText("Last Updated: " + tsExpected)).toBeInTheDocument(); // "Last Updated: 04/24/2020 1:21PM"
     expect(getByText("Mapping2")).toBeInTheDocument();
-    expect(getByText("Last Updated: 10/01/2020 2:38AM")).toBeInTheDocument();
+    let ts2: string = mapping[1].lastUpdated; // "2020-10-01T02:38:00.169198-07:00"
+    let tsExpected2: string = moment(ts2).format("MM/DD/YYYY h:mmA");
+    expect(getByText("Last Updated: " + tsExpected2)).toBeInTheDocument(); // "Last Updated: 10/01/2020 2:38AM"
 
     // Hover for options
     fireEvent.mouseOver(getByText("Mapping2"));
@@ -385,7 +390,9 @@ describe("Mapping Card component", () => {
 
     //Check if the card is rendered properly
     expect(getByText("Add New")).toBeInTheDocument();
-    expect(getByText("Last Updated: 04/24/2020 1:21PM")).toBeInTheDocument();
+    let ts: string = mapping[0].lastUpdated; // "2020-04-24T13:21:00.169198-07:00"
+    let tsExpected: string = moment(ts).format("MM/DD/YYYY h:mmA");
+    expect(getByText("Last Updated: " + tsExpected)).toBeInTheDocument(); // "Last Updated: 04/24/2020 1:21PM"
 
     fireEvent.mouseOver(getByText("Mapping1")); // Hover over the Map Card to get more options
 

--- a/marklogic-data-hub-central/ui/src/components/job-response/job-response.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/job-response/job-response.test.tsx
@@ -6,6 +6,8 @@ import JobResponse from "./job-response";
 import {BrowserRouter as Router} from "react-router-dom";
 import {CurationContext} from "../../util/curation-context";
 import {curationContextMock} from "../../assets/mock-data/curation/curation-context-mock";
+import moment from "moment";
+import curateData from "../../assets/mock-data/curation/flows.data";
 
 jest.mock("axios");
 
@@ -65,7 +67,9 @@ describe("Job response modal", () => {
 
     // check that
     await (waitForElement(() => (getByText("testFlow"))));
-    expect(getByText("2020-04-24 14:05")).toBeInTheDocument();
+    let ts: string = curateData.jobRespSuccess.data.timeEnded; // "2020-04-24T14:05:01.019819-07:00"
+    let tsExpected: string = moment(ts).format("YYYY-MM-DD HH:mm");
+    expect(getByText(tsExpected)).toBeInTheDocument(); // "2020-04-24 14:05"
     expect(getByText("0s 702ms")).toBeInTheDocument();
 
     // check that expected steps are listed
@@ -95,7 +99,9 @@ describe("Job response modal", () => {
 
     // check that
     await (waitForElement(() => (getByText("testFlow"))));
-    expect(getByText("2020-04-04 01:17")).toBeInTheDocument();
+    let ts: string = curateData.jobRespFailedWithError.data.stepResponses["1"].stepEndTime; // "2020-04-04T01:17:45.012137-07:00"
+    let tsExpected: string = moment(ts).format("YYYY-MM-DD HH:mm");
+    expect(getByText(tsExpected)).toBeInTheDocument(); // "2020-04-04 01:17"
     expect(getByText("0s 702ms")).toBeInTheDocument();
 
     // check that expected steps are listed

--- a/marklogic-data-hub-central/ui/src/components/job-results-table-view/job-results-table-view.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/job-results-table-view/job-results-table-view.test.tsx
@@ -4,6 +4,7 @@ import {BrowserRouter as Router} from "react-router-dom";
 import JobResultsTableView from "./job-results-table-view";
 import {jobResults} from "../../assets/mock-data/monitor/job-results";
 import {validateTableRow} from "../../util/test-utils";
+import moment from "moment";
 
 
 describe("Job results Table view component", () => {
@@ -26,7 +27,9 @@ describe("Job results Table view component", () => {
     //check table data is rendered correctly
     expect(getByText("mapClientJSON")).toBeInTheDocument();
     expect(getByText("mapping")).toBeInTheDocument();
-    expect(getByText("2021-04-21 20:37")).toBeInTheDocument();
+    let ts: string = jobResults.results[0].startTime; // "2021-04-21T20:37:42.962833-05:00"
+    let tsExpected: string = moment(ts).format("YYYY-MM-DD HH:mm");
+    expect(getByText(tsExpected)).toBeInTheDocument(); // "2021-04-21 20:37"
     expect(getByText("0s 66ms")).toBeInTheDocument();
     expect(getByText("pari")).toBeInTheDocument();
 

--- a/marklogic-data-hub-central/ui/src/components/load/load-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-card.test.tsx
@@ -8,6 +8,7 @@ import axiosMock from "axios";
 import mocks from "../../api/__mocks__/mocks.data";
 import {AuthoritiesService, AuthoritiesContext} from "../../util/authorities";
 import {SecurityTooltips} from "../../config/tooltips.config";
+import moment from "moment";
 jest.mock("axios");
 
 const mockHistoryPush = jest.fn();
@@ -50,7 +51,9 @@ describe("Load Card component", () => {
     expect(getByText("Add New")).toBeInTheDocument();
     expect(getByText("testLoadXML")).toBeInTheDocument();
     expect(getByLabelText("testLoadXML-sourceFormat")).toBeInTheDocument();
-    expect(getByText("Last Updated: 04/15/2020 2:22PM")).toBeInTheDocument();
+    let ts: string = data.loadData.data[1].lastUpdated; // "2020-04-15T14:22:54.057519-07:00"
+    let tsExpected: string = moment(ts).format("MM/DD/YYYY h:mmA");
+    expect(getByText("Last Updated: " + tsExpected)).toBeInTheDocument(); // "Last Updated: 04/15/2020 2:22PM"
 
     fireEvent.mouseOver(getByText("testLoadXML")); // Hover over the Load Card to get more options
 
@@ -218,7 +221,9 @@ describe("Load Card component", () => {
     expect(getByText("Add New")).toBeInTheDocument();
     expect(getByText("testLoadXML")).toBeInTheDocument();
     expect(getByLabelText("testLoadXML-sourceFormat")).toBeInTheDocument();
-    expect(getByText("Last Updated: 04/15/2020 2:22PM")).toBeInTheDocument();
+    let ts: string = data.loadData.data[1].lastUpdated; // "2020-04-15T14:22:54.057519-07:00"
+    let tsExpected: string = moment(ts).format("MM/DD/YYYY h:mmA");
+    expect(getByText("Last Updated: " + tsExpected)).toBeInTheDocument(); // "Last Updated: 04/15/2020 2:22PM"
 
     fireEvent.mouseOver(getByText("testLoadXML")); // Hover over the Load Card to get more options
 

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.test.tsx
@@ -10,6 +10,7 @@ import {AuthoritiesService, AuthoritiesContext} from "../../util/authorities";
 import {validateTableRow} from "../../util/test-utils";
 import {SecurityTooltips} from "../../config/tooltips.config";
 import {LoadingContext} from "../../util/loading-context";
+import moment from "moment";
 
 jest.mock("axios");
 
@@ -54,7 +55,9 @@ describe("Load data component", () => {
     expect(dataRow.getByText(data.loadData.data[1].description)).toBeInTheDocument();
     expect(dataRow.getByText(data.loadData.data[1].sourceFormat)).toBeInTheDocument();
     expect(dataRow.getByText(data.loadData.data[1].targetFormat)).toBeInTheDocument();
-    expect(dataRow.getByText("04/15/2020 2:22PM")).toBeInTheDocument();
+    let ts: string = data.loadData.data[1].lastUpdated; // "2020-04-15T14:22:54.057519-07:00"
+    let tsExpected: string = moment(ts).format("MM/DD/YYYY h:mmA");
+    expect(dataRow.getByText(tsExpected)).toBeInTheDocument(); // "04/15/2020 2:22PM"
     expect(dataRow.getByTestId(`${data.loadData.data[1].name}-delete`)).toBeInTheDocument();
 
     // check if delete tooltip appears

--- a/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.test.tsx
@@ -4,6 +4,7 @@ import {entitySearch, entityPropertyDefinitions, selectedPropertyDefinitions, en
 import ResultsTabularView from "./results-tabular-view";
 import {BrowserRouter as Router} from "react-router-dom";
 import {validateTableRow} from "../../util/test-utils";
+import moment from "moment";
 
 describe("Results Table view component", () => {
   test("Results table with data renders", async () => {
@@ -119,7 +120,9 @@ describe("Results Table view component", () => {
     expect(getByText("101")).toBeInTheDocument();
     expect(getByTestId("Customer-101")).toBeInTheDocument();
     expect(getByTestId("json-101")).toBeInTheDocument();
-    expect(getByText("2020-06-21 23:44")).toBeInTheDocument();
+    let ts: string = entitySearchAllEntities.results[0].createdOn; // "2020-06-21T23:44:46.225063-07:00"
+    let tsExpected: string = moment(ts).format("YYYY-MM-DD HH:mm");
+    expect(getByText(tsExpected)).toBeInTheDocument(); // "2020-06-21 23:44"
     expect(getByTestId("101-detailOnSeparatePage")).toBeInTheDocument();
     expect(getByTestId("101-sourceOnSeparatePage")).toBeInTheDocument();
 

--- a/marklogic-data-hub-central/ui/src/pages/Load.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Load.test.tsx
@@ -8,6 +8,8 @@ import Load from "./Load";
 import {MemoryRouter} from "react-router-dom";
 import tiles from "../config/tiles.config";
 import {getViewSettings} from "../util/user-context";
+import moment from "moment";
+import loadData from "../assets/mock-data/curation/ingestion.data";
 
 jest.mock("axios");
 jest.setTimeout(30000);
@@ -205,14 +207,18 @@ describe("Load component", () => {
     expect(getByText("testLoad")).toBeInTheDocument();
     expect(getByText("Test JSON.")).toBeInTheDocument();
     expect(getAllByText("json").length > 0);
-    expect(getByText("01/01/2000 4:00AM")).toBeInTheDocument();
+    let ts: string = loadData.loads.data[0].lastUpdated; // "2000-01-01T12:00:00.000000-00:00"
+    let tsExpected: string = moment(ts).format("MM/DD/YYYY H:mmA");
+    expect(getByText(tsExpected)).toBeInTheDocument(); // "01/01/2000 4:00AM"
     expect(getByLabelText("icon: delete")).toBeInTheDocument();
 
     // Check card view
     fireEvent.click(getByLabelText("switch-view-card"));
     expect(getByText("testLoad")).toBeInTheDocument();
     expect(getByText("JSON")).toBeInTheDocument();
-    expect(getByText("Last Updated: 01/01/2000 4:00AM")).toBeInTheDocument();
+    let ts2: string = loadData.loads.data[0].lastUpdated; // "2000-01-01T12:00:00.000000-00:00"
+    let tsExpected2: string = moment(ts2).format("MM/DD/YYYY H:mmA");
+    expect(getByText("Last Updated: " + tsExpected2)).toBeInTheDocument(); // "Last Updated: 01/01/2000 4:00AM"
     expect(getByTestId("testLoad-edit")).toBeInTheDocument();
     expect(getByLabelText("icon: delete")).toBeInTheDocument();
 

--- a/marklogic-data-hub-central/ui/src/pages/Run.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Run.test.tsx
@@ -18,6 +18,8 @@ import {act} from "react-dom/test-utils";
 import {MemoryRouter} from "react-router-dom";
 import tiles from "../config/tiles.config";
 import {createMemoryHistory} from "history";
+import moment from "moment";
+import curateData from "../assets/mock-data/curation/flows.data";
 
 jest.mock("axios");
 jest.setTimeout(30000);
@@ -437,7 +439,10 @@ describe("Verify step display", () => {
     expect(getByText("XML")).toHaveStyle("height: 35px; width: 35px; line-height: 35px; text-align: center;");
     expect(notification).toBeInTheDocument();
     fireEvent.mouseOver(notification);
-    expect(await(waitForElement(() => getByText("Step last ran successfully on 7/13/2020, 11:54:06 PM")))).toBeInTheDocument();
+    let ts: string = curateData.flowsXMLLatestJob.data.steps[0].stepEndTime; // "2020-07-13T23:54:06.30257-07:00"
+    let dateExpected: string = moment(ts).format("M/D/YYYY");
+    let timeExpected: string = moment(ts).format("h:mm:ss A");
+    expect(await(waitForElement(() => getByText("Step last ran successfully on " + dateExpected + ", " + timeExpected)))).toBeInTheDocument(); // "Step last ran successfully on 7/13/2020, 11:54:06 PM"
   });
 
   test("Verify a mapping step's notification shows up correctly", async () => {
@@ -450,7 +455,10 @@ describe("Verify step display", () => {
     let notification = await(waitForElement(() => getByLabelText("icon: exclamation-circle")));
     expect(notification).toBeInTheDocument();
     fireEvent.mouseOver(notification);
-    expect(await(waitForElement(() => getByText("Step last ran with errors on 4/4/2020, 1:17:45 AM")))).toBeInTheDocument();
+    let ts: string = curateData.jobRespFailedWithError.data.stepResponses["1"].stepEndTime; // "2020-04-04T01:17:45.012137-07:00"
+    let dateExpected: string = moment(ts).format("M/D/YYYY");
+    let timeExpected: string = moment(ts).format("H:mm:ss A");
+    expect(await(waitForElement(() => getByText("Step last ran with errors on " + dateExpected + ", " + timeExpected)))).toBeInTheDocument(); // "Step last ran with errors on 4/4/2020, 1:17:45 AM"
 
     fireEvent.click(notification);
     // New Modal with Error message, uri and details is opened


### PR DESCRIPTION
Use Moment.js to dynamically build expected timestamp based on local timezone. See Jira ticket for details. 

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [x] Run UI tests
  

- ##### Reviewer:

- [x] Reviewed Tests

