### PR TITLE
DHFPROD-7963: Session time out throws negative seconds and does not allow to logout

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/modal-status/modal-status.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modal-status/modal-status.tsx
@@ -122,6 +122,8 @@ const ModalStatus: React.FC<Props> = (props) => {
       } catch (error) {
         if (error.response) {
           handleError(error);
+        } else {
+          userNotAuthenticated();
         }
       } finally {
         setSessionTime(SESSION_WARNING_COUNTDOWN);


### PR DESCRIPTION
At logout, when backend does not respond we call userNotAuthorized.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [X] JIRA_ID included in all the commit messages
- [X] PR title is in the format JIRA_ID:Title
- [X] Rebase the branch with upstream
- [X] Squashed all commits into a single commit
- [X] Code passes ESLint tests
- N/A Added Tests
- [X] Run UI tests
  

- ##### Reviewer:

- [x] Reviewed Tests

