### PR TITLE
DHFPROD-7924: Same property name as entity error

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/modeling/graph-view/relationship-modal/add-edit-relationship.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/graph-view/relationship-modal/add-edit-relationship.test.tsx
@@ -24,6 +24,8 @@ describe("Add Edit Relationship component", () => {
         relationshipModalVisible={true}
         toggleRelationshipModal={true}
         updateSavedEntity={updateSavedEntity}
+        canReadEntityModel={true}
+        canWriteEntityModel={true}
         entityMetadata={{}}
       />
     );
@@ -96,7 +98,7 @@ describe("Add Edit Relationship component", () => {
 
   test("Verify Add Relationship dialog renders correctly", () => {
     const updateSavedEntity = jest.fn(() => {});
-    const {getByText, getByTestId, getByLabelText, queryByText} = render(
+    const {getByText, getByTestId, getByLabelText, queryByText, rerender} = render(
       <AddEditRelationship
         openRelationshipModal={true}
         setOpenRelationshipModal={jest.fn()}
@@ -106,6 +108,8 @@ describe("Add Edit Relationship component", () => {
         relationshipModalVisible={true}
         toggleRelationshipModal={true}
         updateSavedEntity={updateSavedEntity}
+        canReadEntityModel={true}
+        canWriteEntityModel={true}
         entityMetadata={{}}
       />
     );
@@ -130,10 +134,35 @@ describe("Add Edit Relationship component", () => {
     expect(getByText("You can select the foreign key now or later:")).toBeInTheDocument();
     expect(getByText("Select foreign key")).toBeInTheDocument();
 
-    //verify error message upon Save click with no selected entity, entity selection tested in e2e
+    // verify error message upon Save click with no selected entity, entity selection tested in e2e
     fireEvent.click(getByText("Add"));
     wait(() => expect(getByLabelText("error-circle")).toBeInTheDocument());
     fireEvent.mouseOver(getByLabelText("error-circle"));
     wait(() => expect(getByText(ModelingTooltips.targetEntityEmpty)).toBeInTheDocument());
+
+    const mockRelationshipWithTarget = {...mockAddRelationshipInfo, targetNodeName: "Customer"};
+
+    rerender(<AddEditRelationship
+      openRelationshipModal={true}
+      setOpenRelationshipModal={jest.fn()}
+      isEditing={false}
+      relationshipInfo={mockRelationshipWithTarget}
+      entityTypes={entityTypesWithRelationship}
+      relationshipModalVisible={true}
+      toggleRelationshipModal={true}
+      updateSavedEntity={updateSavedEntity}
+      canReadEntityModel={true}
+      canWriteEntityModel={true}
+      entityMetadata={{}}
+    />
+    );
+    //verify duplicate property error message
+    fireEvent.change(getByLabelText("relationship-textarea"), {target: {value: "BabyRegistry"}});
+    fireEvent.click(getByText("Add"));
+    wait(() => expect(getByLabelText("error-circle")).toBeInTheDocument());
+    fireEvent.mouseOver(getByLabelText("error-circle"));
+    wait(() => expect(getByTestId("name-error")).toBeInTheDocument());
+
+
   });
 });

--- a/marklogic-data-hub-central/ui/src/components/modeling/graph-view/relationship-modal/add-edit-relationship.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/graph-view/relationship-modal/add-edit-relationship.tsx
@@ -300,8 +300,8 @@ const AddEditRelationship: React.FC<Props> = (props) => {
       let sourceEntityIdx = props.entityTypes.findIndex(obj => obj.entityName === props.relationshipInfo.sourceNodeName);
       let sourceProperties = props.entityTypes[sourceEntityIdx].model.definitions[props.relationshipInfo.sourceNodeName].properties;
       let propertyNamesArray = props.isEditing ? Object.keys(sourceProperties).filter(propertyName => propertyName !== props.relationshipInfo.relationshipName) : Object.keys(sourceProperties);
-      if (propertyNamesArray.includes(relationshipName)) {
-        setErrorMessage(`A property already exists with a name of ${relationshipName}`);
+      if (propertyNamesArray.includes(relationshipName) || props.relationshipInfo.sourceNodeName === relationshipName) {
+        setErrorMessage("name-error");
       } else {
 
         const newEditPropertyOptions = {
@@ -613,7 +613,7 @@ const AddEditRelationship: React.FC<Props> = (props) => {
             aria-label="relationship-textarea"
             style={errorMessage && submitClicked? {border: "solid 1px #C00"} : {}}
           />
-          {errorMessage && submitClicked? <MLTooltip title={errorMessage} placement={"bottom"}><Icon aria-label="error-circle" type="exclamation-circle" theme="filled" className={styles.errorIcon}/></MLTooltip> : ""}
+          {errorMessage && submitClicked? <MLTooltip title={errorMessage === "name-error" ? ModelingTooltips.duplicatePropertyError(relationshipName) : errorMessage} placement={"bottom"}><Icon aria-label="error-circle" type="exclamation-circle" theme="filled" className={styles.errorIcon}/></MLTooltip> : ""}
           <MLTooltip title={ModelingTooltips.relationshipNameInfo(props.relationshipInfo.sourceNodeName)} placement={"bottom"}>
             <Icon type="question-circle" className={styles.questionCircle} theme="filled"/>
           </MLTooltip>

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.tsx
@@ -848,7 +848,7 @@ const PropertyModal: React.FC<Props> = (props) => {
           colon={false}
           labelAlign="left"
           validateStatus={errorMessage ? "error" : ""}
-          help={errorMessage === "name-error" ? <span data-testid="property-name-error">A property or structured type are already using the name <b>{name}</b>. A property cannot use the same name as an existing property or structured type.</span> : errorMessage}
+          help={errorMessage === "name-error" ? ModelingTooltips.duplicatePropertyError(name) : errorMessage}
         >
           <Input
             id="property-name"

--- a/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
+++ b/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
@@ -49,7 +49,7 @@ const ModelingTooltips = {
     'Names must start with a letter and can contain letters, numbers, hyphens, and underscores.',  /* intended dupe: all names */
   descriptionEntityType: 'A description of this entity type.',
   nameEntityProperty: 'Names must start with a letter and can contain letters, numbers, hyphens, and underscores. ' +
-    'Names cannot use the same name as an existing property or structured type.',
+    'Property names cannot use the same name as the associated entity type or its existing properties.',
   descriptionEntityProperty: 'A description of this entity property.',
   namespace: 'Use of entity type namespaces is optional. If you choose to use a namespace, you must specify both a namespace URI and a prefix in your entity type definition.',
 
@@ -101,10 +101,17 @@ const ModelingTooltips = {
   deleteRelationshipIcon: "Delete this relationship",
   editModeInfo: <span>To add a relationship between entity types, drag the source entity type to the target entity type. You can also click the source entity type to configure a relationship. Press <strong>Esc</strong> to exit this mode.</span>,
   addRelationshipHeader: <span aria-label="addRelationshipHeader">Set the relationship type, relationship name, and foreign key. You are not required to specify a foreign key to save the relationship.</span>,
+  duplicatePropertyError: function (relationshipName) {
+    return (
+    <span data-testid="property-name-error">
+      The associated entity type or one of its properties is already using the name <b>{relationshipName}</b>. A property cannot use the same name as the associated entity type or its existing properties.
+    </span>
+    )
+  },
   relationshipNameInfo: function (entityName) {
     return (
       <span>
-        The name that identifies the relationship between the source and target entity types. The relationship is saved as a property in the <strong>{entityName}</strong> entity type.<br/>Names must start with a letter and can contain letters, numbers, hyphens, and underscores. Names cannot use the same name as an existing property or structured type.
+        The name that identifies the relationship between the source and target entity types. The relationship is saved as a property in the <strong>{entityName}</strong> entity type.<br/>Names must start with a letter and can contain letters, numbers, hyphens, and underscores. Property names cannot use the same name as the associated entity type or its existing properties.
       </span>
     )
   },


### PR DESCRIPTION
### Description
- This fix handles messaging and extra error checking for if the property name being created matches the entity name.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [x] Run UI tests
  

- ##### Reviewer:

- [x] Reviewed Tests
