### PR TITLE
DHFPROD-7901: Apply order to timeline items

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
@@ -8,8 +8,6 @@ import {act} from "react-dom/test-utils";
 import {AuthoritiesService, AuthoritiesContext} from "../../../util/authorities";
 import mocks from "../../../api/__mocks__/mocks.data";
 import {SecurityTooltips} from "../../../config/tooltips.config";
-import {CurationContext} from "../../../util/curation-context";
-import {customerMappingStep} from "../../../assets/mock-data/curation/curation-context-mock";
 import moment from "moment";
 
 jest.mock("axios");

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/matching-step-detail/matching-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/matching-step-detail/matching-step-detail.tsx
@@ -505,6 +505,21 @@ const MatchingStepDetail: React.FC = () => {
     await updateMatchingArtifact(stepArtifact);
   };
 
+  const timelineOrder = (a, b) => {
+    let aParts = a.value.split(":");
+    let bParts = b.value.split(":");
+    // If weights not equal
+    if (bParts[bParts.length-1] !== aParts[aParts.length-1]) {
+      // By weight
+      return parseInt(bParts[bParts.length-1]) - parseInt(aParts[aParts.length-1]);
+    } else {
+      // Else alphabetically
+      let aUpper = a.value.toUpperCase();
+      let bUpper = b.value.toUpperCase();
+      return (aUpper < bUpper) ? 1 : (aUpper > bUpper) ? -1 : 0;
+    }
+  };
+
   const rulesetOptions:any = {
     max: 120,
     min: -20,
@@ -563,7 +578,8 @@ const MatchingStepDetail: React.FC = () => {
         }
       }
     },
-    maxMinorChars: 4
+    maxMinorChars: 4,
+    order: timelineOrder
   };
 
   const thresholdOptions:any = {
@@ -620,7 +636,8 @@ const MatchingStepDetail: React.FC = () => {
         return "<div data-testid=\"threshold"+" "+item.value.split(":")[0]+"\">" + item.value.split(":")[0] + "<div class=\"itemValue\">" + item.value.split(":")[1] + "</div></div>";
       }
     },
-    maxMinorChars: 4
+    maxMinorChars: 4,
+    order: timelineOrder
   };
 
   const renderRulesetTimeline = () => {

--- a/marklogic-data-hub-central/ui/src/pages/Curate.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Curate.test.tsx
@@ -99,11 +99,11 @@ describe("Curate component", () => {
     fireEvent.click(getByTestId("Mapping1-delete"));
     await wait(() => {
       fireEvent.click(getByText("No"));
-    });    
+    });
     fireEvent.click(getByTestId("Mapping1-delete"));
     await wait(() => {
       fireEvent.click(getByText("Yes"));
-    });    
+    });
     expect(axiosMock.delete).toHaveBeenNthCalledWith(1, "/api/steps/mapping/Mapping1");
   });
 


### PR DESCRIPTION
### Description

In the Match Step Details view, slider handles should be ordered consistently by value (low to high) and secondarily by name (alphabetically), with ordering going from top to bottom (e.g., handles with lower values are above higher values). You shouldn't see the order change when sliding the Edit switch. 

The following screenshot shows ordering by value in the match scale and alphabetically in the thresholds:

<img width="793" alt="DHFPROD-7901-slider-order" src="https://user-images.githubusercontent.com/477757/137811356-0d3890e6-963c-43a9-926a-9d720629aaa6.png">

Testing will be manual for now. Ticket for automated testing is here: https://project.marklogic.com/jira/browse/DHFPROD-8039

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [x] Run UI tests
  

- ##### Reviewer:

- [x] Reviewed Tests

