### PR TITLE
DHFPROD-7978: Handle case when entity name has no definition

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
@@ -8,8 +8,6 @@ import {act} from "react-dom/test-utils";
 import {AuthoritiesService, AuthoritiesContext} from "../../../util/authorities";
 import mocks from "../../../api/__mocks__/mocks.data";
 import {SecurityTooltips} from "../../../config/tooltips.config";
-import {CurationContext} from "../../../util/curation-context";
-import {customerMappingStep} from "../../../assets/mock-data/curation/curation-context-mock";
 import moment from "moment";
 
 jest.mock("axios");

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.module.scss
@@ -143,3 +143,9 @@
   margin-bottom: -1px;
   cursor: pointer;
 }
+
+.titleNoDefinition {
+  width: 100%;
+  padding-top: 5px;
+  padding-bottom: 10px;
+}

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.test.tsx
@@ -220,6 +220,25 @@ describe("Entity Modeling Property Table Component", () => {
     expect(getAllByText("string")).toHaveLength(10);
   });
 
+  test("Property Table renders and shows messaging when entity name does not match a definition", async () => {
+    let entityName = propertyTableEntities[2].entityName + "-different";
+    let definitions = propertyTableEntities[2].model.definitions;
+    const {getByLabelText, queryByTestId} =  render(
+      <PropertyTable
+        canReadEntityModel={true}
+        canWriteEntityModel={false}
+        entityName={entityName}
+        definitions={definitions}
+        sidePanelView={false}
+        updateSavedEntity={jest.fn()}
+      />
+    );
+
+    expect(getByLabelText(entityName + "-add-property")).toBeDisabled();
+    expect(queryByTestId("customerId-span")).not.toBeInTheDocument();
+    expect(getByLabelText("titleNoDefinition")).toBeInTheDocument();
+  });
+
   test("can add sortable and facetable Property to the table", async () => {
     let entityName = propertyTableEntities[2].entityName;
     let definitions = propertyTableEntities[2].model.definitions;

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
@@ -25,6 +25,7 @@ import {getViewSettings, setViewSettings, UserContext} from "../../../util/user-
 import {ModelingContext} from "../../../util/modeling-context";
 import {definitionsParser} from "../../../util/data-conversion";
 import {ModelingTooltips} from "../../../config/tooltips.config";
+import {ModelingMessages} from "../../../config/tooltips.config";
 import {getSystemInfo} from "../../../api/environment";
 import arrayIcon from "../../../assets/icon_array.png";
 
@@ -898,18 +899,23 @@ const PropertyTable: React.FC<Props> = (props) => {
 
   };
 
+  // Check if entity name has no matching definition
+  const titleNoDefinition = () => {
+    return props.definitions ? !props.definitions.hasOwnProperty(props.entityName) : false;
+  };
+
   const addPropertyButton = <MLButton
     type="primary"
     aria-label={props.entityName + "-add-property"}
-    disabled={!props.canWriteEntityModel}
-    className={!props.canWriteEntityModel && styles.disabledButton}
+    disabled={!props.canWriteEntityModel || titleNoDefinition()}
+    className={(!props.canWriteEntityModel || titleNoDefinition()) && styles.disabledButton}
     onClick={() => addPropertyButtonClicked()}
   >Add Property</MLButton>;
 
   return (
     <div>
       <div className={styles.extraButtonContainer} id="extraButtonsContainer">
-        {props.sidePanelView ?
+        {props.sidePanelView && !titleNoDefinition() ?
           <span className={styles.expandCollapseBtns}><ExpandCollapse handleSelection={(id) => handleSourceExpandCollapse(id)} currentSelection={""} /></span> : ""
         }
         {props.canWriteEntityModel ?
@@ -942,18 +948,21 @@ const PropertyTable: React.FC<Props> = (props) => {
         toggleModal={toggleConfirmModal}
         confirmAction={confirmAction}
       />
-      <MLTable
-        rowClassName={(record) => {
-          let propertyName = record.hasOwnProperty("add") && record.add !== "" ? record.add.split(",").map(item => encrypt(item)).join("-") : encrypt(record.propertyName);
-          return "scroll-" + encrypt(props.entityName) + "-" + propertyName;
-        }}
-        locale={{emptyText: " "}}
-        columns={headerColumns}
-        dataSource={tableData}
-        onExpand={onExpand}
-        expandedRowKeys={expandedRows}
-        pagination={false}
-      />
+      {titleNoDefinition() ?
+        <div aria-label="titleNoDefinition" className={styles.titleNoDefinition}>{ModelingMessages.titleNoDefinition}</div> :
+        <MLTable
+          rowClassName={(record) => {
+            let propertyName = record.hasOwnProperty("add") && record.add !== "" ? record.add.split(",").map(item => encrypt(item)).join("-") : encrypt(record.propertyName);
+            return "scroll-" + encrypt(props.entityName) + "-" + propertyName;
+          }}
+          locale={{emptyText: " "}}
+          columns={headerColumns}
+          dataSource={tableData}
+          onExpand={onExpand}
+          expandedRowKeys={expandedRows}
+          pagination={false}
+        />
+      }
     </div>
   );
 };

--- a/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
+++ b/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
@@ -149,7 +149,8 @@ const ModelingPlaceholders = {
 
 const ModelingMessages = {
   entityEditedAlert: <span>You have unpublished changes for one or more entity types. Unpublished changes are saved automatically and have no impact on your project. Click the <strong>Publish</strong> button to apply changes to the rest of your project.</span>,
-  saveEntityConfirm: <span>You have unpublished changes that are only available in the <strong>Model</strong> screen. Publish changes to apply changes to the rest of your project. Publishing changes could trigger a reindex of your data.</span>
+  saveEntityConfirm: <span>You have unpublished changes that are only available in the <strong>Model</strong> screen. Publish changes to apply changes to the rest of your project. Publishing changes could trigger a reindex of your data.</span>,
+  titleNoDefinition: <span>Unable to display properties because the definition cannot be found for this entity type. To learn more, see <a href="https://docs.marklogic.com/datahub/refs/troubleshooting.html" target="_blank">Troubleshooting</a> in the documentation.</span>,
 };
 
 

--- a/marklogic-data-hub-central/ui/src/pages/Curate.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Curate.test.tsx
@@ -99,11 +99,11 @@ describe("Curate component", () => {
     fireEvent.click(getByTestId("Mapping1-delete"));
     await wait(() => {
       fireEvent.click(getByText("No"));
-    });    
+    });
     fireEvent.click(getByTestId("Mapping1-delete"));
     await wait(() => {
       fireEvent.click(getByText("Yes"));
-    });    
+    });
     expect(axiosMock.delete).toHaveBeenNthCalledWith(1, "/api/steps/mapping/Mapping1");
   });
 


### PR DESCRIPTION
### Description

In Modeling, display messaging when an entity definition's title does not match any of the property IDs in the model definitions. For example, for this entity the title is "CustomerTitle" but the entity definition has a "Customer1" ID (no "CustomerTitle" ID):

<img width="1165" alt="Screen Shot 2021-10-19 at 3 31 01 PM" src="https://user-images.githubusercontent.com/477757/137999796-bc9d7314-db6b-403a-b24b-c0598f8c0c20.png">

<img width="718" alt="Screen Shot 2021-10-19 at 3 30 47 PM" src="https://user-images.githubusercontent.com/477757/137999812-08bbf399-51f3-42e9-a1e4-c46e60ad0f77.png">

To test, you can duplicate an existing entity file and change the filename and title value. Then add it to your Data Hub with the following:
```
./gradlew hubDeployUserArtifacts
```

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [x] Run UI tests
  

- ##### Reviewer:

- [x] Reviewed Tests

