### PR TITLE
DHFPROD-8099: Fix legend overlap in Mapping Step Details

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.module.scss
@@ -473,4 +473,5 @@ hr {
   padding-right: 55px;
   left: 63%;
   position: relative;
+  z-index: -1000;
 }


### PR DESCRIPTION
### Description

Add z-index CSS to place legend in Mapping Step Details under the Test and Clear buttons. 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- N/A Added Tests
- [x] Run UI tests
  

- ##### Reviewer:

- N/A Reviewed Tests

