### PR TITLE
DHFPROD-7750: Matching/expandable-table-view

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario2.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/modeling/writerScenario2.spec.tsx
@@ -75,6 +75,7 @@ describe("Entity Modeling: Writer Role", () => {
     propertyModal.getYesRadio("pii").click();
     //propertyModal.clickCheckbox('wildcard');
     propertyModal.getSubmitButton().click();
+    cy.waitUntil(() => propertyTable.getExpandIcon("address").click());
     propertyTable.getMultipleIcon("street").should("not.exist");
     propertyTable.getPiiIcon("street").should("exist");
     //propertyTable.getWildcardIcon('street').should('exist');

--- a/marklogic-data-hub-central/ui/src/components/common/hc-table/hc-table.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/common/hc-table/hc-table.module.scss
@@ -37,14 +37,26 @@
         background-color: red;
     }
 }
-.borderedIndicator {
+.expandButtonIndicator { 
     width: 17px;
     height: 17px;
     text-align: center !important;
     line-height: 13px !important;
-    padding: 2px !important;
-    border: 1px solid #e8e8e8;
+    padding: 1px !important;
+    border: none !important;
+    border-radius: 0 !important;
     margin-right: 8px;
+    
+    &:focus, &:focus-visible {
+        box-shadow: none !important;
+    }
+}
+.borderedIndicator {
+    border: 1px solid #e8e8e8;
+    border-radius: 2px !important;
+}
+.iconIndicator {
+    font-size: 12px;
 }
 .expandedRowWrapper {
     background-color: #fbfbfb !important;
@@ -81,6 +93,7 @@
 }
 .childrenIndentExpanded {
     padding-left: 0 !important;
+    background-color: inherit !important;
 }
 .childrenIndentTableExpanded {
     display: table;
@@ -97,7 +110,12 @@
 .childrenIndentIndicatorCell {
     display: table-cell;
     width: 50px;
+    min-width: 50px;
     text-align: center;
+}
+.childrenIndentIndicatorEmptyCell {
+    width: 4%;
+    display: table-cell;
 }
 .childrenIndentElementCell {
     display: table-cell;

--- a/marklogic-data-hub-central/ui/src/components/common/hc-table/hc-table.scss
+++ b/marklogic-data-hub-central/ui/src/components/common/hc-table/hc-table.scss
@@ -104,6 +104,9 @@
             }
         }
     }
+    .hc-table_row:hover {
+        background-color: #e9f7fe;
+    }
     .hc-table_row:not(:last-child) {
         border-bottom: 1px solid #e8e8e8;
     }

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/expandable-table-view/expandable-table-view.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/expandable-table-view/expandable-table-view.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import ProgressBar from "react-bootstrap/ProgressBar";
-import {Table} from "antd";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import styles from "./expandable-table-view.module.scss";
 import {faCheck} from "@fortawesome/free-solid-svg-icons";
+import {HCTable} from "@components/common";
 
 interface Props {
     rowData: any;
@@ -15,93 +15,94 @@ let counter = 0;
 
 const testMatchedUriTableColumns = [
   {
-    title: "Ruleset",
-    dataIndex: "ruleName",
+    text: "Ruleset",
+    dataField: "ruleName",
     key: "ruleName "+ (counter++),
     width: "16%",
-    render: (ruleName, key) => (ruleName.map(property => {
+    formatter: (ruleName, key) => (ruleName.map(property => {
       return <span className={styles.rulesetColumn} key={key} aria-label={ruleName}>{property}
       </span>;
     }))
   },
   {
-    title: "Exact",
-    dataIndex: "matchedRulesetType",
+    text: "Exact",
+    dataField: "matchedRulesetType",
     key: "matchedRulesetType " + (counter++) + " exact",
     width: "6%",
-    render: (matchedRulesetType, key, index) => (matchedRulesetType.map(rulesetType => {
+    formatter: (matchedRulesetType, key, index) => (matchedRulesetType.map(rulesetType => {
       return (rulesetType && rulesetType.toLowerCase() === "exact") && <span className={styles.testMatchedColumns} key={key} aria-label={matchedRulesetType + " " + (index)}>
         <FontAwesomeIcon className={styles.checkIcon} icon={faCheck} data-testid={"facet-" + rulesetType} />
       </span>;
     }))
   },
   {
-    title: "Synonym",
-    dataIndex: "matchedRulesetType",
+    text: "Synonym",
+    dataField: "matchedRulesetType",
     key: "matchedRulesetType " + (counter++) + " synonym",
     width: "8%",
-    render: (matchedRulesetType, key, index) => (matchedRulesetType.map(rulesetType => {
+    formatter: (matchedRulesetType, key, index) => (matchedRulesetType.map(rulesetType => {
       return (rulesetType && rulesetType.toLowerCase() === "synonym") && <span className={styles.testMatchedColumns} key={key} aria-label={matchedRulesetType + " " + (index)}>
         <FontAwesomeIcon className={styles.checkIcon} icon={faCheck} data-testid={"facet-" + rulesetType}/>
       </span>;
     }))
   },
   {
-    title: "Double Metaphone",
-    dataIndex: "matchedRulesetType",
+    text: "Double Metaphone",
+    dataField: "matchedRulesetType",
     width: "10%",
     key: "matchedRulesetType " + (counter++) + " metaphone",
-    render: (matchedRulesetType, key, index) => (matchedRulesetType.map(rulesetType => {
+    formatter: (matchedRulesetType, key, index) => (matchedRulesetType.map(rulesetType => {
       return (rulesetType && rulesetType.toLowerCase() === "double metaphone") && <span className={styles.testMatchedColumns} key={key} aria-label={matchedRulesetType + " " + (index)}>
         <FontAwesomeIcon className={styles.checkIcon} icon={faCheck} data-testid={"facet-" + rulesetType}/>
       </span>;
     }))
   },
   {
-    title: "Zip",
-    dataIndex: "matchedRulesetType",
+    text: "Zip",
+    dataField: "matchedRulesetType",
     key: "matchedRulesetType " + (counter++) + " zip",
     width: "6%",
-    render: (matchedRulesetType, key, index) => (matchedRulesetType.map(rulesetType => {
+    formatter: (matchedRulesetType, key, index) => (matchedRulesetType.map(rulesetType => {
       return (rulesetType && rulesetType.toLowerCase() === "zip") && <span className={styles.testMatchedColumns} key={key} aria-label={matchedRulesetType + " " + (index)}>
         <FontAwesomeIcon className={styles.checkIcon} icon={faCheck} data-testid={"facet-" + rulesetType}/>
       </span>;
     }))
   },
   {
-    title: "Reduce",
-    dataIndex: "matchedRulesetType",
+    text: "Reduce",
+    dataField: "matchedRulesetType",
     key: "matchedRulesetType " + (counter++) + " reduce",
     width: "7%",
-    render: (matchedRulesetType, key, index) => (matchedRulesetType.map(rulesetType => {
+    formatter: (matchedRulesetType, key, index) => (matchedRulesetType.map(rulesetType => {
       return (rulesetType && rulesetType.toLowerCase() === "reduce") && <span className={styles.testMatchedColumns} key={key} aria-label={matchedRulesetType + " " + (index)}>
         <FontAwesomeIcon className={styles.checkIcon} icon={faCheck} data-testid={"facet-" + rulesetType}/>
       </span>;
     }))
   },
   {
-    title: "Custom",
-    dataIndex: "matchedRulesetType",
+    text: "Custom",
+    dataField: "matchedRulesetType",
     key: "matchedRulesetType " + (counter++) + " custom",
     width: "8%",
-    render: (matchedRulesetType, key, index) => (matchedRulesetType.map(rulesetType => {
+    formatter: (matchedRulesetType, key, index) => (matchedRulesetType.map(rulesetType => {
       return (rulesetType && rulesetType.toLowerCase() === "custom") && <span className={styles.testMatchedColumns} key={key} aria-label={matchedRulesetType + " " + (index)}>
         <FontAwesomeIcon className={styles.checkIcon} icon={faCheck} data-testid={"facet-" + rulesetType}/>
       </span>;
     }))
   },
   {
-    title: "Match Score",
-    dataIndex: "scores",
+    text: "Match Score",
+    dataField: "scores",
     key: "matchedRulesetType " + (counter++) + " score",
     width: "15%",
-    render: (scores, key) =>  <span key={key}  aria-label={"score " + scores.scores[0]}>
+    formatter: (scores, key) =>  <span key={key}  aria-label={"score " + scores.scores[0]}>
       {scores.scores[0]>0 && <ProgressBar now={scores.scores[0]} label={scores.matchedRule[0] !== "Reduce" ? `${scores.scores[0]}` : `-${scores.scores[0]}`} variant={scores.matchedRule[0] !== "Reduce" ? "success" : "danger"}/>}
     </span>
   }
 ];
 
 const ExpandableTableView: React.FC<Props> = (props) => {
+  const [expandedNestedRows, setExpandedNestedRows] = React.useState([]);
   let allRuleset = props.allRuleset;
   let multipleRuleset=[{}];
   let data = props.entityData.stepArtifact.matchRulesets;
@@ -178,13 +179,16 @@ const ExpandableTableView: React.FC<Props> = (props) => {
     }
 
   });
-  return <div className={styles.expandedTableView}><Table
-    columns={testMatchedUriTableColumns}
-    dataSource={actionPreviewData}
+  return <div className={styles.expandedTableView}><HCTable columns={testMatchedUriTableColumns}
+    data={actionPreviewData}
     pagination={false}
     rowKey="key"
-    // id="uriMatchedDataTable"
-  ></Table>
+    subTableHeader={true}
+    showExpandIndicator={true}
+    childrenIndent={true}
+    nestedParams={{headerColumns: testMatchedUriTableColumns, state: [expandedNestedRows, setExpandedNestedRows]}}
+  // id="uriMatchedDataTable"
+  />
   <div className={styles.boldTextDisplay}> Total Score: {props.rowData.score}</div></div>;
 };
 export default ExpandableTableView;

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/matching-step-detail/matching-step-detail.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/matching-step-detail/matching-step-detail.module.scss
@@ -216,7 +216,6 @@
 .UriMatchedDataTable {
     padding-top: 20px;
     width: 90.7vw;
-    overflow-y: auto;
     max-height: 60vh;
     margin-left: 2.2%;
     padding-right: 1.1vw;

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/matching-step-detail/matching-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/matching-step-detail/matching-step-detail.tsx
@@ -982,7 +982,7 @@ const MatchingStepDetail: React.FC = () => {
             </div>
             {rulesetDataList.map((rulesetDataList, index) => (
               <Accordion id="testMatchedPanel" className={"w-100"} flush key={index} activeKey={activeMatchedRuleset.includes(rulesetDataList.rulesetName) ? rulesetDataList.rulesetName : ""} defaultActiveKey={activeMatchedRuleset.includes(rulesetDataList.rulesetName) ? rulesetDataList.rulesetName : ""}>
-                <Accordion.Item eventKey={rulesetDataList.rulesetName}>
+                <Accordion.Item eventKey={rulesetDataList.rulesetName} style={{paddingBottom: index === Object.keys(rulesetDataList).length - 1 ? 20 : 0}}>
                   <Card>
                     <div className={"p-0 d-flex"}>
                       <Accordion.Button onClick={() => handleRulesetAccordionChange(rulesetDataList.rulesetName)}>

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.module.scss
@@ -111,3 +111,6 @@
         cursor:pointer;
     }
 }
+.strategyNameColumn {
+    padding-left: 6px !important;
+}

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.scss
@@ -1,3 +1,7 @@
 #strategyText  .ant-tooltip.ml-tooltip.ant-tooltip-placement-top {
-    top:119px !important;
+    top: 119px !important;
+}
+
+.mergeStrategySliders {
+    padding-left: 95px !important;
 }

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.tsx
@@ -171,6 +171,7 @@ const MergingStepDetail: React.FC = () => {
       key: "strategyName",
       sort: true,
       width: 200,
+      className: styles.strategyNameColumn,
       sortFunc: columnSorter,
       formatter: text => {
         return (
@@ -438,6 +439,7 @@ const MergingStepDetail: React.FC = () => {
               expandedRowRender={expandedRowRender}
               pagination={{hideOnSinglePage: mergeStrategiesData.length <= 10}}
               showExpandIndicator={true}
+              expandedContainerClassName="mergeStrategySliders"
             />
           </div>
         </div>


### PR DESCRIPTION
### Description
Replaces old `antd` table component in Curate / Matching `<ExpandableTableView>` with the new `<HCTable>` component.

![image](https://user-images.githubusercontent.com/88854466/145617172-2568ef8a-f65b-454d-8186-c2cdb185d3cc.png)

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [x] Run UI tests
  

- ##### Reviewer:

- [x] Reviewed Tests

