### PR TITLE
DHFPROD-8257: Fix Table headers rendered by default and missing expand icon

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/common/hc-table/hc-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/common/hc-table/hc-table.tsx
@@ -23,14 +23,14 @@ interface Props {
   rowClassName?: string | ((record: any) => string);
   rowKey?: string | ((record: any) => string);
   subTableHeader?: boolean;
-  keyUtil: any;
-  baseIndent: number;
+  keyUtil?: any;
+  baseIndent?: number;
   expandedRowRender?: (record: any, rowIndex?: number) => string | React.ReactNode;
   onExpand?: (record: any, expanded: boolean, rowIndex?: number) => void;
   onTableChange?: (type: string, newState: any) => void;
 }
 
-function HCTable({className, rowStyle, childrenIndent, data, keyUtil, expandedRowKeys, nestedParams, pagination, rowClassName, rowKey, baseIndent, showHeader, showExpandIndicator = false, onExpand, expandedRowRender, ...props}: Props): JSX.Element {
+function HCTable({className, rowStyle, childrenIndent, data, keyUtil, expandedRowKeys, nestedParams, pagination, rowClassName, rowKey, baseIndent = 0, showHeader = true, showExpandIndicator = false, onExpand, expandedRowRender, ...props}: Props): JSX.Element {
   const expandConfig = {
     className: `${showHeader ? styles.expandedRowWrapper : ""} ${props.subTableHeader ? styles.subTableNested : ""} ${childrenIndent ? styles.childrenIndentExpanded : ""}${props.expandedContainerClassName || ""}`,
     expanded: expandedRowKeys,
@@ -284,14 +284,27 @@ const renderRow = ({row, rowIndex, parentRowIndex, keyUtil, indentList, baseInde
     indentation -= isMappingXML(showHeader) ? 1.2 : 2;
   }
 
+  const isKeyColumn = (colIndex) => colIndex === 0;
+
   return <div key={expandKey} className={`${styles.childrenIndentTableRow} hc-table_row`} data-row-key={expandKey}>
-    {showIndicator ? <div key={`indicator_${expandKey}`} className={styles.childrenIndentIndicatorCell}>
-    </div>: <div className={nextColumnHasStaticWidth ? styles.childrenIndentIndicatorCell : styles.childrenIndentIndicatorEmptyCell}></div>}
-    {headerColumns.map((col) => {
+    {showIndicator ?
+      <div key={`indicator_${expandKey}`} className={styles.childrenIndentIndicatorCell}></div>:
+      <div className={nextColumnHasStaticWidth ? styles.childrenIndentIndicatorCell : styles.childrenIndentIndicatorEmptyCell}></div>
+    }
+    {headerColumns.map((col, colIndex) => {
       const hasIconCell = iconCellList?.lastIndexOf(col.dataField) !== -1;
       const childElement = col.formatter ? col.formatter(row[col.dataField], row, rowIndex) : row[col.dataField];
-      return col.text === "Name" || col.text === "Property Name" ? <div key={col.dataField} className={styles.childrenIndentElementCell} style={{padding: hasIconCell ? `12px 12px 12px ${indentation*baseIndent}px` : `16px 16px 16px ${indentation*baseIndent}px`, width: col.width || "auto"}}>{(col.text === "Name" || col.text === "Property Name") && expandIcon ? <div className={styles.childrenTextContainer}><div>{(col.text==="Name" || col.text === "Property Name") ? expandIcon : null}</div><div className={styles.childElementText}>{childElement}</div></div> : <div>{childElement}</div>}</div>
-        : <div key={col.dataField} className={styles.childrenIndentElementCell} style={{padding: hasIconCell ? `12px` : `16px`, width: col.width || "auto"}}>{childElement}</div>;
+      return isKeyColumn(colIndex) ?
+        <div key={col.dataField} className={styles.childrenIndentElementCell} style={{padding: hasIconCell ? `12px 12px 12px ${indentation*baseIndent}px` : `16px 16px 16px ${indentation*baseIndent}px`, width: col.width || "auto"}}>
+          {isKeyColumn(colIndex) && expandIcon ?
+            <div className={styles.childrenTextContainer}><div>
+              {isKeyColumn(colIndex) ? expandIcon : null}</div>
+            <div className={styles.childElementText}>{childElement}</div>
+            </div> : <div>{childElement}</div>}
+        </div>
+        : <div key={col.dataField} className={styles.childrenIndentElementCell} style={{padding: hasIconCell ? `12px` : `16px`, width: col.width || "auto"}}>
+          {childElement}
+        </div>;
     })}</div>;
 };
 

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/compare-values-modal/compare-values-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/compare-values-modal/compare-values-modal.tsx
@@ -418,7 +418,6 @@ const CompareValuesModal: React.FC<Props> = (props) => {
           nestedParams={{headerColumns: columns, iconCellList: [], state: [expandedRows, setExpandedRows]}}
           childrenIndent={true}
           pagination={true}
-          showHeader={true}
           rowStyle={rowStyle2}
           keyUtil="key"
           baseIndent={0}

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/expandable-table-view/expandable-table-view.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/expandable-table-view/expandable-table-view.tsx
@@ -184,9 +184,8 @@ const ExpandableTableView: React.FC<Props> = (props) => {
     pagination={false}
     rowKey="key"
     keyUtil="key"
-    baseIndent={0}
+    baseIndent={10}
     subTableHeader={true}
-    showHeader={true}
     showExpandIndicator={true}
     childrenIndent={true}
     nestedParams={{headerColumns: testMatchedUriTableColumns, state: [expandedNestedRows, setExpandedNestedRows]}}

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merging-step-detail/merging-step-detail.tsx
@@ -436,13 +436,11 @@ const MergingStepDetail: React.FC = () => {
               className={styles.table}
               columns={mergeStrategyColumns}
               data={mergeStrategiesData}
-              showHeader={true}
               expandedRowRender={expandedRowRender}
               pagination={{hideOnSinglePage: mergeStrategiesData.length <= 10}}
               showExpandIndicator={true}
               expandedContainerClassName="mergeStrategySliders"
               keyUtil="key"
-              baseIndent={0}
             />
           </div>
         </div>
@@ -468,7 +466,6 @@ const MergingStepDetail: React.FC = () => {
             columns={mergeRuleColumns}
             data={mergeRulesData}
             subTableHeader={true}
-            showHeader={true}
             keyUtil="key"
             baseIndent={0}
           />

--- a/marklogic-data-hub-central/ui/src/components/load/load-list.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-list.tsx
@@ -549,7 +549,6 @@ const LoadList: React.FC<Props> = (props) => {
         <HCTable
           pagination={{hideOnSinglePage: props.data.length <= 10, showSizeChanger: true, pageSizeOptions: pageSizeOptions, onChange: handlePagination, onShowSizeChange: handlePageSizeChange, defaultCurrent: loadingOptions.start, current: loadingOptions.pageNumber, pageSize: loadingOptions.pageSize}}
           className={styles.loadTable}
-          showHeader={true}
           columns={columns}
           keyUtil={"key"}
           baseIndent={15}

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.tsx
@@ -379,7 +379,6 @@ const EntityTypeTable: React.FC<Props> = (props) => {
         columns={columns}
         keyUtil={"key"}
         baseIndent={15}
-        showHeader={true}
         expandedRowRender={expandedRowRender}
         onExpand={onExpand}
         expandedRowKeys={expandedRows}

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
@@ -1042,7 +1042,6 @@ const PropertyTable: React.FC<Props> = (props) => {
               }}
               columns={headerColumns}
               data={tableData}
-              showHeader={true}
               onExpand={props.sidePanelView ? (record, expanded) => toggleSourceRowExpanded(record, expanded, "key") : onExpand}
               expandedRowKeys={props.sidePanelView ? sourceExpandedKeys : expandedRows}
               keyUtil={"key"}


### PR DESCRIPTION
### Description
Solves an intermittent failure with the nested data tables to be replaced without `Name` or `Property Name` columns (Explore tables being replaced mostly).

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [x] Run UI tests
  

- ##### Reviewer:

- [x] Reviewed Tests

