### PR TITLE
DHFPROD-8248: Modules loader encodes files paths at wrong moment

### DIFF
--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserModulesCommand.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/deploy/commands/LoadUserModulesCommand.java
@@ -56,6 +56,8 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 
 /**
@@ -197,9 +199,18 @@ public class LoadUserModulesCommand extends LoadModulesCommand {
         DatabaseClient finalClient = hubConfig.newFinalClient();
 
         Path userModulesPath = hubConfig.getHubPluginsDir();
-        String baseDir = userModulesPath.normalize().toAbsolutePath().toString();
+        String baseDir = new String();
+        String EncodedBaseDir = userModulesPath.normalize().toAbsolutePath().toString();
         Path startPath = userModulesPath.resolve("entities");
 
+        try {
+            URLDecoder fileNameDecoder = new URLDecoder();
+            //This handles the decoding of special characters in a file location path.
+            baseDir = fileNameDecoder.decode(EncodedBaseDir, StandardCharsets.UTF_8.name());
+        }
+        catch (Exception e){
+            e.printStackTrace();
+        }
         // load any user files under plugins/* int the modules database.
         // this will ignore REST folders under entities
         DefaultModulesLoader modulesLoader = getStagingModulesLoader(config);
@@ -220,7 +231,17 @@ public class LoadUserModulesCommand extends LoadModulesCommand {
         // deploy the auto-generated ES search options, but not if mlWatch is being run, as it will result in the same
         // options being generated and loaded over and over
         if (loadQueryOptions) {
-            Path entityConfigDir = Paths.get(hubConfig.getHubProject().getProjectDirString(), HubConfig.ENTITY_CONFIG_DIR);
+            String gerProjectDir = hubConfig.getHubProject().getProjectDirString();
+            String decodedFileName=new String();
+            try {
+                URLDecoder fileNameDecoder = new URLDecoder();
+                //This handles the decoding of special characters in a file location path
+                decodedFileName = fileNameDecoder.decode(gerProjectDir, StandardCharsets.UTF_8.name());
+            }
+            catch (Exception e){
+                e.printStackTrace();
+            }
+            Path entityConfigDir = Paths.get(decodedFileName, HubConfig.ENTITY_CONFIG_DIR);
             if (!entityConfigDir.toFile().exists()) {
                 entityConfigDir.toFile().mkdirs();
             }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserModulesCommandTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/deploy/commands/LoadUserModulesCommandTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.marklogic.hub.deploy.commands;
+
+import com.marklogic.hub.AbstractHubCoreTest;
+import com.marklogic.hub.impl.Versions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LoadUserModulesCommandTest extends AbstractHubCoreTest {
+
+    @Autowired
+    Versions versions;
+
+    @BeforeEach
+    public void setupEach() {
+        installProjectInFolder("flow-runner-test");
+    }
+
+    @Test
+    void testDecodingSpecialCharsInFilePathName() {
+        runAsDataHubDeveloper();
+        new LoadHubModulesCommand(getHubConfig()).execute(newCommandContext());
+        try {
+            URLDecoder testDecoder = new URLDecoder();
+            String data = testDecoder.decode("testURI/data/%23Name", StandardCharsets.UTF_8.name());
+            assertEquals(data,"testURI/data/#Name");
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- N/A Run UI tests
  

- ##### Reviewer:

- [x] Reviewed Tests

