### PR TITLE
DHFPROD-8332: Every tile is getting rendered blank after navigation from Home

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestionCardView.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/load/defaultIngestionCardView.spec.tsx
@@ -34,9 +34,14 @@ describe("Validate CRUD functionality from card view and run in a flow", () => {
     cy.resetTestUser();
     cy.waitForAsyncRequest();
   });
+  it("Verify Load tile is visible after navigation", () => {
+    toolbar.getLoadToolbarIcon().click();
+    cy.log("DHFPROD-8332: Every tile is getting rendered blank after navigation from Home");
+    loadPage.getContainerTitle().should("be.visible");
+  });
   it("Verify Cancel", () => {
-    cy.waitUntil(() => toolbar.getLoadToolbarIcon()).click();
-    cy.waitUntil(() => loadPage.stepName("ingestion-step").should("be.visible"));
+    toolbar.getLoadToolbarIcon().click();
+    loadPage.stepName("ingestion-step").should("be.visible");
     loadPage.loadView("th-large").click();
     loadPage.addNewButton("card").click();
     loadPage.stepNameInput().type(stepName);

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/load.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/load.tsx
@@ -305,6 +305,9 @@ class LoadPage {
     cy.findByLabelText(`${flowName}-option`).click();
   }
 
+  getContainerTitle() {
+    return cy.get(`[aria-label="title-load"]`);
+  }
 }
 
 const loadPage = new LoadPage();

--- a/marklogic-data-hub-central/ui/src/App.scss
+++ b/marklogic-data-hub-central/ui/src/App.scss
@@ -18,7 +18,7 @@ body {
   height: 90vh;
   max-height: 92vh;
   margin-bottom: 70px;
-  flex: 1;
+  flex: 1 1 auto;
 }
 
 .ant-layout-header {


### PR DESCRIPTION
### Description
Solves the blank tile/container issue on `develop`.

![image](https://user-images.githubusercontent.com/88854466/149794086-95a167fb-4f95-4d0c-b9f4-24274279f249.png)

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [N/A] Added Tests
- [x] Run UI tests
  

- ##### Reviewer:

- [x] Reviewed Tests

