### PR TITLE
DHFPROD-8370: [Explore] Properties with long names on the sidebar overstep each other

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/facet/facet.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/facet/facet.module.scss
@@ -70,6 +70,12 @@
     display: flex;
     justify-content: space-between;
     height: 23px;
+    label {
+      max-width: 200px;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
   }
 
   .value {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/94134837/151188280-cf5078b6-14ae-49ff-acde-eeeac7e8bc4b.png)

After:
![image](https://user-images.githubusercontent.com/94134837/151188211-0cb4f394-0903-429b-9d75-9325c46f9a17.png)


### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [N/A] Added Tests
- [x] Run UI tests
  

- ##### Reviewer:

- [N/A] Reviewed Tests
- [n/a ] Added Release Notes

