### PR TITLE
DHFPROD-8281: Matching/ruleset-multiple-modal - TABLE tests and UX issues

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/matching/ruleset-multiple-modal/ruleset-multiple-modal.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/ruleset-multiple-modal/ruleset-multiple-modal.test.tsx
@@ -662,7 +662,7 @@ describe("Matching Multiple Rulesets Modal component", () => {
     });
   });
   // ToDo: Fix rowKey=key or another approach, propertyPath currently doesn't work
-  it.skip("can expand all/collapse all entity structured properties using the expand all/collapse all buttons", async () => {
+  it("can expand all/collapse all entity structured properties using the expand all/collapse all buttons", async () => {
     mockMatchingUpdate.mockResolvedValue({status: 200, data: {}});
     const toggleModalMock = jest.fn();
 

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/ruleset-multiple-modal/ruleset-multiple-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/ruleset-multiple-modal/ruleset-multiple-modal.tsx
@@ -884,7 +884,8 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
       attrs: (cell, row, rowIndex, colIndex) => {
         if (row.hasChildren) {
           return {
-            colspan: 4,
+            colSpan: 4,
+            key: "name",
           };
         }
       }
@@ -893,12 +894,16 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
       ellipsis: true,
       text: "Match Type",
       width: "15%",
+      dataField: "matchType",
       headerFormatter: () => <span data-testid="matchTypeTitle">Match Type</span>,
       style: (cell, row) => {
         if (row.hasChildren) {
           return {display: "none"};
         }
         return "";
+      },
+      attrs: {
+        key: "matchTypeTitle"
       },
       formatter: (text, row, extraData) => {
         return !row.hasOwnProperty("children") ? <div className={styles.typeContainer}>
@@ -938,7 +943,11 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
     {
       text: "Match Type Details",
       //width: "58%",
+      dataField: "matchTypeDetails",
       headerFormatter: () => <span data-testid="matchTypeDetailsTitle">Match Type Details</span>,
+      attrs: {
+        key: "matchTypeDetails"
+      },
       formatter: (text, row, extraData) => {
         switch (matchTypes[row.propertyPath]) {
         case "synonym": return renderSynonymOptions(row.propertyPath);
@@ -1154,6 +1163,7 @@ const MatchRulesetMultipleModal: React.FC<Props> = (props) => {
         generateExpandRowKeys(obj["children"], allKeysToExpand);
       }
     });
+
     return allKeysToExpand;
   };
 


### PR DESCRIPTION
To Do:
- wrap up fixing RTL tests and workaround for expand/collapse all (check the work on `property-table.tsx` for guidance there)
- other points in the JIRA ticket (work with the cells' alignment could be leveraged by the work @yubiselmarklogic is doing on his ticket)

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [ ] JIRA_ID included in all the commit messages
- [ ] PR title is in the format JIRA_ID:Title
- [ ] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [ ] Code passes ESLint tests
- [ ] Added Tests
- [ ] Run UI tests
  

- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added Release Notes

