### PR TITLE
DHFPROD-8344: Add Border to all Color Blocks

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/base-entities-facet/base-entities-facet.tsx
+++ b/marklogic-data-hub-central/ui/src/components/base-entities-facet/base-entities-facet.tsx
@@ -150,7 +150,7 @@ const BaseEntitiesFacet: React.FC<Props> = (props) => {
               <div
                 key={name}
                 aria-label={`base-entities-${name}`}
-                style={{backgroundColor: finalColor}}
+                style={{backgroundColor: finalColor, borderStyle: "solid", borderWidth: "1px", borderColor: "#d9d9d9", borderRadius: "4px"}}
                 className={styles.entityItem}
                 onClick={() => setEntitySpecificPanel({name, color: finalColor, icon: finalIcon})}
               >

--- a/marklogic-data-hub-central/ui/src/components/common/hc-sider/hc-sider.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/common/hc-sider/hc-sider.module.scss
@@ -12,6 +12,7 @@ div.siderContainer {
     a.siderIndicatorContainer {
         display: flex;
         gap: 4px;
+        z-index: 999;
         position: absolute;
         align-items: center;
         text-decoration: none;

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.tsx
@@ -268,7 +268,7 @@ const EntityTypeTable: React.FC<Props> = (props) => {
         let color = parseText[1];
         return (
           <HCTooltip placement="top" id="color-tooltip" text={<span>This color is associated with the <b>{entityName}</b> entity throughout your project.</span>}>
-            <div style={{width: "30px", height: "32px", background: color, marginLeft: "3%"}} data-testid={`${entityName}-${color}-color`} aria-label={`${entityName}-${color}-color`}></div>
+            <div style={{width: "33px", height: "35px", background: color, marginLeft: "3%", borderStyle: "solid", borderWidth: "1px", borderColor: "#eeeeee", borderRadius: "4px"}} data-testid={`${entityName}-${color}-color`} aria-label={`${entityName}-${color}-color`}></div>
           </HCTooltip>
         );
       }
@@ -383,7 +383,7 @@ const EntityTypeTable: React.FC<Props> = (props) => {
       entityName: entity.entityName,
       instances: entity.entityName + "," + parseInt(entity.entityInstanceCount),
       lastProcessed: entity.entityName + "," + entity.latestJobId + "," + entity.latestJobDateTime,
-      color: colorExistsForEntity(entity.entityName) ? (entity.entityName + "," + props.hubCentralConfig.modeling.entities[entity.entityName].color) : (entity.entityName + "," + "#EEEEFF1"),
+      color: colorExistsForEntity(entity.entityName) ? (entity.entityName + "," + props.hubCentralConfig.modeling.entities[entity.entityName].color) : (entity.entityName + "," + "#EEEFF1"),
       icon: iconExistsForEntity(entity.entityName) ? (entity.entityName + "," + props.hubCentralConfig.modeling.entities[entity.entityName].icon) : (entity.entityName + "," + "FaShapes"),
       actions: entity.entityName,
       definitions: entity.model.definitions,


### PR DESCRIPTION
### Description

- Added borders to entity colors in Modeling table view and Explore sidebar
- Also fixed the sidebar collapse icon being cut off
- Designs approved by @jbelonoj 

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- N/A Added Tests
- [x] Run UI tests
  

- ##### Reviewer:

- N/A Reviewed Tests
- N/A Added to Release Wiki

