### PR TITLE
DHFPROD-8533: Componentize ResultsList and Detail views

### DIFF
--- a/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/ui-config/config.json
+++ b/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/ui-config/config.json
@@ -150,7 +150,7 @@
                 "all": "#cccccc",
                 "filters": "#1ACCA8"
             },
-            "totalRecords": 100
+            "totalRecords": 99
         },
         "facets": {
             "selected": "#1acca8",
@@ -178,11 +178,16 @@
         },
         "results": {
             "thumbnail": {
-                "arrayPath": "extracted.person.images.image",
-                "path": "url",
-                "width": "70px",
-                "height": "70px",
-                "alt": "result thumbnail"
+                "component": "Image",
+                "config": {
+                    "arrayPath": "extracted.person.images.image",
+                    "path": "url",
+                    "alt": "result thumbnail",
+                    "style": {
+                        "width": "70px",
+                        "height": "70px"
+                    }
+                }
             },
             "title": { 
                 "id": "extracted.person.personId",
@@ -198,17 +203,20 @@
                         "city": "city",
                         "state": "state",
                         "postal1": "postal",
-                        "country": "country"
-                    },
-                    "style": {
-                        "width": "350px",
-                        "overflow": "hidden",
-                        "textOverflow": "ellipsis"
+                        "country": "country",
+                        "style": {
+                            "width": "350px",
+                            "overflow": "hidden",
+                            "textOverflow": "ellipsis"
+                        }
                     }
                 },
                 { 
-                    "path": "extracted.person.phone", 
-                    "className": "phone" 
+                    "component": "Value",
+                    "config": {
+                        "path": "extracted.person.phone", 
+                        "className": "phone"
+                    }
                 },
                 { 
                     "arrayPath": "extracted.person.emails.email",
@@ -250,11 +258,16 @@
         "heading": {
             "id": "result[0].extracted.person.personId",
             "thumbnail": {
-                "arrayPath": "result[0].extracted.person.images.image",
-                "path": "url",
-                "width": "70px",
-                "height": "70px",
-                "alt": "detail thumbnail"
+                "component": "Image",
+                "config": {
+                    "arrayPath": "result[0].extracted.person.images.image",
+                    "path": "url",
+                    "alt": "detail thumbnail",
+                    "style": {
+                        "width": "60px",
+                        "height": "60px"
+                    }
+                }
             },
             "title": { 
                 "path": "result[0].extracted.person.nameGroup.fullname.value"
@@ -264,213 +277,225 @@
         "personal": {
             "items": [
                 {
-                    "id": "name",
                     "component": "DataTableValue",
-                    "title": "Name",
-                    "path": "result[0].extracted.person.nameGroup.fullname.value",
-                    "width": "400px",
-                    "metadata": [
-                        {
-                            "type": "block",
-                            "color": "#96bde4",
-                            "value": "B"
-                        },
-                        {
-                            "type": "block",
-                            "color": "#5d6aaa",
-                            "value": "3",
-                            "popover": {
-                                "title": "Sources",
-                                "dataPath": "result[0].extracted.person.sources",
-                                "placement": "right",
-                                "cols": [
-                                    {
-                                        "path": "name",
-                                        "type": "chiclet",
-                                        "colors": {
-                                            "New York Times": "#d5e1de",
-                                            "USA Today": "#ebe1fa",
-                                            "Los Angeles Times": "#cae4ea",
-                                            "Wall Street Journal": "#fae9d3",
-                                            "Washington Post": "#fae3df",
-                                            "Chicago Tribune": "#f0f6d9"
+                    "config": {
+                        "id": "name",
+                        "title": "Name",
+                        "path": "result[0].extracted.person.nameGroup.fullname.value",
+                        "width": "400px",
+                        "metadata": [
+                            {
+                                "type": "block",
+                                "color": "#96bde4",
+                                "value": "B"
+                            },
+                            {
+                                "type": "block",
+                                "color": "#5d6aaa",
+                                "value": "3",
+                                "popover": {
+                                    "title": "Sources",
+                                    "dataPath": "result[0].extracted.person.sources",
+                                    "placement": "right",
+                                    "cols": [
+                                        {
+                                            "path": "name",
+                                            "type": "chiclet",
+                                            "colors": {
+                                                "New York Times": "#d5e1de",
+                                                "USA Today": "#ebe1fa",
+                                                "Los Angeles Times": "#cae4ea",
+                                                "Wall Street Journal": "#fae9d3",
+                                                "Washington Post": "#fae3df",
+                                                "Chicago Tribune": "#f0f6d9"
+                                            }
+                                        },
+                                        {
+                                            "path": "timestamp",
+                                            "type": "datetime",
+                                            "format": "yyyy-MM-dd"
                                         }
-                                    },
-                                    {
-                                        "path": "timestamp",
-                                        "type": "datetime",
-                                        "format": "yyyy-MM-dd"
-                                    }
-                                ]
+                                    ]
+                                }
                             }
-                        }
-                    ]
+                        ]
+                    }
                 },
                 {
-                    "id": "phone",
                     "component": "DataTableValue",
-                    "title": "Phone Number",
-                    "path": "result[0].extracted.person.phone",
-                    "icon": "phone",
-                    "width": "400px",
-                    "metadata": [
-                        {
-                            "type": "block",
-                            "color": "#96bde4",
-                            "value": "B"
-                        },
-                        {
-                            "type": "block",
-                            "color": "#5d6aaa",
-                            "value": "4"
-                        }
-                    ]
+                    "config": {
+                        "id": "phone",
+                        "title": "Phone Number",
+                        "path": "result[0].extracted.person.phone",
+                        "icon": "phone",
+                        "width": "400px",
+                        "metadata": [
+                            {
+                                "type": "block",
+                                "color": "#96bde4",
+                                "value": "B"
+                            },
+                            {
+                                "type": "block",
+                                "color": "#5d6aaa",
+                                "value": "4"
+                            }
+                        ]
+                    }
                 },        
                 {
-                    "id": "email",
                     "component": "DataTableValue",
-                    "title": "Email",
-                    "arrayPath": "result[0].extracted.person.emails.email",
-                    "path": "value", 
-                    "icon": "email",
-                    "width": "400px",
-                    "metadata": [
-                        {
-                            "type": "block",
-                            "color": "#96bde4",
-                            "value": "B"
-                        },
-                        {
-                            "type": "block",
-                            "color": "#5d6aaa",
-                            "value": "4"
-                        }
-                    ]
-                },
-                {
-                    "id": "ssn",
-                    "component": "DataTableValue",
-                    "title": "SSN",
-                    "path": "result[0].extracted.person.ssn.value",
-                    "width": "400px",
-                    "metadata": [
-                        {
-                            "type": "block",
-                            "color": "#e67485",
-                            "value": "R"
-                        },
-                        {
-                            "type": "block",
-                            "color": "#5d6aaa",
-                            "value": "4"
-                        }
-                    ]
-                },
-                {
-                    "id": "address",
-                    "component": "DataTableMultiValue",
-                    "title": "Address",
-                    "width": "680px",
-                    "arrayPath": "result[0].extracted.person.addresses.address",
-                    "cols": [
-                        {
-                            "title": "Street",
-                            "value": "street",
-                            "width": "220px"
-                        },
-                        {
-                            "title": "City",
-                            "value": "city",
-                            "width": "130px"
-                        },
-                        {
-                            "title": "State",
-                            "value": "state",
-                            "width": "60px"
-                        },
-                        {
-                            "title": "Postal Code",
-                            "value": "postal",
-                            "width": "85px"
-                        },
-                        {
-                            "title": "Country",
-                            "value": "country",
-                            "width": "100px"
-                        }
-                    ],
-                    "metadata": [
-                        {
-                            "type": "block",
-                            "color": "#96bde4",
-                            "value": "B"
-                        },
-                        {
-                            "type": "block",
-                            "color": "#5d6aaa",
-                            "value": "4"
-                        }
-                    ]
-                },
-                {
-                    "id": "school",
-                    "component": "DataTableMultiValue",
-                    "title": "School",
-                    "width": "680px",
-                    "arrayPath": "result[0].extracted.person.schools.school",
-                    "cols": [
-                        {
-                            "title": "Name",
-                            "value": "name",
-                            "width": "240px"
-                        },
-                        {
-                            "title": "City",
-                            "value": "city",
-                            "width": "130px"
-                        },
-                        {
-                            "title": "Country",
-                            "value": "country",
-                            "width": "100px"
-                        }
-                    ],
-                    "metadata": [
-                        {
-                            "type": "block",
-                            "color": "#96bde4",
-                            "value": "B"
-                        },
-                        {
-                            "type": "block",
-                            "color": "#5d6aaa",
-                            "value": "3",
-                            "popover": {
-                                "title": "Sources",
-                                "dataPath": "result[0].extracted.person.sources",
-                                "placement": "right",
-                                "cols": [
-                                    {
-                                        "path": "name",
-                                        "type": "chiclet",
-                                        "colors": {
-                                            "New York Times": "#d5e1de",
-                                            "USA Today": "#ebe1fa",
-                                            "Los Angeles Times": "#cae4ea",
-                                            "Wall Street Journal": "#fae9d3",
-                                            "Washington Post": "#fae3df",
-                                            "Chicago Tribune": "#f0f6d9"
-                                        }
-                                    },
-                                    {
-                                        "path": "timestamp",
-                                        "type": "datetime",
-                                        "format": "yyyy-MM-dd"
-                                    }
-                                ]
+                    "config": {
+                        "id": "email",
+                        "title": "Email",
+                        "arrayPath": "result[0].extracted.person.emails.email",
+                        "path": "value", 
+                        "icon": "email",
+                        "width": "400px",
+                        "metadata": [
+                            {
+                                "type": "block",
+                                "color": "#96bde4",
+                                "value": "B"
+                            },
+                            {
+                                "type": "block",
+                                "color": "#5d6aaa",
+                                "value": "4"
                             }
-                        }
-                    ]
+                        ]
+                    }
+                },
+                {
+                    "component": "DataTableValue",
+                    "config": {
+                        "id": "ssn",
+                        "title": "SSN",
+                        "path": "result[0].extracted.person.ssn.value",
+                        "width": "400px",
+                        "metadata": [
+                            {
+                                "type": "block",
+                                "color": "#e67485",
+                                "value": "R"
+                            },
+                            {
+                                "type": "block",
+                                "color": "#5d6aaa",
+                                "value": "4"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "component": "DataTableMultiValue",
+                    "config": {
+                        "id": "address",
+                        "title": "Address",
+                        "width": "680px",
+                        "arrayPath": "result[0].extracted.person.addresses.address",
+                        "cols": [
+                            {
+                                "title": "Street",
+                                "value": "street",
+                                "width": "220px"
+                            },
+                            {
+                                "title": "City",
+                                "value": "city",
+                                "width": "130px"
+                            },
+                            {
+                                "title": "State",
+                                "value": "state",
+                                "width": "60px"
+                            },
+                            {
+                                "title": "Postal Code",
+                                "value": "postal",
+                                "width": "85px"
+                            },
+                            {
+                                "title": "Country",
+                                "value": "country",
+                                "width": "100px"
+                            }
+                        ],
+                        "metadata": [
+                            {
+                                "type": "block",
+                                "color": "#96bde4",
+                                "value": "B"
+                            },
+                            {
+                                "type": "block",
+                                "color": "#5d6aaa",
+                                "value": "4"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "component": "DataTableMultiValue",
+                    "config": {
+                        "id": "school",
+                        "title": "School",
+                        "width": "680px",
+                        "arrayPath": "result[0].extracted.person.schools.school",
+                        "cols": [
+                            {
+                                "title": "Name",
+                                "value": "name",
+                                "width": "240px"
+                            },
+                            {
+                                "title": "City",
+                                "value": "city",
+                                "width": "130px"
+                            },
+                            {
+                                "title": "Country",
+                                "value": "country",
+                                "width": "100px"
+                            }
+                        ],
+                        "metadata": [
+                            {
+                                "type": "block",
+                                "color": "#96bde4",
+                                "value": "B"
+                            },
+                            {
+                                "type": "block",
+                                "color": "#5d6aaa",
+                                "value": "3",
+                                "popover": {
+                                    "title": "Sources",
+                                    "dataPath": "result[0].extracted.person.sources",
+                                    "placement": "right",
+                                    "cols": [
+                                        {
+                                            "path": "name",
+                                            "type": "chiclet",
+                                            "colors": {
+                                                "New York Times": "#d5e1de",
+                                                "USA Today": "#ebe1fa",
+                                                "Los Angeles Times": "#cae4ea",
+                                                "Wall Street Journal": "#fae9d3",
+                                                "Washington Post": "#fae3df",
+                                                "Chicago Tribune": "#f0f6d9"
+                                            }
+                                        },
+                                        {
+                                            "path": "timestamp",
+                                            "type": "datetime",
+                                            "format": "yyyy-MM-dd"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
                 }
             ]
         },

--- a/marklogic-data-hub-central/ui-custom/src/components/Address/Address.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Address/Address.test.tsx
@@ -30,21 +30,24 @@ const data2 = {
     }
 };
 
-// If multiple addresses returned, addressPath points to array
+// If array of multiple addresses returned, arrayPath points to array property
 const configArray = { 
-    arrayPath: "address",
-    street1: "street1",
-    street2: "street2",
-    city: "city",
-    state: "state",
-    postal1: "postal1",
-    postal2: "postal2"
+    arrayPath: "addresses",
+    street1: "address.street1",
+    street2: "address.street2",
+    city: "address.city",
+    state: "address.state",
+    postal1: "address.postal1",
+    postal2: "address.postal2",
+    style: {
+        fontWeight: "bold"
+    }
 };
 
 const dataArray = { 
-    address: [
-        data.address,
-        data2.address
+    addresses: [
+        { address: data.address },
+        { address: data2.address }
     ]
 };
 
@@ -63,11 +66,14 @@ describe("Address component", () => {
             + data.address.state + " " + data.address.postal1)).toBeInTheDocument();
     });
 
-    test("Verify first address is rendered for address array", () => {
+    test("Verify first address is rendered for address array with style", () => {
         const {getByText} = render(<Address config={configArray} data={dataArray} />);
         expect(getByText(data.address.street1 + ", " + data.address.street2 + 
             ", " + data.address.city + ", " + data.address.state + " " + 
             data.address.postal1 + "-" + data.address.postal2)).toBeInTheDocument();
+        let addresses = document.getElementsByClassName("Address");
+        let style = window.getComputedStyle(addresses[0]);
+        expect(style.fontWeight).toBe(configArray.style.fontWeight);
     });
 
 });

--- a/marklogic-data-hub-central/ui-custom/src/components/Address/Address.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Address/Address.tsx
@@ -6,6 +6,7 @@ type Props = {
   config?: any;
   data?: any;
   style?: any;
+  className?: any;
 };
 
 /**
@@ -21,7 +22,8 @@ const Address: React.FC<Props> = (props) => {
         return val ? "".concat(pre, val, post) : "";
     }
 
-    const addressStyle: any = props.style ? props.style : {};
+    const addressClassName: any = props.className ? props.className : props.config?.className ? props.config.className : "";
+    const addressStyle: any = props.style ? props.style : (props.config.style ? props.config.style : {});
 
     // Get address-containing object (if array, use first element)
     let addressData = props.config.arrayPath ? getValByConfig(props.data, props.config, true) : props.data;
@@ -43,7 +45,7 @@ const Address: React.FC<Props> = (props) => {
                           display(country, "", "");
 
     return (
-        <span className="Address" style={addressStyle} title={addrFormatted}>
+        <span className={addressClassName ? addressClassName : "Address"} style={addressStyle} title={addrFormatted}>
             {addrFormatted}
         </span>
     );

--- a/marklogic-data-hub-central/ui-custom/src/components/Chiclet/Chiclet.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Chiclet/Chiclet.tsx
@@ -25,12 +25,15 @@ const Chiclet: React.FC<Props> = (props) => {
     }
 
     const chicletColors = props.config.colors || {};
-
+    const defaultColor = "#dfdfdf";
+    
     let chicletStyle: any = props.config.style ? props.config.style : {};
-    chicletStyle = Object.assign({backgroundColor: chicletColors[val]}, chicletStyle);
+    chicletStyle = Object.assign({
+        backgroundColor: chicletColors[val] ? chicletColors[val] : defaultColor
+    }, chicletStyle);
 
     return (
-        <span className="Chiclet" style={Object.assign({backgroundColor: chicletColors[val]}, chicletStyle)}>
+        <span className="Chiclet" style={chicletStyle}>
             {val}
         </span>
     );

--- a/marklogic-data-hub-central/ui-custom/src/components/DataTableMultiValue/DataTableMultiValue.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/DataTableMultiValue/DataTableMultiValue.test.tsx
@@ -4,104 +4,116 @@ import {render} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const configMultiple = {
-    id: "address",
-    title: "Address",
-    width: 600,
-    path: "result[0].extracted.person.address",
-    cols: [
-        {
-            title: "City",
-            value: "city"
-        },
-        {
-            title: "State",
-            value: "state"
-        }
-    ],
-    metadata: [
-        {
-            type: "block",
-            color: "#96bde4",
-            value: "B"
-        },
-        {
-            type: "block",
-            color: "#5d6aaa",
-            value: "4"
-        }
-    ]
+    component: "DataTableMultiValue",
+    config: {
+        id: "address",
+        title: "Address",
+        width: 600,
+        path: "result[0].extracted.person.address",
+        cols: [
+            {
+                title: "City",
+                value: "city"
+            },
+            {
+                title: "State",
+                value: "state"
+            }
+        ],
+        metadata: [
+            {
+                type: "block",
+                color: "#96bde4",
+                value: "B"
+            },
+            {
+                type: "block",
+                color: "#5d6aaa",
+                value: "4"
+            }
+        ]
+    }
 };
 
 const configSingular = {
-    id: "school",
-    title: "School",
-    width: 600,
-    path: "result[0].extracted.person.school",
-    cols: [
-        {
-            title: "Name",
-            value: "name"
-        },
-        {
-            title: "City",
-            value: "city"
-        },
-        {
-            title: "Year",
-            value: "year"
-        }
-    ],
-    metadata: [
-        {
-            type: "block",
-            color: "#96bde4",
-            value: "B"
-        },
-        {
-            type: "block",
-            color: "#5d6aaa",
-            value: "4"
-        }
-    ]
+    component: "DataTableMultiValue",
+    config: {
+        id: "school",
+        title: "School",
+        width: 600,
+        path: "result[0].extracted.person.school",
+        cols: [
+            {
+                title: "Name",
+                value: "name"
+            },
+            {
+                title: "City",
+                value: "city"
+            },
+            {
+                title: "Year",
+                value: "year"
+            }
+        ],
+        metadata: [
+            {
+                type: "block",
+                color: "#96bde4",
+                value: "B"
+            },
+            {
+                type: "block",
+                color: "#5d6aaa",
+                value: "4"
+            }
+        ]
+    }
 };
 
 const configSingularComplex = {
-    id: "school",
-    title: "School",
-    width: 600,
-    path: "result[0].extracted.person.college",
-    cols: [
-        {
-            title: "Name",
-            value: "name.value"
-        },
-        {
-            title: "City",
-            value: "city.value"
-        },
-        {
-            title: "Year",
-            value: "year.value"
-        }
-    ],
-    metadata: [
-        {
-            type: "block",
-            color: "#96bde4",
-            value: "B"
-        },
-        {
-            type: "block",
-            color: "#5d6aaa",
-            value: "4"
-        }
-    ]
+    component: "DataTableMultiValue",
+    config: {
+        id: "school",
+        title: "School",
+        width: 600,
+        path: "result[0].extracted.person.college",
+        cols: [
+            {
+                title: "Name",
+                value: "name.value"
+            },
+            {
+                title: "City",
+                value: "city.value"
+            },
+            {
+                title: "Year",
+                value: "year.value"
+            }
+        ],
+        metadata: [
+            {
+                type: "block",
+                color: "#96bde4",
+                value: "B"
+            },
+            {
+                type: "block",
+                color: "#5d6aaa",
+                value: "4"
+            }
+        ]
+    }
 };
 
 const configNoExist = {
-    id: "noexist", 
-    title: "No Exist", 
-    dataPath: "result[0].extracted.person.noexist",
+    component: "DataTableMultiValue",
+    config: {
+        id: "noexist", 
+        title: "No Exist", 
+        path: "result[0].extracted.person.noexist"
+    }
 };
 
 const detail = {
@@ -162,10 +174,10 @@ describe("DataTableMultiValue component", () => {
     test("Verify data table renders with a property object with multiple values", () => {
         const {getByText, queryAllByText, getByTestId} = render(
             <DetailContext.Provider value={detailContextValue}>
-                <DataTableMultiValue config={configMultiple} />
+                <DataTableMultiValue config={configMultiple.config} data={detail} />
             </DetailContext.Provider>
         );
-        expect(getByText(configMultiple.title)).toBeInTheDocument();
+        expect(getByText(configMultiple.config.title)).toBeInTheDocument();
         expect(getByTestId("hideUp")).toBeInTheDocument();
         expect(getByText("Anytown")).toBeInTheDocument();
         expect(getByText("Anyville")).toBeInTheDocument();
@@ -179,10 +191,10 @@ describe("DataTableMultiValue component", () => {
     test("Verify data table renders with a property object with a single value", () => {
         const {getByText, queryByTestId} = render(
             <DetailContext.Provider value={detailContextValue}>
-                <DataTableMultiValue config={configSingular} />
+                <DataTableMultiValue config={configSingular.config} data={detail} />
             </DetailContext.Provider>
         );
-        expect(getByText(configSingular.title)).toBeInTheDocument();
+        expect(getByText(configSingular.config.title)).toBeInTheDocument();
         expect(queryByTestId("hideUp")).not.toBeInTheDocument();
         expect(getByText("Anytown High School")).toBeInTheDocument();
         expect(getByText("Anytown")).toBeInTheDocument();
@@ -192,10 +204,10 @@ describe("DataTableMultiValue component", () => {
     test("Verify data table renders with a property object with nested data", () => {
         const {getByText, queryByTestId} = render(
             <DetailContext.Provider value={detailContextValue}>
-                <DataTableMultiValue config={configSingularComplex} />
+                <DataTableMultiValue config={configSingularComplex.config} data={detail} />
             </DetailContext.Provider>
         );
-        expect(getByText(configSingularComplex.title)).toBeInTheDocument();
+        expect(getByText(configSingularComplex.config.title)).toBeInTheDocument();
         expect(queryByTestId("hideUp")).not.toBeInTheDocument();
         expect(getByText("Anytown College")).toBeInTheDocument();
         expect(getByText("Anytown")).toBeInTheDocument();
@@ -205,11 +217,11 @@ describe("DataTableMultiValue component", () => {
     test("Verify data table does not render with a property object that does not exist in the results", () => {
         const {queryByText, queryByTestId} = render(
             <DetailContext.Provider value={detailContextValue}>
-                <DataTableMultiValue config={configNoExist} />
+                <DataTableMultiValue config={configNoExist.config} data={detail} />
             </DetailContext.Provider>
         );
-        expect(queryByText(configNoExist.title)).not.toBeInTheDocument();
-        expect(queryByTestId(configNoExist.id)).not.toBeInTheDocument();
+        expect(queryByText(configNoExist.config.title)).not.toBeInTheDocument();
+        expect(queryByTestId(configNoExist.config.id)).not.toBeInTheDocument();
     });
 
 });

--- a/marklogic-data-hub-central/ui-custom/src/components/DataTableMultiValue/DataTableMultiValue.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/DataTableMultiValue/DataTableMultiValue.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useContext } from "react";
 import MetadataValue from "../MetadataValue/MetadataValue";
 import Table from "react-bootstrap/Table";
-import { DetailContext } from "../../store/DetailContext";
 import "./DataTableMultiValue.scss";
 import {ArrowBarDown, ArrowBarRight, GeoAltFill} from "react-bootstrap-icons";
 import Popover from "react-bootstrap/Popover";
@@ -12,7 +11,8 @@ import GeoMap from "../GeoMap/GeoMap"
 
 
 type Props = {
-  config?: any;
+    data?: any;
+    config?: any;
 };
 
 /**
@@ -62,7 +62,6 @@ type Props = {
  */
 const DataTableMultiValue: React.FC<Props> = (props) => {
 
-    const detailContext = useContext(DetailContext);
     const [hide, setHide] = useState<boolean>(false);
 
     const handleHide = (e) => {
@@ -71,7 +70,7 @@ const DataTableMultiValue: React.FC<Props> = (props) => {
 
     let data: any = [];
 
-    data = getValByConfig(detailContext.detail, props.config);
+    data = getValByConfig(props.data, props.config);
     data = _.isNil(data) ? null : (Array.isArray(data) ? data : [data]);
 
     let hideClass: string = hide ? "hide" : "";

--- a/marklogic-data-hub-central/ui-custom/src/components/DataTableValue/DataTableValue.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/DataTableValue/DataTableValue.test.tsx
@@ -4,84 +4,99 @@ import {render} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const configMultiple = {
-    id: "phone", 
-    title: "Phone Number", 
-    path: "result[0].extracted.person.phone", 
-    icon: "phone",
-    metadata: [
-        {
-            type: "block",
-            color: "#96bde4",
-            value: "B"
-        },
-        {
-            type: "block",
-            color: "#5d6aaa",
-            value: "4"
-        }
-    ]
+    component: "DataTableValue",
+    config: {
+        id: "phone", 
+        title: "Phone Number", 
+        path: "result[0].extracted.person.phone", 
+        icon: "phone",
+        metadata: [
+            {
+                type: "block",
+                color: "#96bde4",
+                value: "B"
+            },
+            {
+                type: "block",
+                color: "#5d6aaa",
+                value: "4"
+            }
+        ]
+    }
 };
 
 const configSingular = {
-    id: "ssn", 
-    title: "SSN", 
-    path: "result[0].extracted.person.ssn",
-    metadata: [
-        {
-            type: "block",
-            color: "#96bde4",
-            value: "B"
-        },
-        {
-            type: "block",
-            color: "#5d6aaa",
-            value: "4"
-        }
-    ]
+    component: "DataTableValue",
+    config: {
+        id: "ssn", 
+        title: "SSN", 
+        path: "result[0].extracted.person.ssn",
+        metadata: [
+            {
+                type: "block",
+                color: "#96bde4",
+                value: "B"
+            },
+            {
+                type: "block",
+                color: "#5d6aaa",
+                value: "4"
+            }
+        ]
+    }
 };
 
 const configArrayPathMultiple = {
-    id: "email", 
-    title: "Email", 
-    arrayPath: "result[0].extracted.person.email",
-    path: "value",
-    metadata: [
-        {
-            type: "block",
-            color: "#96bde4",
-            value: "B"
-        },
-        {
-            type: "block",
-            color: "#5d6aaa",
-            value: "4"
-        }
-    ]
+    component: "DataTableValue",
+    config: {
+        id: "email", 
+        title: "Email", 
+        arrayPath: "result[0].extracted.person.email",
+        path: "value",
+        metadata: [
+            {
+                type: "block",
+                color: "#96bde4",
+                value: "B"
+            },
+            {
+                type: "block",
+                color: "#5d6aaa",
+                value: "4"
+            }
+        ]
+    }
 };
 
 const configArrayPathSingular = {
-    id: "email", 
-    title: "Email", 
-    arrayPath: "result[0].extracted.person.image",
-    path: "value",
-    metadata: [
-        {
-            type: "block",
-            color: "#96bde4",
-            value: "B"
-        },
-        {
-            type: "block",
-            color: "#5d6aaa",
-            value: "4"
-        }
-    ]
+    component: "DataTableValue",
+    config: {
+        id: "email", 
+        title: "Email", 
+        arrayPath: "result[0].extracted.person.image",
+        path: "value",
+        metadata: [
+            {
+                type: "block",
+                color: "#96bde4",
+                value: "B"
+            },
+            {
+                type: "block",
+                color: "#5d6aaa",
+                value: "4"
+            }
+        ]
+    }
 };
 
 const configNoExist = {
-    id: "noexist", 
-    title: "No Exist", 
-    dataPath: "result[0].extracted.person.noexist",
+    component: "DataTableValue",
+    config: {
+        id: "noexist", 
+        title: "No Exist", 
+        path: "result[0].extracted.person.noexist"
+    }
 };
 
 const detail = {
@@ -125,17 +140,15 @@ describe("DataTableValue component", () => {
 
     test("Verify data table renders with a property with multiple values and an icon", () => {
         const {getByText, queryAllByText, getByTestId} = render(
-            <DetailContext.Provider value={detailContextValue}>
-                <DataTableValue config={configMultiple} />
-            </DetailContext.Provider>
+            <DataTableValue config={configMultiple.config} data={detail} />
         );
-        expect(getByText(configMultiple.title)).toBeInTheDocument();
+        expect(getByText(configMultiple.config.title)).toBeInTheDocument();
         expect(getByTestId("hideUp")).toBeInTheDocument();
-        expect(getByTestId("icon-" + configMultiple.icon)).toBeInTheDocument();
+        expect(getByTestId("icon-" + configMultiple.config.icon)).toBeInTheDocument();
         expect(getByText("123-456-7890")).toBeInTheDocument();
         expect(getByText("321-654-9876")).toBeInTheDocument();
-        expect(queryAllByText(configMultiple.metadata[0].value).length > 0);
-        expect(queryAllByText(configMultiple.metadata[1].value).length > 0);
+        expect(queryAllByText(configMultiple.config.metadata[0].value).length > 0);
+        expect(queryAllByText(configMultiple.config.metadata[1].value).length > 0);
         userEvent.click(getByTestId("hideUp"));
         expect(getByTestId("hideDown")).toBeInTheDocument();
         userEvent.click(getByTestId("hideDown"));
@@ -145,23 +158,23 @@ describe("DataTableValue component", () => {
     test("Verify data table renders with a property with a single value", () => {
         const {getByText, queryAllByText, queryByTestId} = render(
             <DetailContext.Provider value={detailContextValue}>
-                <DataTableValue config={configSingular} />
+                <DataTableValue config={configSingular.config} data={detail} />
             </DetailContext.Provider>
         );
-        expect(getByText(configSingular.title)).toBeInTheDocument();
+        expect(getByText(configSingular.config.title)).toBeInTheDocument();
         expect(queryByTestId("hideUp")).not.toBeInTheDocument();
         expect(getByText("123-45-6789")).toBeInTheDocument();
-        expect(queryAllByText(configMultiple.metadata[0].value).length > 0);
-        expect(queryAllByText(configMultiple.metadata[1].value).length > 0);
+        expect(queryAllByText(configMultiple.config.metadata[0].value).length > 0);
+        expect(queryAllByText(configMultiple.config.metadata[1].value).length > 0);
     });
 
     test("Verify data table renders with a property in an array of objects using arrayPath", () => {
         const {getByText, getByTestId} = render(
             <DetailContext.Provider value={detailContextValue}>
-                <DataTableValue config={configArrayPathMultiple} />
+                <DataTableValue config={configArrayPathMultiple.config} data={detail} />
             </DetailContext.Provider>
         );
-        expect(getByText(configArrayPathMultiple.title)).toBeInTheDocument();
+        expect(getByText(configArrayPathMultiple.config.title)).toBeInTheDocument();
         expect(getByTestId("hideUp")).toBeInTheDocument();
         expect(getByText("jdoe1@example.org")).toBeInTheDocument();
         expect(getByText("jdoe2@example.org")).toBeInTheDocument();
@@ -170,10 +183,10 @@ describe("DataTableValue component", () => {
     test("Verify data table renders with a property in a single object using arrayPath", () => {
         const {getByText, queryByTestId} = render(
             <DetailContext.Provider value={detailContextValue}>
-                <DataTableValue config={configArrayPathSingular} />
+                <DataTableValue config={configArrayPathSingular.config} data={detail} />
             </DetailContext.Provider>
         );
-        expect(getByText(configArrayPathSingular.title)).toBeInTheDocument();
+        expect(getByText(configArrayPathSingular.config.title)).toBeInTheDocument();
         expect(queryByTestId("hideUp")).not.toBeInTheDocument();
         expect(getByText("http://example.org/entity1.jpg")).toBeInTheDocument();
     });
@@ -181,11 +194,11 @@ describe("DataTableValue component", () => {
     test("Verify data table does not render with a property that does not exist in the results", () => {
         const {queryByText, queryByTestId} = render(
             <DetailContext.Provider value={detailContextValue}>
-                <DataTableValue config={configNoExist} />
+                <DataTableValue config={configNoExist.config} data={detail} />
             </DetailContext.Provider>
         );
-        expect(queryByText(configNoExist.title)).not.toBeInTheDocument();
-        expect(queryByTestId(configNoExist.id)).not.toBeInTheDocument();
+        expect(queryByText(configNoExist.config.title)).not.toBeInTheDocument();
+        expect(queryByTestId(configNoExist.config.id)).not.toBeInTheDocument();
     });
 
 });

--- a/marklogic-data-hub-central/ui-custom/src/components/DataTableValue/DataTableValue.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/DataTableValue/DataTableValue.tsx
@@ -2,14 +2,14 @@ import React, { useState, useContext } from "react";
 import MetadataValue from "../MetadataValue/MetadataValue";
 import Value from "../Value/Value";
 import Table from "react-bootstrap/Table";
-import { DetailContext } from "../../store/DetailContext";
 import "./DataTableValue.scss";
 import {ArrowBarDown, ArrowBarRight, EnvelopeFill, TelephoneFill} from "react-bootstrap-icons";
 import { getValByConfig } from "../../util/util";
 import _ from "lodash";
 
 type Props = {
-  config?: any
+    data?: any;
+    config?: any;
 };
 
 /**
@@ -41,7 +41,6 @@ type Props = {
  */
 const DataTableValue: React.FC<Props> = (props) => {
 
-    const detailContext = useContext(DetailContext);
     const [hide, setHide] = useState<boolean>(false);
 
     const handleHide = (e) => {
@@ -50,7 +49,7 @@ const DataTableValue: React.FC<Props> = (props) => {
 
     let data: any = [];
 
-    data = getValByConfig(detailContext.detail, props.config);
+    data = getValByConfig(props.data, props.config);
     data = _.isNil(data) ? null : (Array.isArray(data) ? data : [data]);
 
     let hideClass: string = hide ? "hide" : "";

--- a/marklogic-data-hub-central/ui-custom/src/components/DateTime/DateTime.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/DateTime/DateTime.tsx
@@ -7,6 +7,7 @@ type Props = {
   config?: any;
   data?: any;
   style?: any;
+  className?: any;
 };
 
 /**
@@ -18,6 +19,8 @@ type Props = {
  */
 const DateTime: React.FC<Props> = (props) => {
 
+    const defaultFormat = "yyyy-MM-dd";
+
     let val;
     if (props.children) {
         val = props.children;
@@ -26,7 +29,7 @@ const DateTime: React.FC<Props> = (props) => {
     }
 
     let formattedDateTime;
-    formattedDateTime = dt.fromISO(val).toFormat(props.config.format);
+    formattedDateTime = dt.fromISO(val).toFormat(props.config.format ? props.config.format : defaultFormat);
 
     if (formattedDateTime && props.config?.prefix) {
         formattedDateTime = props.config?.prefix.concat(formattedDateTime);
@@ -36,10 +39,11 @@ const DateTime: React.FC<Props> = (props) => {
         formattedDateTime = formattedDateTime.concat(props.config?.suffix);
     }
 
+    const dateTimeClassName: any = props.className ? props.className : props.config?.className ? props.config.className : "";
     const dateTimeStyle: any = props.style ? props.style : {};
 
     return (
-        <span className="DateTime" style={dateTimeStyle}>
+        <span className={dateTimeClassName ? dateTimeClassName : "DateTime"} style={dateTimeStyle}>
             {formattedDateTime}
         </span>
     );

--- a/marklogic-data-hub-central/ui-custom/src/components/Image/Image.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Image/Image.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import "./Image.scss";
+import { getValByConfig } from "../../util/util";
+
+type Props = {
+  config?: any;
+  data?: any;
+  style?: any;
+  className?: any;
+};
+
+/**
+ * Component for showing date and time information.
+ *
+ * @component
+ * @example
+ * TBD
+ */
+const Image: React.FC<Props> = (props) => {
+
+    let src;
+    if (props.children) {
+        src = props.children;
+    } else {
+        src = getValByConfig(props.data, props.config, true);
+    }
+
+    const imageClassName: any = props.className ? props.className : props.config?.className ? props.config.className : "";
+    const imageStyle: any = props.style ? props.style : props.config.style ? props.config.style : {};
+
+    return (<img
+        src={src}
+        className={imageClassName ? imageClassName : "Image"}
+        style={imageStyle}
+        alt={props.config.alt}
+    />);
+};
+
+export default Image;

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.scss
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.scss
@@ -67,7 +67,6 @@
                 > .Chiclet {
                     display: inline-block;
                     padding: 1px 6px;
-                    background-color: #cfe3e9;
                     border-radius: 4px;
                     margin-left: 6px;
                     font-size: 14px;

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.test.tsx
@@ -6,10 +6,15 @@ import userEvent from '@testing-library/user-event'
 
 const resultsListConfig = {
     thumbnail: {
-        src: "extracted.person.image",
-        width: "70px",
-        height: "70px",
-        alt: "result thumbnail"
+        component: "Image",
+        config: {
+            path: "extracted.person.image",
+            alt: "result thumbnail",
+            style: {
+                width: "70px",
+                height: "70px"
+            }
+        }
     },
     title: {
         path: "extracted.person.name",
@@ -23,7 +28,13 @@ const resultsListConfig = {
                 state: "extracted.person.address.state"
             }
         },
-        { path: "extracted.person.phone", className: "phone"},
+        { 
+            component: "Value",
+            config: {
+                path: "extracted.person.phone", 
+                className: "phone"
+            }
+        },
         { path: "extracted.person.ssn"}
     ],
     categories: {

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import Address from "../Address/Address";
 import Chiclet from "../Chiclet/Chiclet";
 import DateTime from "../DateTime/DateTime";
+import Image from "../Image/Image";
 import Value from "../Value/Value";
 import { SearchContext } from "../../store/SearchContext";
 import { DetailContext } from "../../store/DetailContext";
@@ -14,7 +15,9 @@ type Props = {
 };
 
 const COMPONENTS = {
-  Address: Address
+  Address: Address,
+  DateTime: DateTime,
+  Value: Value
 }
 
 /**
@@ -84,14 +87,6 @@ const ResultsList: React.FC<Props> = (props) => {
   const searchContext = useContext(SearchContext);
   const detailContext = useContext(DetailContext);
 
-  const catColors = props.config.categories.colors || {};
-  let thumbStyle = {
-    width: (props.config && props.config.thumbnail && props.config.thumbnail.width) ? 
-      props.config.thumbnail.width : "auto",
-    height: (props.config && props.config.thumbnail && props.config.thumbnail.height) ? 
-      props.config.thumbnail.height : "auto"
-  };
-
   const handleNameClick = (e) => {
     detailContext.handleDetail(e.target.id);
   };
@@ -120,11 +115,8 @@ const ResultsList: React.FC<Props> = (props) => {
         <div key={"result-" + index} className="result">
           <div className="thumbnail"> 
             {props.config.thumbnail ? 
-            <img
-              src={getValByConfig(results, props.config.thumbnail, true)}
-              alt={props.config && props.config.thumbnail && props.config.thumbnail.alt}
-              style={thumbStyle}
-            ></img> : null}
+              <Image data={results} config={props.config.thumbnail.config} />
+            : null}
           </div>
           <div className="details">
             <div className="title" onClick={handleNameClick}>
@@ -140,7 +132,6 @@ const ResultsList: React.FC<Props> = (props) => {
                   <Chiclet 
                     key={"category-" + index2} 
                     config={props.config.categories}
-                    style={{backgroundColor: catColors[s]}}
                   >{s}</Chiclet>
                 )
               })}

--- a/marklogic-data-hub-central/ui-custom/src/views/Detail.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/views/Detail.test.tsx
@@ -10,15 +10,19 @@ const config = {
     "detail": {
         "heading": {
             "id": "result[0].extracted.person.personId",
-            "title": "result[0].extracted.person.name"
+            "title": { 
+                "path": "result[0].extracted.person.name"
+            }
         },
         "personal": {
             "items": [
                 {
-                    "id": "phone",
                     "component": "DataTableValue",
-                    "title": "Phone Number",
-                    "path": "result[0].extracted.person.phone"
+                    "config": {
+                        "id": "phone",
+                        "title": "Phone Number",
+                        "path": "result[0].extracted.person.phone"
+                    }
                 }
             ]
         }
@@ -73,7 +77,7 @@ describe("Detail view", () => {
             getByText = renderResults.getByText;
         });
         expect(document.querySelector(".heading")).toBeInTheDocument();
-        expect(getByText(config.detail.personal.items[0].title)).toBeInTheDocument();
+        expect(getByText(config.detail.personal.items[0].config.title)).toBeInTheDocument();
     });
 
     test("Renders loading content with empty config", async () => {

--- a/marklogic-data-hub-central/ui-custom/src/views/Detail.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/views/Detail.tsx
@@ -7,18 +7,22 @@ import Occupations from "../components/Occupations/Occupations";
 import Relationships from "../components/Relationships/Relationships";
 import DataTableValue from "../components/DataTableValue/DataTableValue";
 import DataTableMultiValue from "../components/DataTableMultiValue/DataTableMultiValue";
+import DateTime from "../components/DateTime/DateTime";
+import Image from "../components/Image/Image";
 import Section from "../components/Section/Section";
 import Value from "../components/Value/Value";
 import { ArrowLeft } from "react-bootstrap-icons";
 import "./Detail.scss";
-import { getValByPath, getValByPathAsArray, getValByConfig } from "../util/util";
 import _ from "lodash";
 
 type Props = {};
 
 const COMPONENTS = {
   DataTableValue: DataTableValue,
-  DataTableMultiValue: DataTableMultiValue
+  DataTableMultiValue: DataTableMultiValue,
+  DateTime: DateTime,
+  Image: Image,
+  Value: Value
 }
 
 const Detail: React.FC<Props> = (props) => {
@@ -44,13 +48,6 @@ const Detail: React.FC<Props> = (props) => {
       detailContext.handleDetail(id);
     }
   }, [userContext.config]);
-
-  let thumbStyle = {
-    width: (config?.detail?.heading?.thumbnail && config?.detail?.heading?.thumbnail.width) ? 
-    config.detail.heading.thumbnail.width : "auto",
-    height: (config?.detail?.heading?.thumbnail && config?.detail?.heading?.thumbnail.height) ? 
-    config.detail.heading.thumbnail.height : "auto"
-  };
   
   const getHeading = (configHeading) => {
     return (
@@ -62,11 +59,7 @@ const Detail: React.FC<Props> = (props) => {
         <Value data={detailContext.detail} config={configHeading.title} getFirst={true} />
       </div>
       {configHeading.thumbnail && <div className="thumbnail">
-        <img
-            src={getValByConfig(detailContext.detail, configHeading.thumbnail, true)}
-            alt={getValByPath(detailContext.detail, configHeading.title)}
-            style={thumbStyle}
-        ></img>
+        <Image data={detailContext.detail} config={configHeading.thumbnail.config} />
       </div>}
     </div>
     );
@@ -79,7 +72,7 @@ const Detail: React.FC<Props> = (props) => {
           <div key={"item-" + index} className="item">
             {React.createElement(
               COMPONENTS[it.component], 
-              { config: it }, null
+              { config: it.config, data: detailContext.detail}, null
             )}
           </div>
         );


### PR DESCRIPTION
Pass config info into ResultsList items and the Detail personal section consistently:
- "component" property that specifies the component
- "config" property that specifies the configuration for that component, with consistent properties (arrayPath, path, etc.)

Create an Image widget for thumbnails, etc.
Add a default color to Chiclet widget. Displayed when no color found in widget config.
Fix tests.

