### PR TITLE
DHFPROD-8085: Recently Visited Records widget

### DIFF
--- a/examples/entity-viewer-v2/entity-viewer-client/build.gradle
+++ b/examples/entity-viewer-v2/entity-viewer-client/build.gradle
@@ -35,6 +35,7 @@ task importPersonsViaMlcp(type: com.marklogic.gradle.task.MlcpTask) {
     input_file_type = "documents"
     output_collections = "person"
     output_permissions = "rest-reader,read,rest-reader,update"
+    output_uri_replace = ".*input,'/record'"
     mode = "local"
 }
 

--- a/examples/entity-viewer-v2/entity-viewer-client/input/10033.xml
+++ b/examples/entity-viewer-v2/entity-viewer-client/input/10033.xml
@@ -119,14 +119,6 @@
       <state>TX</state>
     </relation>
     <relation>
-      <id>10054</id>
-      <predicate>worksWith</predicate>
-      <imageSrc>https://cdn1.marklogic.com/wp-content/uploads/2018/01/headshot_square_286x286.jpg</imageSrc>
-      <fullname>Chessell Skye</fullname>
-      <city>Chicago</city>
-      <state>IL</state>
-    </relation>
-    <relation>
       <id>10078</id>
       <predicate>livesWith</predicate>
       <imageSrc>https://cdn1.marklogic.com/wp-content/uploads/2018/02/trinh-lieu-profile.jpg</imageSrc>

--- a/examples/entity-viewer-v2/entity-viewer-client/input/10073.xml
+++ b/examples/entity-viewer-v2/entity-viewer-client/input/10073.xml
@@ -138,14 +138,6 @@
       <state>NY</state>
     </relation>
     <relation>
-      <id>10097</id>
-      <predicate>worksWith</predicate>
-      <imageSrc>https://cdn1.marklogic.com/wp-content/uploads/2021/07/chuck-hollis.jpeg</imageSrc>
-      <fullname>Padly Klemens</fullname>
-      <city>Miami</city>
-      <state>FL</state>
-    </relation>
-    <relation>
       <id>10053</id>
       <predicate>relatedTo</predicate>
       <imageSrc>https://cdn1.marklogic.com/wp-content/uploads/2020/11/george-bloom-headshot-300x300-1.jpg</imageSrc>

--- a/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/ui-config/config.json
+++ b/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/ui-config/config.json
@@ -114,33 +114,67 @@
     "new": {},
 
     "recent": {
-      "id": "entityInstance.personId",
       "thumbnail": {
-        "src": "entityInstance.image",
-        "width": "70px",
-        "height": "70px"
+          "component": "Image",
+          "config": {
+              "arrayPath": "person.images.image",
+              "path": "url",
+              "alt": "recent thumbnail",
+              "style": {
+                  "width": "70px",
+                  "height": "70px"
+              }
+          }
       },
-      "title": "entityInstance.name",
-      "address": {
-        "street": "entityInstance.address.street",
-        "city": "entityInstance.address.city",
-        "state": "entityInstance.address.state",
-        "zip": [
-          "entityInstance.address.zip.fiveDigit",
-          "entityInstance.address.zip.plusFour"
-        ]
+      "title": { 
+          "id": "uri",
+          "arrayPath": "person.nameGroup",
+          "path": "fullname.value"
       },
-      "items": ["entityInstance.phone", "entityInstance.email"],
+      "items": [
+          { 
+              "component": "Address", 
+              "config": {
+                  "arrayPath": "person.addresses.address",
+                  "street1": "street",
+                  "city": "city",
+                  "state": "state",
+                  "postal1": "postal",
+                  "country": "country",
+                  "style": {
+                      "width": "350px",
+                      "overflow": "hidden",
+                      "textOverflow": "ellipsis"
+                  }
+              }
+          },
+          { 
+              "component": "Value",
+              "config": {
+                  "path": "person.phone", 
+                  "className": "phone"
+              }
+          },
+          { 
+              "arrayPath": "person.emails.email",
+              "path": "value", 
+              "className": "email" 
+          },
+          {
+              "path": "person.ssn.value" 
+          }
+      ],
       "categories": {
-        "path": "entityInstance.sources",
-        "colors": {
-          "New York Times": "#d5e1de",
-          "USA Today": "#ebe1fa",
-          "Los Angeles Times": "#cae4ea",
-          "Wall Street Journal": "#fae9d3",
-          "Washington Post": "#fae3df",
-          "Chicago Tribune": "#f0f6d9"
-        }
+          "arrayPath": "person.sources",
+          "path": "source.name",
+          "colors": {
+              "New York Times": "#d5e1de",
+              "USA Today": "#ebe1fa",
+              "Los Angeles Times": "#cae4ea",
+              "Wall Street Journal": "#fae9d3",
+              "Washington Post": "#fae3df",
+              "Chicago Tribune": "#f0f6d9"
+          }
       }
     }
   },
@@ -152,7 +186,7 @@
         "all": "#cccccc",
         "filters": "#1ACCA8"
       },
-      "totalRecords": 99
+      "totalRecords": 100
     },
     "facets": {
       "selected": "#1acca8",
@@ -192,7 +226,7 @@
         }
       },
       "title": {
-        "id": "extracted.person.personId",
+        "id": "uri",
         "arrayPath": "extracted.person.nameGroup",
         "path": "fullname.value"
       },
@@ -256,23 +290,24 @@
   },
 
   "detail": {
+
     "heading": {
-      "id": "result[0].extracted.person.personId",
-      "thumbnail": {
-        "component": "Image",
-        "config": {
-          "arrayPath": "result[0].extracted.person.images.image",
-          "path": "url",
-          "alt": "detail thumbnail",
-          "style": {
-            "width": "60px",
-            "height": "60px"
-          }
+        "id": "uri",
+        "thumbnail": {
+            "component": "Image",
+            "config": {
+                "arrayPath": "person.images.image",
+                "path": "url",
+                "alt": "detail thumbnail",
+                "style": {
+                    "width": "60px",
+                    "height": "60px"
+                }
+            }
+        },
+        "title": { 
+            "path": "person.nameGroup.fullname.value"
         }
-      },
-      "title": {
-        "path": "result[0].extracted.person.nameGroup.fullname.value"
-      }
     },
 
     "personal": {
@@ -280,234 +315,234 @@
         {
           "component": "DataTableValue",
           "config": {
-            "id": "name",
-            "title": "Name",
-            "path": "result[0].extracted.person.nameGroup.fullname.value",
-            "width": "400px",
-            "metadata": [
-              {
-                "type": "block",
-                "color": "#96bde4",
-                "value": "B"
-              },
-              {
-                "type": "block",
-                "color": "#5d6aaa",
-                "value": "3",
-                "popover": {
-                  "title": "Sources",
-                  "dataPath": "result[0].extracted.person.sources",
-                  "placement": "right",
-                  "cols": [
-                    {
-                      "path": "name",
-                      "type": "chiclet",
-                      "colors": {
-                        "New York Times": "#d5e1de",
-                        "USA Today": "#ebe1fa",
-                        "Los Angeles Times": "#cae4ea",
-                        "Wall Street Journal": "#fae9d3",
-                        "Washington Post": "#fae3df",
-                        "Chicago Tribune": "#f0f6d9"
+              "id": "name",
+              "title": "Name",
+              "path": "person.nameGroup.fullname.value",
+              "width": "400px",
+              "metadata": [
+                  {
+                      "type": "block",
+                      "color": "#96bde4",
+                      "value": "B"
+                  },
+                  {
+                      "type": "block",
+                      "color": "#5d6aaa",
+                      "value": "3",
+                      "popover": {
+                          "title": "Sources",
+                          "dataPath": "person.sources",
+                          "placement": "right",
+                          "cols": [
+                              {
+                                  "path": "name",
+                                  "type": "chiclet",
+                                  "colors": {
+                                      "New York Times": "#d5e1de",
+                                      "USA Today": "#ebe1fa",
+                                      "Los Angeles Times": "#cae4ea",
+                                      "Wall Street Journal": "#fae9d3",
+                                      "Washington Post": "#fae3df",
+                                      "Chicago Tribune": "#f0f6d9"
+                                  }
+                              },
+                              {
+                                  "path": "timestamp",
+                                  "type": "datetime",
+                                  "format": "yyyy-MM-dd"
+                              }
+                          ]
                       }
+                  }
+              ]
+          }
+        },
+        {
+            "component": "DataTableValue",
+            "config": {
+                "id": "phone",
+                "title": "Phone Number",
+                "path": "person.phone",
+                "icon": "phone",
+                "width": "400px",
+                "metadata": [
+                    {
+                        "type": "block",
+                        "color": "#96bde4",
+                        "value": "B"
                     },
                     {
-                      "path": "timestamp",
-                      "type": "datetime",
-                      "format": "yyyy-MM-dd"
+                        "type": "block",
+                        "color": "#5d6aaa",
+                        "value": "4"
                     }
-                  ]
-                }
-              }
-            ]
-          }
-        },
+                ]
+            }
+        },        
         {
-          "component": "DataTableValue",
-          "config": {
-            "id": "phone",
-            "title": "Phone Number",
-            "path": "result[0].extracted.person.phone",
-            "icon": "phone",
-            "width": "400px",
-            "metadata": [
-              {
-                "type": "block",
-                "color": "#96bde4",
-                "value": "B"
-              },
-              {
-                "type": "block",
-                "color": "#5d6aaa",
-                "value": "4"
-              }
-            ]
-          }
-        },
-        {
-          "component": "DataTableValue",
-          "config": {
-            "id": "email",
-            "title": "Email",
-            "arrayPath": "result[0].extracted.person.emails.email",
-            "path": "value",
-            "icon": "email",
-            "width": "400px",
-            "metadata": [
-              {
-                "type": "block",
-                "color": "#96bde4",
-                "value": "B"
-              },
-              {
-                "type": "block",
-                "color": "#5d6aaa",
-                "value": "4"
-              }
-            ]
-          }
-        },
-        {
-          "component": "DataTableValue",
-          "config": {
-            "id": "ssn",
-            "title": "SSN",
-            "path": "result[0].extracted.person.ssn.value",
-            "width": "400px",
-            "metadata": [
-              {
-                "type": "block",
-                "color": "#e67485",
-                "value": "R"
-              },
-              {
-                "type": "block",
-                "color": "#5d6aaa",
-                "value": "4"
-              }
-            ]
-          }
-        },
-        {
-          "component": "DataTableMultiValue",
-          "config": {
-            "id": "address",
-            "title": "Address",
-            "width": "680px",
-            "arrayPath": "result[0].extracted.person.addresses.address",
-            "cols": [
-              {
-                "title": "Street",
-                "value": "street",
-                "width": "220px"
-              },
-              {
-                "title": "City",
-                "value": "city",
-                "width": "130px"
-              },
-              {
-                "title": "State",
-                "value": "state",
-                "width": "60px"
-              },
-              {
-                "title": "Postal Code",
-                "value": "postal",
-                "width": "85px"
-              },
-              {
-                "title": "Country",
-                "value": "country",
-                "width": "100px"
-              }
-            ],
-            "metadata": [
-              {
-                "type": "block",
-                "color": "#96bde4",
-                "value": "B"
-              },
-              {
-                "type": "block",
-                "color": "#5d6aaa",
-                "value": "4"
-              }
-            ]
-          }
-        },
-        {
-          "component": "DataTableMultiValue",
-          "config": {
-            "id": "school",
-            "title": "School",
-            "width": "680px",
-            "arrayPath": "result[0].extracted.person.schools.school",
-            "cols": [
-              {
-                "title": "Name",
-                "value": "name",
-                "width": "240px"
-              },
-              {
-                "title": "City",
-                "value": "city",
-                "width": "130px"
-              },
-              {
-                "title": "Country",
-                "value": "country",
-                "width": "100px"
-              }
-            ],
-            "metadata": [
-              {
-                "type": "block",
-                "color": "#96bde4",
-                "value": "B"
-              },
-              {
-                "type": "block",
-                "color": "#5d6aaa",
-                "value": "3",
-                "popover": {
-                  "title": "Sources",
-                  "dataPath": "result[0].extracted.person.sources",
-                  "placement": "right",
-                  "cols": [
+            "component": "DataTableValue",
+            "config": {
+                "id": "email",
+                "title": "Email",
+                "arrayPath": "person.emails.email",
+                "path": "value", 
+                "icon": "email",
+                "width": "400px",
+                "metadata": [
                     {
-                      "path": "name",
-                      "type": "chiclet",
-                      "colors": {
-                        "New York Times": "#d5e1de",
-                        "USA Today": "#ebe1fa",
-                        "Los Angeles Times": "#cae4ea",
-                        "Wall Street Journal": "#fae9d3",
-                        "Washington Post": "#fae3df",
-                        "Chicago Tribune": "#f0f6d9"
-                      }
+                        "type": "block",
+                        "color": "#96bde4",
+                        "value": "B"
                     },
                     {
-                      "path": "timestamp",
-                      "type": "datetime",
-                      "format": "yyyy-MM-dd"
+                        "type": "block",
+                        "color": "#5d6aaa",
+                        "value": "4"
                     }
-                  ]
-                }
-              }
-            ]
-          }
+                ]
+            }
+        },
+        {
+            "component": "DataTableValue",
+            "config": {
+                "id": "ssn",
+                "title": "SSN",
+                "path": "person.ssn.value",
+                "width": "400px",
+                "metadata": [
+                    {
+                        "type": "block",
+                        "color": "#e67485",
+                        "value": "R"
+                    },
+                    {
+                        "type": "block",
+                        "color": "#5d6aaa",
+                        "value": "4"
+                    }
+                ]
+            }
+        },
+        {
+            "component": "DataTableMultiValue",
+            "config": {
+                "id": "address",
+                "title": "Address",
+                "width": "680px",
+                "arrayPath": "person.addresses.address",
+                "cols": [
+                    {
+                        "title": "Street",
+                        "value": "street",
+                        "width": "220px"
+                    },
+                    {
+                        "title": "City",
+                        "value": "city",
+                        "width": "130px"
+                    },
+                    {
+                        "title": "State",
+                        "value": "state",
+                        "width": "60px"
+                    },
+                    {
+                        "title": "Postal Code",
+                        "value": "postal",
+                        "width": "85px"
+                    },
+                    {
+                        "title": "Country",
+                        "value": "country",
+                        "width": "100px"
+                    }
+                ],
+                "metadata": [
+                    {
+                        "type": "block",
+                        "color": "#96bde4",
+                        "value": "B"
+                    },
+                    {
+                        "type": "block",
+                        "color": "#5d6aaa",
+                        "value": "4"
+                    }
+                ]
+            }
+        },
+        {
+            "component": "DataTableMultiValue",
+            "config": {
+                "id": "school",
+                "title": "School",
+                "width": "680px",
+                "arrayPath": "person.schools.school",
+                "cols": [
+                    {
+                        "title": "Name",
+                        "value": "name",
+                        "width": "240px"
+                    },
+                    {
+                        "title": "City",
+                        "value": "city",
+                        "width": "130px"
+                    },
+                    {
+                        "title": "Country",
+                        "value": "country",
+                        "width": "100px"
+                    }
+                ],
+                "metadata": [
+                    {
+                        "type": "block",
+                        "color": "#96bde4",
+                        "value": "B"
+                    },
+                    {
+                        "type": "block",
+                        "color": "#5d6aaa",
+                        "value": "3",
+                        "popover": {
+                            "title": "Sources",
+                            "dataPath": "person.sources",
+                            "placement": "right",
+                            "cols": [
+                                {
+                                    "path": "name",
+                                    "type": "chiclet",
+                                    "colors": {
+                                        "New York Times": "#d5e1de",
+                                        "USA Today": "#ebe1fa",
+                                        "Los Angeles Times": "#cae4ea",
+                                        "Wall Street Journal": "#fae9d3",
+                                        "Washington Post": "#fae3df",
+                                        "Chicago Tribune": "#f0f6d9"
+                                    }
+                                },
+                                {
+                                    "path": "timestamp",
+                                    "type": "datetime",
+                                    "format": "yyyy-MM-dd"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
         },
         {
           "component": "SocialMedia",
           "config": {
             "title": "Social Media",
             "site": {
-              "arrayPath": "result[0].extracted.person.socials.social",
+              "arrayPath": "person.socials.social",
               "path": "site"
             },
             "url": {
-              "arrayPath": "result[0].extracted.person.socials.social",
+              "arrayPath": "person.socials.social",
               "path": "address"
             },
             "sites": {
@@ -548,42 +583,58 @@
     },
 
     "relationships": {
-      "component": "Relationships",
-      "config": {
-        "size": 30,
-        "root": {
-          "id": {
-            "path": "result[0].extracted.person.personId"
-          },
-          "imgSrc": {
-            "arrayPath": "result[0].extracted.person.images.image",
-            "path": "url"
-          },
-          "title": {
-            "path": "result[0].extracted.person.nameGroup.fullname.value"
-          },
-          "city": {
-            "arrayPath": "result[0].extracted.person.addresses.address",
-            "path": "city"
-          },
-          "state": {
-            "arrayPath": "result[0].extracted.person.addresses.address",
-            "path": "state"
-          }
-        },
-        "relations": {
-          "arrayPath": "result[0].extracted.person.relations.relation",
-          "id": "id",
-          "predicate": "predicate",
-          "imgSrc": "imageSrc",
-          "title": "fullname",
-          "city": "city",
-          "state": "state"
-        },
-        "options": {}
-      }
+        "component": "Relationships",
+        "config": {
+            "size": 30,
+            "root": {
+                "id": {
+                    "path": "uri"
+                },
+                "imgSrc": {
+                    "arrayPath": "person.images.image",
+                    "path": "url"
+                },
+                "title": {
+                    "path": "person.nameGroup.fullname.value"
+                },
+                "city": {
+                    "arrayPath": "person.addresses.address",
+                    "path": "city"
+                },
+                "state": {
+                    "arrayPath": "person.addresses.address",
+                    "path": "state"
+                }
+            },
+            "relations": {
+                "arrayPath": "person.relations.relation",
+                "id": {
+                    "path": "id",
+                    "prepend": "/record/",
+                    "append": ".xml"
+                },
+                "predicate": {
+                    "path": "predicate"
+                },
+                "imgSrc": {
+                    "path": "imageSrc"
+                },
+                "title": {
+                    "path": "fullname"
+                },
+                "city": {
+                    "path": "city"
+                },
+                "state": {
+                    "path": "state"
+                }
+            },
+            "options": {}
+        }
     },
 
     "occupations": {}
+
   }
+
 }

--- a/marklogic-data-hub-central/ui-custom/src/api/api.ts
+++ b/marklogic-data-hub-central/ui-custom/src/api/api.ts
@@ -1,5 +1,4 @@
 import axios from "axios";
-import persons from "../mocks/persons.json";
 import {summary} from "../mocks/summary";
 import {saved} from "../mocks/saved";
 import _ from "lodash";
@@ -57,21 +56,6 @@ const getRandomInt = (min, max) => {
   max = Math.floor(max);
   return Math.floor(Math.random() * (max - min) + min); //The maximum is exclusive and the minimum is inclusive
 }
-
-// export const getRecent = async (opts) => { // TODO
-export const getRecent = (opts) => {
-  // return await axios.get(`/api/getRecent`); // TODO
-  const rand = getRandomInt(1, 90);
-  //console.log("getRecent", opts);
-  const myPersons = _.clone(persons);
-  let personsSlice = myPersons.slice(rand, rand+5);
-  const rand2 = getRandomInt(0, 5);
-  personsSlice = personsSlice.map((p, i) => {
-    p["alert"] = i === rand2;
-    return p;
-  });
-  return personsSlice;
-};
 
 export const getProxy = async () => { 
   try {
@@ -132,6 +116,61 @@ export const getConfig = async (userid) => {
   }
   try {
     const response = await axios.get("/api/explore/uiconfig", config);
+    if (response && response.status === 200) {
+      return response;
+    }
+  } catch (error) {
+    let message = error;
+    console.error("Error: getConfig", message);
+  }
+};
+
+export const saveRecentlyVisited = async (uri, userid) => { 
+  let config = {
+    headers: {
+      userid: userid ? userid : null
+    }
+  }
+  let body = {
+    user: userid ? userid : null,
+    recordUri: uri ? uri : null
+  }
+  try {
+    const response = await axios.post("/api/explore/recentlyVisited", body, config);
+    if (response && response.status === 200) {
+      return response;
+    }
+  } catch (error) {
+    let message = error;
+    console.error("Error: getConfig", message);
+  }
+};
+
+export const getRecentlyVisited = async (userid) => { 
+  let config = {
+    headers: {
+      userid: userid ? userid : null
+    }
+  }
+  try {
+    const response = await axios.get("/api/explore/recentlyVisited?user=" + userid, config);
+    if (response && response.status === 200) {
+      return response;
+    }
+  } catch (error) {
+    let message = error;
+    console.error("Error: getConfig", message);
+  }
+};
+
+export const getRecord = async (uri, userid) => { 
+  let config = {
+    headers: {
+      userid: userid ? userid : null
+    }
+  }
+  try {
+    const response = await axios.get("/api/explore/getRecord?recordId=" + uri, config);
     if (response && response.status === 200) {
       return response;
     }

--- a/marklogic-data-hub-central/ui-custom/src/components/List/List.scss
+++ b/marklogic-data-hub-central/ui-custom/src/components/List/List.scss
@@ -1,0 +1,17 @@
+div.list {
+    line-height: 18px;
+    margin-bottom: 10px;
+    div.item {
+        position: relative;
+        display: inline-block;
+        margin-right: 20px;
+        top: 5px;
+        font-size: 15px;
+        span {
+            display: inline-block;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+    }
+}

--- a/marklogic-data-hub-central/ui-custom/src/components/List/List.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/List/List.test.tsx
@@ -1,0 +1,42 @@
+import List from "./List";
+import {render} from "@testing-library/react";
+
+const listConfig = [
+    { 
+        "component": "Value",
+        "config": {
+            "arrayPath": "person.email",
+            "path": "value"
+        }
+    },
+    { 
+        "component": "DateTime",
+        "config": {
+            "path": "person.createdOn",
+            "format": "yyyy-MM-dd"
+        }
+    }
+];
+
+const item = {
+    "uri": "doc1.xml",
+    "person": {
+        "email": [
+            { "value": "jdoe1@example.org" },
+            { "value": "jdoe2@example.org" }
+        ],
+        "createdOn": "2020-01-01T08:00:00-07:00"
+    }
+};
+
+describe("List component", () => {
+
+    test("Verify list items appear", () => {
+        const {getByText} = render(
+            <List data={item} config={listConfig} />
+        );
+        expect(getByText(item.person.email[0].value)).toBeInTheDocument(); // Email
+        expect(getByText("2020-01-01")).toBeInTheDocument(); // Datetime formatted
+    });
+
+});

--- a/marklogic-data-hub-central/ui-custom/src/components/List/List.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/List/List.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import Address from "../Address/Address";
+import DateTime from "../DateTime/DateTime";
+import Image from "../Image/Image";
+import Value from "../Value/Value";
+import "./List.scss";
+
+type Props = {
+    config?: any;
+    data?: any;
+};
+
+const COMPONENTS = {
+    Address: Address,
+    DateTime: DateTime,
+    Image: Image,
+    Value: Value
+}
+
+/**
+ * Component for displaying a list of values.
+ *
+ * @component
+ * @prop {object} data  Raw data for list.
+ * @prop {object[]} config  Array of configuration objects for each list item.
+ * @prop {string} config.component Name of component used for display.
+ * @prop {object} config.config Configuration object for list item.
+ * @prop {string} config.config.arrayPath Path to array of objects in raw data.
+ * @prop {string} config.config.path Path to value in raw data (from arrayPath root if arrayPath is set).
+ * 
+ * @example
+ * Array of configuration objects:
+ * [
+ *  { 
+ *      "component": "Value",
+ *      "config": {
+ *          "arrayPath": "person.email",
+ *          "path": "value"
+ *      }
+ *  },
+ *  { 
+ *      "component": "DateTime",
+ *      "config": {
+ *          "arrayPath": "person.createdOn",
+ *          "path": "yyyy-MM-dd"
+ *      }
+ *  }
+ * ]
+ */
+const List: React.FC<Props> = (props) => {
+
+    const getItems = () => {
+        let items = props.config && props.config.map((item, index) => {
+            if (item.component) {
+                return (
+                <div key={"item-" + index} className="item">
+                    {React.createElement(
+                    COMPONENTS[item.component], 
+                    { config: item.config, data: props.data, style: item.style }, null
+                    )}
+                </div>
+                );
+            } else {
+                return (
+                <div key={"item-" + index} className="item">
+                    <Value data={props.data} config={item} getFirst={true} />
+                </div>
+                )
+            }
+        })
+        return items;
+    }
+
+    return (
+        <div className="list">
+            {getItems()}
+        </div>
+    );
+
+};
+
+export default List;

--- a/marklogic-data-hub-central/ui-custom/src/components/Recent/Recent.scss
+++ b/marklogic-data-hub-central/ui-custom/src/components/Recent/Recent.scss
@@ -35,25 +35,22 @@
         position: relative;
     }
     div.title {
-        font-size: 17px;
-        font-weight: bold;
-        color: #5d6aaa;
-        cursor: pointer;
-        margin-bottom: 1px;
-    }
-    div.items > div {
         position: relative;
         display: inline-block;
-        width: 160px;
-        font-size: 15px;
-        top: -2px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        font-size: 18px;
+        font-weight: bold;
+        text-decoration: none;
+        color: #394494;
+        cursor: pointer;
+        span {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            display: inline-block;
+        }
     }
-    .address {
-        width: 100%;
-        font-size: 15px;
+    div.subtitle {
+        position: relative;
+        top: -6px;
     }
     .phone {
         font-weight: bold;
@@ -63,12 +60,11 @@
     }
     .categories {
         position: absolute;
-        top: 0;
+        top: -4px;
         right: 0;
-        > div {
+        > .Chiclet {
             display: inline-block;
             padding: 1px 6px;
-            background-color: #cfe3e9;
             border-radius: 4px;
             margin-left: 6px;
             font-size: 14px;

--- a/marklogic-data-hub-central/ui-custom/src/components/Recent/Recent.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Recent/Recent.test.tsx
@@ -1,0 +1,94 @@
+import Recent from "./Recent";
+import { DetailContext } from "../../store/DetailContext";
+import { render } from "@testing-library/react";
+import userEvent from '@testing-library/user-event'
+
+const recentConfig = {
+    "thumbnail": {
+        "component": "Image",
+        "config": {
+            "path": "person.image",
+            "alt": "recent thumbnail",
+            "style": {
+                "width": "70px",
+                "height": "70px"
+            }
+        }
+    },
+    "title": { 
+        "id": "uri",
+        "path": "person.id"
+    },
+    "items": [
+        { 
+            "component": "Value",
+            "config": {
+                "arrayPath": "person.email",
+                "path": "value"
+            }
+        }
+    ],
+    "categories": {
+        "arrayPath": "person.sources",
+        "path": "source",
+        "colors": {
+            "source1": "#d5e1de",
+            "source2": "#ebe1fa"
+        }
+    }
+};
+
+const recent = [{
+    "uri": "doc1.xml",
+    "person": {
+        "id": "10001",
+        "email": [
+            { "value": "jdoe1@example.org" },
+            { "value": "jdoe2@example.org" }
+        ],
+        "image": "http://example.org/img.jpg",
+        "sources": [
+            { "source": "source1" },
+            { "source": "source2" }
+        ],
+    }
+}];
+
+const recentEmpty = [];
+
+const detailContextValue = {
+    detail: {},
+    recent: recent,
+    handleGetDetail: jest.fn(),
+    handleGetRecentlyVisited: jest.fn(),
+    handleSaveRecentlyVisited: jest.fn(),
+    handleGetRecord: jest.fn()
+};
+
+describe("Recent component", () => {
+
+    test("Verify list items appear and title is clickable when recently visited records returned", () => {
+        const {getByText, getAllByAltText} = render(
+            <DetailContext.Provider value={detailContextValue}>
+                <Recent data={recent} config={recentConfig} />
+            </DetailContext.Provider>
+        );
+        let title = getByText(recent[0].person.id);
+        expect(getAllByAltText(recentConfig.thumbnail.config.alt)[0]).toBeInTheDocument(); // Image
+        expect(title).toBeInTheDocument(); // Title
+        expect(getByText(recent[0].person.email[0].value)).toBeInTheDocument(); // Email
+        expect(getByText(recent[0].person.sources[0].source)).toBeInTheDocument(); // Source
+        userEvent.click(title);
+        expect(detailContextValue.handleGetDetail).toHaveBeenCalledWith(recent[0].uri);
+    });
+
+    test("Verify messaging appears when no recently visited records returned", () => {
+        const {getByText} = render(
+            <DetailContext.Provider value={detailContextValue}>
+                <Recent data={recentEmpty} config={recentConfig} />
+            </DetailContext.Provider>
+        );
+        expect(getByText("No recently visited records")).toBeInTheDocument();
+    });
+
+});

--- a/marklogic-data-hub-central/ui-custom/src/components/Relationships/Relationships.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Relationships/Relationships.tsx
@@ -101,14 +101,14 @@ const Relationships: React.FC<Props> = (props) => {
         const nodes: any = [{ id: rootId, shape: "image", size: nodeSize, image: rootImgSrc, title: rootPopover}];
         relations.forEach(rel => {
             nodes.push({ 
-                id: rel[props.config.relations.id], 
-                image: rel[props.config.relations.imgSrc],
+                id: getValByConfig(rel, props.config.relations.id), 
+                image: getValByConfig(rel, props.config.relations.imgSrc),
                 shape: "image", 
                 size: nodeSize, 
                 title: getPopover(
-                    rel[props.config.relations.title], 
-                    rel[props.config.relations.city], 
-                    rel[props.config.relations.state]
+                    getValByConfig(rel, props.config.relations.title),
+                    getValByConfig(rel, props.config.relations.city),
+                    getValByConfig(rel, props.config.relations.state)
                 ) 
             });
         });
@@ -118,8 +118,8 @@ const Relationships: React.FC<Props> = (props) => {
         relations.forEach(rel => {
             edges.push({ 
                 from: rootId, 
-                to: rel[props.config.relations.id], 
-                label: rel[props.config.relations.predicate]
+                to: getValByConfig(rel, props.config.relations.id), 
+                label: getValByConfig(rel, props.config.relations.predicate)
             });
         });
 
@@ -131,9 +131,8 @@ const Relationships: React.FC<Props> = (props) => {
 
     const events = {
         select: ({ nodes, edges }) => {
-            console.log("select", nodes);
             if (nodes && nodes[0]) {
-                detailContext.handleDetail(nodes[0]);
+                detailContext.handleGetDetail(nodes[0]);
             }
         },
         hoverNode: (event) => {

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.scss
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.scss
@@ -35,23 +35,6 @@
                     display: inline-block;
                 }
             }
-            div.subtitle {
-                line-height: 18px;
-                margin-bottom: 10px;
-                div.item {
-                    position: relative;
-                    display: inline-block;
-                    margin-right: 20px;
-                    top: 5px;
-                    font-size: 15px;
-                    span {
-                        display: inline-block;
-                        white-space: nowrap;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                    }
-                }
-            }
             .phone {
                 width: 120px;
                 font-weight: bold;

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.test.tsx
@@ -118,7 +118,11 @@ const searchContextValueEmpty = {
 
 const detailContextValue = {
     detail: {},
-    handleDetail: jest.fn()
+    recent: [],
+    handleGetDetail: jest.fn(),
+    handleGetRecentlyVisited: jest.fn(),
+    handleSaveRecentlyVisited: jest.fn(),
+    handleGetRecord: jest.fn()
 };
 
 describe("ResultsList component", () => {
@@ -140,9 +144,9 @@ describe("ResultsList component", () => {
         expect(getByText("active")).toBeInTheDocument(); // Status
         expect(getByText("Time is 2020-01-01")).toBeInTheDocument(); // Timestamp
         userEvent.click(title);
-        expect(detailContextValue.handleDetail).toHaveBeenCalledWith("101");
+        expect(detailContextValue.handleGetDetail).toHaveBeenCalledWith("101");
         userEvent.click(getByText("Jane Doe"));
-        expect(detailContextValue.handleDetail).toHaveBeenCalledWith("102");
+        expect(detailContextValue.handleGetDetail).toHaveBeenCalledWith("102");
     });
 
     test("Verify messaging appears when no results returned", () => {

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.tsx
@@ -3,6 +3,7 @@ import Address from "../Address/Address";
 import Chiclet from "../Chiclet/Chiclet";
 import DateTime from "../DateTime/DateTime";
 import Image from "../Image/Image";
+import List from "../List/List";
 import Value from "../Value/Value";
 import { SearchContext } from "../../store/SearchContext";
 import { DetailContext } from "../../store/DetailContext";
@@ -17,6 +18,7 @@ type Props = {
 const COMPONENTS = {
   Address: Address,
   DateTime: DateTime,
+  Image: Image,
   Value: Value
 }
 
@@ -88,29 +90,11 @@ const ResultsList: React.FC<Props> = (props) => {
   const detailContext = useContext(DetailContext);
 
   const handleNameClick = (e) => {
-    detailContext.handleDetail(e.target.id);
+    detailContext.handleGetDetail(e.target.id);
   };
 
   const getResults = () => {
     let results = searchContext.searchResults.result.map((results, index) => {
-      let items = props.config.items && props.config.items.map((it, index) => {
-        if (it.component) {
-          return (
-            <div key={"item-" + index} className="item">
-              {React.createElement(
-                COMPONENTS[it.component], 
-                { config: it.config, data: results, style: it.style }, null
-              )}
-            </div>
-          );
-        } else {
-          return (
-            <div key={"item-" + index} className="item">
-              <Value data={results} config={it} getFirst={true} />
-            </div>
-          )
-        }
-      });
       return (
         <div key={"result-" + index} className="result">
           <div className="thumbnail"> 
@@ -123,7 +107,9 @@ const ResultsList: React.FC<Props> = (props) => {
               <Value data={results} config={props.config.title} getFirst={true} />
             </div>
             <div className="subtitle">
-              {items}
+              {props.config.items ? 
+                <List data={results} config={props.config.items} />
+              : null}
             </div>
             {props.config.categories ? 
             <div className="categories">

--- a/marklogic-data-hub-central/ui-custom/src/components/Section/Section.scss
+++ b/marklogic-data-hub-central/ui-custom/src/components/Section/Section.scss
@@ -14,5 +14,6 @@
     }
     main {
         padding: 20px;
+        overflow: scroll;
     }
 }

--- a/marklogic-data-hub-central/ui-custom/src/components/Section/Section.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Section/Section.tsx
@@ -1,32 +1,52 @@
 import React from "react";
-import styles from "./Section.module.scss";
+import "./Section.scss";
 
 type Props = {
     title: string;
     width?: string;
+    config?: any;
 };
 
 /**
  * Component for showing a container around one or more other components.
  *
  * @component
- * @prop {string} title - Section label.
- * @prop {string} value - Section width (as CSS width value, default to "100%").
+ * @prop {string} title Section label.
+ * @prop {string} value Section width (as CSS width value, default to "100%").
+ * @prop {object} config Configuration object.
+ * @prop {object} config.style CSS style object applied to outer DIV container.
+ * @prop {object} config.headerStyle CSS style object applied to inner HEADER container.
+ * @prop {object} config.mainStyle CSS style object applied to inner MAIN container.
  * @example
  * <Section title="My Section Title" width="200px">
  *   <SomeComponent />
  * </Section>
+ * 
+ * Configuration object:
+ * 
+ * {
+ *   "headerStyle": {
+ *     "backgroundColor": "white"
+ *   },
+ *   "mainStyle": {
+ *     "maxHeight": "500px"
+ *   }
+ * }
  */
 const Section: React.FC<Props> = (props) => {
 
-  let divStyle = {
+  let divStyle: any = {
     width: props.width ? props.width : "100%"
   };
+  divStyle = props.config?.style ? Object.assign(props.config.style, divStyle) : divStyle;
+
+  let headerStyle: any = props.config?.headerStyle ? props.config.headerStyle : {};
+  let mainStyle: any = props.config?.mainStyle ? props.config.mainStyle : {};
 
   return (
-    <div className={styles.section} style={divStyle}>
-      <header><span>{props.title}</span></header>
-      <main>{props.children}</main>
+    <div className="section" style={divStyle}>
+      <header style={headerStyle}><span>{props.title}</span></header>
+      <main style={mainStyle}>{props.children}</main>
     </div>
   );
 };

--- a/marklogic-data-hub-central/ui-custom/src/components/Value/Value.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Value/Value.tsx
@@ -27,10 +27,10 @@ const Value: React.FC<Props> = (props) => {
         val = getValByConfig(props.data, props.config, true);
     }
 
+    // Handle prefix/suffix during display (different from prepend/append during extraction)
     if (val && props.config?.prefix) {
         val = props.config?.prefix.concat(val);
     }
-
     if (val && props.config?.suffix) {
         val = val.concat(props.config?.suffix);
     }

--- a/marklogic-data-hub-central/ui-custom/src/util/util.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/util/util.tsx
@@ -50,6 +50,12 @@ export const getValByPath = (data, path, getFirst=false) => {
         })
     }
     // Return first element if array and getFirst is set
-    return _.isNil(val) ? null : 
+    let result =  _.isNil(val) ? null : 
         ((Array.isArray(val) && getFirst) ? val[0] : val);
+
+    // Handle prepend/append for non-array values (different from prefix/suffix for display)
+    result = (!Array.isArray(val) && config.prepend) ? config.prepend + result : result;
+    result = (!Array.isArray(val) && config.append) ? result + config.append : result;
+
+    return result;
 };

--- a/marklogic-data-hub-central/ui-custom/src/views/Dashboard.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/views/Dashboard.tsx
@@ -1,4 +1,5 @@
 import React, {useState, useEffect, useContext} from "react";
+import { DetailContext } from "../store/DetailContext";
 import { UserContext } from "../store/UserContext";
 import Metrics from "../components/Metrics/Metrics";
 import SearchBox from "../components/SearchBox/SearchBox";
@@ -7,7 +8,6 @@ import New from "../components/New/New";
 import Recent from "../components/Recent/Recent";
 import Section from "../components/Section/Section";
 import Loading from "../components/Loading/Loading";
-import {getRecent} from "../api/api";
 import {getSaved} from "../api/api";
 import {getSummary} from "../api/api";
 import "./Dashboard.scss";
@@ -16,6 +16,7 @@ type Props = {};
 
 const Dashboard: React.FC<Props> = (props) => {
 
+  const detailContext = useContext(DetailContext);
   const userContext = useContext(UserContext);
 
   const [config, setConfig] = useState<any>(null);
@@ -24,14 +25,18 @@ const Dashboard: React.FC<Props> = (props) => {
   const [summary, setSummary] = useState<any>({});
 
   useEffect(() => {
-    setRecent(getRecent({}));
     setSaved(getSaved({}));
     setSummary(getSummary({}));
+    setRecent(detailContext.handleGetRecentlyVisited());
   }, []);
 
   useEffect(() => {
     setConfig(userContext.config);
   }, [userContext.config]);
+
+  useEffect(() => {
+    setRecent(detailContext.recent);
+  }, [detailContext.recent]);
 
   return (
     <div className="dashboard">
@@ -76,7 +81,11 @@ const Dashboard: React.FC<Props> = (props) => {
             : null}
 
             {config?.dashboard?.recent ? 
-              <Section title="Recently Visited">
+              <Section title="Recently Visited" config={{
+                "mainStyle": {
+                  "maxHeight": "500px"
+                }
+              }}>
                   <Recent data={recent} config={config.dashboard.recent} />
               </Section>
             : null}

--- a/marklogic-data-hub-central/ui-custom/src/views/Detail.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/views/Detail.test.tsx
@@ -45,8 +45,12 @@ const detail = {
 
 const detailContextValue = {
     detail: detail,
-    handleDetail: jest.fn()
+    recent: [],
+    handleGetDetail: jest.fn(),
+    handleGetRecentlyVisited: jest.fn(),
+    handleSaveRecentlyVisited: jest.fn()
 };
+
 
 const userContextValue = {
     userid: "",

--- a/marklogic-data-hub-central/ui-custom/src/views/Detail.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/views/Detail.tsx
@@ -48,9 +48,13 @@ const Detail: React.FC<Props> = (props) => {
     // If config is loaded and id is present but detail context is 
     // empty, load detail context so content is displayed
     if (userContext.config.detail && id && _.isEmpty(detailContext.detail)) {
-      detailContext.handleDetail(id);
+      detailContext.handleGetDetail(id);
     }
   }, [userContext.config]);
+
+  useEffect(() => {
+    detailContext.handleSaveRecentlyVisited();
+  }, [detailContext.detail]);
   
   const getHeading = (configHeading) => {
     return (


### PR DESCRIPTION
Update Recent component to pull from dynamic data.
Create List component for Recent and ResultsList components to use for property data display.
Refactor Detail view and Detail context to work with URIs instead of a record ID.
Integrate new getRecord() endpoint call to get a record based on a URI.
Add output_uri_replace value for cleaner, consistent URIs.
Process IDs in Relationships component so that URIs are referenced for links.
Add prepend/append properties for changing data at extraction (vs. prefix/suffix at display).
Update Section widget to take custom styles as config.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [ ] JIRA_ID included in all the commit messages
- [ ] PR title is in the format JIRA_ID:Title
- [ ] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [ ] Code passes ESLint tests
- [ ] Added Tests  

- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki

