### PR TITLE
DHFPROD-8558: Recently Visited Records widget using local storage

### DIFF
--- a/examples/entity-viewer-v2/entity-viewer-client/input/10035.xml
+++ b/examples/entity-viewer-v2/entity-viewer-client/input/10035.xml
@@ -100,14 +100,6 @@
       <state>CA</state>
     </relation>
     <relation>
-      <id>10035</id>
-      <predicate>worksWith</predicate>
-      <imageSrc>https://cdn1.marklogic.com/wp-content/uploads/2021/02/1612313387205.jpeg</imageSrc>
-      <fullname>Bresnahan Vinny</fullname>
-      <city>Stockton</city>
-      <state>CA</state>
-    </relation>
-    <relation>
       <id>10068</id>
       <predicate>worksWith</predicate>
       <imageSrc>https://cdn1.marklogic.com/wp-content/uploads/2018/01/headshot_square_286x286.jpg</imageSrc>

--- a/examples/entity-viewer-v2/entity-viewer-client/input/10062.xml
+++ b/examples/entity-viewer-v2/entity-viewer-client/input/10062.xml
@@ -137,14 +137,6 @@
       <city>Chicago</city>
       <state>IL</state>
     </relation>
-    <relation>
-      <id>10054</id>
-      <predicate>relatedTo</predicate>
-      <imageSrc>https://cdn1.marklogic.com/wp-content/uploads/2018/01/headshot_square_286x286.jpg</imageSrc>
-      <fullname>Chessell Skye</fullname>
-      <city>Chicago</city>
-      <state>IL</state>
-    </relation>
   </relations>
   <createdOn>
     <ts>2022-02-09T08:30:53Z</ts>

--- a/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/ui-config/config.json
+++ b/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/ui-config/config.json
@@ -3,7 +3,10 @@
     "searchResultsEndpoint": "/api/explore",
     "detailEndpoint": "/api/explore",
     "detailType": "person",
-    "detailConstraint": "personId"
+    "detailConstraint": "personId",
+    "recordsEndpoint": "/api/explore/getRecords",
+    "recentEndpoint": "/api/explore/recentlyVisited",
+    "recentStorage": "local"
   },
 
   "header": {

--- a/marklogic-data-hub-central/ui-custom/src/api/api.ts
+++ b/marklogic-data-hub-central/ui-custom/src/api/api.ts
@@ -77,7 +77,7 @@ export const getUserid = async (proxy) => {
     }
   }
   try {
-    // URL string here just needs to match what is in steupProxy.js
+    // URL string here just needs to match what is in setupProxy.js
     const response = await axios.get("/api/explore/login", config);
     if (response && response.status === 200) {
       return response;
@@ -125,7 +125,7 @@ export const getConfig = async (userid) => {
   }
 };
 
-export const saveRecentlyVisited = async (uri, userid) => { 
+export const saveRecent = async (endpoint, uri, userid) => { 
   let config = {
     headers: {
       userid: userid ? userid : null
@@ -136,7 +136,7 @@ export const saveRecentlyVisited = async (uri, userid) => {
     recordUri: uri ? uri : null
   }
   try {
-    const response = await axios.post("/api/explore/recentlyVisited", body, config);
+    const response = await axios.post(endpoint, body, config);
     if (response && response.status === 200) {
       return response;
     }
@@ -146,14 +146,14 @@ export const saveRecentlyVisited = async (uri, userid) => {
   }
 };
 
-export const getRecentlyVisited = async (userid) => { 
+export const getRecent = async (endpoint, userid) => { 
   let config = {
     headers: {
       userid: userid ? userid : null
     }
   }
   try {
-    const response = await axios.get("/api/explore/recentlyVisited?user=" + userid, config);
+    const response = await axios.get(endpoint + "?user=" + userid, config);
     if (response && response.status === 200) {
       return response;
     }
@@ -163,14 +163,17 @@ export const getRecentlyVisited = async (userid) => {
   }
 };
 
-export const getRecord = async (uri, userid) => { 
+export const getRecords = async (endpoint, uris, userid) => { 
   let config = {
     headers: {
       userid: userid ? userid : null
     }
   }
+  let body = {
+    uris: uris
+  };
   try {
-    const response = await axios.get("/api/explore/getRecord?recordId=" + uri, config);
+    const response = await axios.post(endpoint, body, config);
     if (response && response.status === 200) {
       return response;
     }

--- a/marklogic-data-hub-central/ui-custom/src/views/Dashboard.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/views/Dashboard.tsx
@@ -27,7 +27,12 @@ const Dashboard: React.FC<Props> = (props) => {
   useEffect(() => {
     setSaved(getSaved({}));
     setSummary(getSummary({}));
-    setRecent(detailContext.handleGetRecentlyVisited());
+    if (userContext.config.api && 
+      userContext.config.api.recentStorage === "database") {
+      detailContext.handleGetRecent();
+    } else {
+      detailContext.handleGetRecentLocal();
+    }
   }, []);
 
   useEffect(() => {
@@ -59,7 +64,7 @@ const Dashboard: React.FC<Props> = (props) => {
                 <h4 style={{marginBottom: "20px"}}>New Search</h4>
                 <SearchBox config={config.searchbox} button="vertical" width="100%" />
 
-                {config?.dashboard?.saved ? 
+                {config?.dashboard?.saved &&
                   <div>
                     <div className="divider">- or -</div>
                     <div style={{marginTop: "20px"}}>
@@ -67,20 +72,20 @@ const Dashboard: React.FC<Props> = (props) => {
                       <Saved data={saved} config={config.dashboard.saved} />
                     </div>
                   </div>
-                : null}
+                }
             </Section>
 
           </div>
 
           <div className="col-lg">
 
-            {config?.dashboard?.new ? 
+            {config?.dashboard?.new &&
               <Section title="What's New with Entities">
                 <New />
               </Section>
-            : null}
+            }
 
-            {config?.dashboard?.recent ? 
+            {config?.dashboard?.recent && !detailContext.loading ? 
               <Section title="Recently Visited" config={{
                 "mainStyle": {
                   "maxHeight": "500px"
@@ -88,7 +93,7 @@ const Dashboard: React.FC<Props> = (props) => {
               }}>
                   <Recent data={recent} config={config.dashboard.recent} />
               </Section>
-            : null}
+            : <Loading />}
 
           </div>
 

--- a/marklogic-data-hub-central/ui-custom/src/views/Detail.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/views/Detail.tsx
@@ -53,7 +53,12 @@ const Detail: React.FC<Props> = (props) => {
   }, [userContext.config]);
 
   useEffect(() => {
-    detailContext.handleSaveRecentlyVisited();
+    if (userContext.config.api && 
+      userContext.config.api.recentStorage === "database") {
+      detailContext.handleSaveRecent();
+    } else {
+      detailContext.handleSaveRecentLocal();
+    }
   }, [detailContext.detail]);
   
   const getHeading = (configHeading) => {
@@ -92,7 +97,7 @@ const Detail: React.FC<Props> = (props) => {
 
     <div className="detail">
 
-      {config?.detail && !_.isEmpty(detailContext.detail) ? (
+      {config?.detail && !_.isEmpty(detailContext.detail) && !detailContext.loading ? (
 
       <div>
 
@@ -109,16 +114,16 @@ const Detail: React.FC<Props> = (props) => {
           <div className="row">
             <div className="col-lg-7">
 
-              {config?.detail?.personal ? 
+              {config?.detail?.personal &&
                 <Section title="Personal Info">
                   {getPersonalItems(config?.detail?.personal?.items)}
                 </Section>
-              : null}
+              }
 
             </div>
             <div className="col-lg-5">
 
-              {config?.detail?.relationships ? 
+              {config?.detail?.relationships &&
                 <Section title="Relationships">
                   <div className="relationships">
                     {React.createElement(
@@ -127,13 +132,13 @@ const Detail: React.FC<Props> = (props) => {
                     )}
                   </div>
                 </Section>
-              : null}
+              }
 
-              {config?.detail?.occupations ? 
+              {config?.detail?.occupations &&
                 <Section title="Occupations">
                   <Occupations />
                 </Section>
-              : null}
+              }
 
             </div>
           </div>

--- a/marklogic-data-hub-central/ui-custom/src/views/Header.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/views/Header.tsx
@@ -25,23 +25,23 @@ const Header: React.FC<Props> = (props) => {
           <img src="/marklogic.png" alt="image" />
         </span>
 
-        {config?.header ? 
+        {config?.header && 
           <span className="title">
             <Link to="/">{config.header.title}</Link>
             <span className="subtitle">{config.header.subtitle}</span>
           </span>
-        : null}
+        }
 
-        {config?.header?.menus ? 
+        {config?.header?.menus && 
           <Menus config={config.header.menus} />
-        : null}
+        }
 
       </div>
       <div>
 
-        {config?.searchbox ? 
+        {config?.searchbox && 
           <SearchBox config={config.searchbox} width="600px" />
-        : null}
+        }
 
         <div className="account">
             <PersonCircle color="#ccc" size={28} />

--- a/marklogic-data-hub-central/ui-custom/src/views/Search.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/views/Search.tsx
@@ -31,34 +31,30 @@ const Search: React.FC<Props> = (props) => {
     <div className="search">
 
       {config?.search && !searchContext.loading ? 
-      
       <>
-
         <aside>
 
-          {config?.search?.meter ? 
+          {config?.search?.meter &&
             <SummaryMeter config={config.search.meter} />
-          : null}
+          }
 
-          {config?.search?.facets ? 
+          {config?.search?.facets && 
             <Facets config={config.search.facets} />
-          : null}
+          }
 
         </aside>
         <div className="results">
 
-          {config?.search ? // TODO pass config into SelectedFacets
+          {config?.search && // TODO pass config into SelectedFacets
             <SelectedFacets />
-          : null}
+          }
 
-          {config?.search?.results ? 
+          {config?.search?.results && 
             <ResultsList config={config.search.results} />
-          : null}
+          }
 
         </div>
-
       </>
-
       : <Loading />}
 
     </div>


### PR DESCRIPTION
Add a configurable “local” version of Recently Visited feature.
Make getRecords and getRecent endpoints configurable.
Convert ternaries to AND checks.
Add loading spinners to Detail-related views.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [ ] JIRA_ID included in all the commit messages
- [ ] PR title is in the format JIRA_ID:Title
- [ ] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [ ] Code passes ESLint tests
- [ ] Added Tests  

- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki

