### PR TITLE
DHFPROD-8569: Related entity icons still visible in the new entity icons sidebar, for table/snippet views

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explore/entitiesSidepanel.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explore/entitiesSidepanel.spec.tsx
@@ -176,6 +176,14 @@ describe("Test '/Explore' left sidebar", () => {
     browsePage.getTableViewCell("10248").should("have.length.gt", 0);
     browsePage.getTableViewCell("101").should("have.length.gt", 0);
 
+    cy.log("Verify related entity icons are disabled in table view");
+    entitiesSidebar.openBaseEntityFacets("Customer");
+    entitiesSidebar.getEntityIconFromList("Customer").should("be.visible");
+    entitiesSidebar.getRelatedEntityIcon("Office").should("be.visible");
+    entitiesSidebar.getRelatedEntityIcon("Office").trigger("mouseover");
+    entitiesSidebar.getDisabledRelatedEntityTooltip().should("be.visible");
+    entitiesSidebar.backToMainSidebar();
+
     cy.log("Select BabyRegistry and verify related entities panel appears but is disabled in table view");
     entitiesSidebar.getBaseEntityDropdown().click("right");
     entitiesSidebar.selectBaseEntityOption("BabyRegistry");

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/entitiesSidebar.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/entitiesSidebar.tsx
@@ -133,5 +133,13 @@ class BaseEntitySidebar {
   clickOnRelatedEntity(entity: string) {
     return this.getRelatedEntity(entity).click();
   }
+
+  getRelatedEntityIcon(entityName: string) {
+    return cy.get(`[aria-label="related-entity-icon-${entityName}"]`);
+  }
+
+  getDisabledRelatedEntityTooltip() {
+    return cy.get(`[aria-label="disabled-related-entity-tooltip"]`);
+  }
 }
 export default new BaseEntitySidebar();

--- a/marklogic-data-hub-central/ui/src/components/explore/entity-icons-sidebar/entity-icons-sidebar.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/explore/entity-icons-sidebar/entity-icons-sidebar.module.scss
@@ -1,6 +1,6 @@
 @import "../../../theme/HCVariables.scss";
 
-.entityIconList, .relatedEntityIconList {
+.entityIconList, .relatedEntityIconList, .relatedEntityIconListDisabled {
     color: $secondary-gray;
     font-weight: bold;
     display: flex;
@@ -13,8 +13,14 @@
     margin-top: 12px;
 }
 
-.relatedEntityIconList {
+.relatedEntityIconList, .relatedEntityIconListDisabled {
     margin-top: 4px;
+}
+
+.relatedEntityIconListDisabled {
+    opacity: 50%;
+    cursor: not-allowed;
+    color: #777 !important;
 }
 
 .chevronBack {
@@ -26,7 +32,7 @@
     cursor: pointer;
 }
 
-.entityIconListItem{
+.entityIconListItem, .entityIconListItemDisabled {
     padding-block: 12px;
     padding-left: 17px;
     margin-block: 3px;
@@ -35,6 +41,10 @@
     font-size: 14px;
     border-radius: 3px 0px 0px 3px;
     cursor: pointer;
+}
+
+.entityIconListItemDisabled {
+    cursor: not-allowed;
 }
 
 .separator {

--- a/marklogic-data-hub-central/ui/src/components/explore/entity-icons-sidebar/entity-icons-sidebar.tsx
+++ b/marklogic-data-hub-central/ui/src/components/explore/entity-icons-sidebar/entity-icons-sidebar.tsx
@@ -4,18 +4,20 @@ import {ChevronDoubleRight} from "react-bootstrap-icons";
 import {HCTooltip} from "@components/common";
 import DynamicIcons from "@components/common/dynamic-icons/dynamic-icons";
 import {defaultIcon} from "@config/explore.config";
+import tooltipsConfig from "../../../config/explorer-tooltips.config";
 
 interface Props {
   currentBaseEntities: any[];
   currentRelatedEntities?: Map<string, any>;
   onClose: (status: boolean) => void;
-  updateSelectedEntity
+  updateSelectedEntity;
+  graphView: boolean;
 }
+const {exploreSidebar} = tooltipsConfig;
 
 const EntityIconsSidebar: React.FC<Props> = (props) => {
-  const {currentBaseEntities, onClose, currentRelatedEntities, updateSelectedEntity} = props;
+  const {currentBaseEntities, onClose, currentRelatedEntities, updateSelectedEntity, graphView} = props;
   const currentRelatedEntitiesArray = currentRelatedEntities && currentRelatedEntities.size > 0 ? Array.from(currentRelatedEntities.values()) : [];
-
 
   const closeSpecificSidebar = (event) => {
     onClose(false);
@@ -45,11 +47,13 @@ const EntityIconsSidebar: React.FC<Props> = (props) => {
       </div>
       {currentRelatedEntitiesArray.length > 0 && <div className={styles.separator}></div>}
       {currentRelatedEntitiesArray.length > 0 &&
-        <div className={styles.relatedEntityIconList} aria-label="related-entity-icons-list">
+        <div className={!graphView ? styles.relatedEntityIconListDisabled : styles.relatedEntityIconList} aria-label="related-entity-icons-list">
           {currentRelatedEntitiesArray.map(({color, icon, name}, index) => name &&
-            <div key={name} aria-label={`related-entity-icon-${name}`} style={{backgroundColor: color}} className={styles.entityIconListItem} onClick={() => handleRelatedEntityClicked(index)}>
+          <HCTooltip text={!props.graphView ? exploreSidebar.disabledRelatedEntities: ""} aria-label="disabled-related-entity-tooltip" id="disabled-related-entity-tooltip" placement="bottom">
+            <div key={name} aria-label={`related-entity-icon-${name}`} style={{backgroundColor: color}} className={!graphView ? styles.entityIconListItemDisabled : styles.entityIconListItem} onClick={(e) => !graphView ? e.preventDefault() : handleRelatedEntityClicked(index)}>
               {icon ? <DynamicIcons name={icon} /> : <DynamicIcons name={defaultIcon} />}
             </div>
+          </HCTooltip>
           )}
         </div>
       }

--- a/marklogic-data-hub-central/ui/src/pages/Browse.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Browse.tsx
@@ -598,6 +598,7 @@ const Browse: React.FC<Props> = ({location}) => {
             onClose={closeSpecificSidebar}
             currentRelatedEntities={currentRelatedEntities}
             updateSelectedEntity={onSetEntitySpecificPanel}
+            graphView={viewOptions.graphView}
           />
         </HCSider>
         : <HCSider placement="left" show={showMainSidebar} footer={<SidebarFooter />}>


### PR DESCRIPTION
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests
- [N/A] Added to Release Wiki

