### PR TITLE
DHFPROD-8706: Reset start state on new searches

### DIFF
--- a/marklogic-data-hub-central/ui-custom/src/store/SearchContext.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/store/SearchContext.tsx
@@ -148,6 +148,7 @@ const SearchProvider: React.FC = ({children}) => {
       setEntityType(userContext.config.search.defaultEntity || "");
     }
     setPageNumber(1);
+    setStart(1);
     setNewSearch(true);
   };
 
@@ -160,6 +161,7 @@ const SearchProvider: React.FC = ({children}) => {
       setFacetStrings(newFacetStrings);
     }
     setPageNumber(1);
+    setStart(1);
     setNewSearch(true);
   };
 


### PR DESCRIPTION
### Description

While we reset the pageNumber state on new searches, we aren't resetting the start state. This causes a search error. See the ticket for a description of a test that gives an error.

This fix resets the start state on new searches just as we reset the pageNumber state.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki

