### PR TITLE
DHFPROD-8570: Handle saved searches

### DIFF
--- a/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/ui-config/config.json
+++ b/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/ui-config/config.json
@@ -90,8 +90,8 @@
 
     "recentSearches": {
       "component": "RecentSearches",
-      "maxEntries": 2,
-      "maxTime": 1,
+      "maxEntries": 100,
+      "maxTime": 1440,
       "config": {
         "cols": [
           {
@@ -125,8 +125,8 @@
 
     "recentRecords": {
       "component": "RecentRecords",
-      "maxEntries": 2,
-      "maxTime": 1,
+      "maxEntries": 100,
+      "maxTime": 1440,
       "config": {
         "entities": {
           "person": {

--- a/marklogic-data-hub-central/ui-custom/src/api/api.ts
+++ b/marklogic-data-hub-central/ui-custom/src/api/api.ts
@@ -19,13 +19,12 @@ export const getSearchResults = async (endpoint, query, userid) => {
   }
 };
 
-export const getSearchResultsByGet = async (query, userid) => { 
+export const getSearchResultsByGet = async (queryStr, userid) => { 
   let config = {
     headers: {
       userid: userid ? userid : null
     }
   }
-  let queryStr = encodeURI(JSON.stringify(query));
   try {
     const response = await axios.get("/api/explore?query=" + queryStr, config);
     if (response && response.status === 200) {

--- a/marklogic-data-hub-central/ui-custom/src/components/RecentSearches/RecentSearches.scss
+++ b/marklogic-data-hub-central/ui-custom/src/components/RecentSearches/RecentSearches.scss
@@ -37,6 +37,9 @@
             span.qtext.empty {
                 padding-right: 0;
             }
+            span.entity {
+                padding-right: 4px;
+            }
             span.facet {
                 padding-right: 4px;
             }

--- a/marklogic-data-hub-central/ui-custom/src/components/SearchBox/SearchBox.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/SearchBox/SearchBox.tsx
@@ -6,6 +6,7 @@ import FormControl from "react-bootstrap/FormControl";
 import { SearchContext } from "../../store/SearchContext";
 import { Search } from "react-bootstrap-icons";
 import "./SearchBox.scss";
+import _ from "lodash";
 
 type Props = {
     config?: any;
@@ -71,7 +72,11 @@ const SearchBox: React.FC<Props> = (props) => {
   }, [searchContext.qtext]);
 
   useEffect(() => {
-    let found = items.find(item => item.value === searchContext.entityType);
+    // String menu selections are stored in context as arrays so check both
+    let found = items.find(item => 
+      _.isEqual(item.value, searchContext.entityType)  || 
+      _.isEqual([item.value], searchContext.entityType)
+    );
     if (found && found.label) {
       setSelected(found.label);
     } else {

--- a/marklogic-data-hub-central/ui-custom/src/components/SelectedFacets/SelectedFacets.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/SelectedFacets/SelectedFacets.tsx
@@ -20,19 +20,38 @@ const SelectedFacets: React.FC<Props> = (props) => {
 
   const searchContext = useContext(SearchContext);
 
+  const getFacetType = (facetValue) => {
+    const regexDateRange = /^\d{4}-\d{2}-\d{2} ~ \d{4}-\d{2}-\d{2}$/
+    if (regexDateRange.test(facetValue)) {
+      return "dateRange";
+    } else {
+      return "category";
+    }
+  }
+
   const handleClose = (e) => {
     let parts = e.target.id.split(":");
-    searchContext.handleFacetString(parts[0], parts[1], false);
+    if (getFacetType(parts[1]) === "category") {
+      searchContext.handleFacetString(parts[0], parts[1], false);
+    } else if (getFacetType(parts[1]) === "dateRange") {
+      searchContext.handleFacetDateRange(parts[0], parts[1], false);
+    }
   };
 
   const getSelected = () => {
     const fsObj = {};
     searchContext.facetStrings.forEach(fs => {
-      let parts = fs.split(":");
+      const parts = fs.split(":");
       if (fsObj[parts[0]] === undefined) {
-        fsObj[parts[0]] = [parts[1]];
+        fsObj[parts[0]] = [{
+          value: parts[1],
+          type: parts[2]
+        }];
       } else {
-        fsObj[parts[0]].push(parts[1]);
+        fsObj[parts[0]].push({
+          value: parts[1],
+          type: parts[2]
+        });
       }
     })
     const keys = Object.keys(fsObj);
@@ -44,8 +63,8 @@ const SelectedFacets: React.FC<Props> = (props) => {
               {fsObj[k].map((v, index2) => {
                 return (
                   <span key={"selectedValue-" + index2} className={styles.name}>
-                    <span className={styles.nameLabel}>{v}</span>
-                    <span className={styles.close} id={k + ":" + v} onClick={handleClose}>X</span>
+                    <span className={styles.nameLabel}>{v.value}</span>
+                    <span className={styles.close} id={k + ":" + v.value} onClick={handleClose}>X</span>
                   </span>
                 );
               })}

--- a/marklogic-data-hub-central/ui-custom/src/views/Detail.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/views/Detail.tsx
@@ -60,7 +60,7 @@ const Detail: React.FC<Props> = (props) => {
   const [favorite, setFavorite] = useState<any>(false);
   const [expand, setExpand] = useState<any>(true);
 
-  let id = searchParams.get('recordId')
+  const id = searchParams.get('recordId');
   const entityType = detailContext.detail.entityType;
 
   const handleExpandClick = () => {
@@ -85,7 +85,6 @@ const Detail: React.FC<Props> = (props) => {
   };
 
   useEffect(() => {
-    console.log("useEffect id", id);
     setConfig(userContext.config);
     // If config is loaded and id is present but detail context is
     // empty, load detail context so content is displayed

--- a/marklogic-data-hub-central/ui-custom/src/views/Search.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/views/Search.tsx
@@ -1,4 +1,5 @@
 import React, {useState, useContext, useEffect} from "react";
+import {useSearchParams} from "react-router-dom";
 import {UserContext} from "../store/UserContext";
 import {SearchContext} from "../store/SearchContext";
 import Loading from "../components/Loading/Loading";
@@ -23,16 +24,31 @@ const Search: React.FC<Props> = (props) => {
   const userContext = useContext(UserContext);
   const searchContext = useContext(SearchContext);
 
+  const [searchParams, setSearchParams] = useSearchParams();
   const [config, setConfig] = useState<any>(null);
+  const [checkQuery, setCheckQuery] = useState<boolean>(false);
+
+  const queryFromParam = searchParams.get('query');
 
   useEffect(() => {
     setConfig(userContext.config);
-    // If config is loaded but searchResults context is empty, 
-    // load searchResults context so content is displayed
-    if (userContext.config.search && _.isEmpty(searchContext.searchResults)) {
-      searchContext.handleSearch();
+    if (!_.isEmpty(userContext.config)) {
+      // After config is loaded, check loading query from URL param
+      setCheckQuery(true);
     }
   }, [userContext.config]);
+
+  useEffect(() => {
+    if (checkQuery) {
+      if (queryFromParam) {
+        if (searchContext.queryString === "") {
+          // New page load so search with query from URL param
+          searchContext.handleQueryFromParam(JSON.parse(decodeURI(queryFromParam)));
+        }
+      }
+      setCheckQuery(false);
+    }
+  }, [checkQuery]);
 
   return (
     <div className="search">


### PR DESCRIPTION
Search queries added as query param in browser address bar.
User can execute search by copying/pasting browser URL.
User can execute search by copying via Recent Searches widget and pasting.
Refactored search logic across components to support.
Fixed entity menu updates in SearchBox widget.

To test:

- Check that encoded search string is kept as query param in browser address bar when searches are executed.
- Copy the browser URL and use that in separate browser window and confirm that search is correct with no errors.
- Click the "Copy & Share" icon for a saved search on the Dashboard and use that in separate browser window and confirm that search is correct with no errors 
- Confirm that search information appears OK in Saved Searched. It now includes the entity selection (e.g., [person] or [person, organization, thing]). Clicking the linked text should execute correctly without errors.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [ ] JIRA_ID included in all the commit messages
- [ ] PR title is in the format JIRA_ID:Title
- [ ] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [ ] Code passes ESLint tests
- [ ] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki

