### PR TITLE
DHFPROD-8767: Add Property Modal Messaging

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/entity-tiles.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/entity-tiles.test.tsx
@@ -62,7 +62,7 @@ describe("Entity Tiles component", () => {
     });
     //await fireEvent.click(getByText('Customer'));
     // Check for Mapping tab
-    expect(queryAllByText("Map")).toHaveLength(0);
+    expect(queryAllByText("Mapping")).toHaveLength(0);
   });
 
   test("Map tab does appear with readMapping authority", async () => {
@@ -97,9 +97,9 @@ describe("Entity Tiles component", () => {
     expect(queryAllByText("No Entity Type")).toHaveLength(0);
     await fireEvent.click(getByText("Customer"));
     // Check for Mapping tab
-    expect(getByText("Map")).toBeInTheDocument();
+    expect(getByText("Mapping")).toBeInTheDocument();
     // Check for Matching tab
-    expect(queryAllByText("Match")).toHaveLength(0);
+    expect(queryAllByText("Matching")).toHaveLength(0);
     expect(queryAllByText("Custom")).toHaveLength(0);
   });
 
@@ -141,11 +141,11 @@ describe("Entity Tiles component", () => {
 
     await fireEvent.click(customerPanel);
     // Check for Mapping tab
-    expect(getByText("Map")).toBeInTheDocument();
+    expect(getByText("Mapping")).toBeInTheDocument();
     await fireEvent.click(getByText("Custom"));
     expect(getByLabelText("customEntityTitle")).toBeInTheDocument();
     // Check for Matching tab
-    expect(queryAllByText("Match")).toHaveLength(0);
+    expect(queryAllByText("Matching")).toHaveLength(0);
     await fireEvent.click(customerPanel);
 
     await fireEvent.click(NoEntityTypePanel);

--- a/marklogic-data-hub-central/ui/src/components/entities/entity-tiles.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/entity-tiles.tsx
@@ -471,9 +471,9 @@ const EntityTiles = (props) => {
               </Card.Header>
               <Accordion.Body>
                 <Tabs defaultActiveKey={`map`} onSelect={(eventKey) => updateView(index, eventKey, entityType)} className={styles.entityTabs}>
-                  {canReadMapping ? <Tab id={`${entityType}-Map`} data-testid={`${entityType}-Map`} eventKey={`map`} key={`map-${entityType}`}  title="Map" tabClassName={`curateTab`}/>: null}
-                  {props.canReadMatchMerge ? <Tab  id={`${entityType}-Match`} data-testid={`${entityType}-Match`} eventKey="match" key={`match-${entityType}`}  title="Match" tabClassName={`curateTab`}/>: null}
-                  {props.canReadMatchMerge ? <Tab id={`${entityType}-Merge`} data-testid={`${entityType}-Merge`} eventKey="merge" key={`merge-${entityType}`}   title="Merge" tabClassName={`curateTab`}/>: null}
+                  {canReadMapping ? <Tab id={`${entityType}-Map`} data-testid={`${entityType}-Map`} eventKey={`map`} key={`map-${entityType}`}  title="Mapping" tabClassName={`curateTab`}/>: null}
+                  {props.canReadMatchMerge ? <Tab  id={`${entityType}-Match`} data-testid={`${entityType}-Match`} eventKey="match" key={`match-${entityType}`}  title="Matching" tabClassName={`curateTab`}/>: null}
+                  {props.canReadMatchMerge ? <Tab id={`${entityType}-Merge`} data-testid={`${entityType}-Merge`} eventKey="merge" key={`merge-${entityType}`}   title="Merging" tabClassName={`curateTab`}/>: null}
                   {props.canReadCustom ? <Tab id={`${entityType}-Custom`} data-testid={`${entityType}-Custom`} eventKey="custom" key={`custom-${entityType}`}   title="Custom" tabClassName={`curateTab`}/>: null}
                 </Tabs>
                 {outputCards(index, entityType, mappingArtifacts.find((artifact) => artifact.entityTypeId ===  entityModels[entityType].entityTypeId), matchingArtifacts.find((artifact) => artifact.entityTypeId === entityModels[entityType].entityTypeId), mergingArtifacts.find((artifact) => artifact.entityTypeId === entityModels[entityType].entityTypeId), customArtifactsWithEntity.find((artifact) => artifact.entityTypeId === entityModels[entityType].entityTypeId))}

--- a/marklogic-data-hub-central/ui/src/components/job-response/job-response.tsx
+++ b/marklogic-data-hub-central/ui/src/components/job-response/job-response.tsx
@@ -140,7 +140,7 @@ const JobResponse: React.FC<Props> = ({jobId, setOpenJobResponse, openJobRespons
       formatter: (stepName, response) => {
         let stepType = response.stepDefinitionType === "ingestion" ? "loading" : response.stepDefinitionType;
         return (<div data-testid={`${response.stepName}-${stepType}-type`} id={`${response.stepName}-${stepType}-type`} className={styles.stepResponse}>
-          {stepType?.toLowerCase()}
+          {stepType[0].toUpperCase() + stepType.substring(1)}
         </div>);
       }
     },

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.test.tsx
@@ -258,7 +258,7 @@ describe("Property Modal Component", () => {
 
     userEvent.type(getByLabelText("input-name"), "123-name");
     userEvent.click(getByText("Add"));
-    expect(getByText(ModelingTooltips.nameRegex)).toBeInTheDocument();
+    expect(getByText(ModelingTooltips.nameEntityProperty)).toBeInTheDocument();
     userEvent.clear(getByLabelText("input-name"));
 
     userEvent.type(getByLabelText("input-name"), "name2");

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-modal/property-modal.tsx
@@ -379,7 +379,7 @@ const PropertyModal: React.FC<Props> = (props) => {
   const onSubmit = (event) => {
     event.preventDefault();
     if (!NAME_REGEX.test(name)) {
-      setErrorMessage(ModelingTooltips.nameRegex);
+      setErrorMessage(ModelingTooltips.nameEntityProperty);
     } else {
       if (props.editPropertyOptions.isEdit) {
         let editEntityPropertyNamesArray = entityPropertyNamesArray.filter(propertyName => propertyName !== props.editPropertyOptions.name);
@@ -902,7 +902,7 @@ const PropertyModal: React.FC<Props> = (props) => {
         )}
 
         <Row className={"mb-3"}>
-          <FormLabel column lg={3}>{"Name:"}</FormLabel>
+          <FormLabel column lg={3}>{"Name:"}<span className={styles.asterisk}>*</span></FormLabel>
           <Col>
             <Row>
               <Col className={errorMessage ? "d-flex has-error" : "d-flex"}>

--- a/marklogic-data-hub-central/ui/src/components/monitor-facet/monitor-facet.tsx
+++ b/marklogic-data-hub-central/ui/src/components/monitor-facet/monitor-facet.tsx
@@ -119,10 +119,10 @@ const MonitorFacet: React.FC<Props> = (props) => {
           id={"facet" + index}
           handleClick={(e) => handleClick(e)}
           value={facet.value}
-          label={facet?.value.toLowerCase() === "ingestion" ? "loading": facet.value}
+          label={facet?.value.toLowerCase() === "ingestion" ? "Loading": stringConverter(props.displayName) === "step-type" ? facet.value[0].toUpperCase() + facet.value.substring(1) : facet.value}
           checked={checked.includes(facet.value)}
           dataTestId={`${stringConverter(props.displayName)}-${facet.value}-checkbox`}
-          tooltip={facet?.value.toLowerCase() === "ingestion" ? "loading": facet.value}
+          tooltip={facet?.value.toLowerCase() === "ingestion" ? "Loading": facet.value[0].toUpperCase() + facet.value.substring(1)}
         />
       </div>
     );

--- a/marklogic-data-hub-central/ui/src/components/tiles/tiles.tsx
+++ b/marklogic-data-hub-central/ui/src/components/tiles/tiles.tsx
@@ -203,7 +203,7 @@ const Tiles: React.FC<Props> = (props) => {
           </>)}
         </div>
         <div className={styles.controls}>
-          {showControl("menu") ? (
+          {showControl("menu") && viewId !== "monitor" ? (
             <>
               <div>
                 {exploreSettingsMenu}

--- a/marklogic-data-hub-central/ui/src/pages/Curate.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Curate.test.tsx
@@ -45,9 +45,9 @@ describe("Curate component", () => {
     expect(axiosMock.get).toBeCalledWith("/api/steps/mapping");
     fireEvent.click(getByText("Customer"));
     //Mapping tab should show. Match/Merge should not
-    expect(getByText("Map")).toBeInTheDocument();
-    expect(queryByText("Match")).not.toBeInTheDocument();
-    expect(queryByText("Merge")).not.toBeInTheDocument();
+    expect(getByText("Mapping")).toBeInTheDocument();
+    expect(queryByText("Matching")).not.toBeInTheDocument();
+    expect(queryByText("Merging")).not.toBeInTheDocument();
 
     expect(getByText("Mapping3")).toBeInTheDocument();
 
@@ -79,9 +79,9 @@ describe("Curate component", () => {
     expect(axiosMock.get).toBeCalledWith("/api/steps/mapping");
     fireEvent.click(getByText("Customer"));
     //Mapping tab should show. Match/Merge should not
-    expect(getByText("Map")).toBeInTheDocument();
-    expect(queryByText("Match")).not.toBeInTheDocument();
-    expect(queryByText("Merge")).not.toBeInTheDocument();
+    expect(getByText("Mapping")).toBeInTheDocument();
+    expect(queryByText("Matching")).not.toBeInTheDocument();
+    expect(queryByText("Merging")).not.toBeInTheDocument();
 
     expect(getByText("Mapping1")).toBeInTheDocument();
 


### PR DESCRIPTION
### Description
Includes the following:
- DHFPROD-8767: In Hub Central, displaying incorrect error message in the "Add Property" modal
- DHFPROD-8670: Change step name format in Hub Central
- DHFPROD-8711: Remove Query Settings from Monitoring Tile

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests
- N/A Added to Release Wiki

