### PR TITLE
DHFPROD-8846: Install Entity Viewer modules only on EntityViewer build

### DIFF
--- a/marklogic-data-hub-central/gradle.properties
+++ b/marklogic-data-hub-central/gradle.properties
@@ -1,4 +1,4 @@
-reactUiPath=./ui-custom
+reactUiPath=./ui
 springBootUiPath=src/main/resources/static
 springBootJarName=marklogic-data-hub-central
 

--- a/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/auth/AuthenticationFilter.java
+++ b/marklogic-data-hub-central/src/main/java/com/marklogic/hub/central/auth/AuthenticationFilter.java
@@ -127,7 +127,7 @@ public class AuthenticationFilter extends AbstractAuthenticationProcessingFilter
             throw e;
         }
 
-        if(!environment.getProperty("mlContentServerPort").isEmpty()) {
+        if(environment.getProperty("mlContentServerPort") != null && !environment.getProperty("mlContentServerPort").isEmpty()) {
             hubClientProvider.getHubClient().setCustomDbClient(Integer.parseInt(environment.getProperty("mlContentServerPort")));
         }
         response.get("authorities").iterator().forEachRemaining(node -> {

--- a/marklogic-data-hub-central/ui/package-lock.json
+++ b/marklogic-data-hub-central/ui/package-lock.json
@@ -4703,17 +4703,6 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "optional": true,
-<<<<<<< HEAD
-=======
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
->>>>>>> 5005e907e (Add Twizzlers-UI to repo as ui-custom directory)
       "requires": {
         "file-uri-to-path": "1.0.0"
       }


### PR DESCRIPTION
### Description

There are two things to test on this branch

1. The Hubcentral build and
2. The EntityViewer build

Testing HubCentral build:

1. Run ./gradlew clean build -x test to build hub central war file
2. Clean you ML database and deploy reference-entity-model project
3. Run the war file created in the marklogic-data-hub-central/build/libs directory
4. The application should start up without any issues and should be able to use all the features of HC

Testing EntityViewer build:

1. Run ./gradlew clean build -x test -Pwar.archiveName=marklogic-entity-viewer -Pversion=rc-1 -PreactUiPath=./ui-custom to build entity-viewer war file
2. Clean you ML database and deploy entity-viewer-v2/entity-viewer-client project
3. Run the war file created in the marklogic-data-hub-central/build/libs directory
4. The application should start up and deploy entity-viewer modules without any issues and should be able to use all the features of Entity-Viewer

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
