### PR TITLE
DHFPROD-8857: Remove unneeded config values for Detail

### DIFF
--- a/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/ui-config/config.json
+++ b/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/ui-config/config.json
@@ -2,8 +2,6 @@
   "api": {
     "searchResultsEndpoint": "/api/explore",
     "detailEndpoint": "/api/explore/getRecord",
-    "detailType": "person",
-    "detailConstraint": "personId",
     "recordsEndpoint": "/api/explore/getRecords",
     "recentEndpoint": "/api/explore/recentlyVisited",
     "recentStorage": "local",


### PR DESCRIPTION
We now use a non-search endpoint (in the example app, /api/explore/getRecord) to retrieve a single record for the Detail view.
We don't need the additional config settings to constrain the results to get a single record.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki

