### PR TITLE
DHFPROD-8867: Ensure search response result value is an array

### DIFF
--- a/marklogic-data-hub-central/ui-custom/src/store/SearchContext.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/store/SearchContext.tsx
@@ -170,7 +170,10 @@ const SearchProvider: React.FC = ({children}) => {
         navigate("/search?query=" + newQueryStr); // Handle search submit from another view
       }
       sr.then(result => {
-        console.log("getSearchResultsByGet", result?.data);
+        // Ensure search response result is an array
+        if (result && !Array.isArray(result?.data?.searchResults?.response?.result)) {
+          result.data.searchResults.response.result = [result.data.searchResults.response.result];
+        }
         setSearchResults(result?.data.searchResults.response);
         setReturned(parseInt(result?.data.searchResults.response.total));
         setTotal(_.get(result?.data, userContext.config.search.meter.config.totalPath, null) || 0);


### PR DESCRIPTION
### Description

This fixes the error where a single search result is not displayed in the UI, since the result value is not stored in an array in the result response.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests
- [ ] Added to Release Wiki

