### PR TITLE
DHFPROD-7922: Display concepts related via custom triples in graph view

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/explore/graph-explore-side-panel/graph-explore-side-panel.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/explore/graph-explore-side-panel/graph-explore-side-panel.module.scss
@@ -51,6 +51,10 @@
     .instanceTabContainer {
         padding-top: 5px;
     }
+    
+    .conceptInfoContainer {
+        padding-top: 10px;
+    }
 }
 
 .arrowRightSquare{

--- a/marklogic-data-hub-central/ui/src/components/explore/graph-explore-side-panel/graph-explore-side-panel.tsx
+++ b/marklogic-data-hub-central/ui/src/components/explore/graph-explore-side-panel/graph-explore-side-panel.tsx
@@ -9,7 +9,7 @@ import {SearchContext} from "@util/search-context";
 import styles from "./graph-explore-side-panel.module.scss";
 import {xmlParser, xmlDecoder, xmlFormatter, jsonFormatter} from "@util/record-parser";
 import TableView from "@components/table-view/table-view";
-import {HCTooltip} from "@components/common";
+import {HCTable, HCTooltip} from "@components/common";
 
 type Props = {
     onCloseSidePanel:() => void;
@@ -27,7 +27,7 @@ const GraphExploreSidePanel: React.FC<Props> = (props) => {
     savedNode
   } = useContext(SearchContext);
   const  {database, entityTypeIds, selectedFacets, query, sortOrder} = searchOptions;
-  const {entityName, group, primaryKey, sources, entityInstance, label} = savedNode;
+  const {entityName, group, primaryKey, sources, entityInstance, label, isConcept} = savedNode;
   const docUri = savedNode["docURI"] || savedNode["docUri"] || savedNode["uri"];
   const [currentTab, setCurrentTab] = useState(DEFAULT_TAB);
   const [details, setDetails] = useState<any>(null);
@@ -132,6 +132,52 @@ const GraphExploreSidePanel: React.FC<Props> = (props) => {
     graphView,
   };
 
+  /* TODO: Remove hardcoded data when backend work is completed as part of DHFPROD-8851 */
+  const conceptInfoData = [
+    {
+      entityType: "Product",
+      relatedInstances: "1"
+    }
+  ];
+
+  const conceptInfoColumns = [
+    {
+      text: "Related Instances",
+      title: "Related Instances",
+      dataField: "relatedInstances",
+      key: "relatedInstances",
+      width: "40%",
+      formatter: (value) => {
+        return <span>{value}</span>;
+      }
+    },
+    {
+      text: "Entity Type",
+      title: "Entity Type",
+      dataField: "entityType",
+      key: "entityType",
+      formatter: (value) => {
+        return <span>{value}</span>;
+      },
+      width: "60%",
+    }
+  ];
+
+  const conceptInstanceInfo = (
+    <div className={styles.conceptInfoContainer}>
+      <HCTable columns={conceptInfoColumns}
+        className={styles.conceptInfoTable}
+        data={conceptInfoData}
+        nestedParams={{headerColumns: conceptInfoColumns, iconCellList: [], state: []}}
+        childrenIndent={true}
+        data-cy="document-table"
+        rowKey="entityType"
+        showHeader={true}
+        baseIndent={20}
+      />
+    </div>
+  );
+
   return (
     <div data-testid="graphSidePanel" className={styles.sidePanel}>
       <div>
@@ -151,23 +197,26 @@ const GraphExploreSidePanel: React.FC<Props> = (props) => {
           </i>
         </span>
       </div>
-      <div>
-        {docUri && <span className={styles.selectedNodeUri} data-testid="uriLabel" aria-label={docUri}>URI: {docUri}</span>}
-      </div>
-      <Tabs defaultActiveKey={DEFAULT_TAB} activeKey={currentTab} onSelect={handleTabChange} className={styles.tabsContainer}>
-        <Tab
-          eventKey="instance"
-          aria-label="instanceTabInSidePanel"
-          id="instanceTabInSidePanel"
-          title={INSTANCE_TITLE}
-          className={styles.instanceTabContainer}/>
-        <Tab
-          eventKey="record"
-          aria-label="recordTabInSidePanel"
-          id="recordTabInSidePanel"
-          title={RECORD_TITLE}/>
-      </Tabs>
-      {displayPanelContent()}
+      {
+        !isConcept ? <><div>
+          {docUri && <span className={styles.selectedNodeUri} data-testid="uriLabel" aria-label={docUri}>URI: {docUri}</span>}
+        </div>
+        <Tabs defaultActiveKey={DEFAULT_TAB} activeKey={currentTab} onSelect={handleTabChange} className={styles.tabsContainer}>
+          <Tab
+            eventKey="instance"
+            aria-label="instanceTabInSidePanel"
+            id="instanceTabInSidePanel"
+            title={INSTANCE_TITLE}
+            className={styles.instanceTabContainer}/>
+          <Tab
+            eventKey="record"
+            aria-label="recordTabInSidePanel"
+            id="recordTabInSidePanel"
+            title={RECORD_TITLE}/>
+        </Tabs>
+        {displayPanelContent()}</> :
+          conceptInstanceInfo
+      }
     </div>
   );
 };

--- a/marklogic-data-hub-central/ui/src/config/explore.config.tsx
+++ b/marklogic-data-hub-central/ui/src/config/explore.config.tsx
@@ -22,6 +22,7 @@ export const graphViewConfig = {
 }
 
 export const defaultIcon = "FaShapes";
+export const defaultConceptIcon = "FaLightbulb";
 
 export const expandThresholdExceededWarning = (entityType) => (`This group of ${entityType} records cannot be fully expanded. Expanding this group will exceed the maximum threshold the graph can display. To view the records in this group, see the following table.`);
 

--- a/marklogic-data-hub-central/ui/src/config/themes.config.js
+++ b/marklogic-data-hub-central/ui/src/config/themes.config.js
@@ -46,10 +46,12 @@ const themeColors = {
     "danger": "#b32424",
     "light": "#cccc",
     "dark": "#343a40",
+    "text-color-secondary": "#777777",
 
     "defaults": {
         "entityColor": "#eeeff1",
-        "questionCircle": "#7f86b5"
+        "questionCircle": "#7f86b5",
+        "conceptColor": "#FFFFFF"
     }
 }
 


### PR DESCRIPTION
### Description
This is just a visual enhancement of the already existing concept nodes in explorer. E2E for concept nodes should be added as part of interactions like expand/collapse, in separate stories.

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [ ] JIRA_ID included in all the commit messages
- [ ] PR title is in the format JIRA_ID:Title
- [ ] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [ ] Code passes ESLint tests
- [N/A] Added Tests
  

- ##### Reviewer:

- [N/A] Reviewed Tests
- [ ] Added to Release Wiki

