### PR TITLE
DHFPROD-8871: Support text-based nodes in Relationships

### DIFF
--- a/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/ui-config/config.json
+++ b/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/ui-config/config.json
@@ -822,10 +822,14 @@
         "relationships": {
           "component": "Relationships",
           "config": {
+            "type": "text",
             "size": 30,
             "root": {
               "id": {
                 "path": "uri"
+              },
+              "label": {
+                "path": "person.nameGroup.fullname.value"
               },
               "imgSrc": {
                 "arrayPath": "person.images.image",
@@ -850,6 +854,9 @@
               },
               "predicate": {
                 "path": "predicate"
+              },
+              "label": {
+                "path": "fullname"
               },
               "imgSrc": {
                 "path": "imageSrc"

--- a/marklogic-data-hub-central/ui-custom/src/components/Relationships/Relationships.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Relationships/Relationships.test.tsx
@@ -6,10 +6,14 @@ import userEvent from '@testing-library/user-event'
 const relationshipsConfig = {
     component: "Relationships",
     config: {
+        type: "text",
         size: 30,
         root: {
             id: {
                 path: "result[0].extracted.person.id"
+            },
+            label: {
+                path: "result[0].extracted.person.fullname"
             },
             imgSrc: {
                 path: "result[0].extracted.person.image.url"
@@ -28,6 +32,7 @@ const relationshipsConfig = {
             arrayPath: "result[0].extracted.person.relations.relation",
             id: "id",
             predicate: "predicate",
+            label: "fullname",
             imgSrc: "imageSrc",
             title: "fullname",
             city: "city",

--- a/marklogic-data-hub-central/ui-custom/src/components/Relationships/Relationships.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Relationships/Relationships.tsx
@@ -78,21 +78,63 @@ const Relationships: React.FC<Props> = (props) => {
         return popover;
     }
 
-    useEffect(() => {
-        const nodeSize = props.config.size ? props.config.size : 30;
-
-        // Set up root entity
-        const rootId = getValByConfig(props.data, props.config.root.id);
-        let rootImgSrc = getValByConfig(props.data, props.config.root.imgSrc);
-        rootImgSrc = _.isNil(rootImgSrc) ? null : (Array.isArray(rootImgSrc) ? rootImgSrc[0] : rootImgSrc);
-        const rootTitle = getValByConfig(props.data, props.config.root.title);
-        const rootCity = getValByConfig(props.data, props.config.root.city);
-        const rootState = getValByConfig(props.data, props.config.root.state);
+    const getRootNode = (data, rootConfig, type) => {
+        const rootId = getValByConfig(data, rootConfig.id);
+        const rootTitle = getValByConfig(data, rootConfig.title);
+        const rootCity = getValByConfig(data, rootConfig.city);
+        const rootState = getValByConfig(data, rootConfig.state);
         const rootPopover = getPopover(
             Array.isArray(rootTitle) ? rootTitle[0] : rootTitle, 
             Array.isArray(rootCity) ? rootCity[0] : rootCity,
             Array.isArray(rootState) ? rootState[0] : rootState
         );
+        let rootObj: any;
+        if (type === "text") {
+            let rootLabel = getValByConfig(data, rootConfig.imgSrc);
+            rootLabel = _.isNil(rootLabel) ? null : (Array.isArray(rootLabel) ? rootLabel[0] : rootLabel);
+            rootObj = { id: rootId, label: rootTitle, shape: "box", borderWidth: 0, color: "#D4DEFF", title: rootPopover};
+        } else if (type === "image") {
+            let rootImgSrc = getValByConfig(data, rootConfig.imgSrc);
+            rootImgSrc = _.isNil(rootImgSrc) ? null : (Array.isArray(rootImgSrc) ? rootImgSrc[0] : rootImgSrc);
+            rootObj = { id: rootId, shape: "image", size: 30, image: rootImgSrc, title: rootPopover};
+        }
+        return rootObj;
+    }
+
+    const getRelationNode = (data, relationsConfig, type) => {
+        let relObj: any;
+        if (type === "text") {
+            relObj = { 
+                id: getValByConfig(data, relationsConfig.id), 
+                label: getValByConfig(data, relationsConfig.title),
+                shape: "box",
+                borderWidth: 0, 
+                color: "#D4DEFF",
+                title: getPopover(
+                    getValByConfig(data, relationsConfig.title),
+                    getValByConfig(data, relationsConfig.city),
+                    getValByConfig(data, relationsConfig.state)
+                ) 
+            }
+        } else if (type === "image") {
+            relObj = { 
+                id: getValByConfig(data, relationsConfig.id), 
+                image: getValByConfig(data, relationsConfig.imgSrc),
+                shape: "image", 
+                size: 30, 
+                title: getPopover(
+                    getValByConfig(data, relationsConfig.title),
+                    getValByConfig(data, relationsConfig.city),
+                    getValByConfig(data, relationsConfig.state)
+                ) 
+            }
+        }
+        return relObj;
+    }
+
+    useEffect(() => {
+        const nodeSize = props.config.size ? props.config.size : 30;
+        const rootId = getValByConfig(props.data, props.config.root.id);
 
         // Set up related entities
         let relations = getValByConfig(props.data, props.config.relations);
@@ -104,20 +146,10 @@ const Relationships: React.FC<Props> = (props) => {
             return;
         }
 
-        // Add root, related to nodes
-        const nodes: any = [{ id: rootId, shape: "image", size: nodeSize, image: rootImgSrc, title: rootPopover}];
+        // Add root, relation nodes
+        const nodes: any = [getRootNode(props.data, props.config.root, props.config.type)];
         relations.forEach(rel => {
-            nodes.push({ 
-                id: getValByConfig(rel, props.config.relations.id), 
-                image: getValByConfig(rel, props.config.relations.imgSrc),
-                shape: "image", 
-                size: nodeSize, 
-                title: getPopover(
-                    getValByConfig(rel, props.config.relations.title),
-                    getValByConfig(rel, props.config.relations.city),
-                    getValByConfig(rel, props.config.relations.state)
-                ) 
-            });
+            nodes.push(getRelationNode(rel, props.config.relations, props.config.type));
         });
 
         // Construct edges from root


### PR DESCRIPTION
### Description

Screencast: https://watch.screencastify.com/v/ok6HhcTL8j617D0rEPEG

With this update, users can now use text-based graph nodes in the Relationships widget. In config.json, they set the "type" property to "text" (or to "image" if they want image-based) and add "label" properties to map the text they want on the nodes.

FYI: We currently do not have unit tests for the Relationships widget, these will come later as there are canvas-related errors (Hub Central dev's have experienced similar, per @xnikhil08). Ticket for this: https://project.marklogic.com/jira/browse/DHFPROD-8874

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki

