### PR TITLE
DHFPROD-8831: Refactor Relationships popover tooltip

### DIFF
--- a/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/ui-config/detail.config.sjs
+++ b/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/ui-config/detail.config.sjs
@@ -317,16 +317,23 @@ const detailConfig  = {
                     "arrayPath": "person.images.image",
                     "path": "url"
                   },
-                  "title": {
-                    "path": "person.nameGroup.fullname.value"
-                  },
-                  "city": {
-                    "arrayPath": "person.addresses.address",
-                    "path": "city"
-                  },
-                  "state": {
-                    "arrayPath": "person.addresses.address",
-                    "path": "state"
+                  "popover": {
+                    "items": [
+                      {
+                        "label": "Name",
+                        "path": "person.nameGroup.fullname.value"
+                      },
+                      {
+                        "label": "City",
+                        "arrayPath": "person.addresses.address",
+                        "path": "city"
+                      },
+                      {
+                        "label": "State",
+                        "arrayPath": "person.addresses.address",
+                        "path": "state"
+                      }
+                    ]
                   }
                 },
                 "relations": {
@@ -343,14 +350,21 @@ const detailConfig  = {
                   "imgSrc": {
                     "path": "imageSrc"
                   },
-                  "title": {
-                    "path": "fullname"
-                  },
-                  "city": {
-                    "path": "city"
-                  },
-                  "state": {
-                    "path": "state"
+                  "popover": {
+                    "items": [
+                      {
+                        "label": "Name",
+                        "path": "fullname"
+                      },
+                      {
+                        "label": "City",
+                        "path": "city"
+                      },
+                      {
+                        "label": "State",
+                        "path": "state"
+                      }
+                    ]
                   }
                 },
                 "options": {}

--- a/marklogic-data-hub-central/ui-custom/src/components/Relationships/Relationships.scss
+++ b/marklogic-data-hub-central/ui-custom/src/components/Relationships/Relationships.scss
@@ -8,8 +8,9 @@
         white-space: nowrap;
         font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
         font-size: 14px;
-        .title {
+        .label {
             font-weight: bold;
+            margin-right: 8px;
         }
     }
 }

--- a/marklogic-data-hub-central/ui-custom/src/components/Relationships/Relationships.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Relationships/Relationships.tsx
@@ -63,38 +63,42 @@ const Relationships: React.FC<Props> = (props) => {
     // Any option overrides from config
     options = Object.assign(options, props?.config?.options);
 
-    const getPopover = (title, city, state) => {
+    const getPopover = (items) => {
         const popover = document.createElement("div");
         popover.className = "popover";
-        const titleDiv = document.createElement("div");
-        titleDiv.className = "title";
-        const nameContent = document.createTextNode(title);
-        titleDiv.appendChild(nameContent);
-        const placeDiv = document.createElement("div");
-        const placeContent = document.createTextNode(city + ", " + state);
-        placeDiv.appendChild(placeContent);
-        popover.appendChild(titleDiv);
-        popover.appendChild(placeDiv);
+        items.forEach(item => {
+            const itemDiv = document.createElement("div");
+            const labelSpan = document.createElement("span");
+            labelSpan.className = "label";
+            const labelContent = document.createTextNode(item.label);
+            labelSpan.appendChild(labelContent);
+            const valueSpan = document.createElement("span");
+            valueSpan.className = "value";
+            const valueContent = document.createTextNode(item.value);
+            valueSpan.appendChild(valueContent);
+            itemDiv.appendChild(labelSpan);
+            itemDiv.appendChild(valueSpan);
+            popover.appendChild(itemDiv);
+        });
         return popover;
     }
 
     const getRootNode = (data, rootConfig, type) => {
         const rootId = getValByConfig(data, rootConfig.id);
-        const rootTitle = getValByConfig(data, rootConfig.title);
-        const rootCity = getValByConfig(data, rootConfig.city);
-        const rootState = getValByConfig(data, rootConfig.state);
-        const rootPopover = getPopover(
-            Array.isArray(rootTitle) ? rootTitle[0] : rootTitle, 
-            Array.isArray(rootCity) ? rootCity[0] : rootCity,
-            Array.isArray(rootState) ? rootState[0] : rootState
-        );
+        let rootItems: any = [];
+        rootConfig?.popover?.items.forEach(item => {
+            const label =  item.label;
+            const value =  getValByConfig(data, item, true);
+            rootItems.push({label: label, value: value});
+        })
+        const rootPopover = getPopover(rootItems);
         let rootObj: any;
         if (type === "text") {
-            let rootLabel = getValByConfig(data, rootConfig.imgSrc);
+            let rootLabel = getValByConfig(data, rootConfig.label, true);
             rootLabel = _.isNil(rootLabel) ? null : (Array.isArray(rootLabel) ? rootLabel[0] : rootLabel);
-            rootObj = { id: rootId, label: rootTitle, shape: "box", borderWidth: 0, color: "#D4DEFF", title: rootPopover};
+            rootObj = { id: rootId, label: rootLabel, shape: "box", borderWidth: 0, color: "#D4DEFF", title: rootPopover};
         } else if (type === "image") {
-            let rootImgSrc = getValByConfig(data, rootConfig.imgSrc);
+            let rootImgSrc = getValByConfig(data, rootConfig.imgSrc, true);
             rootImgSrc = _.isNil(rootImgSrc) ? null : (Array.isArray(rootImgSrc) ? rootImgSrc[0] : rootImgSrc);
             rootObj = { id: rootId, shape: "image", size: 30, image: rootImgSrc, title: rootPopover};
         }
@@ -103,30 +107,28 @@ const Relationships: React.FC<Props> = (props) => {
 
     const getRelationNode = (data, relationsConfig, type) => {
         let relObj: any;
+        let relItems: any = [];
+        relationsConfig?.popover?.items.forEach(item => {
+            const label =  item.label;
+            const value =  getValByConfig(data, item, true);
+            relItems.push({label: label, value: value});
+        })
         if (type === "text") {
             relObj = { 
                 id: getValByConfig(data, relationsConfig.id), 
-                label: getValByConfig(data, relationsConfig.title),
+                label: getValByConfig(data, relationsConfig.label, true),
                 shape: "box",
                 borderWidth: 0, 
                 color: "#D4DEFF",
-                title: getPopover(
-                    getValByConfig(data, relationsConfig.title),
-                    getValByConfig(data, relationsConfig.city),
-                    getValByConfig(data, relationsConfig.state)
-                ) 
+                title: getPopover(relItems) 
             }
         } else if (type === "image") {
             relObj = { 
                 id: getValByConfig(data, relationsConfig.id), 
-                image: getValByConfig(data, relationsConfig.imgSrc),
+                image: getValByConfig(data, relationsConfig.imgSrc, true),
                 shape: "image", 
                 size: 30, 
-                title: getPopover(
-                    getValByConfig(data, relationsConfig.title),
-                    getValByConfig(data, relationsConfig.city),
-                    getValByConfig(data, relationsConfig.state)
-                ) 
+                title: getPopover(relItems) 
             }
         }
         return relObj;


### PR DESCRIPTION
Make it configurable with any properties with label/value pairs, similar to Timeline popover.

```
                  "popover": {
                    "items": [
                      {
                        "label": "Name",
                        "path": "person.nameGroup.fullname.value"
                      },
                      {
                        "label": "City",
                        "arrayPath": "person.addresses.address",
                        "path": "city"
                      },
                      {
                        "label": "State",
                        "arrayPath": "person.addresses.address",
                        "path": "state"
                      }
                    ]
                  }
```

<img width="658" alt="Screen Shot 2022-05-10 at 12 12 15 PM" src="https://user-images.githubusercontent.com/477757/167704657-e14f4e7a-509a-4764-a79e-4f16ca1571dc.png">


### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [ ] JIRA_ID included in all the commit messages
- [ ] PR title is in the format JIRA_ID:Title
- [ ] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [ ] Code passes ESLint tests
- [ ] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki

