### PR TITLE
DHFPROD-8894: Handle simple arrays in DataTableValue

### DIFF
--- a/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/ui-config/detail.config.sjs
+++ b/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/ui-config/detail.config.sjs
@@ -98,8 +98,7 @@ const detailConfig  = {
                   "config": {
                     "id": "phone",
                     "title": "Phone Number",
-                    "path": "person",
-                    "value": "phone",
+                    "arrayPath": "person.phone",
                     "icon": "phone",
                     "width": "400px",
                     "metadata": [

--- a/marklogic-data-hub-central/ui-custom/src/components/DataTableValue/DataTableValue.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/DataTableValue/DataTableValue.test.tsx
@@ -72,7 +72,7 @@ const configArrayPathSingular = {
         id: "name",
         title: "Name",
         arrayPath: "person.nameGroup.fullname",
-        path: "value",
+        value: "value",
         metadata: [
             {
                 type: "block",
@@ -346,9 +346,27 @@ const detail = {
     "uri": "/person/10021.xml"
 };
 
+const EXPANDIDS = {
+    membership: true,
+    info: true,
+    relationships: true,
+    imageGallery: true,
+    timeline: true
+}
+
 const detailContextValue = {
     detail: detail,
-    handleDetail: jest.fn()
+    recentRecords: [],
+    loading: false,
+    expandIds: EXPANDIDS,
+    handleGetDetail: jest.fn(),
+    handleGetRecent: jest.fn(),
+    handleGetRecentLocal: jest.fn(),
+    handleSaveRecent: jest.fn(),
+    handleSaveRecentLocal: jest.fn(),
+    handleExpandIds: jest.fn(),
+    handleDeleteAllRecent: jest.fn(), 
+    hasSavedRecords: jest.fn()
 };
 
 describe("DataTableValue component", () => {

--- a/marklogic-data-hub-central/ui-custom/src/components/DataTableValue/DataTableValue.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/DataTableValue/DataTableValue.tsx
@@ -99,7 +99,7 @@ const DataTableValue: React.FC<Props> = (props) => {
                             if (d[props?.config?.value]) {
                                 value = d[props.config.value];
                             } else {
-                                if (Array.isArray(d)) {
+                                if (Array.isArray(d) || !_.isObject(d)) {
                                     value = d
                                 }
                             }


### PR DESCRIPTION
### Description

Handle the case where the original data looks like this:
```
<phone>917-910-6575</phone>
<phone>917-910-6576</phone>
```
The JSON results look like this:
```
['917-910-6575', '917-910-6576']
```
(No metadata.)

And the DataTableValue config looks like this:
```
"config": {
"id": "phone",
"title": "Phone Number",
"arrayPath": "person.phone",
"icon": "phone",
"width": "400px",
```
(In this case, value property is not needed because no metadata and we want to show the two strings.)

This case is tested here: https://github.com/wooldridge/marklogic-data-hub/blob/DHFPROD-8894/marklogic-data-hub-central/ui-custom/src/components/DataTableValue/DataTableValue.test.tsx#L53

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki

