### PR TITLE
DHFPROD-8931: Fix proxying behavior for getting loginAddress

### DIFF
--- a/marklogic-data-hub-central/ui-custom/src/App.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/App.tsx
@@ -16,8 +16,8 @@ const App: React.FC<Props> = (props) => {
 
   const userContext = useContext(UserContext);
 
-  if (!userContext.proxy) {
-    userContext.handleGetProxy();
+  if (!userContext.loginAddress) {
+    userContext.handleGetLoginAddress();
   }
 
   return (

--- a/marklogic-data-hub-central/ui-custom/src/api/api.ts
+++ b/marklogic-data-hub-central/ui-custom/src/api/api.ts
@@ -58,7 +58,7 @@ const getRandomInt = (min, max) => {
   return Math.floor(Math.random() * (max - min) + min); //The maximum is exclusive and the minimum is inclusive
 }
 
-export const getProxy = async () => { 
+export const getLoginAddress = async () => { 
   try {
     const response = await axios.get("/api/explore/proxyAddress");
     if (response && response.status === 200) {
@@ -66,20 +66,26 @@ export const getProxy = async () => {
     }
   } catch (error) {
     let message = error;
-    console.error("Error: getProxy", message);
+    console.error("Error: getLoginAddress", message);
   }
 };
 
-export const getUserid = async (proxy) => { 
+export const getUserid = async (loginAddress) => { 
   // setupProxy.js script will dynamically proxy to x-forward value
   let config = {
     headers: {
-      'x-forward': proxy
+      'x-forward': loginAddress
     }
   }
   try {
-    // URL string here just needs to match what is in setupProxy.js
-    const response = await axios.get("/api/explore/login", config);
+    let response;
+    if (process.env.NODE_ENV === "development") {
+        // Development: URL string here needs to match what is in setupProxy.js
+        response = await axios.get("/proxied", config);
+    } else {
+        // Production: CORS will need to be enabled on the loginAddress server 
+        response = await axios.get(loginAddress);
+    }
     if (response && response.status === 200) {
       return response;
     }

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.test.tsx
@@ -190,7 +190,7 @@ const detailContextValue = {
 describe("ResultsList component", () => {
 
     test("Verify list items appear and titles are clickable when results returned", () => {
-        const {getByText, getAllByAltText, debug} = render(
+        const {getByText, getAllByAltText} = render(
             <SearchContext.Provider value={searchContextValue}>
                 <DetailContext.Provider value={detailContextValue}>
                     <ResultsList config={resultsListConfig} />
@@ -205,7 +205,6 @@ describe("ResultsList component", () => {
         expect(getByText("123-45-6789")).toBeInTheDocument(); // Subtitle 
         expect(getByText("active")).toBeInTheDocument(); // Status
         expect(getByText("Time is 2020-01-01")).toBeInTheDocument(); // Timestamp
-        debug();
         userEvent.click(title);
         expect(detailContextValue.handleGetDetail).toHaveBeenCalledWith(searchResults.result[0].uri);
         userEvent.click(getByText("Jane Doe"));

--- a/marklogic-data-hub-central/ui-custom/src/components/SearchBox/SearchBox.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/SearchBox/SearchBox.test.tsx
@@ -74,7 +74,7 @@ describe("SearchBox component", () => {
     });
 
     test("Verify submit button appears when configured and is clickable", () => {
-        const {getByTestId, queryByTestId, debug} = render(
+        const {getByTestId, queryByTestId} = render(
             <SearchContext.Provider value={searchContextValue}>
                 <SearchBox button="vertical" />
             </SearchContext.Provider>

--- a/marklogic-data-hub-central/ui-custom/src/setupProxy.js
+++ b/marklogic-data-hub-central/ui-custom/src/setupProxy.js
@@ -2,7 +2,7 @@ const { createProxyMiddleware } = require("http-proxy-middleware");
 const request = require('request');
 
 module.exports = function(app) {
-    app.get('/api/explore/login', (req, res) => {
+    app.get('/proxied', (req, res) => {
         // For dynamic proxying, get URI from header
         const { headers } = req;
         const uri = headers['x-forward'];

--- a/marklogic-data-hub-central/ui-custom/src/store/DetailContext.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/store/DetailContext.tsx
@@ -106,7 +106,6 @@ const DetailProvider: React.FC = ({children}) => {
     // Get from database
     let sr = getRecent(userContext.config.api.recentEndpoint, userContext.userid);
     sr.then(result => {
-      console.log("recent", result?.data);
       setRecentRecords(result?.data);
       setLoading(false);
     }).catch(error => {

--- a/marklogic-data-hub-central/ui-custom/src/store/UserContext.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/store/UserContext.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import { getProxy, getUserid, login, getConfig } from "../api/api";
+import { getLoginAddress, getUserid, login, getConfig } from "../api/api";
 interface UserContextInterface {
     userid: string;
-    proxy: string;
+    loginAddress: string;
     config: any;
-    handleGetProxy: any;
+    handleGetLoginAddress: any;
     handleGetUserid: any;
     handleLogin: any;
     handleGetConfig: any;
@@ -12,9 +12,9 @@ interface UserContextInterface {
   
 const defaultState = {
     userid: "",
-    proxy: "",
+    loginAddress: "",
     config: {},
-    handleGetProxy: () => {},
+    handleGetLoginAddress: () => {},
     handleGetUserid: () => {},
     handleLogin: () => {},
     handleGetConfig: () => {}
@@ -33,16 +33,16 @@ export const UserContext = React.createContext<UserContextInterface>(defaultStat
 
 const UserProvider: React.FC = ({ children }) => {
 
-  const [proxy, setProxy] = useState<string>("");
+  const [loginAddress, setLoginAddress] = useState<string>("");
   const [userid, setUserid] = useState<string>("");
   const [authorities, setAuthorites] = useState<any>(null);
   const [config, setConfig] = useState<any>({});
 
-  const handleGetProxy = () => {
-    let sr = getProxy();
+  const handleGetLoginAddress = () => {
+    let sr = getLoginAddress();
     sr.then(result => {
         if (result && result.data) {
-            setProxy(result.data);
+            setLoginAddress(result.data);
         }
     }).catch(error => {
         console.error(error);
@@ -50,13 +50,13 @@ const UserProvider: React.FC = ({ children }) => {
   };
 
   useEffect(() => {
-    if (proxy) {
+    if (loginAddress) {
       handleGetUserid();
     }
-  }, [proxy]);
+  }, [loginAddress]);
 
   const handleGetUserid = () => {
-    let sr = getUserid(proxy);
+    let sr = getUserid(loginAddress);
     sr.then(result => {
         if (result && result.data) {
             setUserid(result.data);
@@ -104,9 +104,9 @@ const UserProvider: React.FC = ({ children }) => {
     <UserContext.Provider
       value={{
         userid,
-        proxy,
+        loginAddress,
         config,
-        handleGetProxy,
+        handleGetLoginAddress,
         handleGetUserid,
         handleLogin,
         handleGetConfig


### PR DESCRIPTION
Our app init strategy offers a CORS workaround (setupProxy.js) for the DEVELOPMENT environment (port 3000).

In PRODUCTION (port 8080), the loginAddress server will need to handle CORS issues if that server differs from the server that serves the React app. If the loginAddress in properties is on the same server as the app (e.g., http://localhost:8080/api/explore/login) then PRODUCTION will work without any CORS handling.

To test:

1. Development (3000). When loginAddress property in properties file is mock server at http://localhost:8888/api/explore/login, correct userid will be set. Change that value to something else (e.g., http://www.google.com) and the userid will be incorrect, but the initial auth should still work since we're not checking validity of userid value.
2. Production (8080). Will work if loginAddress is set to http://localhost:8808/api/explore/login. If set to server that differs from the server that serves the React, will fail due to CORS issues. 

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [ ] JIRA_ID included in all the commit messages
- [ ] PR title is in the format JIRA_ID:Title
- [ ] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [ ] Code passes ESLint tests
- [ ] Added Tests
- [ ] Ran cypress tests on firefox locally
  

- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki

