### PR TITLE
DHFPROD-8981: GraphSearch doesn't show the ellipsis on concepts properly

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/graph-utils.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/graph-utils.sjs
@@ -59,7 +59,9 @@ function getEntityNodesWithRelated(entityTypeIRIs, relatedEntityTypeIRIs, predic
                         FILTER EXISTS {
                         ?subjectIRI @predicateConceptList ?objectIRI.
                         }
-                        }`)
+                       }
+                       GROUP BY ?objectIRI
+`);
 
   const subjectPlan = op.fromSPARQL(`PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                  PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/graph/graphSearch.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/graph/graphSearch.sjs
@@ -161,4 +161,29 @@ assertions.concat([
 ]);
 
 
+const ConceptWithHasRelationship = {
+  "searchText": "",
+  "entityTypeIds": [ "Office" ]
+};
+
+const resultConceptWithHasRelationship = searchNodes(ConceptWithHasRelationship);
+
+assertions.concat([
+  test.assertEqual(2, resultConceptWithHasRelationship.total),
+  test.assertEqual(2, resultConceptWithHasRelationship.nodes.length, xdmp.toJsonString(resultConceptWithHasRelationship)),
+  test.assertEqual(1, resultConceptWithHasRelationship.edges.length),
+]);
+
+resultConceptWithHasRelationship.nodes.forEach(node => {
+  if(node.id === "http://example.org/Office-0.0.1/Office/1") {
+    assertions.push(test.assertFalse(node.hasRelationships), "Office 1 must have relationships flag in false.");
+    assertions.push(test.assertFalse(node.isConcept), "Office 1 shouldn't be a concept.");
+  }
+  else if(node.id === "http://www.example.com/Category/Sneakers") {
+    assertions.push(test.assertTrue(node.hasRelationships), "Should have relationships flag in true.");
+    assertions.push(test.assertTrue(node.isConcept), "Sneakers should be a concept.");
+  }
+})
+
+
 assertions;


### PR DESCRIPTION
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [n/a] Ran cypress tests on firefox locally
  

- ##### Reviewer:

- [x] Reviewed Tests
- [n/a] Added to Release Wiki

