### PR TITLE
DHFPROD-9018: Display collections facet OOTB

### DIFF
--- a/marklogic-data-hub-central/src/main/resources/explore-data/ui-config/search.config.sjs
+++ b/marklogic-data-hub-central/src/main/resources/explore-data/ui-config/search.config.sjs
@@ -26,6 +26,11 @@ const searchConfig  = {
                 items: [
                     {
                         type: "category",
+                        name: "Collection",
+                        tooltip: "Filter by collection."
+                    },
+                    {
+                        type: "category",
                         name: "CONSTRAINT1",
                         tooltip: "Filter by CONSTRAINT1."
                     }

--- a/marklogic-data-hub-central/ui-custom/src/components/Facets/Facets.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Facets/Facets.tsx
@@ -60,6 +60,18 @@ const Facets: React.FC<Props> = (props) => {
 
   const searchContext = useContext(SearchContext);
 
+  let searchResultsFacets: any;
+  // Ensure facet and facet-value are arrays
+  if (searchContext.searchResults && searchContext.searchResults.facet) {
+    searchResultsFacets = searchContext.searchResults.facet;
+    searchResultsFacets = _.isArray(searchResultsFacets) ? searchResultsFacets :[searchResultsFacets];
+    searchResultsFacets.forEach((f, i) => {
+        if (f["facet-value"] && !_.isArray(f["facet-value"])) {
+            searchResultsFacets[i]["facet-value"] = [f["facet-value"]];
+        }
+    })
+  }
+
   let moreLessInit: any = {};
   const moreLessDefault: boolean = true;
   if (props.config.items) {
@@ -164,9 +176,7 @@ const Facets: React.FC<Props> = (props) => {
 
   // Get object for a facet based on facet name
   const getFacetObj = (facetName, facetObjs) => {
-    // Ensure value is array
-    let facetObjsArr = _.isArray(facetObjs) ? facetObjs :[facetObjs];
-    return facetObjs ? facetObjsArr.find(obj => obj.name === facetName) : null;
+    return facetObjs ? facetObjs.find(obj => obj.name === facetName) : null;
   };
 
   // Get number of facet values for a facet based on facet name
@@ -205,13 +215,13 @@ const Facets: React.FC<Props> = (props) => {
               </div>
               <div className="facetValues">
                 {/* Show each facet value (and count) */}
-                {searchContext.searchResults?.facet && searchContext.searchResults.facet?.length > 0 ?
+                {searchResultsFacets && searchResultsFacets.length > 0 ?
                   <Table size="sm" style={{padding: 0, margin: 0}}>
-                    {getFacetObj(f.name, searchContext.searchResults.facet) && displayFacetValues(getFacetObj(f.name, searchContext.searchResults.facet), f.disabled, moreLess[f.name])}
+                    {getFacetObj(f.name, searchResultsFacets) && displayFacetValues(getFacetObj(f.name, searchResultsFacets), f.disabled, moreLess[f.name])}
                   </Table> : null }
-                {(getNumValues(f.name, searchContext.searchResults.facet) > moreThreshold) ? moreLess[f.name] ?
+                {(getNumValues(f.name, searchResultsFacets) > moreThreshold) ? moreLess[f.name] ?
                   <div className="moreLess" data-testid={"more-" + f.name} onClick={handleMoreLess(f.name)}>
-                    {getNumValues(f.name, searchContext.searchResults.facet) - moreThreshold} more
+                    {getNumValues(f.name, searchResultsFacets) - moreThreshold} more
                     <ChevronDoubleRight
                       data-testid="doubleRight"
                       color="#5d6aaa"


### PR DESCRIPTION
Add Collection facet config to OOTB search.config.sjs.

NOTE: @rahulvudutala needs to finish a subtask before we merge this: https://project.marklogic.com/jira/browse/DHFPROD-9043

When following the instructions here to get an OOTB env working (with sample records):

https://wiki.marklogic.com/display/ENGINEERING/Entity+Viewer%3A+Set+up+minimal+UI+with+v1.0.0

I can see the Collection facet appear in the UI:

<img width="989" alt="Screen Shot 2022-06-16 at 11 56 29 AM" src="https://user-images.githubusercontent.com/477757/174144864-620ceec0-0057-4500-8734-bf26cd03e4db.png">

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [x] Ran cypress tests on firefox locally
  

- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki

