### PR TITLE
DHFPROD-9015: Add highlighting to match snippets

### DIFF
--- a/marklogic-data-hub-central/ui-custom/src/components/RecordRaw/RecordRaw.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/RecordRaw/RecordRaw.tsx
@@ -4,7 +4,7 @@ import {getValByConfig} from '../../util/util';
 import "./RecordRaw.scss";
 
 /**
- * Component for showing one or more values for a List of links.
+ * Component for showing the raw JSON of a record.
  *
  * @component
  * @prop {string} component Name of component used for display.

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultSnippet/ResultSnippet.scss
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultSnippet/ResultSnippet.scss
@@ -1,0 +1,3 @@
+.highlight {
+    background-color: #FFFFB0;
+}

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultSnippet/ResultSnippet.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultSnippet/ResultSnippet.test.tsx
@@ -1,0 +1,81 @@
+
+import {render} from "@testing-library/react";
+import ResultSnippet from "./ResultSnippet";
+
+const resultSnippetConfig = {
+  "config": {
+    "highlight": "red",
+    "separator": "---",
+  }
+}
+
+const searchResults = {
+    "result": [
+        {
+            "extracted": {
+                "person": {
+                    "id": "101",
+                    "name": "57 Becker Alley"
+                }
+            },
+            "entityType": "person",
+            "uri": "/person/101.xml",
+            "snippet": {
+                "match": {
+                  "#text": "57Alley",
+                  "path": "fn:doc(&quot;/person/10062.xml&quot;)/person/addresses/address[3]/street",
+                  "match-string": "57 Becker Alley",
+                  "highlight": "Becker"
+                }
+            }
+        },
+        {
+            "extracted": {
+                "person": {
+                    "id": "102",
+                    "name": "2010-02-02T03:23:14Z foo bar"
+                }
+            },
+            "entityType": "person",
+            "uri": "/person/102.xml",
+            "snippet": {
+                "match": [
+                  {
+                    "#text": "foo bar",
+                    "path": "fn:doc(&quot;/person/10016.xml&quot;)/person/sources/source/ts",
+                    "match-string": "2010-02-02T03:23:14Z foo bar",
+                    "highlight": 23
+                  },
+                  {
+                    "#text": "2010-02-02T03:23:14",
+                    "path": "fn:doc(&quot;/person/10016.xml&quot;)/person/memberships/membership[1]/ts",
+                    "match-string": "2010-02-02T03:23:14Z foo bar",
+                    "highlight": [ "foo", "bar" ]
+                  }
+                ]
+            }
+        }
+    ]
+};
+
+describe("ResultSnippet component", () => {
+  test("Verify single match renders", () => {
+    const {getByText, getByTestId} = render(
+      <ResultSnippet config={resultSnippetConfig.config} data={searchResults.result[0]} />
+    );
+    expect(getByText("Becker")).toBeInTheDocument();
+    expect(getByTestId("highlight-0-0")).toHaveStyle(`background-color: red`);
+  });
+
+  test("Verify multiple matches render", () => {
+    const {getByText, getByTestId} = render(
+      <ResultSnippet config={resultSnippetConfig.config} data={searchResults.result[1]} />
+    );
+    expect(getByText("23")).toBeInTheDocument();
+    expect(getByTestId("highlight-0-0")).toHaveStyle(`background-color: red`);
+    expect(getByText("foo")).toBeInTheDocument();
+    expect(getByTestId("highlight-1-0")).toHaveStyle(`background-color: red`);
+    expect(getByText("---")).toBeInTheDocument();
+  });
+
+});

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultSnippet/ResultSnippet.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultSnippet/ResultSnippet.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import "./ResultSnippet.scss";
+import _ from "lodash";
+
+/**
+ * Component for showing the match snippet for a record.
+ *
+ * @component
+ * @prop {object} config  Configuration object.
+ * @prop {string} config.highlight  HTML color for highlighting match text (default "#FFFFB0").
+ * @prop {string} config.weight  CSS weight for match text (default: "bold").
+ * @prop {string} config.separator  String sepator between match strings (default: " ... ").
+ * @prop {object} config.style  CSS style object applied to snippet content.
+ */
+
+type Props = {
+  data?: any;
+  config?: any;
+  style?: any;
+}
+
+const ResultSnippet: React.ComponentType<Props> = (props) => {
+  const {config, data} = props;
+  const highlight = config.highlight ? config.highlight : "#FFFFB0";
+  const weight = config.weight ? config.weight : "bold";
+  const separator = config.separator ? config.separator : " ... ";
+  // Force to array
+  let matches = _.isArray(data.snippet.match) ? data.snippet.match : [data.snippet.match];
+  let processed: any[] = [];
+  matches.forEach((m, i1) => {
+    let replaced = String(m["match-string"] ? m["match-string"] : "");
+    // Force to array
+    let highlights = _.isArray(m.highlight) ? m.highlight : [m.highlight];
+    highlights.forEach((h, i2) => {
+        const re = new RegExp(h, 'g')
+        replaced = replaced.replace(re, 
+            '<span data-testid="highlight-'+i1+'-'+i2+
+            '" style="background-color:'+highlight+'; font-weight:'+weight+
+            '">'+h+'</span>'
+        );
+    })
+    processed.push(replaced);
+  })  
+
+  let snippetStyle: any = props.style ? props.style : config?.style ? config.style : {};
+
+  return (
+    <div 
+        className="ResultSnippetContainer" 
+        data-testid="result-snippet-component" 
+        style={snippetStyle}
+        dangerouslySetInnerHTML={{__html: processed.join('<span>'+separator+'</span>')}} 
+    />
+  );
+}
+
+export default ResultSnippet;

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.scss
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.scss
@@ -82,9 +82,10 @@
             div.title.no-entity {
                 color: #333333;
                 cursor: auto;
+                padding-left: 10px;
             }
             div.subtitle.no-entity {
-                padding: 5px 0 16px 0;
+                padding: 5px 0 16px 10px;
             }
             .phone {
                 width: 120px;

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.test.tsx
@@ -110,8 +110,10 @@ const searchResultsNoEntity = {
             "entityType": "unknown",
             "uri": "/person/101.xml",
             "snippet": {"match": {
-                "#text": "Match text 101",
-                "path": "fn:doc(&quot;/101.xml&quot;)/unknown"
+                "#text": "2010-02-02T03:23:14Z ",
+                "path": "fn:doc(&quot;/101.xml&quot;)/unknown",
+                "match-string": "2010-02-02T03:23:14Z foo bar",
+                "highlight": [ "foo", "bar" ]
             }}
         },
         {
@@ -124,8 +126,10 @@ const searchResultsNoEntity = {
             "entityType": "unknown",
             "uri": "/person/102.xml",
             "snippet": {"match": {
-                "#text": "Match text 102",
-                "path": "fn:doc(&quot;/102.xml&quot;)/unknown"
+                "#text": "2010-02-02T03:23:14Z ",
+                "path": "fn:doc(&quot;/101.xml&quot;)/unknown",
+                "match-string": "2010-02-02T03:23:14Z baz",
+                "highlight": "baz"
             }}
         }
     ]
@@ -231,7 +235,7 @@ describe("ResultsList component", () => {
             </SearchContext.Provider>
         );
         expect(getByText(searchResultsNoEntity.result[0].uri)).toBeInTheDocument();
-        expect(getByText(searchResultsNoEntity.result[0].snippet.match["#text"])).toBeInTheDocument();
+        expect(getByText("foo")).toBeInTheDocument();
     });
 
 });

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.tsx
@@ -5,6 +5,7 @@ import DateTime from "../DateTime/DateTime";
 import Image from "../Image/Image";
 import List from "../List/List";
 import Value from "../Value/Value";
+import ResultSnippet from "../ResultSnippet/ResultSnippet";
 import {SearchContext} from "../../store/SearchContext";
 import {DetailContext} from "../../store/DetailContext";
 import "./ResultsList.scss";
@@ -142,14 +143,11 @@ const ResultsList: React.FC<Props> = (props) => {
   // Display URI and snippet (if available) if result entity not recognized
   const getResultNoEntity = (results, index) => {
     let titleValue = results?.uri ? results?.uri : "No record URI";
-    let matchValue = results?.snippet?.match["#text"] ? results?.snippet?.match["#text"] : "";
     return (
         <div key={"result-" + index} className="result">
             <div className="details">
                 <div className="title no-entity"><Value>{titleValue}</Value></div>
-                <div className="subtitle no-entity">
-                    <div className="match"><Value id={"match-" + index}>{matchValue}</Value></div>
-                </div>
+                <div className="subtitle no-entity"><ResultSnippet config={{}} data={results} /></div>
             </div>
         </div>
     )


### PR DESCRIPTION
### Description

Creates a new ResultSnippet widget for displaying match snippet content from results payload OOTB. Can configure highlight color, font weight for match text, and separator for multiple matches. Minimal OOTB search results now look like the following (default match style is bold/light yellow with " ... " separator):

<img width="1168" alt="Screen Shot 2022-06-23 at 12 26 46 PM" src="https://user-images.githubusercontent.com/477757/175382015-763d26d4-ee7c-49b2-b0cc-a1de4a66639a.png">


#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki

