### PR TITLE
DHFPROD-9079: Change 'category' type in facet configuration to 'string'

### DIFF
--- a/examples/entity-viewer-baseball/src/main/ml-modules/root/explore-data/ui-config/search.config.sjs
+++ b/examples/entity-viewer-baseball/src/main/ml-modules/root/explore-data/ui-config/search.config.sjs
@@ -24,32 +24,32 @@ const searchConfig = {
         displayLong: 5,
         items: [
           {
-            type: "category",
+            type: "string",
             name: "country",
             tooltip: "Filter by country.",
           },
           {
-            type: "category",
+            type: "string",
             name: "state",
             tooltip: "Filter by state.",
           },
           {
-            type: "category",
+            type: "string",
             name: "position",
             tooltip: "Filter by position.",
           },
           {
-            type: "category",
+            type: "string",
             name: "throws",
             tooltip: "Filter by throws.",
           },
           {
-            type: "category",
+            type: "string",
             name: "bats",
             tooltip: "Filter by bats.",
           },
           {
-            type: "category",
+            type: "string",
             name: "field",
             tooltip: "Filter by field.",
           }

--- a/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/search.config.sjs
+++ b/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/search.config.sjs
@@ -35,22 +35,22 @@ const searchConfig  = {
                     "tooltip": "Filter by date updated."
                 },
                 {
-                    "type": "category",
+                    "type": "string",
                     "name": "sources",
                     "tooltip": "Filter by source."
                 },
                 {
-                    "type": "category",
+                    "type": "string",
                     "name": "status",
                     "tooltip": "Filter by status."
                 },
                 {
-                    "type": "category",
+                    "type": "string",
                     "name": "country",
                     "tooltip": "Filter by country."
                 },
                 {
-                    "type": "category",
+                    "type": "string",
                     "name": "area",
                     "tooltip": "Filter by area."
                 }

--- a/marklogic-data-hub-central/ui-custom/src/components/Facets/Facets.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Facets/Facets.test.tsx
@@ -11,9 +11,9 @@ const configMultipleOver = {
     displayLong: 3,
     items: [
         {type: "dateRange", name: "created On"},
-        { type: "category", name: "a" },
-        { type: "category", name: "b" },
-        { type: "category", name: "c" }
+        { type: "string", name: "a" },
+        { type: "string", name: "b" },
+        { type: "string", name: "c" }
     ]
 };
 
@@ -23,14 +23,14 @@ const configMultipleUnder = Object.assign(
 const configMultipleTooltips = Object.assign(
     {}, configMultipleOver, {
         items: [
-            { type: "category", name: "a", tooltip: "a tip" },
-            { type: "category", name: "b" }
+            { type: "string", name: "a", tooltip: "a tip" },
+            { type: "string", name: "b" }
         ]
     });
 
 const configMultipleDisabled = Object.assign(
     {}, configMultipleOver, {
-        items: [{ type: "category", name: "a", disabled: true }]
+        items: [{ type: "string", name: "a", disabled: true }]
     });
 
 const searchResults = {

--- a/marklogic-data-hub-central/ui-custom/src/components/Facets/Facets.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Facets/Facets.tsx
@@ -29,7 +29,7 @@ type Props = {
  * @prop {number} config.displayLong Maximum number of facet values displayed without a more/less
  * link when the number of facets is above the `config.displayThreshold` value.
  * @prop {object[]} config.items Configuration objects for each facet.
- * @prop {string} config.items.type - Type of facet ("category").
+ * @prop {string} config.items.type - Type of facet ("string").
  * @prop {string} config.items.name - Name of the facet.
  * @prop {string} config.items.tooltip - Tooltip associated with the facet's information icon. If
  * no value is provided, no icon is displayed.
@@ -43,13 +43,13 @@ type Props = {
  *  displayLong: 5,
  *  items: [
  *    {
- *      type: "category",
+ *      type: "string",
  *      name: "Collection",
  *      tooltip: "Filter by entity.",
  *      disabled: true
  *    },
  *    {
- *      type: "category",
+ *      type: "string",
  *      name: "sources",
  *      tooltip: "Filter by source."
  *    }

--- a/marklogic-data-hub-central/ui-custom/src/components/SelectedFacets/SelectedFacets.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/SelectedFacets/SelectedFacets.tsx
@@ -25,13 +25,13 @@ const SelectedFacets: React.FC<Props> = (props) => {
     if (regexDateRange.test(facetValue)) {
       return "dateRange";
     } else {
-      return "category";
+      return "string";
     }
   }
 
   const handleClose = (e) => {
     let parts = e.target.id.split(":");
-    if (getFacetType(parts[1]) === "category") {
+    if (getFacetType(parts[1]) === "string") {
       searchContext.handleFacetString(parts[0], parts[1], false);
     } else if (getFacetType(parts[1]) === "dateRange") {
       searchContext.handleFacetDateRange(parts[0], parts[1], false);

--- a/marklogic-data-hub-central/ui-custom/src/store/SearchContext.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/store/SearchContext.tsx
@@ -111,7 +111,7 @@ const SearchProvider: React.FC = ({children}) => {
     if (regexDateRange.test(facetValue)) {
       return "dateRange";
     } else {
-      return "category";
+      return "string";
     }
   };
 
@@ -134,7 +134,7 @@ const SearchProvider: React.FC = ({children}) => {
     if (facetStrings && facetStrings.length > 0) {
       facetStrings.forEach(fs => {
         const parts = fs.split(":");
-        if (getFacetType(parts[1]) === "category") {
+        if (getFacetType(parts[1]) === "string") {
           if (query.selectedFacets[parts[0]]) {
             query.selectedFacets[parts[0]].push(parts[1]);
           } else {

--- a/marklogic-data-hub-central/ui-custom/src/views/Search.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/views/Search.test.tsx
@@ -26,7 +26,7 @@ const config = {
                 "displayLong": 5,
                 "items": [
                     {
-                        "type": "category",
+                        "type": "string",
                         "name": "sources",
                         "tooltip": "Filter by source."
                     }


### PR DESCRIPTION
### Description

Update the facet type called "category" to be called "string" per customer's request.

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
  

- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki

