### PR TITLE
DHFPROD-9057: Handle long status values in ResultsList

### DIFF
--- a/marklogic-data-hub-central/ui-custom/src/components/Chiclet/Chiclet.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Chiclet/Chiclet.tsx
@@ -31,9 +31,15 @@ const Chiclet: React.FC<Props> = (props) => {
     chicletStyle = Object.assign({
         backgroundColor: chicletColors[val] ? chicletColors[val] : defaultColor
     }, chicletStyle);
+    const chicletTitle: string = val;
 
     return (
-        <span data-testid="chiclet-container" className="Chiclet" style={chicletStyle}>
+        <span 
+            className="Chiclet" 
+            style={chicletStyle}
+            title={chicletTitle}
+            data-testid="chiclet-container" 
+        >
             {val}
         </span>
     );

--- a/marklogic-data-hub-central/ui-custom/src/components/DateTime/DateTime.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/DateTime/DateTime.tsx
@@ -45,9 +45,15 @@ const DateTime: React.FC<Props> = (props) => {
 
     const dateTimeClassName: any = props.className ? props.className : props.config?.className ? props.config.className : "";
     const dateTimeStyle: any = props.style ? props.style : props.config?.style ? props.config.style : {};
+    const dateTimeTitle: string = formattedDateTime;
 
     return (
-        <span data-testid="dateTimeContainer" className={dateTimeClassName ? dateTimeClassName : "DateTime"} style={dateTimeStyle}>
+        <span 
+            className={dateTimeClassName ? dateTimeClassName : "DateTime"} 
+            style={dateTimeStyle}
+            title={dateTimeTitle}
+            data-testid="dateTimeContainer" 
+        >
             {formattedDateTime}
         </span>
     );

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.scss
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.scss
@@ -111,9 +111,6 @@
         > div {
             display: inline-block;
         }
-        .timestamp {
-            white-space: nowrap;
-        }
         .actions {
             display: flex;
             flex-flow: column wrap;
@@ -122,6 +119,12 @@
             height: 80px;
             padding: 0 10px 0 20px;
             font-size: 15px;
+            .timestamp {
+                white-space: nowrap;
+                width: 170px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
             .icons {
                 align-self: flex-end;
                 white-space: nowrap;
@@ -129,6 +132,11 @@
                     display: inline-block;
                     width: 100px;
                     font-weight: bold;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    position: relative;
+                    top: 5px;
+                    padding-right: 4px;
                 }
                 svg {
                     margin-left: 10px;


### PR DESCRIPTION
Add ellipses (via CSS) and title attribute.
<img width="680" alt="DHFPROD-9057" src="https://user-images.githubusercontent.com/477757/176978667-1fc8eafc-4bca-4a64-af0e-55c402647350.png">

Make timestamp and chiclet content consistent (by adding titles).

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
  

- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki

