### PR TITLE
DHFPROD-5486: Indicate open tiles by icon state

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/tiles/toolbar.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/tiles/toolbar.module.scss
@@ -1,3 +1,4 @@
+@import "../../theme/HCVariables.scss";
 #toolbar {
     display: flex;
     justify-content: flex-start;
@@ -48,5 +49,8 @@
     }
     :hover {
         color: var(--hoverColor) !important;
+        div{
+            box-shadow: 0px 4px 4px $shadow;
+        }
     }
 }

--- a/marklogic-data-hub-central/ui/src/components/tiles/toolbar.scss
+++ b/marklogic-data-hub-central/ui/src/components/tiles/toolbar.scss
@@ -1,3 +1,5 @@
+@import "../../theme/HCVariables.scss";
+
 @font-face {
     font-family: 'MLCustomFont';
     src: url('../../fonts/ML_IconFont.ttf') format('truetype');
@@ -9,6 +11,8 @@
     justify-content: center;
     align-items: center;
     flex-direction: row;
+    color: $explore-icon;
+    cursor: pointer;
     content: "\68";
     font-family: MLCustomFont;
     font-size: 24px;
@@ -35,6 +39,8 @@
     align-items: center;
     flex-direction: row;
     content: "\e94e";
+    color: $load-icon;
+    cursor: pointer;
     font-family: MLCustomFont;
     font-size: 24px;
     position: relative;
@@ -57,6 +63,8 @@
 
 .modelIcon:before {
     display: flex;
+    color: $model-icon;
+    cursor: pointer;
     justify-content: center;
     align-items: center;
     flex-direction: row;
@@ -86,6 +94,8 @@
     align-items: center;
     flex-direction: row;
     content: "\e955";
+    color: $curate-icon;
+    cursor: pointer;
     font-family: MLCustomFont;
     font-size: 24px;
     position: relative;
@@ -111,6 +121,9 @@
     align-items: center;
     flex-direction: row;
     content: "\e926";
+    
+    color: $run-icon;
+    cursor: pointer;
     font-family: MLCustomFont;
     font-size: 24px;
     position: relative;
@@ -137,6 +150,9 @@
     flex-direction: row;
     content: "\e97a";
     color: #000000;
+    
+    color: $monitor-icon;
+    cursor: pointer;
     font-family: MLCustomFont;
     font-size: 24px;
     position: relative;
@@ -154,4 +170,8 @@
     box-shadow: 0px 0px 1px 1px #7F86B5;
     background-color: #7F86B5;
     outline: none;
+}
+
+.selected:before {
+    box-shadow: 0px 0 3px 2px #7f86b5;
 }

--- a/marklogic-data-hub-central/ui/src/components/tiles/toolbar.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/tiles/toolbar.test.tsx
@@ -32,27 +32,6 @@ describe("Toolbar component", () => {
 
   });
 
-  it("verify rendering of disabled tile icons", () => {
-    let disabledTiles = ["load", "model", "curate", "run", "explore", "monitor"];
-    const {getByLabelText} = render(<Router history={history}><Toolbar tiles={tiles} enabled={[]}/></Router>);
-    expect(getByLabelText("toolbar")).toBeInTheDocument();
-
-    disabledTiles.forEach((tile, i) => {
-      expect(getByLabelText("tool-" + tile)).toHaveStyle("color: grey; opacity: 0.5; cursor: not-allowed;");
-    });
-  });
-
-  it("verify rendering of enabled tile icons", () => {
-    let enabledTiles = ["load", "model", "curate", "run", "explore"];
-    const {getByLabelText} = render(<Router history={history}><Toolbar tiles={tiles} enabled={enabledTiles}/></Router>);
-    expect(getByLabelText("toolbar")).toBeInTheDocument();
-
-    enabledTiles.forEach((tile, i) => {
-      expect(getByLabelText("tool-" + tile)).not.toHaveStyle("color: grey; opacity: 0.5; cursor: not-allowed;");
-      expect(getByLabelText("tool-" + tile)).toHaveStyle("cursor: pointer;");
-    });
-  });
-
   it("verify tile icon selection using tab", () => {
     let i: number;
     let enabledTiles = ["load", "model", "curate", "run", "explore"];

--- a/marklogic-data-hub-central/ui/src/components/tiles/toolbar.tsx
+++ b/marklogic-data-hub-central/ui/src/components/tiles/toolbar.tsx
@@ -34,6 +34,7 @@ const Toolbar: React.FC<Props> = (props) => {
   const {modelingOptions} = useContext(ModelingContext);
   const [tileInfo, setTileInfo] = useState({});
   const location:any = useLocation();
+  const activeTile = location.pathname.split("/").pop();
 
 
   const getTooltip = (id) => {
@@ -44,18 +45,6 @@ const Toolbar: React.FC<Props> = (props) => {
     }
   };
 
-  const getIconStyle = (id) => {
-    let disabled: CSSProperties = {
-      color: "grey",
-      opacity: "0.5",
-      cursor: "not-allowed"
-    };
-    let enabled: CSSProperties = {
-      color: tiles[id]["color"],
-      cursor: "pointer"
-    };
-    return (props.enabled && props.enabled.includes(id)) ? enabled : disabled;
-  };
 
   const linkKeyDownHandler = (event, id, index) => {
     if (event.key === "ArrowUp" && index > 0) tileRefs[index-1].current.focus();
@@ -80,7 +69,7 @@ const Toolbar: React.FC<Props> = (props) => {
     if (!props.enabled || !props.enabled.includes(id)) event.preventDefault();
   };
 
-  /**
+  /*
         structure of the toolbar:
             <wrapper>
                 <tool>
@@ -105,6 +94,20 @@ const Toolbar: React.FC<Props> = (props) => {
             navigated to using arrow keys.
     */
 
+
+  const getIconStyle = (id) => {
+    let disabled: CSSProperties = {
+      color: "grey",
+      opacity: "0.5",
+      cursor: "not-allowed"
+    };
+    let enabled: CSSProperties = {
+      color: tiles[id]["color"],
+      cursor: "pointer"
+    };
+    return (props.enabled && props.enabled.includes(id)) ? enabled : disabled;
+  };
+
   const confirmTileClick = () => {
     toggleConfirmModal(false);
     if (tileInfo) {
@@ -120,9 +123,8 @@ const Toolbar: React.FC<Props> = (props) => {
             <div className={(tiles[id]["title"] === "Explore" || tiles[id]["title"] ===  "Curate") ? styles.toolTallWrapper : styles.toolWrapper} aria-label={`tool-${id}-wrapper`} key={`tool-${id}-wrapper`} tabIndex={-1}>
               <HCTooltip text={getTooltip(id)} id={getTooltip(id)+"-tooltip"} placement="left-start" key={i}>
                 <div
-                  className={tiles[id]["icon"]}
+                  className={`toolbarIcon ${tiles[id]["icon"]} ${(activeTile === id) && "selected"} ${(props.enabled && props.enabled.includes(id)) ? "enabled" : "disabled"}`}
                   aria-label={"tool-" + id}
-                  style={getIconStyle(id)}
                   tabIndex={-1}
                   onClick={(e) => tileOnClickHandler(id, i)}
                 >

--- a/marklogic-data-hub-central/ui/src/config/tiles.config.ts
+++ b/marklogic-data-hub-central/ui/src/config/tiles.config.ts
@@ -3,6 +3,7 @@ import { faLongArrowAltRight, faCube, faCubes, faObjectUngroup, faProjectDiagram
 export type TileId =  'load' | 'model' | 'curate' | 'run' | 'explore' | 'monitor' | 'detail';
 export type IconType = 'fa' | 'custom';
 export type ControlType = 'menu' | 'newTab' | 'maximize' | 'minimize' | 'close';
+export type Tiles =  Record<TileId, TileItem>;
 
 interface TileItem {
     title: string;
@@ -17,7 +18,7 @@ interface TileItem {
     toolbar: boolean;
 }
 
-const tiles: Record<TileId, TileItem>  = {
+const tiles: Tiles = {
     load: {
         title: 'Load',
         iconType: 'custom',

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.test.tsx
@@ -45,15 +45,10 @@ describe("Tiles View component tests for Developer user", () => {
     expect(getByLabelText("toolbar")).toBeInTheDocument();
 
     expect(getByLabelText("tool-load")).toBeInTheDocument();
-    expect(getByLabelText("tool-load")).toHaveStyle("color: rgb(61, 64, 156);");
     expect(getByLabelText("tool-model")).toBeInTheDocument();
-    expect(getByLabelText("tool-model")).toHaveStyle("color: rgb(48, 79, 127);");
     expect(getByLabelText("tool-curate")).toBeInTheDocument();
-    expect(getByLabelText("tool-curate")).toHaveStyle("color: rgb(24, 75, 90);");
     expect(getByLabelText("tool-run")).toBeInTheDocument();
-    expect(getByLabelText("tool-run")).toHaveStyle("color: rgb(130, 56, 138);");
     expect(getByLabelText("tool-explore")).toBeInTheDocument();
-    expect(getByLabelText("tool-explore")).toHaveStyle("color: rgb(55, 111, 99);");
 
     expect(getByLabelText("overview")).toBeInTheDocument();
 

--- a/marklogic-data-hub-central/ui/src/pages/TilesView.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/TilesView.tsx
@@ -159,7 +159,7 @@ const TilesView = (props) => {
         </div>) :
         <Overview enabled={enabled} environment={getEnvironment()}/>
       }
-      <Toolbar tiles={tiles} enabled={enabled}/>
+      <Toolbar tiles={tiles} enabled={enabled} />
       <Modal
         show={errorMessageOptions.isVisible}
       >

--- a/marklogic-data-hub-central/ui/src/theme/HCVariables.scss
+++ b/marklogic-data-hub-central/ui/src/theme/HCVariables.scss
@@ -8,6 +8,7 @@ $light: #cccc;
 $dark: #343a40;
 $black: #000;
 $text-color: #333;
+$shadow: #c0c0c0;
 $alert-text-color: #333;
 $secondary-gray: #777777;
 $separator: #D1D3D4;
@@ -26,6 +27,14 @@ $border-grey: #e0e0e0;
 $danger-disabled: #f0bbbc;
 $question-circle: #7f86b5;
 $highlight: #ffc069;
+
+// Toolbar icon colors
+$model-icon: #304F7F;
+$load-icon: #3D409C;
+$curate-icon: #184B5A;
+$run-icon: #82388A;
+$explore-icon: #376F63;
+$monitor-icon: #f09022;
 
 //backgrounds
 $bg-clean: #e8e8e8;


### PR DESCRIPTION
DHFPROD-5486: Indicate open tiles by icon state

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [ n/a] Added Tests
- [x] Ran cypress tests on firefox locally
  

- ##### Reviewer:

- N/A Reviewed Tests
- [x] Added to Release Wiki

