### PR TITLE
DHFPROD-9001: Verify that no unsaved data is lost when switching tiles

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/model.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/model.tsx
@@ -26,6 +26,10 @@ class ModelPage {
     return cy.findByLabelText("publish-to-database");
   }
 
+  getRevertButton() {
+    return cy.get("[aria-label=\"revert-changes-table-view\"]");
+  }
+
   getPublishButtonDisabledTooltip() {
     return cy.get(`[id="publish-disabled-tooltip"]`);
   }


### PR DESCRIPTION
DHFPROD-9001-e2eVerfTilesNoDataIsLost

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [x] Ran cypress tests on firefox locally
  

- ##### Reviewer:

- [x] Reviewed Tests
- N/A Added to Release Wiki

