### PR TITLE
DHFPROD-9094: EditMappingStepSettingsShowsNoCollection

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/entityMappingMoreLessFunctionality.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/entityMappingMoreLessFunctionality.spec.tsx
@@ -32,6 +32,8 @@ describe("Mapping", () => {
   it("Verify more/less functionality on filtering by name for structured properties", () => {
     cy.waitUntil(() => toolbar.getCurateToolbarIcon()).click();
     mappingStepDetail.customerEntity().click();
+    mappingStepDetail.getEditStepSettingsButton("mapCustomersJSON").click();
+    mappingStepDetail.getColectionInputValue().should("have.value", "loadCustomersJSON");
     curatePage.openMappingStepDetail("Customer", "mapCustomersJSON");
     browsePage.waitForSpinnerToDisappear();
     curatePage.scrollEntityContainer();

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/mapping/mapping-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/mapping/mapping-step-detail.tsx
@@ -419,6 +419,14 @@ class MappingStepDetail {
     cy.get("#resetSearch-source").click({force: true});
   }
 
+  getEditStepSettingsButton(value:string) {
+    return cy.get(`[data-testid=${value}-edit]`);
+  }
+
+  getColectionInputValue() {
+    return cy.get(`.rbt-input-main`);
+  }
+
 }
 
 const mappingStepDetail = new MappingStepDetail();

--- a/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.tsx
@@ -33,6 +33,7 @@ type Props = {
   setHasChanged: any;
   setPayload: any;
   onCancel: any;
+  preloadTypeahead?: string;
 }
 
 const CreateEditStep: React.FC<Props> = (props) => {
@@ -575,6 +576,7 @@ const CreateEditStep: React.FC<Props> = (props) => {
                     aria-label="collection-input"
                     placeholder={"Enter collection name"}
                     value={collections}
+                    defaultInputValue={props.isEditing ? props.preloadTypeahead : ""}
                     disabled={!props.canReadWrite}
                     onInputChange={handleSearch}
                     onChange={handleTypeaheadChange}

--- a/marklogic-data-hub-central/ui/src/components/steps/steps.tsx
+++ b/marklogic-data-hub-central/ui/src/components/steps/steps.tsx
@@ -206,6 +206,17 @@ const Steps: React.FC<Props> = (props) => {
     stepData={props.stepData}
   />);
 
+
+  const preloadTypeahead = (editStepArtifactObject: any) => {
+    if (editStepArtifactObject.selectedSource === "collection") {
+      let srcCollection = editStepArtifactObject.sourceQuery.substring(
+        editStepArtifactObject.sourceQuery.lastIndexOf("[") + 2,
+        editStepArtifactObject.sourceQuery.lastIndexOf("]") - 1
+      );
+      return srcCollection;
+    }
+  };
+
   const createEditMapping = (<CreateEditStep
     {...createEditDefaults}
     isEditing={props.isEditing}
@@ -214,6 +225,7 @@ const Steps: React.FC<Props> = (props) => {
     targetEntityType={props.targetEntityType}
     createStepArtifact={createStep}
     updateStepArtifact={updateStep}
+    preloadTypeahead = {preloadTypeahead(props.stepData)}
   />);
 
   const createEditMatching = (<CreateEditStep


### PR DESCRIPTION
### Description
Edit mapping step settings are not showing collection when editing the new mapping step.

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [x] Ran cypress tests on firefox locally
  

- ##### Reviewer:

- [x] Reviewed Tests
- [x] Added to Release Wiki

