### PR TITLE
DHFPROD-9039: New Concat widget, title reconfig

### DIFF
--- a/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/dashboard.config.sjs
+++ b/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/dashboard.config.sjs
@@ -117,9 +117,23 @@ const dashboardConfig  = {
                         }
                         },
                         "title": {
-                        "id": "uri",
-                        "arrayPath": "person.nameGroup",
-                        "path": "fullname.value"
+                            "id": {
+                                "path": "uri"
+                            },
+                            "component": "Concat",
+                            "config": {
+                                "items": [
+                                    {
+                                        "arrayPath": "person.nameGroup",
+                                        "path": "givenname.value",
+                                        "suffix": " "
+                                    },
+                                    {
+                                        "arrayPath": "person.nameGroup",
+                                        "path": "surname.value"
+                                    }
+                                ]
+                            }
                         },
                         "items": [
                         {
@@ -181,9 +195,14 @@ const dashboardConfig  = {
                             }
                         },
                         "title": {
-                            "id": "uri",
-                            "arrayPath": "organization.names",
-                            "path": "name.value"
+                            "id": {
+                                "path": "uri"
+                            },
+                            "component": "Value",
+                            "config": {
+                                "arrayPath": "organization.names",
+                                "path": "name.value"
+                            }
                         },
                         "items": [
                         {

--- a/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/detail.config.sjs
+++ b/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/detail.config.sjs
@@ -9,17 +9,30 @@ const detailConfig  = {
                 "thumbnail": {
                         "component": "Image",
                         "config": {
-                        "arrayPath": "person.images.image",
-                        "path": "url",
-                        "alt": "detail thumbnail",
-                        "style": {
-                            "width": "60px",
-                            "height": "60px"
-                        }
-                        }
+                            "arrayPath": "person.images.image",
+                            "path": "url",
+                            "alt": "detail thumbnail",
+                            "style": {
+                                "width": "60px",
+                                "height": "60px"
+                            }
+                    }
                 },
                 "title": {
-                    "path": "person.nameGroup.fullname.value"
+                    "component": "Concat",
+                    "config": {
+                        "items": [
+                            {
+                                "arrayPath": "person.nameGroup",
+                                "path": "givenname.value",
+                                "suffix": " "
+                            },
+                            {
+                                "arrayPath": "person.nameGroup",
+                                "path": "surname.value"
+                            }
+                        ]
+                    }
                 }
             },
             "membership": {
@@ -519,7 +532,10 @@ const detailConfig  = {
                 }
               },
               "title": {
-                "path": "organization.names.name.value"
+                    "component": "Value",
+                    "config": {
+                        "path": "organization.names.name.value"
+                    }
               }
             },
             "info": {

--- a/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/search.config.sjs
+++ b/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/search.config.sjs
@@ -96,9 +96,23 @@ const searchConfig  = {
                             }
                         },
                         "title": {
-                            "id": "uri",
-                            "arrayPath": "extracted.person.nameGroup",
-                            "path": "fullname.value"
+                            "id": {
+                                "path": "uri"
+                            },
+                            "component": "Concat",
+                            "config": {
+                                "items": [
+                                    {
+                                        "arrayPath": "extracted.person.nameGroup",
+                                        "path": "givenname.value",
+                                        "suffix": " "
+                                    },
+                                    {
+                                        "arrayPath": "extracted.person.nameGroup",
+                                        "path": "surname.value"
+                                    }
+                                ]
+                            }
                         },
                         "items": [
                         {
@@ -187,9 +201,14 @@ const searchConfig  = {
                             }
                         },
                         "title": {
-                            "id": "uri",
-                            "arrayPath": "extracted.organization.names",
-                            "path": "name.value"
+                            "id": {
+                                "path": "uri"
+                            },
+                            "component": "Value",
+                            "config": {
+                                "arrayPath": "extracted.organization.names",
+                                "path": "name.value"
+                            }
                         },
                         "items": [
                         {
@@ -208,6 +227,23 @@ const searchConfig  = {
                             "component": "Value",
                             "config": {
                             "path": "extracted.organization.areas.area"
+                            }
+                        },
+                        {
+                            "component": "Concat",
+                            "config": {
+                                "items": [
+                                    "Created by: ",
+                                    {
+                                        "path": "extracted.organization.createdOn.user"
+                                    },
+                                    {
+                                        "path": "extracted.organization.createdOn.ts",
+                                        "type": "DateTime",
+                                        "prefix": " (",
+                                        "suffix": ")",
+                                    }
+                                ]
                             }
                         }
                         ],

--- a/marklogic-data-hub-central/ui-custom/e2e/cypress/support/pages/landing.tsx
+++ b/marklogic-data-hub-central/ui-custom/e2e/cypress/support/pages/landing.tsx
@@ -52,7 +52,7 @@ class LandingPage {
     return cy.get(".section").eq(2).find(".none-found");
   }
   recentlyVisitedText() {
-    return cy.get(".recentRecords .title span");
+    return cy.get(".recentRecords .title span span");
   }
   recentlyVisitedRows() {
     return cy.get(".recentRecords").find(".result");

--- a/marklogic-data-hub-central/ui-custom/e2e/cypress/support/pages/recordDetails.tsx
+++ b/marklogic-data-hub-central/ui-custom/e2e/cypress/support/pages/recordDetails.tsx
@@ -4,7 +4,7 @@ class RecordDetailsPage {
     return cy.get(".title .icon svg");
   }
   recordTitle() {
-    return cy.get(".title .text span");
+    return cy.get(".title .text span span span.concat");
   }
   thumbNail() {
     return cy.get(".heading .thumbnail img");

--- a/marklogic-data-hub-central/ui-custom/e2e/cypress/support/pages/search.tsx
+++ b/marklogic-data-hub-central/ui-custom/e2e/cypress/support/pages/search.tsx
@@ -16,7 +16,7 @@ class SearchPage {
     return cy.get(".resultsList");
   }
   resultTitle() {
-    return cy.get(".details .title span");
+    return cy.get(".details .title span span");
   }
   resultAddress() {
     return cy.get(".Address");

--- a/marklogic-data-hub-central/ui-custom/src/components/Concat/Concat.scss
+++ b/marklogic-data-hub-central/ui-custom/src/components/Concat/Concat.scss
@@ -1,0 +1,1 @@
+/* Concat widget styles */

--- a/marklogic-data-hub-central/ui-custom/src/components/Concat/Concat.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Concat/Concat.test.tsx
@@ -1,0 +1,79 @@
+import Concat from "./Concat";
+import {render} from "@testing-library/react";
+
+const valueConfig = {
+    "items": [
+        {
+            "path": "person.first",
+            "suffix": " "
+        },
+        {
+            "path": "person.last"
+        }
+    ]
+};
+
+const dateTimeConfig = {
+    "items": [
+        "Created by: ",
+        {
+            "path": "person.createdOn.user"
+        },
+        {
+            "path": "person.createdOn.ts",
+            "type": "DateTime",
+            "prefix": " (",
+            "suffix": ")",
+        }
+    ]
+};
+
+const errorConfig = {
+    "items": [
+        {
+            "path": "noExist.first",
+            "suffix": " "
+        },
+        {
+            "path": "noExist.last"
+        }
+    ]
+};
+
+const items = {
+    "person": {
+        "first": "John",
+        "last": "Doe",
+        "createdOn": {
+            "ts": "2011-06-17T07:26:39Z",
+            "user": "jdoe"
+        }
+    }
+};
+
+describe("Concat component", () => {
+
+    test("Verify Value items are concatenated", () => {
+        const {getByText, getByTestId} = render(
+            <Concat data={items} config={valueConfig} />
+        );
+        expect(getByTestId("concatId")).toBeInTheDocument();
+        expect(getByText(items.person.first + " " + items.person.last)).toBeInTheDocument();
+    });
+
+    test("Verify DateTime item is concatenated", () => {
+        const {getByText, getByTestId} = render(
+            <Concat data={items} config={dateTimeConfig} />
+        );
+        expect(getByTestId("concatId")).toBeInTheDocument();
+        expect(getByText("Created by: jdoe (2011-06-17)")).toBeInTheDocument();
+    });
+
+    test("Verify config with error is handled", () => {
+        const {getByTestId} = render(
+            <Concat data={items} config={errorConfig} />
+        );
+        expect(getByTestId("concatId")).toBeInTheDocument();
+    });
+
+});

--- a/marklogic-data-hub-central/ui-custom/src/components/Concat/Concat.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Concat/Concat.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { getValByConfig, getFormattedDateTime } from "../../util/util";
+import "./Concat.scss";
+import _ from "lodash";
+
+type Props = {
+    config?: any;
+    data?: any;
+    className?: string;
+    style?: any;
+};
+
+/**
+ * Component for displaying multiple concatenated values.
+ *
+ * @component
+ * 
+ * @example
+ */
+const Concat: React.FC<Props> = (props) => {
+
+    const getVal = (config) => {
+        let val;
+        val = getValByConfig(props.data, config, true);
+
+        if (config.type === "DateTime") {
+            val = getFormattedDateTime(val, config.format, config.from);
+        }
+    
+        // Handle prefix/suffix during display (different from prepend/append during extraction)
+        if (val && config?.prefix) {
+            val = config?.prefix.concat(val);
+        }
+        if (val && config?.suffix) {
+            val = val.concat(config?.suffix);
+        }
+
+        return val;
+    }
+
+    let concatArray = props.config && props.config.items?.map(config => {
+        // Handle string-only case
+        if (_.isString(config)) {
+            return config;
+        } else {
+            return getVal(config);
+        }
+    })
+    const concatVals = concatArray.join("");
+
+    let concatClassName: any = props.className ? props.className : props.config?.className ? props.config.className : "concat";
+    let concatStyle: any = props.style ? props.style : props.config?.style ? props.config.style : {};
+    let concatTitle: string = concatVals;
+
+    return (
+        <span 
+            className={concatClassName} 
+            style={concatStyle} 
+            title={concatTitle} 
+            data-testid="concatId"
+        >
+            {concatVals}
+        </span>
+    );
+
+};
+
+export default Concat;

--- a/marklogic-data-hub-central/ui-custom/src/components/DateTime/DateTime.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/DateTime/DateTime.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import "./DateTime.scss";
-import { getValByConfig } from "../../util/util";
+import { getValByConfig, getFormattedDateTime } from "../../util/util";
 import { DateTime as dt } from "luxon";
+import _ from "lodash";
 
 type Props = {
   config?: any;
@@ -28,33 +29,29 @@ const DateTime: React.FC<Props> = (props) => {
         val = getValByConfig(props.data, props.config, true)
     }
 
-    let formattedDateTime;
-    if (props.config.from) {
-        formattedDateTime = dt["from" + props.config.from](val).toFormat(props.config.format ? props.config.format : defaultFormat);
-    } else {
-        formattedDateTime = dt.fromISO(val).toFormat(props.config.format ? props.config.format : defaultFormat);
-    }
+    val = getFormattedDateTime(val, props.config.format, props.config.from);
 
-    if (formattedDateTime && props.config?.prefix) {
-        formattedDateTime = props.config?.prefix.concat(formattedDateTime);
+    // Handle prefix/suffix during display (different from prepend/append during extraction)
+    if (val && props.config?.prefix) {
+        val = props.config?.prefix.concat(val);
     }
-
-    if (formattedDateTime && props.config?.suffix) {
-        formattedDateTime = formattedDateTime.concat(props.config?.suffix);
+    if (val && props.config?.suffix) {
+        val = val.concat(props.config?.suffix);
     }
 
     const dateTimeClassName: any = props.className ? props.className : props.config?.className ? props.config.className : "";
     const dateTimeStyle: any = props.style ? props.style : props.config?.style ? props.config.style : {};
-    const dateTimeTitle: string = formattedDateTime;
+    const dateTimeTitle: string = val;
 
     return (
+        val && 
         <span 
             className={dateTimeClassName ? dateTimeClassName : "DateTime"} 
             style={dateTimeStyle}
             title={dateTimeTitle}
             data-testid="dateTimeContainer" 
         >
-            {formattedDateTime}
+            {val}
         </span>
     );
 };

--- a/marklogic-data-hub-central/ui-custom/src/components/ImageGallery/ImageGallery.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/ImageGallery/ImageGallery.tsx
@@ -2,6 +2,7 @@ import React, {useState} from 'react';
 import {Carousel} from 'react-bootstrap';
 import {getValByConfig} from '../../util/util';
 import "./ImageGallery.scss";
+import Concat from "../Concat/Concat";
 import DateTime from '../DateTime/DateTime';
 import {Modal} from "react-bootstrap";
 import _ from "lodash";
@@ -14,6 +15,7 @@ type Props = {
 };
 
 const COMPONENTS = {
+  Concat: Concat,
   DateTime: DateTime,
   Value: Value
 };

--- a/marklogic-data-hub-central/ui-custom/src/components/ImageGalleryMulti/ImageGalleryMulti.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/ImageGalleryMulti/ImageGalleryMulti.tsx
@@ -3,6 +3,7 @@ import {getValByConfig} from "../../util/util";
 import "./ImageGalleryMulti.scss";
 
 import Carousel from "react-multi-carousel";
+import Concat from "../Concat/Concat";
 import "react-multi-carousel/lib/styles.css";
 import {Modal} from "react-bootstrap";
 import _ from "lodash";
@@ -17,6 +18,7 @@ type Props = {
 };
 
 const COMPONENTS = {
+  Concat: Concat,
   DateTime: DateTime,
   Value: Value
 };

--- a/marklogic-data-hub-central/ui-custom/src/components/List/List.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/List/List.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Address from "../Address/Address";
+import Concat from "../Concat/Concat";
 import DateTime from "../DateTime/DateTime";
 import Image from "../Image/Image";
 import Value from "../Value/Value";
@@ -12,6 +13,7 @@ type Props = {
 
 const COMPONENTS = {
     Address: Address,
+    Concat: Concat,
     DateTime: DateTime,
     Image: Image,
     Value: Value

--- a/marklogic-data-hub-central/ui-custom/src/components/Occupations/Occupations.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Occupations/Occupations.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "./Occupations.scss";
 
 type Props = {
   data?: any;

--- a/marklogic-data-hub-central/ui-custom/src/components/RecentRecords/RecentRecords.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/RecentRecords/RecentRecords.test.tsx
@@ -20,8 +20,13 @@ const recentConfig = {
                     }
                 },
                 "title": {
-                    "id": "uri",
-                    "path": "person.id"
+                    "id": {
+                        "path": "uri"
+                    },
+                    "component": "Value",
+                    "config": {
+                        "path": "person.id"
+                    }
                 },
                 "items": [
                     {

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.scss
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.scss
@@ -73,7 +73,7 @@
                 text-decoration: none;
                 color: #394494;
                 cursor: pointer;
-                span {
+                > span {
                     overflow: hidden;
                     text-overflow: ellipsis;
                     display: inline-block;

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.test.tsx
@@ -20,8 +20,13 @@ const resultsListConfig = {
                 }
             },
             title: {
-                id: "uri",
-                path: "extracted.person.name"
+                id: {
+                    path: "uri"
+                },
+                component: "Value",
+                config: {
+                    path: "extracted.person.name"
+                }
             },
             items: [
                 {

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.tsx
@@ -1,6 +1,7 @@
 import React, {useContext} from "react";
 import Address from "../Address/Address";
 import Chiclet from "../Chiclet/Chiclet";
+import Concat from "../Concat/Concat";
 import DateTime from "../DateTime/DateTime";
 import Image from "../Image/Image";
 import List from "../List/List";
@@ -23,6 +24,7 @@ type Props = {
 
 const COMPONENTS = {
   Address: Address,
+  Concat: Concat,
   DateTime: DateTime,
   Image: Image,
   Value: Value,
@@ -110,8 +112,8 @@ const ResultsList: React.FC<Props> = (props) => {
       handleSort(props.config?.sort.sortBy, "ascending");
     }
   };
-  const handleNameClick = (e) => {
-    detailContext.handleGetDetail(e.target.id);
+  const handleTitleClick = (id) => {
+    detailContext.handleGetDetail(id);
   };
 
   const handleChangePage = (page: number) => {
@@ -146,7 +148,7 @@ const ResultsList: React.FC<Props> = (props) => {
     return (
         <div key={"result-" + index} className="result">
             <div className="details">
-          <div className="title no-entity" onClick={handleNameClick}><Value id={results?.uri}>{titleValue}</Value></div>
+          <div className="title no-entity" onClick={handleTitleClick}><Value id={results?.uri}>{titleValue}</Value></div>
                 <div className="subtitle no-entity"><ResultSnippet config={{}} data={results} /></div>
             </div>
         </div>
@@ -167,10 +169,21 @@ const ResultsList: React.FC<Props> = (props) => {
       }
       let defaultIcon = props.config.defaultIcon
       let iconElement = (configEntityType && configEntityType.icon) ? FaDictionary[configEntityType.icon.type] : FaDictionary[defaultIcon.type];
-      let titleValue = getValByConfig(results, configEntityType.title, true);
-      if (!titleValue) {
+      let titleValue: any, idValue: any;
+      if (configEntityType.title?.component && configEntityType.title?.config) {
+        titleValue = (<span>
+            {React.createElement(
+                COMPONENTS[configEntityType.title.component], 
+                { config: configEntityType.title.config, data: results }, null
+            )}
+            </span>);   
+        if (configEntityType.title?.id) {
+            idValue = getValByConfig(results, configEntityType.title.id);
+        }
+      } else {
         if (results?.uri) {
-          titleValue = results?.uri;
+            titleValue = results?.uri;
+            idValue = results?.uri;
         }
       }
       return (
@@ -182,8 +195,8 @@ const ResultsList: React.FC<Props> = (props) => {
               : null}
           </div>
           <div className="details">
-            <div className="title" onClick={handleNameClick}>
-              <Value id={results?.uri}>{titleValue}</Value>
+            <div className="title" onClick={e => handleTitleClick(idValue)}>
+                {titleValue}
             </div>
             <div className="subtitle">
               {configEntityType.items ?

--- a/marklogic-data-hub-central/ui-custom/src/components/SummaryMeter/SummaryMeter.scss
+++ b/marklogic-data-hub-central/ui-custom/src/components/SummaryMeter/SummaryMeter.scss
@@ -1,0 +1,68 @@
+.meter {
+    position: relative;
+    width: 360px; 
+    height: 176px; 
+    float: "left";
+    font-size: 15px;
+    // border: solid 1px red;
+    margin-left: 10px;
+
+    .labelAll, .labelFilters {
+        position: absolute;
+        top: 8px;
+    }
+
+    .labelAll {
+        left: 20px;
+        .block {
+            background-color: #eee;
+        }
+    }
+
+    .labelFilters {
+        left: 125px;
+        .block {
+            background-color: #1ACCA8;
+        }
+    }
+
+    .block {
+        display: inline-block;
+        width: 16px;
+        height: 11px;
+        margin: 0 5px 0 0;
+    }
+
+    .text {
+        display: inline-block;
+    }
+
+    .min, .max {
+        position: absolute;
+        top: 105px;
+    }
+    .min {
+        left: 78px;
+    }
+    .max {
+        left: 274px;
+    }
+    .returned {
+        position: absolute;
+        width: 100%;
+        top: 124px;
+        text-align: center;
+        font-weight: bold;
+        padding-top: 3px;
+    }
+
+    .separator {
+        height: 5px;
+        width: 320px;
+        position: absolute;
+        border-bottom: solid 1px #ddd;
+        top: -2px;
+        left: 18px;
+        z-index: 1000;
+    }
+}

--- a/marklogic-data-hub-central/ui-custom/src/components/Timeline/Timeline.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Timeline/Timeline.tsx
@@ -1,5 +1,6 @@
 import React, {useState} from "react";
 import "./Timeline.scss";
+import Concat from "../Concat/Concat";
 import DateTime from "../DateTime/DateTime";
 import Value from "../Value/Value";
 import { getValByConfig } from "../../util/util";
@@ -14,6 +15,7 @@ type Props = {
 };
 
 const COMPONENTS = {
+    Concat: Concat,
     DateTime: DateTime,
     Value: Value,
 }

--- a/marklogic-data-hub-central/ui-custom/src/components/Value/Value.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Value/Value.tsx
@@ -48,6 +48,7 @@ const Value: React.FC<Props> = (props) => {
     }
 
     return (
+        val && 
         <span
             id={id}
             className={valueClassName}

--- a/marklogic-data-hub-central/ui-custom/src/util/util.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/util/util.tsx
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import { DateTime as dt } from "luxon";
 
 /**
  * Extract a value from a data object based on a dot-notation path.
@@ -57,5 +58,15 @@ export const getValByPath = (data, path, getFirst=false) => {
     result = (!Array.isArray(val) && config?.prepend) ? config.prepend + result : result;
     result = (!Array.isArray(val) && config?.append) ? result + config.append : result;
 
+    return result;
+};
+
+export const getFormattedDateTime = (val, format=null, from=null) => {
+    const defaultFormat = "yyyy-MM-dd";
+    let result = val;
+    const fr = from ? from : "ISO";
+    if (!_.isNil(result)) {
+        result = dt["from" + fr](val).toFormat(format ? format : defaultFormat);
+    }
     return result;
 };

--- a/marklogic-data-hub-central/ui-custom/src/views/Detail.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/views/Detail.test.tsx
@@ -10,11 +10,13 @@ const config = {
     "detail": {
         "entities": {
             "person": {
-
                 "heading": {
                     "id": "result[0].extracted.person.personId",
                     "title": {
-                        "path": "result[0].extracted.person.name"
+                        "component": "Value",
+                        "config": {
+                            "path": "result[0].extracted.person.name"
+                        }
                     }
                 },
                 "info": {
@@ -104,6 +106,7 @@ describe("Detail view", () => {
             getByText = renderResults.getByText;
         });
         expect(document.querySelector(".heading")).toBeInTheDocument();
+        expect(getByText(detail.result[0].extracted.person.name[0])).toBeInTheDocument();
         expect(getByText(config.detail.entities.person.info.items[0].config.title)).toBeInTheDocument();
     });
 

--- a/marklogic-data-hub-central/ui-custom/src/views/Detail.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/views/Detail.tsx
@@ -8,6 +8,7 @@ import Timeline from "../components/Timeline/Timeline";
 import Relationships from "../components/Relationships/Relationships";
 import DataTableValue from "../components/DataTableValue/DataTableValue";
 import DataTableMultiValue from "../components/DataTableMultiValue/DataTableMultiValue";
+import Concat from "../components/Concat/Concat";
 import DateTime from "../components/DateTime/DateTime";
 import Image from "../components/Image/Image";
 import Section from "../components/Section/Section";
@@ -29,6 +30,7 @@ import ReactJson from "react-json-view";
 type Props = {};
 
 const COMPONENTS = {
+  Concat: Concat,
   DataTableValue: DataTableValue,
   DataTableMultiValue: DataTableMultiValue,
   DateTime: DateTime,
@@ -120,10 +122,17 @@ const Detail: React.FC<Props> = (props) => {
   }, [detailContext.detail]);
 
   const getHeading = (configHeading) => {
-    let titleValue = getValByConfig(detailContext.detail, configHeading.title, true);
-    if (!titleValue) {
+    let titleValue: any;
+    if (configHeading.title?.component && configHeading.title?.config) {
+      titleValue = (<span>
+          {React.createElement(
+              COMPONENTS[configHeading.title.component], 
+              { config: configHeading.title.config, data: detailContext.detail }, null
+          )}
+          </span>);       
+    } else {
       if (detailContext.detail?.uri) {
-        titleValue = detailContext.detail?.uri;
+          titleValue = detailContext.detail?.uri;
       }
     }
     return (
@@ -211,23 +220,24 @@ const Detail: React.FC<Props> = (props) => {
     );
   };
   const getDetailEntity = () => {
+    const configEntityType = entityType && config.detail.entities[entityType];
     return (
       <div>
 
-        {config?.detail?.entities[entityType]?.heading ?
-          getHeading(config.detail.entities[entityType].heading)
+        {configEntityType.heading ?
+          getHeading(configEntityType.heading)
           : null}
 
         <div className="container-fluid">
 
-          {config?.detail?.entities[entityType]?.linkList?.config && <div>
+          {configEntityType.linkList?.config && <div>
             {React.createElement(
               COMPONENTS.LinkList,
-              {config: config?.detail?.entities[entityType]?.linkList.config, data: detailContext.detail}, null
+              {config: configEntityType.linkList.config, data: detailContext.detail}, null
             )}
           </div>}
 
-          {config?.detail?.entities[entityType]?.membership && <div className="row">
+          {configEntityType.membership && <div className="row">
             <div className="col-12">
               <Section title="Membership" config={{
                 "headerStyle": {
@@ -241,10 +251,10 @@ const Detail: React.FC<Props> = (props) => {
                 expand={expandIds.membership}
                 onExpand={() => {handleExpandIdsClick("membership", true);}}
                 onCollapse={() => {handleExpandIdsClick("membership", false);}}>
-                {config.detail.entities[entityType]?.membership.component && config.detail.entities[entityType]?.membership.config &&
+                {configEntityType.membership.component && configEntityType.membership.config &&
                   React.createElement(
-                    COMPONENTS[config?.detail?.entities[entityType]?.membership.component],
-                    {config: config?.detail?.entities[entityType]?.membership.config, data: detailContext.detail}, null
+                    COMPONENTS[configEntityType.membership.component],
+                    {config: configEntityType.membership.config, data: detailContext.detail}, null
                   )}
               </Section>
             </div>
@@ -253,20 +263,20 @@ const Detail: React.FC<Props> = (props) => {
           <div className="row">
             <div className="col-lg-7">
 
-              {config?.detail?.entities[entityType]?.info &&
-                <Section title={config?.detail?.entities[entityType]?.info.title}
+              {configEntityType.info &&
+                <Section title={configEntityType.info.title}
                   collapsible={true}
                   expand={expandIds.info}
                   onExpand={() => {handleExpandIdsClick("info", true);}}
                   onCollapse={() => {handleExpandIdsClick("info", false);}} >
-                  {getRecordItems(config?.detail?.entities[entityType]?.info?.items)}
+                  {getRecordItems(configEntityType.info?.items)}
                 </Section>
               }
 
             </div>
             <div className="col-lg-5">
 
-              {config?.detail?.entities[entityType]?.relationships &&
+              {configEntityType.relationships &&
                 <Section
                   title="Relationships"
                   collapsible={true}
@@ -278,26 +288,26 @@ const Detail: React.FC<Props> = (props) => {
                     }
                   }}>
                   <div className="relationships">
-                    {config.detail.entities[entityType]?.relationships.component && config.detail.entities[entityType]?.relationships.config &&
+                    {configEntityType.relationships.component && configEntityType.relationships.config &&
                       React.createElement(
-                        COMPONENTS[config?.detail?.entities[entityType]?.relationships.component],
-                        {config: config?.detail?.entities[entityType]?.relationships.config, data: detailContext.detail}, null
+                        COMPONENTS[configEntityType.relationships.component],
+                        {config: configEntityType.relationships.config, data: detailContext.detail}, null
                       )}
                   </div>
                 </Section>
               }
 
-              {config?.detail?.entities[entityType]?.imageGallery &&
+              {configEntityType.imageGallery &&
                 <Section title="Image Gallery"
                   collapsible={true}
                   expand={expandIds.imageGallery}
                   onExpand={() => {handleExpandIdsClick("imageGallery", true);}}
                   onCollapse={() => {handleExpandIdsClick("imageGallery", false);}}
                 >
-                  {config.detail.entities[entityType]?.imageGallery.component && config.detail.entities[entityType]?.imageGallery.config &&
+                  {configEntityType.imageGallery.component && configEntityType.imageGallery.config &&
                     React.createElement(
-                      COMPONENTS[config?.detail?.entities[entityType]?.imageGallery.component],
-                      {config: config?.detail?.entities[entityType]?.imageGallery.config, data: detailContext.detail}, null
+                      COMPONENTS[configEntityType.imageGallery.component],
+                      {config: configEntityType.imageGallery.config, data: detailContext.detail}, null
                     )
                   }
                 </Section>
@@ -305,7 +315,7 @@ const Detail: React.FC<Props> = (props) => {
 
             </div>
           </div>
-          {config?.detail?.entities[entityType]?.timeline && <div className="row">
+          {configEntityType.timeline && <div className="row">
             <div className="col-12">
               <Section
                 title="Timeline"
@@ -315,10 +325,10 @@ const Detail: React.FC<Props> = (props) => {
                 onExpand={() => {handleExpandIdsClick("timeline", true);}}
                 onCollapse={() => {handleExpandIdsClick("timeline", false);}}
               >
-                {config.detail.entities[entityType]?.timeline.component && config.detail.entities[entityType]?.timeline.config &&
+                {configEntityType.timeline.component && configEntityType.timeline.config &&
                   React.createElement(
-                    COMPONENTS[config.detail.entities[entityType].timeline.component],
-                    {config: config.detail.entities[entityType].timeline.config, data: detailContext.detail}, null
+                    COMPONENTS[configEntityType.timeline.component],
+                    {config: configEntityType.timeline.config, data: detailContext.detail}, null
                   )}
               </Section>
             </div>


### PR DESCRIPTION
### Description

Added a new Concat widget for displaying concatenated elements from the payload. 

Also refactored title configuration on search results, detail page, and recently viewed (which is where users specifically wanted to use the Concat widget).

Example configuration (concatenate given name and surname for search titles) is here: https://github.com/wooldridge/marklogic-data-hub/blob/DHFPROD-9039/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/search.config.sjs#L102

Content between concatenated elements can be added with "prefix" and "suffix" properties (which are already in our configuration patterns).

Concat supports regular values and also a "type" of "DateTime" which works similar to the "DateTime" widget. (See the unit tests for an example).

Tests pass, detailed documentation will come later.

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [x] Reviewed Tests
- [x] Added to Release Wiki

