### PR TITLE
DHFPROD-9135: Merge documents modal icons

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/mergeNotification.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/mergeNotification.spec.tsx
@@ -1,0 +1,53 @@
+import {Application} from "../../../support/application.config";
+import {toolbar} from "../../../support/components/common";
+import "cypress-wait-until";
+import LoginPage from "../../../support/pages/login";
+import browsePage from "../../../support/pages/browse";
+import explorePage from "../../../support/pages/explore";
+import runPage from "../../../support/pages/run";
+
+describe("Merge Notification Functionality From Explore Card View", () => {
+
+  before(() => {
+    cy.visit("/");
+    cy.contains(Application.title);
+    cy.loginAsTestUserWithRoles("hub-central-flow-writer", "hub-central-match-merge-writer", "hub-central-mapping-writer", "hub-central-load-writer").withRequest();
+    LoginPage.postLogin();
+    //Saving Local Storage to preserve session
+    cy.saveLocalStorage();
+  });
+  beforeEach(() => {
+    //Restoring Local Storage to Preserve Session
+    cy.restoreLocalStorage();
+  });
+  after(() => {
+    cy.loginAsDeveloper().withRequest();
+    cy.resetTestUser();
+    cy.waitForAsyncRequest();
+  });
+  it("Run Match and Merge steps to generate Notifcation Docs", () => {
+    cy.waitUntil(() => toolbar.getRunToolbarIcon()).click();
+    runPage.getFlowName("personJSON").should("be.visible");
+    runPage.toggleExpandFlow("personJSON");
+    cy.log("** Run Match and Merge Steps **");
+    runPage.runStep("match-person", "personJSON");
+    runPage.verifyStepRunResult("match-person", "success");
+    runPage.getDocumentsWritten("match-person").should("be.greaterThan", 0);
+    runPage.closeFlowStatusModal("personJSON");
+    runPage.runStep("merge-person", "personJSON");
+    runPage.verifyStepRunResult("merge-person", "success");
+    runPage.getDocumentsWritten("merge-person").should("be.greaterThan", 0);
+    runPage.closeFlowStatusModal("personJSON");
+  });
+  it("Navigate to Explore tile All Data View", () => {
+    cy.waitUntil(() => toolbar.getExploreToolbarIcon()).click();
+    explorePage.getAllDataButton().click();
+    cy.log("**filter for notification collection and verify merge icon**");
+    browsePage.getShowMoreLink("collection").click();
+    browsePage.getFacetItemCheckbox("collection", "sm-Person-notification").scrollIntoView().click({force: true});
+    browsePage.getSelectedFacets().should("exist");
+    browsePage.getFacetApplyButton().click();
+    browsePage.waitForSpinnerToDisappear();
+    browsePage.getMergeIcon().should("be.visible");
+  });
+});

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/unMerge.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/curation/curate/unMerge.spec.tsx
@@ -1,0 +1,40 @@
+import {Application} from "../../../support/application.config";
+import {toolbar} from "../../../support/components/common";
+import entitiesSidebar from "../../../support/pages/entitiesSidebar";
+import "cypress-wait-until";
+import LoginPage from "../../../support/pages/login";
+import browsePage from "../../../support/pages/browse";
+
+describe("UnMerge Functionality in Table and Snippet View", () => {
+
+  before(() => {
+    cy.visit("/");
+    cy.contains(Application.title);
+    cy.loginAsTestUserWithRoles("hub-central-flow-writer", "hub-central-match-merge-writer", "hub-central-mapping-writer", "hub-central-load-writer").withRequest();
+    LoginPage.postLogin();
+    //Saving Local Storage to preserve session
+    cy.saveLocalStorage();
+  });
+  beforeEach(() => {
+    //Restoring Local Storage to Preserve Session
+    cy.restoreLocalStorage();
+  });
+  after(() => {
+    cy.loginAsDeveloper().withRequest();
+    cy.resetTestUser();
+    cy.waitForAsyncRequest();
+  });
+  it("Navigate to Explore tile Table View and Filter Person entity", () => {
+    cy.waitUntil(() => toolbar.getExploreToolbarIcon()).click();
+    browsePage.clickTableView();
+    entitiesSidebar.getBaseEntityDropdown().click();
+    entitiesSidebar.selectBaseEntityOption("Person");
+    cy.log("** unmerge icon should be visible on merged records in table view**");
+    browsePage.getUnmergeIcon().should("be.visible");
+  });
+  it("Switch to Snippet View", () => {
+    browsePage.clickSnippetView();
+    cy.log("** unmerge icon should be visible on merged records in snippet view**");
+    browsePage.getUnmergeIcon().should("be.visible");
+  });
+});

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explore/crudQueriesFromManageQueries.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explore/crudQueriesFromManageQueries.spec.tsx
@@ -238,7 +238,7 @@ describe("manage queries modal scenarios, developer role", () => {
     browsePage.waitForSpinnerToDisappear();
 
     //check table rows
-    browsePage.getHCTableRows().should("have.length", 1);
+    browsePage.getHCTableRows().should("have.length", 2);
     //check table columns
     table.getTableColumns().should("have.length", 9);
     //Check query facet is applied

--- a/marklogic-data-hub-central/ui/e2e/cypress/integration/explore/jsonTableViewValidations.spec.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/integration/explore/jsonTableViewValidations.spec.tsx
@@ -83,8 +83,8 @@ describe("json scenario for table on browse documents page", () => {
     entitiesSidebar.getMainPanelSearchInput("Alice");
     entitiesSidebar.getApplyFacetsButton().click();
     browsePage.waitForSpinnerToDisappear();
-    browsePage.getTotalDocuments().should("be.equal", 1);
-    browsePage.getHCTableRows().should("have.length", 1);
+    browsePage.getTotalDocuments().should("be.equal", 2);
+    browsePage.getHCTableRows().should("have.length", 2);
   });
 
   it("verify instance view of the document without pk", () => {
@@ -93,8 +93,8 @@ describe("json scenario for table on browse documents page", () => {
     browsePage.getFacetItemCheckbox("fname", "Alice").click();
     browsePage.getGreySelectedFacets("Alice").should("exist");
     browsePage.getFacetApplyButton().click();
-    browsePage.getTotalDocuments().should("be.equal", 1);
-    browsePage.getTableViewInstanceIcon().click();
+    browsePage.getTotalDocuments().should("be.equal", 2);
+    browsePage.getFirstTableViewInstanceIcon().click();
     detailPage.getInstanceView().should("exist");
     detailPage.getDocumentEntity().should("contain", "Person");
     detailPage.getDocumentTimestamp().should("exist");

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/browse.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/browse.tsx
@@ -392,6 +392,11 @@ class BrowsePage {
   }
 
   // common
+  getFirstTableViewInstanceIcon() {
+    return cy.get(".hc-table_row:first-child [data-cy=instance]");
+  }
+
+  // common
   getTableViewInstanceIcon() {
     return cy.get(".hc-table_row:last-child [data-cy=instance]");
   }
@@ -704,8 +709,13 @@ class BrowsePage {
   }
 
   // unmerge icon
-  getUnmergeIcon(primaryKeyValue: string) {
-    return cy.get(`[aria-label="${primaryKeyValue}-unmerge-icon"`);
+  getUnmergeIcon() {
+    return cy.get(`[aria-label="unmerge-icon"]`);
+  }
+
+  //merge icon
+  getMergeIcon() {
+    return cy.get(`[data-testid="merge-icon"]`);
   }
 }
 

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/run.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/run.tsx
@@ -6,6 +6,10 @@ class RunPage {
     return cy.findByText("Create Flow").closest("button");
   }
 
+  toggleExpandFlow(flowName: string) {
+    return cy.get(`[data-testid="accordion-${flowName}"]`).click();
+  }
+
   toggleFlowConfig(flowName: string) {
     cy.waitUntil(() => cy.findByText(flowName).closest("div")).click();
     cy.waitUntil(() => cy.contains("Map"));
@@ -152,6 +156,12 @@ class RunPage {
   clickSuccessCircleIcon(stepName: string, flowName: string) {
     cy.get(`#${flowName}`).within(() => {
       cy.findByTestId(`check-circle-${stepName}`).scrollIntoView().click();
+    });
+  }
+
+  getDocumentsWritten(stepName: string) {
+    return cy.get(`[aria-label=${stepName}-documents-written]`).then(value => {
+      return parseInt(value.first().text().replace(/,/, ""));
     });
   }
 

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/entities/OneToOneNotes
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/entities/OneToOneNotes
@@ -1,0 +1,9 @@
+9/21/20 3:31 PM 
+	• Started on E2E tests
+	• Update best practices based on repeated test failures bcs of test issues.
+	• Code Reviews of E2E :
+		○ Best practices being followed
+		○ Test coverage 
+		○ Should run on DHS
+		○ Update best practices to run tests on windows before creating PR.
+	

--- a/marklogic-data-hub-central/ui/e2e/hc-qa-project/entities/temp/Customer.entity.json
+++ b/marklogic-data-hub-central/ui/e2e/hc-qa-project/entities/temp/Customer.entity.json
@@ -1,0 +1,124 @@
+{
+  "info": {
+    "title": "Customer",
+    "version": "0.0.1",
+"baseUri": "http://example.org/",
+"draft": false
+  },
+  "definitions": {
+    "Customer": {
+      "required": [
+        "name"
+      ],
+      "pii": [
+        "pin"
+      ],
+      "primaryKey": "customerId",
+      "properties": {
+        "customerId": {
+          "datatype": "integer",
+          "sortable": true
+        },
+        "name": {
+          "datatype": "string",
+          "description": "This has a case-insensitive collation for the match queries that use range indexes",
+          "collation": "http://marklogic.com/collation//S2",
+          "facetable": true,
+          "sortable": true
+        },
+        "email": {
+          "datatype": "string",
+          "description": "This has a case-insensitive collation for the match queries that use range indexes",
+          "collation": "http://marklogic.com/collation//S2",
+          "facetable": true
+        },
+        "pin": {
+          "datatype": "integer",
+          "facetable": true,
+          "sortable": true
+        },
+        "nicknames": {
+          "datatype": "array",
+          "description": "Example of a multi-value property of simple values",
+          "items": {
+            "datatype": "string"
+          }
+        },
+        "hasOffice": {
+          "datatype": "integer",
+          "relatedEntityType": "http://example.org/Office-0.0.1/Office",
+          "joinPropertyName": "officeId"
+        },
+        "shipping": {
+          "datatype": "array",
+          "description": "Example of a multi-value property of structured values",
+          "items": {
+            "$ref": "#/definitions/Address"
+          }
+        },
+        "billing": {
+          "description": "Example of a single-value structured property",
+          "$ref": "#/definitions/Address"
+        },
+        "birthDate": {
+          "datatype": "date",
+          "facetable": true
+        },
+        "status": {
+          "datatype": "string"
+        },
+        "customerSince": {
+          "datatype": "date"
+        },
+        "orders": {
+          "datatype": "array",
+          "description": "Example of a relationship to another entity type",
+          "items": {
+            "$ref": "http://example.org/Order-0.0.1/Order"
+          }
+        }
+    },
+"description": ""
+},
+    "Address": {
+      "required": [ ],
+      "pii": [ ],
+      "elementRangeIndex": [ ],
+      "rangeIndex": [ ],
+      "wordLexicon": [ ],
+      "properties": {
+        "street": {
+          "datatype": "array",
+          "items": {
+            "datatype": "string",
+            "collation": "http://marklogic.com/collation/codepoint"
+          }
+        },
+        "city": {
+          "datatype": "string",
+          "collation": "http://marklogic.com/collation/codepoint"
+        },
+        "state": {
+          "datatype": "string",
+          "collation": "http://marklogic.com/collation/codepoint"
+        },
+        "zip": {
+          "$ref": "#/definitions/Zip"
+        }
+      }
+    },
+    "Zip": {
+      "required": [ ],
+      "properties": {
+        "fiveDigit": {
+          "datatype": "string",
+          "collation": "http://marklogic.com/collation/codepoint"
+        },
+        "plusFour": {
+          "datatype": "string",
+          "collation": "http://marklogic.com/collation/codepoint"
+        }
+      }
+    }
+}
+}

--- a/marklogic-data-hub-central/ui/src/assets/mock-data/explore/entity-search.js
+++ b/marklogic-data-hub-central/ui/src/assets/mock-data/explore/entity-search.js
@@ -770,6 +770,30 @@ export const entitySearch = {
         }
       ],
     },
+    {
+      "index": 9,
+      "uri": "/com.marklogic.smart-mastering/matcher/notifications/613ba6185e0d3a08d6dbfdb01edbe8d3.xml",
+      "documentSize": {value: 509, units: "B"},
+      "primaryKey": {
+      },
+      "path": "fn:doc(\"/Customer/Cust8.json\")",
+      "score": 0,
+      "confidence": 0,
+      "fitness": 0,
+      "href": "/v1/documents?uri=%2Fcom.marklogic.smart-mastering%2Fmatcher%2Fnotifications%2F613ba6185e0d3a08d6dbfdb01edbe8d3.xml",
+      "mimetype": "text/plain",
+      "format": "xml",
+      "matches": [
+        {
+          "path": "fn:doc(\"/com.marklogic.smart-mastering/matcher/notifications/613ba6185e0d3a08d6dbfdb01edbe8d3.xml\")/*:notification",
+          mimetype: "application/xml",
+          "match-text": [
+            "2022-07-26T10:32:21.565445-07:00 hc-developer unread Likely Match /json/persons/last-name-address-reduce1.json /json/persons/last-name-address-reduce2.json"
+          ]
+        }
+      ],
+      "notifiedDoc": true
+    }
   ],
   "facets": {
     "Collection": {
@@ -1372,6 +1396,7 @@ export const entitySearchAllEntities = {
       "score": 0,
       "confidence": 0,
       "fitness": 0,
+      "unmerge": true,
       "href": "/v1/documents?uri=%2FCustomer%2FCust1.json",
       "mimetype": "application/json",
       "format": "json",

--- a/marklogic-data-hub-central/ui/src/components/job-response/job-response.tsx
+++ b/marklogic-data-hub-central/ui/src/components/job-response/job-response.tsx
@@ -177,12 +177,12 @@ const JobResponse: React.FC<Props> = ({jobId, setOpenJobResponse, setUserCanStop
         const {stepName, success} = response;
         const stepIsFinished = response.stepEndTime && response.stepEndTime !== "N/A";
         if (isStepCanceled(response)) {
-          return (<span className={styles.canceled}>
+          return (<span className={styles.canceled} aria-label={`${stepName}-documents-written`}>
             Canceled
           </span>);
         } else if (stepIsFinished) {
           if (success) {
-            return (<span className={styles.documentsWritten}>
+            return (<span className={styles.documentsWritten} aria-label={`${stepName}-documents-written`}>
               {successfulEvents}
             </span>);
           }

--- a/marklogic-data-hub-central/ui/src/components/record-view/record-view.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/record-view/record-view.module.scss
@@ -122,13 +122,33 @@
   color: #777;
 }
 
+.mergeIconDiv {
+  cursor: pointer;
+  font-size: 24px;
+  display: flex;
+  justify-content: flex-end;
+  position: absolute;
+  bottom: -2px;
+  right: 28px;
+}
+
+.mergeIcon:hover {
+  color: var(--hoverColor);
+  cursor: pointer;
+}
+
 .downloadIcon {
-  font-size: 12px;
+  cursor: pointer;
   display: flex;
   justify-content: flex-end;
   position: absolute;
   bottom: 4px;
   right: 4px;
+}
+
+.downloadIcon:hover {
+  color: var(--hoverColor);
+  cursor: pointer;
 }
 
 .arrowRightSquare{

--- a/marklogic-data-hub-central/ui/src/components/record-view/record-view.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/record-view/record-view.test.tsx
@@ -89,7 +89,7 @@ describe("Raw data card view component", () => {
     expect(getAllByText("none")).toHaveLength(4);
   });
 
-  test("Verify file download on Raw data card ", async () => {
+  test("Verify file download and merge on Raw data card ", async () => {
     axiosMock.get["mockImplementationOnce"](jest.fn(() => Promise.resolve(testData.allDataRecordDownloadResponse)));
 
     const {getByTestId, getByText} = render(<MemoryRouter>
@@ -103,6 +103,10 @@ describe("Raw data card view component", () => {
           data={entitySearch.results}
         />
       </SearchContext.Provider></MemoryRouter>);
+
+    //verify merge icon tooltip
+    fireEvent.mouseOver(getByTestId("merge-icon"));
+    await(waitForElement(() => (getByText("Merge Documents"))));
 
     //verify download icon
     expect(getByTestId("/Customer/Cust1.json-download-icon")).toBeInTheDocument();

--- a/marklogic-data-hub-central/ui/src/components/record-view/record-view.tsx
+++ b/marklogic-data-hub-central/ui/src/components/record-view/record-view.tsx
@@ -16,6 +16,7 @@ import {Download, FileEarmark, ArrowRightSquare} from "react-bootstrap-icons";
 import {HCCard, HCTooltip} from "@components/common";
 import Popover from "react-bootstrap/Popover";
 import {OverlayTrigger} from "react-bootstrap";
+import {RiMergeCellsHorizontal} from "react-icons/ri";
 
 const RecordCardView = (props) => {
   const authorityService = useContext(AuthoritiesContext);  // eslint-disable-line @typescript-eslint/no-unused-vars
@@ -232,9 +233,17 @@ const RecordCardView = (props) => {
                 <div className={styles.snippetContainer} data-testid={elem.uri + "-snippet"} >
                   {displaySnippet(elem)}
                 </div>
+                {
+                  elem.notifiedDoc ?
+                    <div className={styles.mergeIconDiv}>
+                      <HCTooltip text={"Merge Documents"} id="merge-icon" placement="top-end">
+                        <i><RiMergeCellsHorizontal className={styles.mergeIcon} data-testid={"merge-icon"}/></i>
+                      </HCTooltip>
+                    </div>
+                    : null}
                 <span className={styles.downloadIcon}>
                   <HCTooltip text={displayFileSize(elem)} id="download-icon-tooltip" placement="bottom" >
-                    <Download onClick={() => download(elem.uri)} data-testid={elem.uri + "-download-icon"}  size={13} />
+                    <Download onClick={() => download(elem.uri)} data-testid={elem.uri + "-download-icon"}  size={18} />
                   </HCTooltip>
                 </span>
               </HCCard>

--- a/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.test.tsx
@@ -72,9 +72,6 @@ describe("Results Table view component", () => {
     //Check if the tooltip on 'source on separate page' icon works fine.
     fireEvent.mouseOver(getByTestId("101-sourceOnSeparatePage"));
     await(waitForElement(() => (getByText("Show the complete JSON"))));
-
-    fireEvent.mouseOver(getByTestId("101-unmergeIcon"));
-    await(waitForElement(() => (getByText("Unmerge Documents"))));
   });
 
   test("Result table with no data renders", async () => {
@@ -181,6 +178,10 @@ describe("Results Table view component", () => {
     //Check if the tooltip on 'graph' icon works fine.
     fireEvent.mouseOver(getByTestId("101-graphOnSeparatePage"));
     await(waitForElement(() => (getByText("View entity in graph view"))));
+
+    //verify unmerge icon and tooltip
+    fireEvent.mouseOver(getByTestId("unmergeIcon"));
+    await(waitForElement(() => (getByText("Unmerge Documents"))));
 
   });
 

--- a/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.tsx
+++ b/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.tsx
@@ -6,7 +6,7 @@ import ColumnSelector from "@components/column-selector/column-selector";
 import {SearchContext} from "@util/search-context";
 import {Link} from "react-router-dom";
 import {faCode, faProjectDiagram, faThList, IconDefinition, faFileExport, faColumns} from "@fortawesome/free-solid-svg-icons";
-import {TbArrowsSplit} from "react-icons/tb";
+import {RiSplitCellsHorizontal} from "react-icons/ri";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {dateConverter} from "@util/date-conversion";
 import {HCTooltip, HCTable} from "@components/common";
@@ -372,16 +372,10 @@ const ResultsTabularView = (props) => {
           item.unmerge ?
             <div className={styles.unMergeIcon}>
               <HCTooltip text={"Unmerge Documents"} id="unmerge-icon-tooltip" placement="top-end">
-                <i><TbArrowsSplit className={styles.unMergeIcon} data-testid={`${primaryKeyValue}-unmergeIcon`} aria-label={`${primaryKeyValue}-unmerge-icon`}/></i>
+                <i><RiSplitCellsHorizontal className={styles.unMergeIcon} data-testid={`unmergeIcon`} aria-label={`unmerge-icon`}/></i>
               </HCTooltip>
             </div>
             : null
-            // <div className={styles.mergeIcon}>
-            //   <HCTooltip text={"Merge Documents"} id="merge-icon" placement="top-end">
-            //     <i><TbArrowsJoin className={styles.unMerge}/></i>
-            //   </HCTooltip>
-            // </div>
-
         }
       </div> : "";
     if (props.selectedEntities?.length > 1 && item.hasOwnProperty("entityName")) {

--- a/marklogic-data-hub-central/ui/src/components/search-result/search-result.tsx
+++ b/marklogic-data-hub-central/ui/src/components/search-result/search-result.tsx
@@ -6,7 +6,7 @@ import {dateConverter} from "@util/date-conversion";
 import ExpandableTableView from "../expandable-table-view/expandable-table-view";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faThList, faCode, faProjectDiagram} from "@fortawesome/free-solid-svg-icons";
-import {TbArrowsSplit} from "react-icons/tb";
+import {RiSplitCellsHorizontal} from "react-icons/ri";
 import {SearchContext} from "@util/search-context";
 import {ChevronDown, ChevronRight} from "react-bootstrap-icons";
 import {HCTooltip} from "@components/common";
@@ -142,7 +142,7 @@ const SearchResult: React.FC<Props> = (props) => {
             props.item.unmerge ?
               <div className={styles.unMergeIcon}>
                 <HCTooltip text={"Unmerge Documents"} id="unmerge-icon-tooltip" placement="top-end">
-                  <i><TbArrowsSplit data-testid="unmerge-icon" className={styles.unMergeIcon} aria-label={`${primaryKeyValue}-unmerge-icon`}/></i>
+                  <i><RiSplitCellsHorizontal className={styles.unMergeIcon} data-testid={`unmerge-icon`} aria-label={`unmerge-icon`}/></i>
                 </HCTooltip>
               </div>
               : null

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/entities/entity-search-lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/entities/entity-search-lib.sjs
@@ -498,6 +498,7 @@ function addDocumentMetadataToSearchResults(searchResponse) {
     }
     result["documentSize"] = getDocumentSize(cts.doc(docUri));
     result["hubMetadata"] = hubMetadata;
+    result["notifiedDoc"] = docUri.startsWith("/com.marklogic.smart-mastering/matcher/notifications");
   });
 }
 


### PR DESCRIPTION
### Description

- Added merge icon setup for merge notifications in Explore (only in All Data Card view)
- Includes @AkshayBajajML 's backend changes
- Reference:
<img width="1680" alt="Screen Shot 2022-07-29 at 11 22 09 AM" src="https://user-images.githubusercontent.com/18374593/181821362-83f063b9-ac62-4e11-81d6-a969b781241d.png">


#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [x] Ran cypress tests on firefox locally
  

- ##### Reviewer:

- [x] Reviewed Tests
- [x] Added to Release Wiki

