### PR TITLE
DHFPROD-9110: Use JSONPath expressions for config paths

### DIFF
--- a/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/dashboard.config.sjs
+++ b/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/dashboard.config.sjs
@@ -107,8 +107,9 @@ const dashboardConfig  = {
                         "thumbnail": {
                         "component": "Image",
                         "config": {
-                            "arrayPath": "person.images.image",
-                            "path": "url",
+                            //"arrayPath": "person.images.image",
+                            //"path": "url",
+                            "path": "person.images..*[?(@property === 'url')]",
                             "alt": "recent thumbnail",
                             "style": {
                             "width": "70px",
@@ -160,8 +161,9 @@ const dashboardConfig  = {
                             }
                         },
                         {
-                            "arrayPath": "person.emails.email",
-                            "path": "value",
+                            //"arrayPath": "person.emails.email",
+                            //"path": "value",
+                            "path": "person.emails..*[?(@property === 'value')]",
                             "className": "email"
                         },
                         {
@@ -169,8 +171,11 @@ const dashboardConfig  = {
                         }
                         ],
                         "categories": {
-                        "arrayPath": "person.sources",
-                        "path": "source.name",
+                        //"arrayPath": "person.sources",
+                        //"path": "source.name",
+                        "path": "person.sources..*[?(@property === 'name')]",
+                        // Filter out all categories NOT ("New York Times" OR "Wall Street Journal")
+                        //"path": "person.sources..*[?(@property === 'name' && (@ === 'New York Times' || @ === 'Wall Street Journal'))]",
                         "colors": {
                             "New York Times": "#d5e1de",
                             "USA Today": "#ebe1fa",

--- a/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/search.config.sjs
+++ b/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/search.config.sjs
@@ -86,8 +86,9 @@ const searchConfig  = {
                         "thumbnail": {
                             "component": "Image",
                             "config": {
-                                "arrayPath": "extracted.person.images.image",
-                                "path": "url",
+                                //"arrayPath": "extracted.person.images.image",
+                                //"path": "url",
+                                "path": "extracted.person.images..*[?(@property === 'url')]",
                                 "alt": "result thumbnail",
                                 "style": {
                                     "width": "70px",
@@ -134,13 +135,15 @@ const searchConfig  = {
                         {
                             "component": "Value",
                             "config": {
-                                "path": "extracted.person.phone",
+                                //"path": "extracted.person.phone",
+                                "path": "extracted.person.contacts..[?(@[`type`] === 'phone')].value",
                                 "className": "phone"
                             }
                         },
-                        {
-                            "arrayPath": "extracted.person.emails.email",
-                            "path": "value",
+                        { 
+                            //"arrayPath": "extracted.person.emails.email",
+                            //"path": "value",
+                            "path": "extracted.person.emails..*[?(@property === 'value')]",
                             "className": "email"
                         },
                         {
@@ -148,8 +151,11 @@ const searchConfig  = {
                         }
                         ],
                         "categories": {
-                            "arrayPath": "extracted.person.sources",
-                            "path": "source.name",
+                            //"arrayPath": "extracted.person.sources",
+                            //"path": "source.name",
+                            "path": "$.extracted.person.sources..*[?(@property === 'name')]",
+                            // Filter out all categories NOT ("New York Times" OR "Wall Street Journal")
+                            //"path": "extracted.person.sources..*[?(@property === 'name' && (@ === 'New York Times' || @ === 'Wall Street Journal'))]",
                             "colors": {
                                 "New York Times": "#d5e1de",
                                 "USA Today": "#ebe1fa",
@@ -160,8 +166,9 @@ const searchConfig  = {
                             }
                         },
                         "timestamp": {
-                            "arrayPath": "extracted.person.createdOn",
-                            "path": "ts",
+                            //"arrayPath": "extracted.person.createdOn",
+                            //"path": "ts",
+                            "path": "extracted.person.createdOn..ts",
                             "type": "datetime",
                             "format": "yyyy-MM-dd",
                             "prefix": "Created on ",
@@ -248,8 +255,11 @@ const searchConfig  = {
                         }
                         ],
                         "categories": {
-                            "arrayPath": "extracted.organization.sources",
-                            "path": "source.name",
+                            //"arrayPath": "extracted.organization.sources",
+                            //"path": "source.name",
+                            "path": "$.extracted.organization.sources..*[?(@property === 'name')]",
+                            // Filter out all categories NOT ("New York Times" OR "Wall Street Journal")
+                            // "path": "$.extracted.organization.sources..*[?(@property === 'name' && (@ === 'New York Times' || @ === 'Wall Street Journal'))]",
                             "colors": {
                                 "New York Times": "#d5e1de",
                                 "USA Today": "#ebe1fa",

--- a/marklogic-data-hub-central/ui-custom/e2e/cypress/support/pages/search.tsx
+++ b/marklogic-data-hub-central/ui-custom/e2e/cypress/support/pages/search.tsx
@@ -1,7 +1,7 @@
 class SearchPage {
 
   summaryMeter() {
-    return cy.get(".meter");
+    return cy.get(".summaryMeter");
   }
   menuSearchBox() {
     return cy.get(".sticky-top").findByTestId("searchBox");

--- a/marklogic-data-hub-central/ui-custom/package.json
+++ b/marklogic-data-hub-central/ui-custom/package.json
@@ -24,6 +24,7 @@
     "highcharts-react-official": "^3.1.0",
     "http-proxy-middleware": "^2.0.1",
     "jsdoc": "^3.6.7",
+    "jsonpath-plus": "^7.0.0",
     "lodash": "^4.17.21",
     "luxon": "^2.3.0",
     "node-sass": "^6.0.1",

--- a/marklogic-data-hub-central/ui-custom/src/components/ImageGallery/ImageGallery.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/ImageGallery/ImageGallery.tsx
@@ -1,12 +1,12 @@
 import React, {useState} from 'react';
 import {Carousel} from 'react-bootstrap';
-import {getValByConfig} from '../../util/util';
-import "./ImageGallery.scss";
 import Concat from "../Concat/Concat";
 import DateTime from '../DateTime/DateTime';
 import {Modal} from "react-bootstrap";
-import _ from "lodash";
 import Value from '../Value/Value';
+import {getValByPath, getValByConfig} from '../../util/util';
+import "./ImageGallery.scss";
+import _ from "lodash";
 
 type Props = {
   data?: any;
@@ -93,7 +93,7 @@ const ImageGallery: React.FC<Props> = (props) => {
     values = items.map((item, index) => {
       if (!item) return null;
       const {component, label, path, config} = item
-      let value: any = path ? _.get(selectedImage, path, null) : null;
+      let value: any = path ? getValByPath(selectedImage, path) : null;
       if (!value) return null;
       return (
         <div className="metadata-row">
@@ -112,8 +112,8 @@ const ImageGallery: React.FC<Props> = (props) => {
 
   const CenteredModal = (props) => {
     const {images: {url}, modal: {title: {component, path, config: titleConfig}}} = config;
-    let urlValue: any = _.get(selectedImage, url, null);
-    let titleValue: any = path ? _.get(selectedImage, path, null) : null;
+    let urlValue: any = (url && selectedImage) ? getValByPath(selectedImage, url) : null;
+    let titleValue: any = (path && selectedImage) ? getValByPath(selectedImage, path) : null;
     return (
       <Modal
         {...props}
@@ -154,7 +154,7 @@ const ImageGallery: React.FC<Props> = (props) => {
 
   const getItems = () => {
     const carouselItems = images?.map((item, index) => {
-      let urlValue: any = _.get(item, config?.images?.url, []);
+      let urlValue: any = getValByPath(item, config?.images?.url);
       return (
         <Carousel.Item key={index}>
           <div data-testid={`item-${index}`}>

--- a/marklogic-data-hub-central/ui-custom/src/components/ImageGalleryMulti/ImageGalleryMulti.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/ImageGalleryMulti/ImageGalleryMulti.tsx
@@ -1,14 +1,13 @@
 import React, {useState} from "react";
-import {getValByConfig} from "../../util/util";
-import "./ImageGalleryMulti.scss";
-
 import Carousel from "react-multi-carousel";
 import Concat from "../Concat/Concat";
 import "react-multi-carousel/lib/styles.css";
 import {Modal} from "react-bootstrap";
-import _ from "lodash";
 import DateTime from '../DateTime/DateTime';
 import Value from "../Value/Value";
+import "./ImageGalleryMulti.scss";
+import {getValByPath, getValByConfig} from "../../util/util";
+import _ from "lodash";
 
 
 type Props = {
@@ -95,7 +94,7 @@ const ImageGalleryMulti: React.FC<Props> = (props) => {
     values = items.map((item, index) => {
       if (!item) return null;
       const {component, label, path, config} = item
-      let value: any = path ? _.get(selectedImage, path, null) : null;
+      let value: any = path ? getValByPath(selectedImage, path) : null;
       if (!value) return null;
       return (
         <div className="metadata-row" key={"meta-" + index}>
@@ -114,8 +113,8 @@ const ImageGalleryMulti: React.FC<Props> = (props) => {
 
   const CenteredModal = (props) => {
     const {images: {url}, modal: {title: {component, path, config:titleConfig}}} = config;
-    let urlValue: any = _.get(selectedImage, url, null);
-    let titleValue: any = path ? _.get(selectedImage, path, null) : null;
+    let urlValue: any = (url && selectedImage) ? getValByPath(selectedImage, url) : null;
+    let titleValue: any = (path && selectedImage) ? getValByPath(selectedImage, path) : null;
     return (
       <Modal
         {...props}
@@ -156,7 +155,7 @@ const ImageGalleryMulti: React.FC<Props> = (props) => {
 
   const getItems = () => {
     const carouselItems = images?.map((item, index) => {
-      let urlValue: any = _.get(item, config?.images?.url, []);
+      let urlValue: any = getValByPath(item, config?.images?.url);
       return (
         <div key={index} style={imageStyle} data-testid={`item-${index}`}>
           <img

--- a/marklogic-data-hub-central/ui-custom/src/components/LinkList/LinkList.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/LinkList/LinkList.tsx
@@ -1,10 +1,11 @@
 import React, {useState} from 'react';
 import {ChevronDoubleRight, ChevronDoubleLeft, EyeFill} from "react-bootstrap-icons";
-import _ from "lodash";
-import "./LinkList.scss";
-import {getValByConfig} from '../../util/util';
+import {getValByPath, getValByConfig} from '../../util/util';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome'
 import * as FaDictionary  from '@fortawesome/free-solid-svg-icons'
+import "./LinkList.scss";
+import _ from "lodash";
+
 type Props = {
   data?: any;
   config?: any;
@@ -44,9 +45,9 @@ const LinkList: React.FC<Props> = (props) => {
     linksData = _.isNil(linksData) ? null : (Array.isArray(linksData) ? linksData : [linksData]);
     const links = linksData?.map((link, index) => {
       const {link: {icon, label, url}} = config;
-      let iconValue: any = _.get(link, icon, null);
-      let labelValue: any = _.get(link, label, null);
-      let urlValue: any = _.get(link, url, null);
+      let iconValue: any = getValByPath(link, icon);
+      let labelValue: any = getValByPath(link, label);
+      let urlValue: any = getValByPath(link, url);
       let iconElement = FaDictionary[iconValue];
       return (
         <a href={urlValue ? urlValue : "#"} target="_blank" className="LinkList-item" key={index}>

--- a/marklogic-data-hub-central/ui-custom/src/components/Membership/Membership.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Membership/Membership.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import "./Membership.scss";
 import {Check, X} from "react-bootstrap-icons";
 import _ from "lodash";
-import {getValByConfig} from "../../util/util";
+import {getValByPath, getValByConfig} from "../../util/util";
 import DateTime from "../DateTime/DateTime";
 
 type Props = {
@@ -57,8 +57,8 @@ const Membership: React.FC<Props> = (props) => {
     let membershipStyle: React.CSSProperties = props.style ? props.style : props.config?.style ? props.config.style : {};
     const items = config?.lists?.map((list, index) => {
       const membership = memberships?.find(el => el?.list.toLowerCase() === list.toLowerCase());
-      const tsValue = ts?.path ? _.get(membership, ts?.path, null) : null;
-      const statusValue = status?.path ? _.get(membership, status?.path, false) : false;
+      const tsValue = ts?.path ? getValByPath(membership, ts?.path) : null;
+      const statusValue = status?.path ? getValByPath(membership, status?.path) : false;
       const important = statusValue === true;
       const classes = important ? "item highlighted" : membership ? "item success" : "item";
       return (

--- a/marklogic-data-hub-central/ui-custom/src/components/MetadataValue/MetadataValue.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/MetadataValue/MetadataValue.tsx
@@ -6,7 +6,7 @@ import Table from "react-bootstrap/Table";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import Popover from "react-bootstrap/Popover";
 import "./MetadataValue.scss";
-import {getValByConfig} from "../../util/util";
+import {getValByPath, getValByConfig} from "../../util/util";
 import _ from "lodash";
 
 type Props = {
@@ -57,7 +57,7 @@ type Props = {
 const MetadataValue: React.FC<Props> = (props) => {
 
     const value = getValByConfig(props.data, props.config);
-    let popoverData = props?.config?.popover ? _.get(props.data, props?.config?.popover?.dataPath, []):[];
+    let popoverData = props?.config?.popover ? getValByPath(props.data, props?.config?.popover?.dataPath) : [];
     popoverData = _.isNil(popoverData) ? null : (Array.isArray(popoverData) ? popoverData : [popoverData]);
 
     let metadataStyle: any = props.style ? props.style : props.config?.style ? props.config.style : {};
@@ -119,7 +119,7 @@ const MetadataValue: React.FC<Props> = (props) => {
 
     return (
         <span className="MetadataValue">
-            { props.config.popover && popoverData.length > 0 ? getOverlay() : getMetadata() }
+            { props.config.popover && popoverData?.length > 0 ? getOverlay() : getMetadata() }
         </span>
     );
 };

--- a/marklogic-data-hub-central/ui-custom/src/components/Metrics/Metric.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Metrics/Metric.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 const Metric: React.FC<Props> = (props) => {
 
-  let val = _.get(props.data, props.config.path, null);
+  let val = getValByPath(props.data, props.config.path, true);
   let valFmt = _.isNumber(val) ? val.toLocaleString() : val;
 
   return (

--- a/marklogic-data-hub-central/ui-custom/src/components/Pagination/Pagination.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React from 'react';
 import {Form, Pagination as PaginationBootstrap} from "react-bootstrap";
 import "./Pagination.scss";
 

--- a/marklogic-data-hub-central/ui-custom/src/components/Relationships/Relationships.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Relationships/Relationships.tsx
@@ -98,7 +98,7 @@ const Relationships: React.FC<Props> = (props) => {
     }
 
     const getRootNode = (data, rootConfig, type) => {
-        const rootId = getValByConfig(data, rootConfig.id);
+        const rootId = getValByConfig(data, rootConfig.id, true);
         let rootItems: any = [];
         rootConfig?.popover?.items.forEach(item => {
             const label =  item.label;
@@ -129,7 +129,7 @@ const Relationships: React.FC<Props> = (props) => {
         })
         if (type === "text") {
             relObj = { 
-                id: getValByConfig(data, relationsConfig.id), 
+                id: getValByConfig(data, relationsConfig.id, true), 
                 label: getValByConfig(data, relationsConfig.label, true),
                 shape: "box",
                 borderWidth: 0, 
@@ -138,7 +138,7 @@ const Relationships: React.FC<Props> = (props) => {
             }
         } else if (type === "image") {
             relObj = { 
-                id: getValByConfig(data, relationsConfig.id), 
+                id: getValByConfig(data, relationsConfig.id, true), 
                 image: getValByConfig(data, relationsConfig.imgSrc, true),
                 shape: "image", 
                 size: 30, 
@@ -150,10 +150,10 @@ const Relationships: React.FC<Props> = (props) => {
 
     useEffect(() => {
         const nodeSize = props.config.size ? props.config.size : 30;
-        const rootId = getValByConfig(props.data, props.config.root.id);
+        const rootId = getValByConfig(props.data, props.config.root.id, true);
 
         // Set up related entities
-        let relations = getValByConfig(props.data, props.config.relations);
+        let relations = getValByConfig(props.data, props.config.relations, false);
         relations = _.isNil(relations) ? null : (Array.isArray(relations) ? relations : [relations]);
 
         // if no relations, minimize container and return
@@ -173,8 +173,8 @@ const Relationships: React.FC<Props> = (props) => {
         relations.forEach(rel => {
             edges.push({ 
                 from: rootId, 
-                to: getValByConfig(rel, props.config.relations.id), 
-                label: getValByConfig(rel, props.config.relations.predicate)
+                to: getValByConfig(rel, props.config.relations.id, true), 
+                label: getValByConfig(rel, props.config.relations.predicate, true)
             });
         });
 

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultActions/ResultActions.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultActions/ResultActions.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {GearFill, CodeSlash, ArrowRepeat} from "react-bootstrap-icons";
-import {getValByConfig} from '../../util/util';
+import {getValByPath, getValByConfig} from '../../util/util';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome'
 import * as FaDictionary from '@fortawesome/free-solid-svg-icons'
 import _ from "lodash";
@@ -42,9 +42,9 @@ const ResultActions: React.FC<Props> = (props) => {
     const links = actionsData?.map((action, index) => {
       const {action: {icon = null, color = null, url = null}} = config;
       if (!icon) return;
-      let iconValue: any = _.get(action, icon, null);
-      let colorValue: any = _.get(action, color, null);
-      let urlValue: any = _.get(action, url, null);
+      let iconValue: any = getValByPath(action, icon, true);
+      let colorValue: any = getValByPath(action, color, true);
+      let urlValue: any = getValByPath(action, url, true);
       let iconElement = FaDictionary[iconValue];
 
       let iconClassName: any = props.className ? props.className : props.config?.className ? props.config.className : "";

--- a/marklogic-data-hub-central/ui-custom/src/components/SocialMedia/SocialMedia.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/SocialMedia/SocialMedia.tsx
@@ -3,7 +3,7 @@ import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import Tooltip from "react-bootstrap/Tooltip";
 import "./SocialMedia.scss";
 import * as IconDictionary from 'react-bootstrap-icons';
-import {getValByConfig} from '../../util/util';
+import {getValByPath, getValByConfig} from '../../util/util';
 import _ from "lodash";
 
 type Props = {
@@ -82,9 +82,9 @@ const SocialMedia: React.FC<Props> = (props) => {
     if (Object.keys(sites).length === 0 || !socials || socials.length === 0) return [];
 
     const icons = socials.reduce((acc, socialItem, index) => {
-      let siteVal: any = _.get(socialItem, site, []);
-      let handleVal: any = _.get(socialItem, handle, []);
-      let urlVal: any = _.get(socialItem, url, []);
+      let siteVal: any = getValByPath(socialItem, site, true);
+      let handleVal: any = getValByPath(socialItem, handle, true);
+      let urlVal: any = getValByPath(socialItem, url, true);
 
       if (!sites[siteVal]) return acc;
       const {title, color, icon, size = 18} = sites[siteVal];

--- a/marklogic-data-hub-central/ui-custom/src/components/SummaryMeter/SummaryMeter.scss
+++ b/marklogic-data-hub-central/ui-custom/src/components/SummaryMeter/SummaryMeter.scss
@@ -1,4 +1,4 @@
-.meter {
+.summaryMeter {
     position: relative;
     width: 360px; 
     height: 176px; 

--- a/marklogic-data-hub-central/ui-custom/src/components/SummaryMeter/SummaryMeter.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/SummaryMeter/SummaryMeter.tsx
@@ -124,7 +124,7 @@ const SummaryMeter: React.FC<Props> = (props) => {
   };
 
   return (
-    <div className="meter" data-testid="summaryMeterId">
+    <div className="summaryMeter" data-testid="summaryMeterId">
       <div style={{zIndex: 1}}>
         <HighchartsReact
             highcharts={Highcharts}

--- a/marklogic-data-hub-central/ui-custom/src/components/Timeline/Timeline.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/Timeline/Timeline.tsx
@@ -1,9 +1,9 @@
-import React, {useState} from "react";
+import React from "react";
 import "./Timeline.scss";
 import Concat from "../Concat/Concat";
 import DateTime from "../DateTime/DateTime";
 import Value from "../Value/Value";
-import { getValByConfig } from "../../util/util";
+import { getValByPath, getValByConfig } from "../../util/util";
 import _ from "lodash";
 import {default as TimelineVis} from "react-visjs-timeline";
 import "./Timeline.scss";
@@ -58,9 +58,9 @@ const Timeline: React.FC<Props> = (props) => {
 
     data?.map((activity, id) => {
         let obj={content: "", start: null, id: "", title: "", type:""};
-        obj.content = _.get(activity, props.config.marker.label.path, null)
-        obj.start = _.get(activity, props.config.marker.ts.path, null)
-        obj.id = _.get(activity, props.config.marker.label.path, null) + id;
+        obj.content = getValByPath(activity, props.config.marker.label.path, true)
+        obj.start = getValByPath(activity, props.config.marker.ts.path, true)
+        obj.id = getValByPath(activity, props.config.marker.label.path, true) + id;
         obj.title = ReactDOMServer.renderToString(
             <span>{getItems(data[id])}</span>)
         timelineData.push(obj);
@@ -68,7 +68,7 @@ const Timeline: React.FC<Props> = (props) => {
 
     let minDate = new Date(), maxDate = new Date, currItemDate;
     data?.map((activity) => {
-        let date = _.get(activity, props.config.marker.ts.path, null);
+        let date = getValByPath(activity, props.config.marker.ts.path);
 
         currItemDate = new Date(date);
         if(currItemDate < minDate) {

--- a/marklogic-data-hub-central/ui-custom/src/components/WhatsNew/WhatsNew.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/WhatsNew/WhatsNew.tsx
@@ -8,6 +8,7 @@ import highchartsMore from "highcharts/highcharts-more.js"
 import solidGauge from "highcharts/modules/solid-gauge.js";
 import HighchartsReact from 'highcharts-react-official'
 import "./WhatsNew.scss";
+import { getValByPath } from "../../util/util";
 import _ from "lodash";
 
 type Props = {
@@ -46,7 +47,7 @@ const WhatsNew: React.FC<Props> = (props) => {
   }
 
   const formatNumber = (data, path) => {
-        let  result = _.get(data, path, null);
+        let  result = getValByPath(data, path);
         return result ? parseInt(result).toLocaleString() : null;
   }
 
@@ -137,7 +138,7 @@ const WhatsNew: React.FC<Props> = (props) => {
     options.series[0]["data"] = [];
     // Reversing puts first one at bottom, then clockwise
     props.config.items.reverse().forEach((item, i) => {
-      let val = _.get(props.data, item.path, null);
+      let val = getValByPath(props.data, item.path, true);
       let normalized = 100 * (val/total);
       let chartVal = 100 - adjustment;
       adjustment = adjustment + normalized;

--- a/marklogic-data-hub-central/ui-custom/src/store/MetricsContext.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/store/MetricsContext.tsx
@@ -10,8 +10,8 @@ interface MetricsContextInterface {
 }
   
 const defaultState = {
-    metrics: [],
-    whatsNew: [],
+    metrics: {},
+    whatsNew: {},
     handleGetMetrics: () => {},
     handleGetWhatsNew: () => {},
 };
@@ -31,8 +31,8 @@ const MetricsProvider: React.FC = ({ children }) => {
 
     const userContext = useContext(UserContext);
 
-    const [metrics, setMetrics] = useState<any>([]);
-    const [whatsNew, setWhatsNew] = useState<any>([]);
+    const [metrics, setMetrics] = useState<any>({});
+    const [whatsNew, setWhatsNew] = useState<any>({});
 
     const handleGetMetrics = () => {
       // If not configured, don't execute

--- a/marklogic-data-hub-central/ui-custom/src/store/SearchContext.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/store/SearchContext.tsx
@@ -2,6 +2,7 @@ import React, {useEffect, useState, useContext} from "react";
 import {useNavigate, useLocation} from "react-router-dom";
 import {UserContext} from "../store/UserContext";
 import {getSearchResults, getSearchResultsByGet} from "../api/api";
+import { getValByPath } from "../util/util";
 import _ from "lodash";
 
 interface SearchContextInterface {
@@ -177,7 +178,7 @@ const SearchProvider: React.FC = ({children}) => {
         }
         setSearchResults(result?.data.searchResults.response);
         setReturned(parseInt(result?.data.searchResults.response.total));
-        setTotal(_.get(result?.data, userContext.config.search.meter.config.totalPath, null) || 0);
+        setTotal(getValByPath(result?.data, userContext.config.search.meter.config.totalPath) || 0);
         handleSaveSearchLocal();
         handleGetSearchLocal();
         setNewSearch(false);

--- a/marklogic-data-hub-central/ui-custom/src/util/util.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/util/util.test.tsx
@@ -1,0 +1,147 @@
+import {getValByPath, getValByConfig} from "./util";
+
+const data = {
+    root: {
+        contact: "emailVal1",
+        contactObj: {email: "emailVal1", phone: "phoneVal1"},
+        contactArraySingle: ["emailVal1", "emailVal2"],
+        contactArrayObj: [{email: "emailVal1"}, {email: "emailVal2"}],
+        contactNestedArrays: [
+            {
+                emailArray: ["emailVal1-1", "emailVal1-1"],
+                phone: "phoneVal1"
+            }, 
+            {
+                emailArray: ["emailVal2-1", "emailVal2-1"],
+                phone: "phoneVal2"
+            },
+        ],
+        contactAttr: [
+            {
+                contact: "emailVal1",
+                attr: "email"
+            },
+            {
+                contact: "phoneVal1",
+                attr: "phone"
+            }
+        ],
+        contactSingleEmpty: "",
+        contactObjEmpty: {},
+        contactArrayEmpty: [],
+    }
+}
+const dataSingleCase = {
+    root: {
+        // XML-to-JSON conversion returns singletons as objects
+        contacts: {contact: {email: "emailVal1"}},
+    }
+}
+const dataArrayCase = {
+    root: {
+        // XML-to-JSON conversion returns multiples as arrays
+        contacts: {contact: [{email: "emailVal1"}, {email: "emailVal2"}]},
+    }
+}
+
+const exprSingle = "root.contact";
+const exprObj = "root.contactObj";
+const exprArraySingle = "root.contactArraySingle";
+const exprArrayObj = "root.contactArrayObj";
+// Handle case where result value could be array or singleton
+const exprSingleOrArray = "root.contacts..*[?(@property === 'email')]";
+const exprNestedArrays = "root..emailArray";
+const exprPropAttr = "root.contactAttr..[?(@[`attr`] === 'email')]";
+const exprSingleEmpty = "root.contactSingleEmpty";
+const exprObjEmpty = "root.contactObjEmpty";
+const exprArrayEmpty = "root.contactArrayEmpty";
+const exprNotFound = "root.doesNotExist";
+
+describe("getValByPath method", () => {
+    test("Handle single value", () => {
+        const result = getValByPath(data, exprSingle);
+        expect(result).toEqual(data.root.contact);
+    });
+    test("Handle object value", () => {
+        const result = getValByPath(data, exprObj);
+        expect(result).toEqual(data.root.contactObj);
+    });
+    test("Handle array of single values", () => {
+        const result = getValByPath(data, exprArraySingle);
+        expect(result).toEqual(data.root.contactArraySingle);
+    });
+    test("Handle array of object values", () => {
+        const result = getValByPath(data, exprArrayObj);
+        expect(result).toEqual(data.root.contactArrayObj);
+    });
+    test("Handle single object value (array or single case)", () => {
+        const result = getValByPath(dataSingleCase, exprSingleOrArray);
+        expect(result).toEqual([dataSingleCase.root.contacts.contact.email]);
+    });
+    test("Handle array of object values (array or single case)", () => {
+        const result = getValByPath(dataArrayCase, exprSingleOrArray);
+        expect(result).toEqual([
+            dataArrayCase.root.contacts.contact[0].email, 
+            dataArrayCase.root.contacts.contact[1].email
+        ]);
+    });
+    test("Handle inner array within nested arrays", () => {
+        const result = getValByPath(data, exprNestedArrays);
+        expect(result).toEqual([
+            data.root.contactNestedArrays[0].emailArray, 
+            data.root.contactNestedArrays[1].emailArray
+        ]);
+    });
+    test("Handle object filtered by attribute property", () => {
+        const result = getValByPath(data, exprPropAttr);
+        expect(result).toEqual([data.root.contactAttr[0]]);
+    });
+    test("Handle array when getFirst is true", () => {
+        const result = getValByPath(data, exprArraySingle, true);
+        expect(result).toEqual(data.root.contactArraySingle[0]);
+    });
+    test("Handle empty single value", () => {
+        const result = getValByPath(data, exprSingleEmpty);
+        expect(result).toEqual("");
+    });
+    test("Handle empty object value", () => {
+        const result = getValByPath(data, exprObjEmpty);
+        expect(result).toEqual({});
+    });
+    test("Handle empty array value", () => {
+        const result = getValByPath(data, exprArrayEmpty);
+        expect(result).toEqual([]);
+    });
+    test("Handle expression yielding no values", () => {
+        const result = getValByPath(data, exprNotFound);
+        expect(result).toEqual(undefined);
+    });
+})
+
+const configPath = { path: "root.contact" };
+const configArrayPath = { arrayPath: "root.contactNestedArrays" };
+const configArrayPathAndPath = { arrayPath: "root.contactAttr", path: "contact" };
+const configDoesNotExist = { path: "root.doesNotExist" };
+
+describe("getValByConfig method", () => {
+    test("Handle config with path ONLY", () => {
+        const result = getValByConfig(data, configPath);
+        expect(result).toEqual(data.root.contact);
+    });
+    test("Handle config with arrayPath ONLY", () => {
+        const result = getValByConfig(data, configArrayPath);
+        expect(result).toEqual(data.root.contactNestedArrays);
+    });
+    test("Handle config with arrayPath and path", () => {
+        const result = getValByConfig(data, configArrayPathAndPath);
+        expect(result).toEqual(["emailVal1", "phoneVal1"]);
+    });
+    test("Handle config when getFirst is true", () => {
+        const result = getValByConfig(data, configArrayPathAndPath, true);
+        expect(result).toEqual(data.root.contactAttr[0].contact);
+    });
+    test("Handle config yielding no values", () => {
+        const result = getValByConfig(data, configDoesNotExist);
+        expect(result).toEqual(null);
+    });
+})

--- a/marklogic-data-hub-central/ui-custom/src/views/Dashboard.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/views/Dashboard.tsx
@@ -30,8 +30,8 @@ const Dashboard: React.FC<Props> = (props) => {
   const userContext = useContext(UserContext);
 
   const [config, setConfig] = useState<any>(null);
-  const [metrics, setMetrics] = useState<any>([]);
-  const [whatsNew, setWhatsNew] = useState<any>([]);
+  const [metrics, setMetrics] = useState<any>({});
+  const [whatsNew, setWhatsNew] = useState<any>({});
   const [recentSearches, setRecentSearches] = useState<any>([]);
   const [recentRecords, setRecentRecords] = useState<any>({});
 

--- a/marklogic-data-hub-central/ui-custom/src/views/Search.test.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/views/Search.test.tsx
@@ -114,7 +114,7 @@ describe("Search view", () => {
             );
             getByText = renderResults.getByText;
         });
-        expect(document.querySelector(".meter")).toBeInTheDocument();
+        expect(document.querySelector(".summaryMeter")).toBeInTheDocument();
         expect(getByText(config.search.facets.config.items[0].name)).toBeInTheDocument();
         expect(document.querySelector(".results")).toBeInTheDocument();
     });


### PR DESCRIPTION
Use the jsonpath-plus library.
Create alternative functions in util.tsx.
Add tests to util functions.

### Description

There are places in the configuration where I've updated the paths to use JSONPath notation:

- https://github.com/wooldridge/marklogic-data-hub/blob/DHFPROD-9110/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/search.config.sjs#L91
- https://github.com/wooldridge/marklogic-data-hub/blob/DHFPROD-9110/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/search.config.sjs#L139
- https://github.com/wooldridge/marklogic-data-hub/blob/DHFPROD-9110/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/search.config.sjs#L156
- https://github.com/wooldridge/marklogic-data-hub/blob/DHFPROD-9110/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/search.config.sjs#L171
- https://github.com/wooldridge/marklogic-data-hub/blob/DHFPROD-9110/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/dashboard.config.sjs#L166
- https://github.com/wooldridge/marklogic-data-hub/blob/DHFPROD-9110/examples/entity-viewer/src/main/ml-modules/root/explore-data/ui-config/dashboard.config.sjs#L176

But the example application itself should work as before, as should all the existing path configurations.

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki

