### PR TITLE
DHFPROD-9336: In Load tile, modals show the wrong data after editing/creating a new step

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/load/create-edit-load/create-edit-load.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/create-edit-load/create-edit-load.tsx
@@ -30,14 +30,14 @@ interface Props {
 }
 
 const CreateEditLoad: React.FC<Props> = (props) => {
-  const [stepName, setStepName] = useState(props.stepData && props.stepData !== {} ? props.stepData.name : "");
-  const [description, setDescription] = useState(props.stepData && props.stepData !== {} ? props.stepData.description : "");
-  const [srcFormat, setSrcFormat] = useState(props.stepData && props.stepData !== {} ? props.stepData.sourceFormat : StepsConfig.defaultSourceFormat);
-  const [tgtFormat, setTgtFormat] = useState(props.stepData && props.stepData !== {} ? props.stepData.targetFormat : StepsConfig.defaultTargetFormat);
-  const [sourceName, setSourceName] = useState(props.stepData && props.stepData !== {} ? props.stepData.sourceName : "");
-  const [sourceType, setSourceType] = useState(props.stepData && props.stepData !== {} ? props.stepData.sourceType : "");
-  const [outputUriPrefix, setOutputUriPrefix] = useState(props.stepData && props.stepData !== {} ? props.stepData.outputURIPrefix : "");
-  const [fieldSeparator, setFieldSeparator] = useState(props.stepData && props.stepData !== {} ? props.stepData.fieldSeparator : StepsConfig.defaultFieldSeparator);
+  const [stepName, setStepName] = useState("");
+  const [description, setDescription] = useState("");
+  const [srcFormat, setSrcFormat] = useState(StepsConfig.defaultSourceFormat);
+  const [tgtFormat, setTgtFormat] = useState(StepsConfig.defaultTargetFormat);
+  const [sourceName, setSourceName] = useState("");
+  const [sourceType, setSourceType] = useState("");
+  const [outputUriPrefix, setOutputUriPrefix] = useState("");
+  const [fieldSeparator, setFieldSeparator] = useState(StepsConfig.defaultFieldSeparator);
   const [otherSeparator, setOtherSeparator] = useState("");
 
   //To check submit validity
@@ -117,7 +117,8 @@ const CreateEditLoad: React.FC<Props> = (props) => {
     setIsValid(true);
     props.setIsValid(true);
     setTobeDisabled(true);
-
+    setSourceName(props.stepData.sourceName);
+    setSourceType(props.stepData.sourceType);
     setDescriptionTouched(false);
     setSrcFormatTouched(false);
     setTgtFormatTouched(false);

--- a/marklogic-data-hub-central/ui/src/components/load/load-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-card.tsx
@@ -56,7 +56,7 @@ const LoadCard: React.FC<Props> = (props) => {
 
   const OpenStepSettings = (index) => {
     setIsEditing(true);
-    setStepData(prevState => ({...prevState, ...props.data[index]}));
+    setStepData({...props.data[index]});
     setOpenStepSettings(true);
   };
 


### PR DESCRIPTION
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [ ] JIRA_ID included in all the commit messages
- [ ] PR title is in the format JIRA_ID:Title
- [ ] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [ ] Code passes ESLint tests
- [ ] Added Tests
- [ ] Ran cypress tests on firefox locally
  

- ##### Reviewer:

- [ ] Reviewed Tests
- N/A Added to Release Wiki

