### PR TITLE
DHFPROD-9419: Notifications should not be generated when only one URI

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/mastering/merging/merger.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/mastering/merging/merger.sjs
@@ -103,7 +103,9 @@ function buildContentObjectsFromMatchSummary(
       case "notify":
         const matchStepName = matchSummary["matchSummary"]["matchStepName"];
         const matchStepFlow = matchSummary["matchSummary"]["matchStepFlow"];
-        currentContentObject = mergeable.buildNotification(uri, uriActionDetails.threshold, uriActionDetails.query ? cts.query(uriActionDetails.query): uriActionDetails.uris, matchStepName, matchStepFlow);
+        if(uriActionDetails.uris.length > 1) {
+          currentContentObject = mergeable.buildNotification(uri, uriActionDetails.threshold, uriActionDetails.query ? cts.query(uriActionDetails.query): uriActionDetails.uris, matchStepName, matchStepFlow);
+        }
         break;
       case "custom":
         for (const action of uriActionDetails.actions) {


### PR DESCRIPTION
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit

