### PR TITLE
DHFPROD-9543: BE - Group nodes are displaying incorrectly

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/graph-utils.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/graph-utils.sjs
@@ -289,9 +289,9 @@ function getEntityNodesByDocument(docURI, limit) {
       SELECT ?firstObjectIRI ?additionalEdge ?additionalIRI ?docRelated  WHERE {
           ?firstObjectIRI rdf:type ?entityTypeOrConceptIRI.
           {
-            ?firstObjectIRI ?additionalEdge ?additionalIRI. 
+            ?firstObjectIRI ?additionalEdge ?additionalIRI.
           } UNION {
-            ?additionalIRI ?additionalEdge ?firstObjectIRI. 
+            ?additionalIRI ?additionalEdge ?firstObjectIRI.
           }
           FILTER (isIRI(?additionalEdge) && ?additionalEdge = $allPredicates)
       }
@@ -357,6 +357,7 @@ function graphResultsToNodesAndEdges(result, entityTypeIds = [], isSearch = true
   const docUriToSubjectIri = {};
   const distinctIriPredicateCombos = {};
   const groupNodeCount = {};
+  let allEntitiesAreSelected = entityTypeIds.length === fn.count(fn.collection(entityLib.getModelCollection()));
   const getEdgeCount = (iri) => {
     if (!distinctIriPredicateCombos[iri]) {
       return 0;
@@ -511,7 +512,7 @@ function graphResultsToNodesAndEdges(result, entityTypeIds = [], isSearch = true
             };
           }
         }
-      } else if (fn.exists(item.nodeCount) && fn.head(item.nodeCount) > 1) {
+      } else if (fn.exists(item.nodeCount) && fn.head(item.nodeCount) > 1 && !(allEntitiesAreSelected === true && isSearch === true )) {
         const entityType = objectIRIArr[objectIRIArr.length - 2];
         const objectId = originId + "-" + item.predicateIRI + "-" + entityType;
         let edge = {};

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/graph/graphSearch.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/data-services/graph/graphSearch.sjs
@@ -165,11 +165,12 @@ const RelatedByPropertyDifferentFromID = {
 };
 
 const ResultRelatedByPropertyDifferentFromID = searchNodes(RelatedByPropertyDifferentFromID);
+expectedCountDifferentFromID = graphUtils.supportsGraphConceptsSearch() ? 3 : 2;
 
 assertions.concat([
-  test.assertEqual(3, ResultRelatedByPropertyDifferentFromID.total),
-  test.assertEqual(3, ResultRelatedByPropertyDifferentFromID.nodes.length, xdmp.toJsonString(ResultRelatedByPropertyDifferentFromID)),
-  test.assertEqual(3, ResultRelatedByPropertyDifferentFromID.edges.length),
+  test.assertEqual(expectedCountDifferentFromID, ResultRelatedByPropertyDifferentFromID.total),
+  test.assertEqual(expectedCountDifferentFromID, ResultRelatedByPropertyDifferentFromID.nodes.length, xdmp.toJsonString(ResultRelatedByPropertyDifferentFromID)),
+  test.assertEqual(expectedCountDifferentFromID, ResultRelatedByPropertyDifferentFromID.edges.length),
 ]);
 
 const conceptFilterQuery = {
@@ -259,5 +260,19 @@ assertions.concat([
   test.assertEqual(expectedNodeCount, structuredConceptQueryResults.nodes.length, xdmp.toJsonString(structuredConceptQueryResults)),
   test.assertEqual(expectedEdgeCount, structuredConceptQueryResults.edges.length, "One edge between concept node and structured property concept node")
 ]);
+
+const withAllEntitiesSelectedQuery = {
+  "searchText": "",
+  "entityTypeIds": [ "BabyRegistry","Product", "Customer", "NamespacedCustomer", "Office"]
+
+};
+const resultsAllEntitiesSelected = searchNodes(withAllEntitiesSelectedQuery);
+
+
+resultsAllEntitiesSelected.nodes.forEach(node => {
+    if(node.count != null && node.count > 1){
+      test.assertFail("a node with count greater than 1 must not exists");
+    }
+})
 
 assertions;


### PR DESCRIPTION
### Description
This PR include a fix for DHFPROD-9540
#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [n/a] Ran cypress tests on firefox locally
  

- ##### Reviewer:

- [x] Reviewed Tests
- [n/a] Added to Release Wiki

