### PR TITLE
DHFPROD-9627: Fixes on UI

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/explore/data-model-display-settings-modal/data-model-display-settings-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/explore/data-model-display-settings-modal/data-model-display-settings-modal.tsx
@@ -114,7 +114,7 @@ const DataModelDisplaySettingsModal: React.FC<Props> = ({isVisible, toggleModal,
         entityData.label = e.value;
         break;
       case EntityTableColumns.PropertiesOnHover:
-        entityData.propertiesOnHover = e.map(property => property.replaceAll(" > ", "."));
+        entityData.propertiesOnHover = e.map(property => property.split(" > ").join("."));
         break;
       }
     };

--- a/marklogic-data-hub-central/ui/src/components/explore/data-model-display-settings-modal/entity-display-settings/entity-display-settings.tsx
+++ b/marklogic-data-hub-central/ui/src/components/explore/data-model-display-settings-modal/entity-display-settings/entity-display-settings.tsx
@@ -162,7 +162,7 @@ const EntityDisplaySettings: React.FC<Props> = ({entityModels, exploreSettingsDa
             isForMerge={true}
             propertyDropdownOptions={entityTypeDefinition.properties}
             entityDefinitionsArray={definitions}
-            value={row.propertiesOnHover?.length ? row.propertiesOnHover.map(property => property.replaceAll(".", " > ")) : undefined}
+            value={row.propertiesOnHover?.length ? row.propertiesOnHover.map(property => property.split(".").join(" > ")) : undefined}
             onValueSelected={(value) => {
               onEntityColumnValueChange(row, value, EntityTableColumns.PropertiesOnHover);
             }}

--- a/marklogic-data-hub-central/ui/src/components/explore/graph-vis-explore/graph-vis-explore.tsx
+++ b/marklogic-data-hub-central/ui/src/components/explore/graph-vis-explore/graph-vis-explore.tsx
@@ -278,11 +278,11 @@ const GraphVisExplore: React.FC<Props> = (props) => {
       Object.keys(property).forEach(propertyName => {
         const propertySpan = document.createElement("span");
         if (typeof property[propertyName] === "string" || typeof property[propertyName] === "number") {
-          propertySpan.innerHTML = `${propertyName.replaceAll(".", " > ")}: ${property[propertyName]}`;
+          propertySpan.innerHTML = `${propertyName.split(".").join(" > ")}: ${property[propertyName]}`;
           topSpan.appendChild(propertySpan);
           topSpan.appendChild(document.createElement("br"));
         } else {
-          propertySpan.innerHTML = `${propertyName.replaceAll(".", " > ")}:`;
+          propertySpan.innerHTML = `${propertyName.split(".").join(" > ")}:`;
           const pre = document.createElement("pre");
           pre.innerText = JSON.stringify(property[propertyName], undefined, 2);
           paddingElementes.appendChild(propertySpan);

--- a/marklogic-data-hub-central/ui/src/components/modeling/graph-view/side-panel/side-panel.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/graph-view/side-panel/side-panel.tsx
@@ -348,7 +348,7 @@ const GraphViewSidePanel: React.FC<Props> = ({dataModel,
   };
 
   const handlePropertiesOnHoverChange = (e) => {
-    const propertiesOnHover = e.map(property => property.replaceAll(" > ", "."));
+    const propertiesOnHover = e.map(property => property.split(" > ").join("."));
     setSelectedEntityPropOnHover(propertiesOnHover);
     handleUpdateHubCentralConfig({propertiesOnHover});
   };
@@ -709,7 +709,7 @@ const GraphViewSidePanel: React.FC<Props> = ({dataModel,
                   isForMerge={true}
                   propertyDropdownOptions={entityTypeDefinition?.properties}
                   entityDefinitionsArray={definitions}
-                  value={selectedEntityPropOnHover?.length ? selectedEntityPropOnHover.map(property => property.replaceAll(".", " > ")) : undefined}
+                  value={selectedEntityPropOnHover?.length ? selectedEntityPropOnHover.map(property => property.split(".").join(" > ")) : undefined}
                   onValueSelected={handlePropertiesOnHoverChange}
                   multiple={true}
                   identifier={modelingOptions.selectedEntity}


### PR DESCRIPTION
This is a UI fix that solves Automation problems "replaceAll" method is not allowed on Chrome below version 80, it was replaced by "split"/"join".

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Code passes ESLint tests
- [x] Added Tests
- [x] Ran cypress tests on firefox locally
  

- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki

