### PR TITLE
DHFPROD-9701: Moving linting step on pipeline

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,6 @@
 - [ ] PR title is in the format JIRA_ID:Title
 - [ ] Rebase the branch with upstream
 - [ ] Squashed all commits into a single commit
-- [ ] Code passes ESLint tests
 - [ ] Added Tests
 - [ ] Ran cypress tests on firefox locally
   

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -302,7 +302,7 @@ void RTLTests(String type,String mlVersion){
 
       export PATH=$JAVA_HOME/bin:$PATH
       cd $WORKSPACE/data-hub
-      ./gradlew -g ./cache-build --continue clean marklogic-data-hub:bootstrap :marklogic-data-hub-central:testUI :marklogic-data-hub-central:lintUI |& tee console.log
+      ./gradlew -g ./cache-build --continue clean marklogic-data-hub:bootstrap :marklogic-data-hub-central:testUI |& tee console.log
 
     '''
 

--- a/marklogic-data-hub-central/build.gradle
+++ b/marklogic-data-hub-central/build.gradle
@@ -230,6 +230,8 @@ task testUI(type: NpmTask, dependsOn: installDependencies, group: taskGroup){
     execOverrides { it.workingDir = reactUiPath }
 }
 
+buildUi.dependsOn lintUI
+
 build.dependsOn buildRpm
 
 processTestResources {


### PR DESCRIPTION
### Description

This PR changes the place where the linting process is done.
Now the linting is done in the build task so we removed it from the pipeline.

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- N/A Code passes ESLint tests
- N/A Added Tests
- [x] Ran cypress tests on firefox locally
  

- ##### Reviewer:

- N/A Reviewed Tests
- N/A Added to Release Wiki

