### PR TITLE
DHFPROD-5624: Load + Curate: Keyboard navigation within Cards

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/common/switch-view/view-switch.tsx
+++ b/marklogic-data-hub-central/ui/src/components/common/switch-view/view-switch.tsx
@@ -20,37 +20,39 @@ const ViewSwitch: FC<Props> = ({handleViewChange, selectedView, snippetView, loa
   return (<div id="switch-view" aria-label="switch-view" >
     {loadTile ? (
       <div className={"switch-button-group outline"}>
-        <span
-          className={styles.leftButton} tabIndex={0} onKeyDown={(event) => {
-            if (event.key === "Enter"|| event.key === " ") { handleViewChange("card"); }
-          }}
-        >
+        <span>
           <input
             type="radio"
             id="switch-view-card"
-            name="switch-view-radiogroupA"
+            name="switch-view-radiogroup"
             key={ViewType.card}
             value={"card"}
             checked={selectedView === ViewType.card}
             onChange={e => handleViewChange(e.target.value)}
-            tabIndex={-1}
+            onKeyDown={e => {
+              if (e.key === "Enter" || e.key === " ") {
+                handleViewChange(ViewType.card);
+              }
+            }}
           />
           <label aria-label="switch-view-card" htmlFor="switch-view-card" className={`${className} ${styles.leftButton}`} style={{height: "40px", fontSize: "22px"}}>
-            <i>{<FontAwesomeIcon icon={faThLarge}   />}</i>
+            <i>{<FontAwesomeIcon icon={faThLarge} />}</i>
           </label>
         </span>
-        <span tabIndex={0} className={styles.leftButton} onKeyDown={(event) => {
-          if (event.key === "Enter"|| event.key === " ") { handleViewChange("list"); }
-        }}>
+        <span>
           <input
             type="radio"
             id="switch-view-list"
-            name="switch-view-radiogroupB"
+            name="switch-view-radiogroup-list"
             key={ViewType.list}
             value={"list"}
             checked={selectedView === ViewType.list}
             onChange={e => handleViewChange(e.target.value)}
-            tabIndex={-1}
+            onKeyDown={e => {
+              if (e.key === "Enter" || e.key === " ") {
+                handleViewChange(ViewType.list);
+              }
+            }}
           />
           <HCTooltip text="List View" id="list-view-tooltip" placement="top">
             <label aria-label="switch-view-list" htmlFor="switch-view-list" className={`${className} ${styles.rightButton}`} id={"listView"} style={style}>
@@ -66,7 +68,7 @@ const ViewSwitch: FC<Props> = ({handleViewChange, selectedView, snippetView, loa
         <input
           type="radio"
           id="switch-view-graph"
-          name="switch-view-radiogroup"
+          name="switch-view-radiogroup-graph"
           key={"graph-view"}
           value={"graph"}
           checked={selectedView === ViewType.graph}
@@ -84,7 +86,7 @@ const ViewSwitch: FC<Props> = ({handleViewChange, selectedView, snippetView, loa
         <input
           type="radio"
           id="switch-view-table"
-          name="switch-view-radiogroup"
+          name="switch-view-radiogroup-table"
           key={ViewType.table}
           value={"table"}
           checked={selectedView === ViewType.table}
@@ -104,7 +106,7 @@ const ViewSwitch: FC<Props> = ({handleViewChange, selectedView, snippetView, loa
           <input
             type="radio"
             id="switch-view-snippet"
-            name="switch-view-radiogroup"
+            name="switch-view-radiogroup-sippet"
             value={"snippet"}
             checked={selectedView === ViewType.snippet}
             key={ViewType.snippet}

--- a/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/create-edit-step/create-edit-step.tsx
@@ -195,16 +195,16 @@ const CreateEditStep: React.FC<Props> = (props) => {
   const [targetQueryPopover, setTargetQueryPopover] = useState(null);
 
   const collectionQueryInfo =
-  <Overlay
-    show={showQueryPopover}
-    target={targetQueryPopover}
-    placement="left"
-  >
-    <Popover id={`popover-create-edit-step`} className={styles.popoverCreateEditStep}><Popover.Body className={styles.popoverCreateEditStepBody}>
-      <div className={styles.collectionQueryInfo}>{CommonStepTooltips.radioQuery}</div></Popover.Body></Popover>
-  </Overlay>;
+    <Overlay
+      show={showQueryPopover}
+      target={targetQueryPopover}
+      placement="left"
+    >
+      <Popover id={`popover-create-edit-step`} className={styles.popoverCreateEditStep}><Popover.Body className={styles.popoverCreateEditStepBody}>
+        <div className={styles.collectionQueryInfo}>{CommonStepTooltips.radioQuery}</div></Popover.Body></Popover>
+    </Overlay>;
 
-  const handleSubmit = async (event: { preventDefault: () => void; }) => {
+  const handleSubmit = async (event: {preventDefault: () => void;}) => {
     if (!stepName) {
       // missing name
       setStepNameTouched(true);
@@ -436,7 +436,7 @@ const CreateEditStep: React.FC<Props> = (props) => {
       }
     }
   };
-  let time:any;
+  let time: any;
   const handleShowQueryPopover = (event) => {
     event.persist();
     time = delayTooltip(() => {
@@ -503,16 +503,16 @@ const CreateEditStep: React.FC<Props> = (props) => {
                   onBlur={sendPayload}
                 />}
                 <div className={"p-2 d-flex align-items-center"}>
-                  { props.stepType === StepType.Mapping ?
+                  {props.stepType === StepType.Mapping ?
                     <HCTooltip text={NewMapTooltips.name} id="map-step-name-tooltip" placement={"left"}>
-                      <QuestionCircleFill color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle}/>
-                    </HCTooltip>:
+                      <QuestionCircleFill tabIndex={0} color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle} />
+                    </HCTooltip> :
                     props.stepType === StepType.Matching ?
                       <HCTooltip text={NewMatchTooltips.name} id="match-step-name-tooltip" placement={"left"}>
-                        <QuestionCircleFill color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle}/>
-                      </HCTooltip>:
+                        <QuestionCircleFill tabIndex={0} color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle} />
+                      </HCTooltip> :
                       <HCTooltip text={NewMergeTooltips.name} id="merge-step-name-tooltip" placement={"left"}>
-                        <QuestionCircleFill color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle}/>
+                        <QuestionCircleFill tabIndex={0} color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle} />
                       </HCTooltip>
                   }
                 </div>
@@ -536,16 +536,16 @@ const CreateEditStep: React.FC<Props> = (props) => {
               onBlur={sendPayload}
             />
             <div className={"p-2 d-flex align-items-center"}>
-              { props.stepType === StepType.Mapping ?
+              {props.stepType === StepType.Mapping ?
                 <HCTooltip text={NewMapTooltips.description} id="map-step-description-tooltip" placement={"left"}>
-                  <QuestionCircleFill color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle}/>
-                </HCTooltip>:
+                  <QuestionCircleFill tabIndex={0} color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle} />
+                </HCTooltip> :
                 props.stepType === StepType.Matching ?
                   <HCTooltip text={NewMatchTooltips.description} id="match-step-description-tooltip" placement={"left"}>
-                    <QuestionCircleFill color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle}/>
-                  </HCTooltip>:
+                    <QuestionCircleFill tabIndex={0} color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle} />
+                  </HCTooltip> :
                   <HCTooltip text={NewMergeTooltips.description} id="merge-step-description-tooltip" placement={"left"}>
-                    <QuestionCircleFill color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle}/>
+                    <QuestionCircleFill tabIndex={0} color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle} />
                   </HCTooltip>
               }
             </div>
@@ -570,9 +570,9 @@ const CreateEditStep: React.FC<Props> = (props) => {
                   disabled={!props.canReadWrite}
                   className={"mb-0"}
                 />
-                <span  id={props.stepType !== StepType.Merging ? "radioCollectionPopover" : "radioCollectionMergePopover" } className={"me-4"}>
+                <span id={props.stepType !== StepType.Merging ? "radioCollectionPopover" : "radioCollectionMergePopover"} className={"me-4"}>
                   <HCTooltip text={CommonStepTooltips.radioCollection} id="radio-collection-tooltip" placement={"top"}>
-                    <QuestionCircleFill color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircleCollection} data-testid="collectionTooltip"/>
+                    <QuestionCircleFill tabIndex={0} color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircleCollection} data-testid="collectionTooltip" />
                   </HCTooltip>  </span>
                 <Form.Check
                   inline
@@ -587,9 +587,19 @@ const CreateEditStep: React.FC<Props> = (props) => {
                   disabled={!props.canReadWrite}
                   className={"mb-0"}
                 />
-                <span onMouseEnter={handleShowQueryPopover} onMouseLeave={() => handleMouseLeaveTooltip()}>
+                <span
+                  tabIndex={0}
+                  onMouseEnter={handleShowQueryPopover}
+                  onMouseLeave={() => handleMouseLeaveTooltip()}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      handleShowQueryPopover(event);
+                    }
+                  }}
+                  onBlur={() => handleMouseLeaveTooltip()}
+                >
                   {collectionQueryInfo}
-                  <QuestionCircleFill color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircleQuery} data-testid="queryTooltip"/>
+                  <QuestionCircleFill color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircleQuery} data-testid="queryTooltip" />
                 </span>
               </Col>
               <Col xs={12} className={((collections && selectedSource === "collection") || (srcQuery && selectedSource !== "collection") || (!isSelectedSourceTouched && !isCollectionsTouched && !isSrcQueryTouched)) ? "d-flex pe-4" : "d-flex pe-4 has-error"}>
@@ -640,7 +650,7 @@ const CreateEditStep: React.FC<Props> = (props) => {
               />
               <div className={"p-2 d-flex align-items-center"}>
                 <HCTooltip text={NewMergeTooltips.timestampPath} id="timestamp-path-tooltip" placement="left">
-                  <QuestionCircleFill aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle} />
+                  <QuestionCircleFill tabIndex={0} aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle} />
                 </HCTooltip>
               </div>
             </Col>

--- a/marklogic-data-hub-central/ui/src/components/entities/custom/custom-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/custom/custom-card.tsx
@@ -66,11 +66,12 @@ const CustomCard: React.FC<Props> = (props) => {
     setSelectVisible(true);
     setTooltipVisible(true);
     if (typeof e.target.className === "string" &&
-            (e.target.className === "card-body" ||
-             e.target.className.startsWith("custom-card_cardContainer") ||
-             e.target.className.startsWith("custom-card_formatFileContainer") ||
-             e.target.className.startsWith("custom-card_sourceQuery") ||
-             e.target.className.startsWith("custom-card_lastUpdatedStyle"))
+      (e.target.className === "card-body" ||
+        e.target.className === "ContentContainer" ||
+        e.target.className.startsWith("custom-card_cardContainer") ||
+        e.target.className.startsWith("custom-card_formatFileContainer") ||
+        e.target.className.startsWith("custom-card_sourceQuery") ||
+        e.target.className.startsWith("custom-card_lastUpdatedStyle"))
     ) {
       setShowLinks(name);
     }
@@ -81,7 +82,7 @@ const CustomCard: React.FC<Props> = (props) => {
     setTooltipVisible(false);
   }
 
-  const OpenStepSettings = async (name : String) => {
+  const OpenStepSettings = async (name: String) => {
     setStepData(await props.getArtifactProps(name));
     setOpenStepSettings(true);
   };
@@ -116,7 +117,7 @@ const CustomCard: React.FC<Props> = (props) => {
       </Modal.Header>
       <Modal.Body className={"pt-0 pb-4"}>
         <div aria-label="add-step-confirmation" style={{fontSize: "16px"}}>
-          { isStepInFlow(stepName, flowName) ?
+          {isStepInFlow(stepName, flowName) ?
             <p aria-label="step-in-flow">The step <strong>{stepName}</strong> is already in the flow <strong>{flowName}</strong>. Would you like to add another instance?</p> :
             <p aria-label="step-not-in-flow">Are you sure you want to add the step <strong>{stepName}</strong> to the flow <strong>{flowName}</strong>?</p>
           }
@@ -148,7 +149,7 @@ const CustomCard: React.FC<Props> = (props) => {
 
   const flowOptions = props.flows?.length > 0 ? props.flows.map((f, i) => ({value: f.name, label: f.name})) : {};
 
-  const MenuList  = (selector, props) => (
+  const MenuList = (selector, props) => (
     <div id={`${selector}-select-MenuList`}>
       <SelectComponents.MenuList {...props} />
     </div>
@@ -161,7 +162,11 @@ const CustomCard: React.FC<Props> = (props) => {
           props && props.data.length > 0 ? props.data.map((elem, index) => (
 
             <Col xs={"auto"} key={index}>
-              <div
+              <div className="ContentContainer"
+                tabIndex={0}
+                onFocus={(e: React.FocusEvent<HTMLElement>) => {
+                  handleMouseOver(e, elem.name);
+                }}
                 data-testid={`${props.entityTypeTitle}-${elem.name}-step`}
                 onMouseOver={(e) => handleMouseOver(e, elem.name)}
                 onMouseLeave={handleMouseLeave}
@@ -169,7 +174,21 @@ const CustomCard: React.FC<Props> = (props) => {
                 <HCCard
                   actions={[
                     <HCTooltip text={CustomStepTooltips.viewCustom} id="custom-card-tooltip" placement="bottom">
-                      <span className={styles.viewStepSettingsIcon} onClick={() => OpenStepSettings(elem.name)} role="edit-custom button" data-testid={elem.name+"-edit"}><FontAwesomeIcon icon={faCog}/> Edit Step Settings</span>
+                      <span
+                        className={styles.viewStepSettingsIcon}
+                        onClick={() => OpenStepSettings(elem.name)}
+                        role="edit-custom button"
+                        data-testid={elem.name + "-edit"}
+                        tabIndex={0}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            OpenStepSettings(elem.name);
+                          }
+                        }}
+                      >
+                        <FontAwesomeIcon icon={faCog} />
+                        Edit Step Settings
+                      </span>
                     </HCTooltip>,
                   ]}
                   className={styles.cardStyle}
@@ -204,11 +223,11 @@ const CustomCard: React.FC<Props> = (props) => {
                         </div>
                     }
                     <div className={styles.cardNonLink} data-testid={`${elem.name}-toExistingFlow`}>
-                        Add step to an existing flow
+                      Add step to an existing flow
                       {
                         /** dropdown of flow names to add this custom step to */
                         selectVisible ?
-                          <HCTooltip text={"Curate: "+SecurityTooltips.missingPermission} id="select-flow-tooltip" placement="top" show={tooltipVisible && !props.canWriteFlow}>
+                          <HCTooltip text={"Curate: " + SecurityTooltips.missingPermission} id="select-flow-tooltip" placement="top" show={tooltipVisible && !props.canWriteFlow}>
                             <div className={styles.cardLinkSelect} data-testid={`add-${elem.name}-select`}>
                               <Select
                                 id={`${elem.name}-flowsList-select-wrapper`}
@@ -229,6 +248,8 @@ const CustomCard: React.FC<Props> = (props) => {
                                     </span>
                                   );
                                 }}
+                                tabSelectsValue={false}
+                                openMenuOnFocus={true}
                               />
                             </div>
                           </HCTooltip>

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
@@ -111,6 +111,7 @@ const MappingCard: React.FC<Props> = (props) => {
     setSelectVisible(true);
     if (typeof e.target.className === "string" &&
       (e.target.className === "card-body" ||
+        e.target.className === "ContentContainer" ||
         e.target.className.startsWith("mapping-card_cardContainer") ||
         e.target.className.startsWith("mapping-card_formatFileContainer") ||
         e.target.className.startsWith("mapping-card_sourceQuery") ||
@@ -350,7 +351,7 @@ const MappingCard: React.FC<Props> = (props) => {
                   targetEntityType: props.entityModel.entityTypeId,
                   existingFlow: false
                 }
-              }}><div className={styles.stepLink} data-testid={`${mappingArtifactName}-run-toNewFlow`}><PlusCircleFill className={styles.plusIconNewFlow}/>New flow</div></Link>
+              }}><div className={styles.stepLink} data-testid={`${mappingArtifactName}-run-toNewFlow`}><PlusCircleFill className={styles.plusIconNewFlow} />New flow</div></Link>
           </Col>
         </Row>
       </Modal.Body>
@@ -426,7 +427,7 @@ const MappingCard: React.FC<Props> = (props) => {
 
   const flowOptions = props.flows?.length > 0 ? props.flows.map((f, i) => ({value: f.name, label: f.name})) : {};
 
-  const MenuList  = (selector, props) => (
+  const MenuList = (selector, props) => (
     <div id={`${selector}-select-MenuList`}>
       <SelectComponents.MenuList {...props} />
     </div>
@@ -435,17 +436,25 @@ const MappingCard: React.FC<Props> = (props) => {
   return (
     <div className={styles.loadContainer}>
       <Row>
-        {props.canReadWrite ?<Col xs={"auto"}>
+        {props.canReadWrite ? <Col xs={"auto"}>
           <HCCard
             className={styles.addNewCard}>
-            <div><PlusCircleFill aria-label="icon: plus-circle" className={styles.plusIcon} onClick={OpenAddNew}/></div>
+            <div>
+              <PlusCircleFill
+                aria-label="icon: plus-circle"
+                className={styles.plusIcon}
+                tabIndex={0}
+                onClick={OpenAddNew}
+                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { OpenAddNew(); } }}
+              />
+            </div>
             <br />
             <p className={styles.addNewContent}>Add New</p>
           </HCCard>
         </Col> : <Col xs={"auto"}>
-          <HCTooltip id="curate-tooltip" text={"Curate: "+SecurityTooltips.missingPermission} placement="bottom" className={styles.tooltipOverlay}><HCCard
+          <HCTooltip id="curate-tooltip" text={"Curate: " + SecurityTooltips.missingPermission} placement="bottom" className={styles.tooltipOverlay}><HCCard
             className={styles.addNewCardDisabled}>
-            <div aria-label="add-new-card-disabled"><PlusCircleFill className={styles.plusIconDisabled}/></div>
+            <div aria-label="add-new-card-disabled"><PlusCircleFill className={styles.plusIconDisabled} /></div>
             <br />
             <p className={styles.addNewContent}>Add New</p>
           </HCCard></HCTooltip>
@@ -454,17 +463,105 @@ const MappingCard: React.FC<Props> = (props) => {
           props.data && props.data.length > 0 ?
             props.data.map((elem, index) => (
               <Col xs={"auto"} key={index}>
-                <div
+                <div className="ContentContainer"
+                  tabIndex={0}
+                  onFocus={(e: React.FocusEvent<HTMLElement>) => {
+                    handleMouseOver(e, elem.name);
+                  }}
                   data-testid={`${props.entityTypeTitle}-${elem.name}-step`}
                   onMouseOver={(e) => handleMouseOver(e, elem.name)}
                   onMouseLeave={(e) => handleMouseLeave()}
                 >
                   <HCCard
                     actions={[
-                      <HCTooltip id="details-tooltip" text={"Step Details"} placement="bottom"><i className={styles.stepDetails}><FontAwesomeIcon icon={faPencilAlt} onClick={() => openMapStepDetails(elem.name, index)} data-testid={`${elem.name}-stepDetails`} /></i></HCTooltip>,
-                      <HCTooltip id="settings-tooltip" text={"Step Settings"} placement="bottom"><i className={styles.editIcon} role="edit-mapping button" key="last"><FontAwesomeIcon icon={faCog} data-testid={elem.name + "-edit"} onClick={() => OpenStepSettings(index)} /></i></HCTooltip>,
-                      props.canReadWrite ? <HCTooltip id="run-tooltip" text={RunToolTips.runStep} placement="bottom"><i aria-label="icon:run"><PlayCircleFill className={styles.runIcon} data-testid={elem.name + "-run"} onClick={() => handleStepRun(elem.name)} /></i></HCTooltip> : <HCTooltip id="run-disabled-tooltip" text={"Run: " + SecurityTooltips.missingPermission} placement="bottom" className={styles.tooltipOverlay}><i aria-label="icon: run"><PlayCircleFill className={styles.disabledRunIcon} role="disabled-run-mapping button" data-testid={elem.name + "-disabled-run"} onClick={(event) => event.preventDefault()}/></i></HCTooltip>,
-                      props.canReadWrite ? <HCTooltip id="delete-tooltip" text={"Delete"} placement="bottom"><i key="last" role="delete-mapping button" data-testid={elem.name + "-delete"} onClick={() => handleCardDelete(elem.name)}><FontAwesomeIcon icon={faTrashAlt} className={styles.deleteIcon} size="lg" /></i></HCTooltip> : <HCTooltip id="delete-disabled-tooltip" text={"Delete: " + SecurityTooltips.missingPermission} placement="bottom" className={styles.tooltipOverlay}><i role="disabled-delete-mapping button" data-testid={elem.name + "-disabled-delete"} onClick={(event) => event.preventDefault()}><FontAwesomeIcon icon={faTrashAlt} className={styles.disabledIcon} size="lg" /></i></HCTooltip>,
+                      <HCTooltip
+                        id="details-tooltip"
+                        text={"Step Details"}
+                        placement="bottom">
+                        <i className={styles.stepDetails}>
+                          <FontAwesomeIcon
+                            icon={faPencilAlt}
+                            onClick={() => openMapStepDetails(elem.name, index)}
+                            data-testid={`${elem.name}-stepDetails`}
+                            tabIndex={0}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter" || e.key === " ") {
+                                openMapStepDetails(elem.name, index);
+                              }
+                            }}
+                          />
+                        </i>
+                      </HCTooltip>,
+                      <HCTooltip
+                        id="settings-tooltip"
+                        text={"Step Settings"}
+                        placement="bottom">
+                        <i className={styles.editIcon}
+                          role="edit-mapping button"
+                          key="last">
+                          <FontAwesomeIcon
+                            icon={faCog}
+                            data-testid={elem.name + "-edit"}
+                            onClick={() => OpenStepSettings(index)}
+                            tabIndex={0}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter" || e.key === " ") {
+                                OpenStepSettings(index);
+                              }
+                            }}
+                          />
+                        </i>
+                      </HCTooltip>,
+                      props.canReadWrite ?
+                        <HCTooltip id="run-tooltip" text={RunToolTips.runStep} placement="bottom">
+                          <i aria-label="icon:run">
+                            <PlayCircleFill
+                              className={styles.runIcon}
+                              data-testid={elem.name + "-run"}
+                              onClick={() => handleStepRun(elem.name)}
+                              tabIndex={0}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter" || e.key === " ") {
+                                  handleStepRun(elem.name);
+                                }
+                              }}
+                            />
+                          </i>
+                        </HCTooltip> :
+                        <HCTooltip id="run-disabled-tooltip" text={"Run: " + SecurityTooltips.missingPermission} placement="bottom" className={styles.tooltipOverlay}>
+                          <i aria-label="icon: run">
+                            <PlayCircleFill
+                              className={styles.disabledRunIcon}
+                              role="disabled-run-mapping button"
+                              data-testid={elem.name + "-disabled-run"}
+                              onClick={(event) => event.preventDefault()} />
+                          </i>
+                        </HCTooltip>,
+                      props.canReadWrite ?
+                        <HCTooltip id="delete-tooltip" text={"Delete"} placement="bottom">
+                          <i key="last"
+                            role="delete-mapping button"
+                            data-testid={elem.name + "-delete"}
+                            onClick={() => handleCardDelete(elem.name)}
+                            tabIndex={0}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter" || e.key === " ") {
+                                handleCardDelete(elem.name);
+                              }
+                            }}
+                          >
+                            <FontAwesomeIcon icon={faTrashAlt} className={styles.deleteIcon} size="lg" />
+                          </i>
+                        </HCTooltip>
+                        :
+                        <HCTooltip
+                          id="delete-disabled-tooltip"
+                          text={"Delete: " + SecurityTooltips.missingPermission}
+                          placement="bottom" className={styles.tooltipOverlay}>
+                          <i role="disabled-delete-mapping button" data-testid={elem.name + "-disabled-delete"} onClick={(event) => event.preventDefault()}>
+                            <FontAwesomeIcon icon={faTrashAlt} className={styles.disabledIcon} size="lg" />
+                          </i>
+                        </HCTooltip>,
                     ]}
                     className={styles.cardStyle}
                   >
@@ -501,7 +598,7 @@ const MappingCard: React.FC<Props> = (props) => {
                         Add step to an existing flow
                         {
                           selectVisible ?
-                            <HCTooltip id={`${elem.name}curate-disabled-tooltip`} show={props?.canWriteFlow ? !props?.canWriteFlow: undefined} text={"Curate: " + SecurityTooltips.missingPermission} placement={"bottom"} ><div className={styles.cardLinkSelect}>
+                            <HCTooltip id={`${elem.name}curate-disabled-tooltip`} show={props?.canWriteFlow ? !props?.canWriteFlow : undefined} text={"Curate: " + SecurityTooltips.missingPermission} placement={"bottom"} ><div className={styles.cardLinkSelect}>
                               <Select
                                 id={`${elem.name}-flowsList-select-wrapper`}
                                 inputId={`${elem.name}-flowsList`}
@@ -521,6 +618,8 @@ const MappingCard: React.FC<Props> = (props) => {
                                     </span>
                                   );
                                 }}
+                                tabSelectsValue={false}
+                                openMenuOnFocus={true}
                               />
                             </div></HCTooltip>
                             :

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/matching-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/matching-card.tsx
@@ -97,6 +97,7 @@ const MatchingCard: React.FC<Props> = (props) => {
     setTooltipVisible(true);
     if (typeof e.target.className === "string" &&
       (e.target.className === "card-body" ||
+        e.target.className === "ContentContainer" ||
         e.target.className.startsWith("matching-card_cardContainer") ||
         e.target.className.startsWith("matching-card_formatFileContainer") ||
         e.target.className.startsWith("matching-card_sourceQuery") ||
@@ -119,7 +120,7 @@ const MatchingCard: React.FC<Props> = (props) => {
   }
 
   const countStepInFlow = (matchingName) => {
-    let result : string[] = [];
+    let result: string[] = [];
     if (props.flows) props.flows.forEach(f => f["steps"].findIndex(s => s.stepName === matchingName) > -1 ? result.push(f.name) : "");
     return result;
   };
@@ -246,7 +247,7 @@ const MatchingCard: React.FC<Props> = (props) => {
       </Modal.Header>
       <Modal.Body className={"pt-0 pb-4 text-center"}>
         <div aria-label="add-step-confirmation" style={{fontSize: "16px"}}>
-          { isStepInFlow(matchingArtifactName, flowName) ?
+          {isStepInFlow(matchingArtifactName, flowName) ?
             <p aria-label="step-in-flow">The step <strong>{matchingArtifactName}</strong> is already in the flow <strong>{flowName}</strong>. Would you like to add another instance of the step?</p> :
             <p aria-label="step-not-in-flow">Are you sure you want to add the step <strong>{matchingArtifactName}</strong> to the flow <strong>{flowName}</strong>?</p>
           }
@@ -309,12 +310,14 @@ const MatchingCard: React.FC<Props> = (props) => {
           </Col>
           <Col>
             <Link data-testid="link" id="tiles-add-run-new-flow" to={
-              {pathname: "/tiles/run/add-run",
+              {
+                pathname: "/tiles/run/add-run",
                 state: {
                   stepToAdd: matchingArtifactName,
                   stepDefinitionType: "matching",
                   existingFlow: false
-                }}}><div className={styles.stepLink} data-testid={`${matchingArtifactName}-run-toNewFlow`}><PlusCircleFill className={styles.plusIconNewFlow}/>New flow</div></Link>
+                }
+              }}><div className={styles.stepLink} data-testid={`${matchingArtifactName}-run-toNewFlow`}><PlusCircleFill className={styles.plusIconNewFlow} />New flow</div></Link>
           </Col>
         </Row>
       </Modal.Body>
@@ -363,16 +366,18 @@ const MatchingCard: React.FC<Props> = (props) => {
       <Modal.Body className={"pt-0"}>
         <div aria-label="run-step-mult-flows-confirmation" style={{fontSize: "16px", padding: "10px"}}>
           <div aria-label="step-in-mult-flows">Choose the flow in which to run the step <strong>{matchingArtifactName}</strong>.</div>
-          <div className = {styles.flowSelectGrid}>{flowsWithStep.map((flowName, i) => (
+          <div className={styles.flowSelectGrid}>{flowsWithStep.map((flowName, i) => (
             <Link data-testid="link" id="tiles-run-step" key={i} to={
-              {pathname: "/tiles/run/run-step",
+              {
+                pathname: "/tiles/run/run-step",
                 state: {
                   flowName: flowName,
                   stepToAdd: matchingArtifactName,
                   stepDefinitionType: "matching",
                   existingFlow: false,
                   flowsDefaultKey: [props.flows.findIndex(el => el.name === flowName)],
-                }}}><p className={styles.stepLink} data-testid={`${flowName}-run-step`}>{flowName}</p></Link>
+                }
+              }}><p className={styles.stepLink} data-testid={`${flowName}-run-step`}>{flowName}</p></Link>
           ))}
           </div>
         </div>
@@ -389,39 +394,79 @@ const MatchingCard: React.FC<Props> = (props) => {
     return [
       <HCTooltip id="step-details-tooltip" text={"Step Details"} placement="bottom">
         <i className={styles.stepDetails}>
-          <FontAwesomeIcon icon={faPencilAlt} data-testid={`${step.name}-stepDetails`} onClick={() => openStepDetails(step)}/>
+          <FontAwesomeIcon
+            icon={faPencilAlt}
+            data-testid={`${step.name}-stepDetails`}
+            onClick={() => openStepDetails(step)}
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                openStepDetails(step);
+              }
+            }}
+          />
         </i>
       </HCTooltip>,
       <HCTooltip id="step-settings-tooltip" text={"Step Settings"} placement="bottom">
-        <i className={styles.editIcon} key ="last" role="edit-merging button">
-          <FontAwesomeIcon icon={faCog} data-testid={step.name+"-edit"} onClick={() => OpenStepSettings(index)}/>
+        <i className={styles.editIcon} key="last" role="edit-merging button">
+          <FontAwesomeIcon
+            icon={faCog}
+            data-testid={step.name + "-edit"}
+            onClick={() => OpenStepSettings(index)}
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                OpenStepSettings(index);
+              }
+            }}
+          />
         </i>
       </HCTooltip>,
 
       props.canWriteMatchMerge ? (
         <HCTooltip id="run-tooltip" text={RunToolTips.runStep} placement="bottom">
           <i aria-label="icon: run">
-            <PlayCircleFill className={styles.runIcon} data-testid={step.name+"-run"} onClick={() => handleStepRun(step.name)}/>
+            <PlayCircleFill
+              className={styles.runIcon}
+              data-testid={step.name + "-run"}
+              onClick={() => handleStepRun(step.name)}
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  handleStepRun(step.name);
+                }
+              }}
+            />
           </i>
         </HCTooltip>
       ) : (
         <HCTooltip id="run-disabled-tooltip" text={"Run: " + SecurityTooltips.missingPermission} placement="bottom" className={styles.tooltipOverlay}>
           <i aria-label="icon: run">
-            <PlayCircleFill className={styles.disabledRunIcon} role="disabled-run-matching button" data-testid={step.name+"-disabled-run"} onClick={(event) => event.preventDefault()}/>
+            <PlayCircleFill className={styles.disabledRunIcon} role="disabled-run-matching button" data-testid={step.name + "-disabled-run"} onClick={(event) => event.preventDefault()} />
           </i>
         </HCTooltip>
       ),
 
       props.canWriteMatchMerge ? (
         <HCTooltip id="delete-tooltip" text={"Delete"} placement="bottom">
-          <i key ="last" role="delete-merging button" data-testid={step.name+"-delete"} onClick={() => deleteStepClicked(step.name)}>
-            <FontAwesomeIcon icon={faTrashAlt} className={styles.deleteIcon} size="lg"/>
+          <i key="last"
+            role="delete-merging button"
+            data-testid={step.name + "-delete"}
+            onClick={() => deleteStepClicked(step.name)}
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                deleteStepClicked(step.name);
+              }
+            }}
+          >
+            <FontAwesomeIcon icon={faTrashAlt} className={styles.deleteIcon} size="lg" />
           </i>
         </HCTooltip>
       ) : (
         <HCTooltip id="delete-disabled-tooltip" text={"Delete: " + SecurityTooltips.missingPermission} placement="bottom" className={styles.tooltipOverlay}>
-          <i className={styles.deleteIcon} role="disabled-delete-merging button" data-testid={step.name+"-disabled-delete"} onClick={(event) => event.preventDefault()}>
-            <FontAwesomeIcon icon={faTrashAlt} className={styles.disabledDeleteIcon} size="lg"/>
+          <i className={styles.deleteIcon} role="disabled-delete-merging button" data-testid={step.name + "-disabled-delete"} onClick={(event) => event.preventDefault()}>
+            <FontAwesomeIcon icon={faTrashAlt} className={styles.disabledDeleteIcon} size="lg" />
           </i>
         </HCTooltip>
       ),
@@ -430,7 +475,7 @@ const MatchingCard: React.FC<Props> = (props) => {
 
   const flowOptions = props.flows?.length > 0 ? props.flows.map((f, i) => ({value: f.name, label: f.name})) : {};
 
-  const MenuList  = (selector, props) => (
+  const MenuList = (selector, props) => (
     <div id={`${selector}-select-MenuList`}>
       <SelectComponents.MenuList {...props} />
     </div>
@@ -443,23 +488,39 @@ const MatchingCard: React.FC<Props> = (props) => {
           <Col xs={"auto"}>
             <HCCard
               className={styles.addNewCard}>
-              <div><PlusCircleFill aria-label="icon: plus-circle" className={styles.plusIcon} onClick={OpenAddNew}/></div>
-              <br/>
+              <div>
+                <PlusCircleFill
+                  aria-label="icon: plus-circle"
+                  className={styles.plusIcon}
+                  onClick={OpenAddNew}
+                  tabIndex={0}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      OpenAddNew();
+                    }
+                  }}
+                />
+              </div>
+              <br />
               <p className={styles.addNewContent}>Add New</p>
             </HCCard>
           </Col>
         ) : <Col xs={"auto"}>
-          <HCTooltip id="curate-disabled-tooltip" text={"Curate: "+SecurityTooltips.missingPermission} placement="bottom" className={styles.tooltipOverlay}><HCCard
+          <HCTooltip id="curate-disabled-tooltip" text={"Curate: " + SecurityTooltips.missingPermission} placement="bottom" className={styles.tooltipOverlay}><HCCard
             className={styles.addNewCardDisabled}>
-            <div aria-label="add-new-card-disabled"><PlusCircleFill aria-label="icon: plus-circle" className={styles.plusIconDisabled}/></div>
-            <br/>
+            <div aria-label="add-new-card-disabled"><PlusCircleFill aria-label="icon: plus-circle" className={styles.plusIconDisabled} /></div>
+            <br />
             <p className={styles.addNewContent}>Add New</p>
           </HCCard></HCTooltip>
         </Col>}
         {props.matchingStepsArray.length > 0 ? (
           props.matchingStepsArray.map((step, index) => (
             <Col xs={"auto"} key={index}>
-              <div
+              <div className="ContentContainer"
+                tabIndex={0}
+                onFocus={(e: React.FocusEvent<HTMLElement>) => {
+                  handleMouseOver(e, step.name);
+                }}
                 data-testid={`${props.entityName}-${step.name}-step`}
                 onMouseOver={(e) => handleMouseOver(e, step.name)}
                 onMouseLeave={(e) => handleMouseLeave()}
@@ -488,16 +549,17 @@ const MatchingCard: React.FC<Props> = (props) => {
                           state: {
                             stepToAdd: step.name,
                             stepDefinitionType: "matching"
-                          }}}
+                          }
+                        }}
                       >
                         <div className={styles.cardLink} data-testid={`${step.name}-toNewFlow`}> Add step to a new flow</div>
                       </Link>
                     ) : <div className={styles.cardDisabledLink} data-testid={`${step.name}-disabledToNewFlow`}> Add step to a new flow</div>
                     }
                     <div className={styles.cardNonLink} data-testid={`${step.name}-toExistingFlow`}>
-                    Add step to an existing flow
+                      Add step to an existing flow
                       {selectVisible ? (
-                        <HCTooltip text={"Curate: "+SecurityTooltips.missingPermission} id="add-matching-step-to-flow-tooltip" placement={"top"} show={tooltipVisible && !props.canWriteMatchMerge}><div className={styles.cardLinkSelect}>
+                        <HCTooltip text={"Curate: " + SecurityTooltips.missingPermission} id="add-matching-step-to-flow-tooltip" placement={"top"} show={tooltipVisible && !props.canWriteMatchMerge}><div className={styles.cardLinkSelect}>
                           <Select
                             id={`${step.name}-flowsList-select-wrapper`}
                             inputId={`${step.name}-flowsList`}
@@ -517,6 +579,8 @@ const MatchingCard: React.FC<Props> = (props) => {
                                 </span>
                               );
                             }}
+                            tabSelectsValue={false}
+                            openMenuOnFocus={true}
                           />
                         </div></HCTooltip>
                       ) : null}

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/matching-step-detail/matching-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/matching-step-detail/matching-step-detail.tsx
@@ -56,9 +56,9 @@ const DEFAULT_MATCHING_STEP: MatchingStep = {
 
 const MatchingStepDetail: React.FC = () => {
   const storage = getViewSettings();
-  const expandedRulesetStorage = storage.match?.rulesetExpanded? storage.match.rulesetExpanded : false;
-  const rulesetToggleStorage = storage.match?.editRulesetTimeline? storage.match.editRulesetTimeline : false;
-  const thresholdToggleStorage = storage.match?.editThresholdTimeline? storage.match.editThresholdTimeline : false;
+  const expandedRulesetStorage = storage.match?.rulesetExpanded ? storage.match.rulesetExpanded : false;
+  const rulesetToggleStorage = storage.match?.editRulesetTimeline ? storage.match.editRulesetTimeline : false;
+  const thresholdToggleStorage = storage.match?.editThresholdTimeline ? storage.match.editThresholdTimeline : false;
   const rulesetTextStorage = storage.match?.rulesetTextExpanded ? storage.match.rulesetTextExpanded : false;
   const thresholdTextStorage = storage.match?.thresholdTextExpanded ? storage.match.thresholdTextExpanded : false;
   const testRadioStorage = storage.match?.testRadioSelection ? storage.match.testRadioSelection : 1;
@@ -71,7 +71,7 @@ const MatchingStepDetail: React.FC = () => {
   const uriData1Storage = storage.match?.uriTableData1 ? storage.match.uriTableData1 : [];
   const uriData2Storage = storage.match?.uriTableData2 ? storage.match.uriTableData2 : [];
   const inputUriDisabledStorage = storage.match?.hasOwnProperty("inputUriState") ? storage.match?.inputUriState : false;
-  const inputUriDisabled2Storage = storage.match?.hasOwnProperty("inputUri2State") ? storage.match?.inputUri2State  : true;
+  const inputUriDisabled2Storage = storage.match?.hasOwnProperty("inputUri2State") ? storage.match?.inputUri2State : true;
 
   // Prevents an infinite loop issue with sessionStorage due to user refreshing in step detail page.
   clearSessionStorageOnRefresh();
@@ -167,31 +167,35 @@ const MatchingStepDetail: React.FC = () => {
   }, [JSON.stringify(curationOptions.activeStep.stepArtifact)]);
 
   useEffect(() => {
-      refMatchingRuleset.current! = matchingStep.matchRulesets;
+    refMatchingRuleset.current! = matchingStep.matchRulesets;
   }, [matchingStep]);
 
   useEffect(() => { setColourElementAdded(false); }, [uriContent]);
   useEffect(() => { setColourElementAdded2(false); }, [uriContent2]);
 
   useEffect(() => {
-    setViewSettings({...storage, match: {...storage.match,
-      rulesetExpanded: expandRuleset,
-      editRulesetTimeline: displayRulesetTimeline,
-      editThresholdTimeline: displayThresholdTimeline,
-      rulesetTextExpanded: moreRulesetText,
-      thresholdTextExpanded: moreThresholdText,
-      testRadioSelection: value,
-      previewMatchedDataValue: previewMatchedData,
-      previewMatchedDataActivity: previewMatchedActivity,
-      previewNonMatchedDataValue: previewNonMatchedData,
-      previewNonMatchedDataActivity: previewNonMatchedActivity,
-      uriTestClicked: uriTestMatchClicked,
-      rulesetData: rulesetDataList,
-      rulesetNonMatchedData: rulesetNonMatchedDataList,
-      inputUriState: inputUriDisabled,
-      inputUri2State: inputUriDisabled2,
-      uriTableData1: UriTableData,
-      uriTableData2: UriTableData2}});
+    setViewSettings({
+      ...storage, match: {
+        ...storage.match,
+        rulesetExpanded: expandRuleset,
+        editRulesetTimeline: displayRulesetTimeline,
+        editThresholdTimeline: displayThresholdTimeline,
+        rulesetTextExpanded: moreRulesetText,
+        thresholdTextExpanded: moreThresholdText,
+        testRadioSelection: value,
+        previewMatchedDataValue: previewMatchedData,
+        previewMatchedDataActivity: previewMatchedActivity,
+        previewNonMatchedDataValue: previewNonMatchedData,
+        previewNonMatchedDataActivity: previewNonMatchedActivity,
+        uriTestClicked: uriTestMatchClicked,
+        rulesetData: rulesetDataList,
+        rulesetNonMatchedData: rulesetNonMatchedDataList,
+        inputUriState: inputUriDisabled,
+        inputUri2State: inputUriDisabled2,
+        uriTableData1: UriTableData,
+        uriTableData2: UriTableData2
+      }
+    });
   }, [expandRuleset, displayRulesetTimeline, displayThresholdTimeline, moreRulesetText, moreThresholdText, value, previewMatchedActivity, previewNonMatchedActivity, uriTestMatchClicked, rulesetDataList, inputUriDisabled, inputUriDisabled2, previewMatchedData, UriTableData, UriTableData2]);
 
 
@@ -202,7 +206,7 @@ const MatchingStepDetail: React.FC = () => {
 
   const handlePreviewMatchingActivity = async (testMatchData, previewActivity = previewMatchedActivity, thresholds = curationOptions.activeStep.stepArtifact.thresholds, setDataFunction = setPreviewMatchedData, setActivityFunction = setPreviewMatchedActivity, setDataList = setRulesetDataList) => {
     const test = () => {
-      let localRulesetDataList:any = [];
+      let localRulesetDataList: any = [];
       for (let i = 0; i < thresholds.length; i++) {
         let ruleset = thresholds[i].thresholdName.concat(" - ") + thresholds[i].action;
         let score = thresholds[i].score;
@@ -348,7 +352,19 @@ const MatchingStepDetail: React.FC = () => {
     dataField: "uriValue",
     formatter: (text, key) => (
       <span className={styles.tableRow}>{text}<i className={styles.positionDeleteIcon} aria-label="deleteIcon">
-        <FontAwesomeIcon data-testid={`${text}-delete`} icon={faTrashAlt} className={styles.deleteIcon} onClick={() => handleDeleteUri(key)} size="lg" /></i>
+        <FontAwesomeIcon
+          data-testid={`${text}-delete`}
+          icon={faTrashAlt}
+          className={styles.deleteIcon}
+          onClick={() => handleDeleteUri(key)} size="lg"
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              handleDeleteUri(key);
+            }
+          }}
+        />
+      </i>
       </span>
     ),
     formatExtraData: {UriTableData}
@@ -359,8 +375,21 @@ const MatchingStepDetail: React.FC = () => {
     text: "uriValues",
     dataField: "uriValue",
     formatter: (text, key) => (
-      <span className={styles.tableRow}>{text}<i className={styles.positionDeleteIcon} aria-label="deleteIcon">
-        <FontAwesomeIcon data-testid={`${text}-delete`} icon={faTrashAlt} className={styles.deleteIcon} onClick={() => handleDeleteUri2(key)} size="lg"/></i>
+      <span className={styles.tableRow}>{text}
+        <i className={styles.positionDeleteIcon} aria-label="deleteIcon">
+          <FontAwesomeIcon
+            data-testid={`${text}-delete`}
+            icon={faTrashAlt}
+            className={styles.deleteIcon}
+            onClick={() => handleDeleteUri2(key)} size="lg"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                handleDeleteUri2(key);
+              }
+            }}
+          />
+        </i>
       </span>
     ),
     formatExtraData: {UriTableData2}
@@ -541,7 +570,7 @@ const MatchingStepDetail: React.FC = () => {
     const uris = [arr[0], arr[1]];
     setUris(uris);
 
-    const flowName= result1.data.recordMetadata.datahubCreatedInFlow;
+    const flowName = result1.data.recordMetadata.datahubCreatedInFlow;
     const preview = (flowName) ? await getPreviewFromURIs(flowName, arr) : null;
 
     if (result1.status === 200 && result2.status === 200 && preview?.status === 200) {
@@ -703,19 +732,19 @@ const MatchingStepDetail: React.FC = () => {
   };
 
   const renderRulesetTimeline = () => {
-    return <div data-testid={"active-ruleset-timeline"}><TimelineVis items={rulesetItems} options={rulesetOptions} clickHandler={onRuleSetTimelineItemClicked} borderMargin="0px"/></div>;
+    return <div data-testid={"active-ruleset-timeline"}><TimelineVis items={rulesetItems} options={rulesetOptions} clickHandler={onRuleSetTimelineItemClicked} borderMargin="0px" /></div>;
   };
 
   const renderDefaultRulesetTimeline = () => {
-    return <div data-testid={"default-ruleset-timeline"}><TimelineVisDefault items={rulesetItems} options={rulesetOptions} borderMargin="0px"/></div>;
+    return <div data-testid={"default-ruleset-timeline"}><TimelineVisDefault items={rulesetItems} options={rulesetOptions} borderMargin="0px" /></div>;
   };
 
   const renderDefaultThresholdTimeline = () => {
-    return <div data-testid={"default-threshold-timeline"}><TimelineVisDefault items={thresholdItems} options={thresholdOptions} borderMargin="0px"/></div>;
+    return <div data-testid={"default-threshold-timeline"}><TimelineVisDefault items={thresholdItems} options={thresholdOptions} borderMargin="0px" /></div>;
   };
 
   const renderThresholdTimeline = () => {
-    return <div data-testid={"active-threshold-timeline"}><TimelineVis items={thresholdItems} options={thresholdOptions} clickHandler={onThresholdTimelineItemClicked} borderMargin="0px"/></div>;
+    return <div data-testid={"active-threshold-timeline"}><TimelineVis items={thresholdItems} options={thresholdOptions} clickHandler={onThresholdTimelineItemClicked} borderMargin="0px" /></div>;
   };
 
   const updateThresholdItems = async (id, newvalue) => {
@@ -842,9 +871,35 @@ const MatchingStepDetail: React.FC = () => {
                 The action could be the merging of those entities, the creation of a match notification, or a custom action that is defined programmatically.
                 Click the <span className={styles.bold}>Add</span> button to create a threshold. If most of the values in the entities should match to trigger the action associated with your threshold,
                 then move the threshold higher on the scale. If only some of the values in the entities must match, then move the threshold lower.
-              <span aria-label="threshold-less" className={styles.link} onClick={() => toggleMoreThresholdText(!moreThresholdText)}>less</span>
+              {moreThresholdText && <span
+                aria-label="threshold-less"
+                className={styles.link}
+                onClick={() => toggleMoreThresholdText(!moreThresholdText)}
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    toggleMoreThresholdText(!moreThresholdText);
+                  }
+                }}
+              >
+                  less
+              </span>}
               </p>
-              {!moreThresholdText && <span aria-label="threshold-more" className={styles.link} onClick={() => toggleMoreThresholdText(!moreThresholdText)}>more</span>}
+              {!moreThresholdText &&
+                <span
+                  aria-label="threshold-more"
+                  className={styles.link}
+                  onClick={() => toggleMoreThresholdText(!moreThresholdText)}
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      toggleMoreThresholdText(!moreThresholdText);
+                    }
+                  }}
+                >
+                  more
+                </span>
+              }
             </div>
             <div className={styles.addButtonContainer}>
               <HCButton
@@ -861,7 +916,14 @@ const MatchingStepDetail: React.FC = () => {
           <div className={styles.switchToggleContainer}><span className={styles.editingLabel}><b>Edit Thresholds</b></span><FormCheck type="switch" aria-label="threshold-scale-switch" onChange={({target}) => toggleDisplayThresholdTimeline(target.checked)} defaultChecked={displayThresholdTimeline} className={styles.switchToggle}></FormCheck>
             <span>
               <HCTooltip text={MatchingStepTooltips.thresholdScale} id="threshold-scale-tooltip" placement="right">
-                <QuestionCircleFill aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} className={styles.scaleTooltip} data-testid={"info-tooltip-threshold"} />
+                <QuestionCircleFill
+                  aria-label="icon: question-circle"
+                  color={themeColors.defaults.questionCircle}
+                  size={13}
+                  className={styles.scaleTooltip}
+                  data-testid={"info-tooltip-threshold"}
+                  tabIndex={0}
+                />
               </HCTooltip>
               <br />
             </span>
@@ -881,9 +943,37 @@ const MatchingStepDetail: React.FC = () => {
                 The way you define your rulesets, and where you place them on the scale, influences whether the entities are considered a match.
                 Click the <span className={styles.bold}>Add</span> button to create a ruleset. If you want the ruleset to have a major influence over whether entities are qualified as a "match",
                 move it higher on the scale. If you want it to have only some influence, then move the ruleset lower.
-              <span aria-label="ruleset-less" className={styles.link} onClick={() => toggleMoreRulesetText(!moreRulesetText)}>less</span>
+              {moreRulesetText &&
+                  <span
+                    aria-label="ruleset-less"
+                    className={styles.link}
+                    onClick={() => toggleMoreRulesetText(!moreRulesetText)}
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        toggleMoreRulesetText(!moreRulesetText);
+                      }
+                    }}
+                  >
+                    less
+                  </span>
+              }
               </p>
-              {!moreRulesetText && <span aria-label="ruleset-more" className={styles.link} onClick={() => toggleMoreRulesetText(!moreRulesetText)}>more</span>}
+              {!moreRulesetText
+                && <span
+                  aria-label="ruleset-more"
+                  className={styles.link}
+                  onClick={() => toggleMoreRulesetText(!moreRulesetText)}
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      toggleMoreRulesetText(!moreRulesetText);
+                    }
+                  }}
+                >
+                  more
+                </span>
+              }
             </div>
             <div
               id="panelActionsMatch"
@@ -899,7 +989,14 @@ const MatchingStepDetail: React.FC = () => {
           <div className={styles.switchToggleContainer}><span className={styles.editingLabel}><b>Edit Rulesets</b></span><FormCheck type="switch" aria-label="ruleset-scale-switch" onChange={({target}) => toggleDisplayRulesetTimeline(target.checked)} defaultChecked={displayRulesetTimeline} className={styles.switchToggle}></FormCheck>
             <span>
               <HCTooltip text={MatchingStepTooltips.rulesetScale} id="ruleset-scale-tooltip" placement="right">
-                <QuestionCircleFill aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} className={`${styles.scaleTooltip} ps-0`} data-testid={`info-tooltip-ruleset`} />
+                <QuestionCircleFill
+                  aria-label="icon: question-circle"
+                  color={themeColors.defaults.questionCircle}
+                  size={13}
+                  className={`${styles.scaleTooltip} ps-0`}
+                  data-testid={`info-tooltip-ruleset`}
+                  tabIndex={0}
+                />
               </HCTooltip>
               <br />
             </span></div>
@@ -927,10 +1024,11 @@ const MatchingStepDetail: React.FC = () => {
                 value={1}
                 aria-label={"inputUriOnlyRadio"}
                 className={"mb-0"}
+                tabIndex={0}
               />
               <span className={styles.selectTooltip} aria-label="testUriOnlyTooltip">
                 <HCTooltip text={MatchingStepTooltips.testUris} id="test-all-uris-tooltip" placement="right">
-                  <QuestionCircleFill color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle} />
+                  <QuestionCircleFill tabIndex={0} color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle} />
                 </HCTooltip><br />
               </span>
               <div style={{display: "flex", justifyContent: "space-between", alignItems: "center", paddingRight: 12}}>
@@ -943,7 +1041,18 @@ const MatchingStepDetail: React.FC = () => {
                   disabled={inputUriDisabled}
                   classNameFull={colourElementAdded ? styles.uriInputColor : ""}
                 />
-                <FontAwesomeIcon icon={faPlusSquare} className={inputUriDisabled ? styles.disabledAddIcon : styles.addIcon} onClick={handleClickAddUri} aria-label="addUriOnlyIcon" />
+                <FontAwesomeIcon
+                  icon={faPlusSquare}
+                  className={inputUriDisabled ? styles.disabledAddIcon : styles.addIcon}
+                  onClick={handleClickAddUri}
+                  aria-label="addUriOnlyIcon"
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      handleClickAddUri(e);
+                    }
+                  }}
+                />
               </div>
               {duplicateUriWarning ? <div className={styles.duplicateUriWarning}>This URI has already been added.</div> : ""}
               {singleUriWarning ? <div className={styles.duplicateUriWarning}>At least Two URIs are required.</div> : ""}
@@ -977,10 +1086,11 @@ const MatchingStepDetail: React.FC = () => {
               value={2}
               aria-label={"inputUriRadio"}
               className={"mb-0"}
+              tabIndex={0}
             />
             <span aria-label="testUriTooltip">
               <HCTooltip text={MatchingStepTooltips.testUrisAllData} id="test-uris-all-data-tooltip" placement="right">
-                <QuestionCircleFill color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle} />
+                <QuestionCircleFill tabIndex={0} color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle} />
               </HCTooltip>
             </span><br />
             <div style={{display: "flex", justifyContent: "space-between", alignItems: "center", paddingRight: 12}}>
@@ -993,7 +1103,18 @@ const MatchingStepDetail: React.FC = () => {
                 disabled={inputUriDisabled2}
                 classNameFull={colourElementAdded2 ? styles.uriInputColor : ""}
               />
-              <FontAwesomeIcon icon={faPlusSquare} className={inputUriDisabled2 ? styles.disabledAddIcon : styles.addIcon} onClick={handleClickAddUri2} aria-label="addUriIcon" />
+              <FontAwesomeIcon
+                icon={faPlusSquare}
+                className={inputUriDisabled2 ? styles.disabledAddIcon : styles.addIcon}
+                onClick={handleClickAddUri2}
+                aria-label="addUriIcon"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    handleClickAddUri2(e);
+                  }
+                }}
+              />
             </div>
             {duplicateUriWarning2 ? <div className={styles.duplicateUriWarning}>This URI has already been added.</div> : ""}
             {singleUriWarning2 ? <div className={styles.duplicateUriWarning}>At least one URI is required.</div> : ""}
@@ -1026,10 +1147,11 @@ const MatchingStepDetail: React.FC = () => {
               value={3}
               aria-label={"allDataRadio"}
               className={"mb-0"}
+              tabIndex={0}
             />
             <span aria-label={"allDataTooltip"}>
               <HCTooltip text={MatchingStepTooltips.testAllData} id="test-all-data-tooltip" placement="right">
-                <QuestionCircleFill color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle} />
+                <QuestionCircleFill tabIndex={0} color={themeColors.defaults.questionCircle} size={13} className={styles.questionCircle} />
               </HCTooltip>
             </span>
             <div aria-label="allDataContent" className={styles.allDataContent}>
@@ -1045,8 +1167,8 @@ const MatchingStepDetail: React.FC = () => {
           }
         </div>
         <div className={styles.matchedTab}>
-          { uriTestMatchClicked ?
-            <Tabs defaultActiveKey={testMatchTab} onSelect={(eventKey) => setTestMatchTab(eventKey ? eventKey:"matched")} className={styles.previewTabs}>
+          {uriTestMatchClicked ?
+            <Tabs defaultActiveKey={testMatchTab} onSelect={(eventKey) => setTestMatchTab(eventKey ? eventKey : "matched")} className={styles.previewTabs}>
               <Tab title="Matched Entities" eventKey="matched">
                 {(previewMatchedData === 0) && <div className={styles.noMatchedDataView} aria-label="noMatchedDataView"><span>No matches found. You can try: </span><br />
                   <div className={styles.noMatchedDataContent}>
@@ -1166,7 +1288,7 @@ const MatchingStepDetail: React.FC = () => {
                     ))}
                   </div> : ""}
               </Tab>
-            </Tabs>: ""}
+            </Tabs> : ""}
         </div>
       </div>
       <RulesetSingleModal

--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merging-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merging-card.tsx
@@ -113,6 +113,7 @@ const MergingCard: React.FC<Props> = (props) => {
     setTooltipVisible(true);
     if (typeof e.target.className === "string" &&
       (e.target.className === "card-body" ||
+        e.target.className === "ContentContainer" ||
         e.target.className.startsWith("merging-card_cardContainer") ||
         e.target.className.startsWith("merging-card_formatFileContainer") ||
         e.target.className.startsWith("merging-card_sourceQuery") ||
@@ -128,7 +129,7 @@ const MergingCard: React.FC<Props> = (props) => {
   }
 
   const countStepInFlow = (mergingName) => {
-    let result : string[] = [];
+    let result: string[] = [];
     if (props.flows) props.flows.forEach(f => f["steps"].findIndex(s => s.stepName === mergingName) > -1 ? result.push(f.name) : "");
     return result;
   };
@@ -246,7 +247,7 @@ const MergingCard: React.FC<Props> = (props) => {
       </Modal.Header>
       <Modal.Body className={"pt-0 pb-4 px-4 text-center"}>
         <div aria-label="add-step-confirmation" style={{fontSize: "16px"}}>
-          { isStepInFlow(mergingArtifactName, flowName) ?
+          {isStepInFlow(mergingArtifactName, flowName) ?
             <p aria-label="step-in-flow">The step <strong>{mergingArtifactName}</strong> is already in the flow <strong>{flowName}</strong>. Would you like to add another instance of the step?</p> :
             <p aria-label="step-not-in-flow">Are you sure you want to add the step <strong>{mergingArtifactName}</strong> to the flow <strong>{flowName}</strong>?</p>
           }
@@ -310,12 +311,14 @@ const MergingCard: React.FC<Props> = (props) => {
           </Col>
           <Col>
             <Link data-testid="link" id="tiles-add-run-new-flow" to={
-              {pathname: "/tiles/run/add-run",
+              {
+                pathname: "/tiles/run/add-run",
                 state: {
                   stepToAdd: mergingArtifactName,
                   stepDefinitionType: "merging",
                   existingFlow: false
-                }}}><div className={styles.stepLink} data-testid={`${mergingArtifactName}-run-toNewFlow`}><PlusCircleFill className={styles.plusIconNewFlow}/>New flow</div></Link>
+                }
+              }}><div className={styles.stepLink} data-testid={`${mergingArtifactName}-run-toNewFlow`}><PlusCircleFill className={styles.plusIconNewFlow} />New flow</div></Link>
           </Col>
         </Row>
       </Modal.Body>
@@ -364,16 +367,18 @@ const MergingCard: React.FC<Props> = (props) => {
       <Modal.Body className={"pt-0"}>
         <div aria-label="run-step-mult-flows-confirmation" style={{fontSize: "16px", padding: "10px"}}>
           <div aria-label="step-in-mult-flows">Choose the flow in which to run the step <strong>{mergingArtifactName}</strong>.</div>
-          <div className = {styles.flowSelectGrid}>{flowsWithStep.map((flowName, i) => (
+          <div className={styles.flowSelectGrid}>{flowsWithStep.map((flowName, i) => (
             <Link data-testid="link" id="tiles-run-step" key={i} to={
-              {pathname: "/tiles/run/run-step",
+              {
+                pathname: "/tiles/run/run-step",
                 state: {
                   flowName: flowName,
                   stepToAdd: mergingArtifactName,
                   stepDefinitionType: "merging",
                   existingFlow: false,
                   flowsDefaultKey: [props.flows.findIndex(el => el.name === flowName)],
-                }}}><p className={styles.stepLink} data-testid={`${flowName}-run-step`}>{flowName}</p></Link>
+                }
+              }}><p className={styles.stepLink} data-testid={`${flowName}-run-step`}>{flowName}</p></Link>
           ))}
           </div>
         </div>
@@ -390,39 +395,80 @@ const MergingCard: React.FC<Props> = (props) => {
     return [
       <HCTooltip id="step-details-tooltip" text={"Step Details"} placement="bottom">
         <i className={styles.stepDetails}>
-          <FontAwesomeIcon icon={faPencilAlt} data-testid={`${step.name}-stepDetails`} onClick={() => openStepDetails(step)}/>
+          <FontAwesomeIcon
+            icon={faPencilAlt}
+            data-testid={`${step.name}-stepDetails`}
+            onClick={() => openStepDetails(step)}
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                openStepDetails(step);
+              }
+            }}
+          />
         </i>
       </HCTooltip>,
       <HCTooltip id="step-settings-tooltip" text={"Step Settings"} placement="bottom">
-        <i className={styles.editIcon} key ="last" role="edit-merging button">
-          <FontAwesomeIcon icon={faCog} data-testid={step.name+"-edit"} onClick={() => OpenStepSettings(index)}></FontAwesomeIcon>
+        <i className={styles.editIcon} key="last" role="edit-merging button">
+          <FontAwesomeIcon
+            icon={faCog}
+            data-testid={step.name + "-edit"}
+            onClick={() => OpenStepSettings(index)}
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                OpenStepSettings(index);
+              }
+            }}
+          />
         </i>
       </HCTooltip>,
 
       props.canWriteMatchMerge ? (
         <HCTooltip id="run-tooltip" text={RunToolTips.runStep} placement="bottom">
           <i aria-label="icon: run">
-            <PlayCircleFill className={styles.runIcon} data-testid={step.name+"-run"} onClick={() => handleStepRun(step.name)}/>
+            <PlayCircleFill
+              className={styles.runIcon}
+              data-testid={step.name + "-run"}
+              onClick={() => handleStepRun(step.name)}
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  handleStepRun(step.name);
+                }
+              }}
+            />
           </i>
         </HCTooltip>
       ) : (
         <HCTooltip id="run-disabled-tooltip" text={"Run: " + SecurityTooltips.missingPermission} placement="bottom" className={styles.tooltipOverlay}>
           <i aria-label="icon: run">
-            <PlayCircleFill className={styles.disabledRunIcon} role="disabled-run-merging button" data-testid={step.name+"-disabled-run"} onClick={(event) => event.preventDefault()}/>
+            <PlayCircleFill className={styles.disabledRunIcon} role="disabled-run-merging button" data-testid={step.name + "-disabled-run"} onClick={(event) => event.preventDefault()} />
           </i>
         </HCTooltip>
       ),
 
       props.canWriteMatchMerge ? (
         <HCTooltip id="delete-tootlip" text={"Delete"} placement="bottom">
-          <i className={styles.deleteIcon}key ="last" role="delete-merging button" data-testid={step.name+"-delete"} onClick={() => deleteStepClicked(step.name)}>
-            <FontAwesomeIcon icon={faTrashAlt} className={styles.deleteIcon} size="lg"/>
+          <i className={styles.deleteIcon}
+            key="last"
+            role="delete-merging button"
+            data-testid={step.name + "-delete"}
+            onClick={() => deleteStepClicked(step.name)}
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                deleteStepClicked(step.name);
+              }
+            }}
+          >
+            <FontAwesomeIcon icon={faTrashAlt} className={styles.deleteIcon} size="lg" />
           </i>
         </HCTooltip>
       ) : (
         <HCTooltip id="delete-disabled-tooltip" text={"Delete: " + SecurityTooltips.missingPermission} placement="bottom" className={styles.tooltipOverlay}>
-          <i role="disabled-delete-merging button" data-testid={step.name+"-disabled-delete"} onClick={(event) => event.preventDefault()}>
-            <FontAwesomeIcon icon={faTrashAlt} className={styles.disabledDeleteIcon} size="lg"/>
+          <i role="disabled-delete-merging button" data-testid={step.name + "-disabled-delete"} onClick={(event) => event.preventDefault()}>
+            <FontAwesomeIcon icon={faTrashAlt} className={styles.disabledDeleteIcon} size="lg" />
           </i>
         </HCTooltip>
       ),
@@ -431,7 +477,7 @@ const MergingCard: React.FC<Props> = (props) => {
 
   const flowOptions = props.flows?.length > 0 ? props.flows.map((f, i) => ({value: f.name, label: f.name})) : {};
 
-  const MenuList  = (selector, props) => (
+  const MenuList = (selector, props) => (
     <div id={`${selector}-select-MenuList`}>
       <SelectComponents.MenuList {...props} />
     </div>
@@ -444,23 +490,39 @@ const MergingCard: React.FC<Props> = (props) => {
           <Col xs={"auto"}>
             <HCCard
               className={styles.addNewCard}>
-              <div><PlusCircleFill aria-label="icon: plus-circle" className={styles.plusIcon} onClick={OpenAddNew}/></div>
+              <div>
+                <PlusCircleFill
+                  aria-label="icon: plus-circle"
+                  className={styles.plusIcon}
+                  onClick={OpenAddNew}
+                  tabIndex={0}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      OpenAddNew();
+                    }
+                  }}
+                />
+              </div>
               <br />
               <p className={styles.addNewContent}>Add New</p>
             </HCCard>
           </Col>
         ) : <Col xs={"auto"}>
-          <HCTooltip id="curate-tooltip" text={"Curate: "+SecurityTooltips.missingPermission} placement="bottom" className={styles.tooltipOverlay}><HCCard
+          <HCTooltip id="curate-tooltip" text={"Curate: " + SecurityTooltips.missingPermission} placement="bottom" className={styles.tooltipOverlay}><HCCard
             className={styles.addNewCardDisabled}>
-            <div aria-label="add-new-card-disabled"><PlusCircleFill aria-label="icon: plus-circle" className={styles.plusIconDisabled} onClick={OpenAddNew}/></div>
-            <br/>
+            <div aria-label="add-new-card-disabled"><PlusCircleFill aria-label="icon: plus-circle" className={styles.plusIconDisabled} onClick={OpenAddNew} /></div>
+            <br />
             <p className={styles.addNewContent}>Add New</p>
           </HCCard></HCTooltip>
         </Col>}
         {props.mergingStepsArray && props.mergingStepsArray.length > 0 ? (
           props.mergingStepsArray.map((step, index) => (
             <Col xs={"auto"} key={index}>
-              <div
+              <div className="ContentContainer"
+                tabIndex={0}
+                onFocus={(e: React.FocusEvent<HTMLElement>) => {
+                  handleMouseOver(e, step.name);
+                }}
                 data-testid={`${props.entityName}-${step.name}-step`}
                 onMouseOver={(e) => handleMouseOver(e, step.name)}
                 onMouseLeave={(e) => handleMouseLeave()}
@@ -475,7 +537,7 @@ const MergingCard: React.FC<Props> = (props) => {
                   <br />
                   {step.selectedSource === "collection" ? (
                     <div className={styles.sourceQuery}>Collection: {extractCollectionFromSrcQuery(step.sourceQuery)}</div>
-                  ): (
+                  ) : (
                     <div className={styles.sourceQuery}>Source Query: {getInitialChars(step.sourceQuery, 32, "...")}</div>
                   )}
                   <br /><br />
@@ -489,16 +551,17 @@ const MergingCard: React.FC<Props> = (props) => {
                           state: {
                             stepToAdd: step.name,
                             stepDefinitionType: "merging"
-                          }}}
+                          }
+                        }}
                       >
                         <div className={styles.cardLink} data-testid={`${step.name}-toNewFlow`}> Add step to a new flow</div>
                       </Link>
                     ) : <div className={styles.cardDisabledLink} data-testid={`${step.name}-disabledToNewFlow`}> Add step to a new flow</div>
                     }
                     <div className={styles.cardNonLink} data-testid={`${step.name}-toExistingFlow`}>
-                    Add step to an existing flow
+                      Add step to an existing flow
                       {selectVisible ? (
-                        <HCTooltip text={"Curate: "+SecurityTooltips.missingPermission} id="add-merging-step-to-flow-tooltip" placement="top" show={tooltipVisible && !props.canWriteMatchMerge}><div className={styles.cardLinkSelect}>
+                        <HCTooltip text={"Curate: " + SecurityTooltips.missingPermission} id="add-merging-step-to-flow-tooltip" placement="top" show={tooltipVisible && !props.canWriteMatchMerge}><div className={styles.cardLinkSelect}>
                           <Select
                             id={`${step.name}-flowsList-select-wrapper`}
                             inputId={`${step.name}-flowsList`}
@@ -518,9 +581,11 @@ const MergingCard: React.FC<Props> = (props) => {
                                 </span>
                               );
                             }}
+                            tabSelectsValue={false}
+                            openMenuOnFocus={true}
                           />
                         </div></HCTooltip>
-                      ): null}
+                      ) : null}
 
                     </div>
                   </div>

--- a/marklogic-data-hub-central/ui/src/components/entities/page-header/page-header.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/page-header/page-header.tsx
@@ -14,7 +14,19 @@ const PageHeader: React.FC<Props> = (props) => {
     <div className={styles.customHeader}>
       <Row id="back-button" className={"py-3 px-3 header-heading-title"}>
         <Col>
-          <span className={`d-flex align-items-center`} data-testid="arrow-left"><ArrowLeftShort aria-label="Back" className={"d-inline-block me-2 fs-1 header-back-button cursor-pointer"} onClick={props.handleOnBack}/>{props.title}</span>
+          <span className={`d-flex align-items-center`} data-testid="arrow-left">
+            <ArrowLeftShort
+              tabIndex={0}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  props.handleOnBack();
+                }
+              }}
+              aria-label="Back"
+              className={"d-inline-block me-2 fs-1 header-back-button cursor-pointer"}
+              onClick={props.handleOnBack} />
+            {props.title}
+          </span>
         </Col>
       </Row>
     </div>

--- a/marklogic-data-hub-central/ui/src/components/load/create-edit-load/create-edit-load.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/create-edit-load/create-edit-load.tsx
@@ -684,7 +684,7 @@ const CreateEditLoad: React.FC<Props> = (props) => {
                 <span tabIndex={0} ref={nameInputTooltipRef} onKeyDown={(e) => serviceNameKeyDownHandler(e, "nameTooltip")} className={styles.tooltipRef}>
                   <div className={"p-2 d-flex"}>
                     <HCTooltip text={NewLoadTooltips.name} id="name-tooltip" placement="left" show={nameTooltipVisible ? nameTooltipVisible : undefined}>
-                      <QuestionCircleFill aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} />
+                      <QuestionCircleFill tabIndex={0} aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} />
                     </HCTooltip>
                   </div>
                 </span>
@@ -713,7 +713,7 @@ const CreateEditLoad: React.FC<Props> = (props) => {
             <span tabIndex={0} ref={descInputTooltipRef} onKeyDown={(e) => serviceNameKeyDownHandler(e, "descTooltip")} className={styles.tooltipRef}>
               <div className={"p-2 d-flex"}>
                 <HCTooltip text={NewLoadTooltips.description} id="description-tooltip" placement="left" show={descTooltipVisible ? descTooltipVisible : undefined}>
-                  <QuestionCircleFill aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} />
+                  <QuestionCircleFill tabIndex={0} aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} />
                 </HCTooltip>
               </div>
             </span>
@@ -743,7 +743,7 @@ const CreateEditLoad: React.FC<Props> = (props) => {
             <span tabIndex={0} ref={srcFormatSelectTooltipRef} onKeyDown={(e) => serviceNameKeyDownHandler(e, "srcFormatTooltip")} className={styles.tooltipRef}>
               <div className={"p-2 d-flex"}>
                 <HCTooltip text={NewLoadTooltips.sourceFormat} id="source-format-tooltip" placement="left"  show={srcFormatTooltipVisible2 ? srcFormatTooltipVisible2 : undefined} >
-                  <QuestionCircleFill aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} />
+                  <QuestionCircleFill tabIndex={0} aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} />
                 </HCTooltip>
               </div>
             </span>
@@ -789,7 +789,7 @@ const CreateEditLoad: React.FC<Props> = (props) => {
                   <span tabIndex={0} ref={fieldSepInputTooltipRef} onKeyDown={(e) => serviceNameKeyDownHandler(e, "fieldSepTooltip")} className={styles.tooltipRef}>
                     <div className={"p-2 d-flex"}>
                       <HCTooltip text={NewLoadTooltips.fieldSeparator} id="field-separator-tooltip" placement="top" show={fieldSepTooltipVisible ? fieldSepTooltipVisible : undefined}>
-                        <QuestionCircleFill aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} />
+                        <QuestionCircleFill tabIndex={0} aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} />
                       </HCTooltip>
                     </div>
                   </span>
@@ -798,7 +798,7 @@ const CreateEditLoad: React.FC<Props> = (props) => {
                 <span tabIndex={0} ref={fieldSepInputTooltipRef2} onKeyDown={(e) => serviceNameKeyDownHandler(e, "fieldSepTooltip")} className={styles.tooltipRef}>
                   <div className={"p-2 d-flex"}>
                     <HCTooltip text={NewLoadTooltips.fieldSeparator} id="field-separator-tooltip" placement="right" show={fieldSepTooltipVisible2 ? fieldSepTooltipVisible2 : undefined}>
-                      <QuestionCircleFill aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} />
+                      <QuestionCircleFill tabIndex={0} aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} />
                     </HCTooltip>
                   </div>
                 </span>
@@ -829,7 +829,7 @@ const CreateEditLoad: React.FC<Props> = (props) => {
             <span tabIndex={0} ref={tgtFormatSelectTooltipRef} onKeyDown={(e) => serviceNameKeyDownHandler(e, "tgtFormatTooltip")} className={styles.tooltipRef}>
               <div className={"p-2 d-flex"}>
                 <HCTooltip text={NewLoadTooltips.targetFormat} id="target-format-tooltip" placement="left" show={tgtFormatTooltipVisible === true ? true : undefined}>
-                  <QuestionCircleFill aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} />
+                  <QuestionCircleFill tabIndex={0} aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} />
                 </HCTooltip>
               </div></span>
           </Col>
@@ -853,7 +853,7 @@ const CreateEditLoad: React.FC<Props> = (props) => {
               <span tabIndex={0} ref={srcNameInputTooltipRef} onKeyDown={(e) => serviceNameKeyDownHandler(e, "srcNameTooltip")} className={styles.tooltipRef}>
                 <div className={"p-2 d-flex"}>
                   <HCTooltip text={NewLoadTooltips.sourceName} id="source-name-tooltip" placement="left" show={srcNameTooltipVisible === true ? true : undefined}>
-                    <QuestionCircleFill aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} />
+                    <QuestionCircleFill tabIndex={0} aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} />
                   </HCTooltip>
                 </div>
               </span>
@@ -879,7 +879,7 @@ const CreateEditLoad: React.FC<Props> = (props) => {
               <span tabIndex={0} ref={srcTypeInputTooltipRef} onKeyDown={(e) => serviceNameKeyDownHandler(e, "srcTypeTooltip")} className={styles.tooltipRef}>
                 <div className={"p-2 d-flex"}>
                   <HCTooltip text={NewLoadTooltips.sourceType} id="source-type-tooltip" placement="left" show={srcTypeTooltipVisible === true ? true : undefined}>
-                    <QuestionCircleFill aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} />
+                    <QuestionCircleFill tabIndex={0} aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} />
                   </HCTooltip>
                 </div>
               </span>
@@ -904,7 +904,7 @@ const CreateEditLoad: React.FC<Props> = (props) => {
             <span tabIndex={0} ref={tgtPrefixInputTooltipRef} onKeyDown={(e) => serviceNameKeyDownHandler(e, "tgtPrefixTooltip")} className={styles.tooltipRef}>
               <div className={"p-2 d-flex"}>
                 <HCTooltip text={NewLoadTooltips.outputURIPrefix} id="output-uri-refix-tooltip" placement="left"  show={tgtPrefixTooltipVisible === true ? true : undefined}>
-                  <QuestionCircleFill aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} />
+                  <QuestionCircleFill tabIndex={0} aria-label="icon: question-circle" color={themeColors.defaults.questionCircle} size={13} />
                 </HCTooltip>
               </div>
             </span>

--- a/marklogic-data-hub-central/ui/src/components/load/load-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-card.tsx
@@ -118,7 +118,7 @@ const LoadCard: React.FC<Props> = (props) => {
     setSelectVisible(true);
     if (typeof e.target.className === "string" &&
       (e.target.className === "card-body" ||
-
+        e.target.className === "ContentContainer" ||
         e.target.className.startsWith("load-card_formatFileContainer") ||
 
         e.target.className.startsWith("load-card_stepNameStyle"))
@@ -338,7 +338,7 @@ const LoadCard: React.FC<Props> = (props) => {
                   stepDefinitionType: "ingestion",
                   existingFlow: false
                 }
-              }}><div className={styles.stepLink} data-testid={`${loadArtifactName}-run-toNewFlow`}><PlusCircleFill className={styles.plusIconNewFlow}/>New flow</div></Link>
+              }}><div className={styles.stepLink} data-testid={`${loadArtifactName}-run-toNewFlow`}><PlusCircleFill className={styles.plusIconNewFlow} />New flow</div></Link>
           </Col>
         </Row>
       </Modal.Body>
@@ -413,7 +413,7 @@ const LoadCard: React.FC<Props> = (props) => {
 
   const flowOptions = props.flows?.length > 0 ? props.flows.map((f, i) => ({value: f.name, label: f.name})) : {};
 
-  const MenuList  = (selector, props) => (
+  const MenuList = (selector, props) => (
     <div id={`${selector}-select-MenuList`}>
       <SelectComponents.MenuList {...props} />
     </div>
@@ -424,57 +424,112 @@ const LoadCard: React.FC<Props> = (props) => {
       <Row>
         {props.canReadWrite ? <Col xs={"auto"}>
           <HCCard className={styles.addNewCard}>
-            <div aria-label="add-new-card"><PlusCircleFill className={styles.plusIcon} onClick={OpenAddNew}/></div>
+            <div aria-label="add-new-card">
+              <PlusCircleFill
+                className={styles.plusIcon}
+                tabIndex={0}
+                onClick={OpenAddNew}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    OpenAddNew();
+                  }
+                }} />
+            </div>
             <br />
             <p className={styles.addNewContent}>Add New</p>
           </HCCard>
         </Col> : <Col xs={"auto"}>
-          <HCTooltip id="disabled-load-tooltip" placement={"top"} text={"Load: "+SecurityTooltips.missingPermission} className={styles.tooltipOverlayStyle}>
+          <HCTooltip id="disabled-load-tooltip" placement={"top"} text={"Load: " + SecurityTooltips.missingPermission} className={styles.tooltipOverlayStyle}>
             <span>
               <HCCard
                 className={styles.addNewCardDisabled}
                 data-testid="disabledAddNewCard">
-                <div aria-label="add-new-card-disabled"><PlusCircleFill className={styles.plusIconDisabled}/></div>
+                <div aria-label="add-new-card-disabled"><PlusCircleFill className={styles.plusIconDisabled} /></div>
                 <br />
                 <p className={styles.addNewContentDisabled}>Add New</p>
               </HCCard>
             </span>
           </HCTooltip>
-        </Col>}{ props.data && props.data.length > 0 ? props.data.map((elem, index) => (
+        </Col>}{props.data && props.data.length > 0 ? props.data.map((elem, index) => (
           <Col xs={"auto"} key={index}>
-            <div
+            <div className="ContentContainer"
+              tabIndex={0}
+
+              onFocus={(e: React.FocusEvent<HTMLElement>) => {
+                handleMouseOver(e, elem.name);
+              }}
               onMouseOver={(e) => handleMouseOver(e, elem.name)}
-              onMouseLeave={(e) => handleMouseLeave()}
-            >
+              onMouseLeave={(e) => handleMouseLeave()}>
 
               <HCCard
                 className={styles.cardStyle}
                 actions={[
                   <HCTooltip text="Step Settings" id="step-settings-tooltip" placement="bottom">
                     <i key="edit" className={styles.editIcon}>
-                      <FontAwesomeIcon icon={faCog} data-testid={elem.name+"-edit"} onClick={() => OpenStepSettings(index)}/>
+                      <FontAwesomeIcon
+                        icon={faCog}
+                        data-testid={elem.name + "-edit"}
+                        tabIndex={0}
+                        onClick={() => OpenStepSettings(index)}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter" || event.key === " ") {
+                            OpenStepSettings(index);
+                          }
+                        }} />
                     </i>
                   </HCTooltip>,
                   props.canReadWrite ?
                     <HCTooltip text={RunToolTips.runStep} id="run-tooltip" placement="bottom">
                       <i aria-label="icon: run">
-                        <PlayCircleFill data-testid={elem.name+"-run"} size={20} onClick={() => handleStepRun(elem.name)}/>
+                        <PlayCircleFill
+                          data-testid={elem.name + "-run"}
+                          size={20}
+                          onClick={() => handleStepRun(elem.name)}
+                          tabIndex={0}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                              handleStepRun(elem.name);
+                            }
+                          }} />
                       </i>
                     </HCTooltip> :
                     <HCTooltip text={"Run: " + SecurityTooltips.missingPermission} id="run-tooltip" placement="bottom">
-                      <i role="disabled-run-load button" data-testid={elem.name+"-disabled-run"}>
-                        <PlayCircleFill data-testid={elem.name+"-run"} size={23} onClick={(event) => event.preventDefault()} className={styles.disabledIcon}/>
+                      <i role="disabled-run-load button" data-testid={elem.name + "-disabled-run"}>
+                        <PlayCircleFill
+                          data-testid={elem.name + "-run"}
+                          size={23}
+                          onClick={(event) => event.preventDefault()}
+                          className={styles.disabledIcon}
+                          tabIndex={0}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                              event.preventDefault();
+                            }
+                          }}
+                        />
                       </i>
                     </HCTooltip>,
                   props.canReadWrite ?
                     <HCTooltip text="Delete" id="delete-tooltip" placement="bottom">
                       <i aria-label="icon: delete">
-                        <FontAwesomeIcon icon={faTrashAlt} className={styles.deleteIcon} size="lg"  data-testid={elem.name+"-delete"} onClick={() => handleCardDelete(elem.name)}/>
+                        <FontAwesomeIcon
+                          icon={faTrashAlt}
+                          className={styles.deleteIcon}
+                          size="lg"
+                          data-testid={elem.name + "-delete"}
+                          onClick={() => handleCardDelete(elem.name)}
+                          tabIndex={0}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                              handleCardDelete(elem.name);
+                            }
+                          }}
+                        />
                       </i>
                     </HCTooltip> :
                     <HCTooltip text={"Delete: " + SecurityTooltips.missingPermission} id="delete-tooltip" placement="bottom" >
-                      <i data-testid={elem.name+"-disabled-delete"}>
-                        <FontAwesomeIcon icon={faTrashAlt} onClick={(event) => event.preventDefault()} className={styles.disabledIcon} size="lg"/>
+                      <i data-testid={elem.name + "-disabled-delete"}>
+                        <FontAwesomeIcon icon={faTrashAlt} onClick={(event) => event.preventDefault()} className={styles.disabledIcon} size="lg" />
                       </i>
                     </HCTooltip>,
                 ]}
@@ -502,9 +557,9 @@ const LoadCard: React.FC<Props> = (props) => {
 
 
                   <div className={styles.cardNonLink} data-testid={`${elem.name}-toExistingFlow`}>
-                                    Add step to an existing flow
-                    {selectVisible ? <HCTooltip id={`${elem.name}missing-permission-tooltip`} show={props?.canWriteFlow ? !props?.canWriteFlow: undefined}
-                      text={"Load: "+SecurityTooltips.missingPermission} placement={"bottom"}><div className={styles.cardLinkSelect}><div className={styles.cardLinkSelect}>
+                    Add step to an existing flow
+                    {selectVisible ? <HCTooltip id={`${elem.name}missing-permission-tooltip`} show={props?.canWriteFlow ? !props?.canWriteFlow : undefined}
+                      text={"Load: " + SecurityTooltips.missingPermission} placement={"bottom"}><div className={styles.cardLinkSelect}><div className={styles.cardLinkSelect}>
                         <Select
                           id={`${elem.name}-flowsList-select-wrapper`}
                           inputId={`${elem.name}-flowsList`}
@@ -524,6 +579,8 @@ const LoadCard: React.FC<Props> = (props) => {
                               </span>
                             );
                           }}
+                          tabSelectsValue={false}
+                          openMenuOnFocus={true}
                         />
                       </div></div></HCTooltip> : null}
                   </div>

--- a/marklogic-data-hub-central/ui/src/components/steps/steps.tsx
+++ b/marklogic-data-hub-central/ui/src/components/steps/steps.tsx
@@ -15,22 +15,22 @@ import {ConfirmYesNo, HCTooltip} from "@components/common";
 import {CurationContext} from "@util/curation-context";
 
 interface Props {
-    isEditing: boolean;
-    createStep?: any;
-    updateStep?: any;
-    stepData: any;
-    sourceDatabase?: any;
-    canReadWrite: any;
-    canReadOnly: any;
-    tooltipsData: any;
-    openStepSettings: any;
-    setOpenStepSettings: any;
-    activityType: string;
-    canWrite?: any;
-    targetEntityType?: any;
-    targetEntityName?: any;
-    toggleModal?: any;
-    openStepDetails?: any;
+  isEditing: boolean;
+  createStep?: any;
+  updateStep?: any;
+  stepData: any;
+  sourceDatabase?: any;
+  canReadWrite: any;
+  canReadOnly: any;
+  tooltipsData: any;
+  openStepSettings: any;
+  setOpenStepSettings: any;
+  activityType: string;
+  canWrite?: any;
+  targetEntityType?: any;
+  targetEntityName?: any;
+  toggleModal?: any;
+  openStepDetails?: any;
 }
 
 const DEFAULT_TAB = "1";
@@ -227,7 +227,7 @@ const Steps: React.FC<Props> = (props) => {
     targetEntityType={props.targetEntityType}
     createStepArtifact={createStep}
     updateStepArtifact={updateStep}
-    preloadTypeahead = {preloadTypeahead(props.stepData)}
+    preloadTypeahead={preloadTypeahead(props.stepData)}
   />);
 
   const createEditMatching = (<CreateEditStep
@@ -238,7 +238,7 @@ const Steps: React.FC<Props> = (props) => {
     targetEntityType={props.targetEntityType}
     createStepArtifact={createStep}
     updateStepArtifact={updateStep}
-    preloadTypeahead = {preloadTypeahead(props.stepData)}
+    preloadTypeahead={preloadTypeahead(props.stepData)}
   />);
 
   const createEditMerging = (<CreateEditStep
@@ -249,7 +249,7 @@ const Steps: React.FC<Props> = (props) => {
     targetEntityType={props.targetEntityType}
     createStepArtifact={createStep}
     updateStepArtifact={updateStep}
-    preloadTypeahead = {preloadTypeahead(props.stepData)}
+    preloadTypeahead={preloadTypeahead(props.stepData)}
   />);
 
   const viewCustom = (<CreateEditStep
@@ -258,7 +258,7 @@ const Steps: React.FC<Props> = (props) => {
     editStepArtifactObject={props.stepData}
     stepType={StepType.Custom}
     targetEntityType={props.targetEntityType}
-    createStepArtifact={() => {} /** custom steps cannot be created through hub central */}
+    createStepArtifact={() => { } /** custom steps cannot be created through hub central */}
     updateStepArtifact={updateStep}
   />);
 
@@ -355,11 +355,16 @@ const Steps: React.FC<Props> = (props) => {
           </Tabs>
         </div>
         {/* Step Details link for Mapping steps */}
-        { (props.isEditing && props.activityType === StepType.Mapping) ?
-          <div className={styles.stepDetailsLink} onClick={() => handleStepDetails(props.stepData.name)}>
-            <FontAwesomeIcon icon={faPencilAlt} aria-label={"stepDetails"}/>
+        {(props.isEditing && props.activityType === StepType.Mapping) ?
+          <div
+            className={styles.stepDetailsLink}
+            onClick={() => handleStepDetails(props.stepData.name)}
+            tabIndex={0}
+            onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") handleStepDetails(props.stepData.name); }}
+          >
+            <FontAwesomeIcon icon={faPencilAlt} aria-label={"stepDetails"} />
             <span className={styles.stepDetailsLabel}>Step Details</span>
-          </div> : null }
+          </div> : null}
         {discardChanges}
         {errorModal}
       </div>

--- a/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
+++ b/marklogic-data-hub-central/ui/src/config/tooltips.config.tsx
@@ -226,7 +226,7 @@ const CommonStepTooltips = {
   options: 'Key-value pairs to pass as parameters to the custom module.',
   customModuleURI: 'The path to your custom step module.',
   radioCollection : 'A single collection that selects the source data to process in this configuration.',
-  radioQuery: <span aria-label="radio-query-tooltip">The CTS query that selects the source data to process in this configuration. CTS queries can be written in JavaScript or XQuery, and must return the URIs to be processed by the step. For XQuery, the query has to be passed as a string to xdmp.xqueryEval(), as shown in the example below.  Learn more: <a target="_blank" href="https://docs.marklogic.com/guide/search-dev/cts_query" style={{ color: themeColors.info }}>CTS Query.</a><br /><br />
+  radioQuery: <span aria-label="radio-query-tooltip">The CTS query that selects the source data to process in this configuration. CTS queries can be written in JavaScript or XQuery, and must return the URIs to be processed by the step. For XQuery, the query has to be passed as a string to xdmp.xqueryEval(), as shown in the example below.  Learn more: <a target="_blank" href="https://docs.marklogic.com/guide/search-dev/cts_query" style={{ color: themeColors.info }} tabIndex={0}>CTS Query.</a><br /><br />
     The following example source queries select data from multiple collections.<br /><br />
     JavaScript:<br />
     <span style={{ fontFamily: "monospace" }}>cts.collectionQuery(['collection1', 'collection2'])</span><br /><br />

--- a/marklogic-data-hub-central/ui/src/theme/HCTheme.scss
+++ b/marklogic-data-hub-central/ui/src/theme/HCTheme.scss
@@ -248,7 +248,15 @@ div[role="dialog"][aria-modal="true"]:nth-last-child(5) {
                 color: $primary;
             }
         }
+        input {
+            &:focus-visible {
+                + label {
+                    outline: auto !important;
+                }
+            }
+        }
     }
+    
 }
 
 .form-switch {


### PR DESCRIPTION
### Description

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
- [x] Ran cypress tests on firefox locally
  

- ##### Reviewer:

- [x] Reviewed Tests
- [n/a] Added to Release Wiki

