### PR TITLE
DHFPROD-9882: Updating dependencies

### DIFF
--- a/installer-for-dhs/build.gradle
+++ b/installer-for-dhs/build.gradle
@@ -17,10 +17,10 @@ snyk {
 
 dependencies {
     implementation project(":marklogic-data-hub")
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.11.1"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.14.1"
     implementation "com.beust:jcommander:1.81"
     implementation 'commons-io:commons-io:2.11.0'
-    implementation "org.slf4j:slf4j-api:1.7.31"
+    implementation "org.slf4j:slf4j-api:1.7.36"
 
     testImplementation(testFixtures(project(":marklogic-data-hub")))
 }

--- a/marklogic-data-hub-api/build.gradle
+++ b/marklogic-data-hub-api/build.gradle
@@ -16,10 +16,10 @@ snyk {
 }
 
 dependencies {
-    api "com.marklogic:ml-app-deployer:4.3.6"
+    api "com.marklogic:ml-app-deployer:4.4.0"
 
     implementation "org.apache.commons:commons-lang3:3.12.0"
-    implementation "org.slf4j:slf4j-api:1.7.31"
+    implementation "org.slf4j:slf4j-api:1.7.36"
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/marklogic-data-hub-client-jar/build.gradle
+++ b/marklogic-data-hub-client-jar/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation project(":marklogic-data-hub")
     implementation "com.beust:jcommander:1.81"
     implementation "org.apache.commons:commons-lang3:3.12.0"
-    implementation "org.slf4j:slf4j-api:1.7.31"
+    implementation "org.slf4j:slf4j-api:1.7.36"
 
     testImplementation(testFixtures(project(":marklogic-data-hub")))
 }

--- a/marklogic-data-hub-junit5/build.gradle
+++ b/marklogic-data-hub-junit5/build.gradle
@@ -17,8 +17,8 @@ snyk {
 
 dependencies {
     api "org.junit.jupiter:junit-jupiter:5.7.2"
-    api "org.slf4j:slf4j-api:1.7.31"
-    api "org.springframework:spring-test:5.3.22"
+    api "org.slf4j:slf4j-api:1.7.36"
+    api "org.springframework:spring-test:5.3.24"
     api project(":marklogic-data-hub")
 
     api "com.marklogic:marklogic-unit-test-client:1.1.0"

--- a/marklogic-data-hub-test/build.gradle
+++ b/marklogic-data-hub-test/build.gradle
@@ -23,11 +23,11 @@ dependencies {
     api "org.slf4j:slf4j-api:1.7.36"
 
     // This is an API dependency due to the test methods that return a class that depends on a JDOM2 class
-    api "org.jdom:jdom2:2.0.6"
+    api "org.jdom:jdom2:2.0.6.1"
 
-    api "com.fasterxml.jackson.core:jackson-databind:2.11.1"
+    api "com.fasterxml.jackson.core:jackson-databind:2.14.1"
 
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.1"
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -3,9 +3,9 @@ plugins {
     id 'java-library'
     id 'java-test-fixtures'
     id 'maven-publish'
-    id 'com.marklogic.ml-gradle' version '4.3.6'
+    id 'com.marklogic.ml-gradle' version '4.4.0'
     id "com.github.node-gradle.node" version "2.2.4"
-    id 'com.marklogic.ml-development-tools' version '5.5.0'
+    id 'com.marklogic.ml-development-tools' version '6.0.0'
 
     // Declaring this at each subproject level, as declaring it at root level resulted in an error about the plugin
     // not being able to resolve its "dataFiles" configuration
@@ -41,17 +41,22 @@ dependencies {
     api project(":marklogic-data-hub-api")
 
     implementation "org.apache.commons:commons-lang3:3.12.0"
-    implementation "org.apache.httpcomponents:httpclient:4.5.13"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.11.1"
-    implementation "org.slf4j:slf4j-api:1.7.31"
-    implementation "org.jdom:jdom2:2.0.6"
+
+    // Required by the 'legacy' collector implementation
+    implementation "org.apache.httpcomponents:httpclient:4.5.14"
+
+    // Required for CSV support in ingestion steps
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.14.1"
+
+    implementation "org.slf4j:slf4j-api:1.7.36"
+    implementation "org.jdom:jdom2:2.0.6.1"
 
     // Required for some code that accesses OkHttp APIs directly; intended to match the version of
     // OkHttp that the Java Client brings in
-    implementation "com.squareup.okhttp3:okhttp:4.7.2"
+    implementation "com.squareup.okhttp3:okhttp:4.10.0"
 
-    implementation 'com.marklogic:mlcp-util:1.0'
-    implementation 'com.marklogic:marklogic-data-movement-components:2.4.0'
+    // Required for 'legacy' job support
+    implementation 'com.marklogic:marklogic-data-movement-components:2.5.0'
 
     implementation 'commons-io:commons-io:2.11.0'
 
@@ -71,6 +76,8 @@ dependencies {
     testFixturesApi "com.fasterxml.jackson.core:jackson-databind:2.11.1"
     testFixturesApi "org.junit.jupiter:junit-jupiter:5.7.2"
     testFixturesImplementation 'commons-io:commons-io:2.11.0'
+
+    testImplementation 'com.marklogic:mlcp-util:1.0.1'
 
     // Projects that depend on this project's testFixtures will have access to these resources.
     // But this project apparently needs to use testImplementation to reference them in tests.

--- a/ml-data-hub-plugin/build.gradle
+++ b/ml-data-hub-plugin/build.gradle
@@ -38,9 +38,9 @@ snyk {
 dependencies {
     implementation gradleApi()
     implementation (project(':marklogic-data-hub'))
-    implementation 'com.marklogic:ml-gradle:4.3.6'
+    implementation 'com.marklogic:ml-gradle:4.4.0'
     implementation "org.apache.commons:commons-lang3:3.12.0"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.11.1"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.14.1"
     implementation 'commons-io:commons-io:2.11.0'
 
     testImplementation localGroovy()
@@ -53,9 +53,9 @@ dependencies {
     testImplementation('org.spockframework:spock-core:2.0-groovy-3.0') {
         exclude module: 'groovy-all'
     }
-    testImplementation 'org.springframework:spring-test:5.3.22'
+    testImplementation 'org.springframework:spring-test:5.3.24'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.2'
-    testImplementation 'org.jdom:jdom2:2.0.6'
+    testImplementation 'org.jdom:jdom2:2.0.6.1'
 
     // Confusingly, junit4 is needed on the classpath, even though JUnit 5 is used for all tests / assertions.
     // Without it, running "test" will throw a class-not-found exception for junit.framework.Assert


### PR DESCRIPTION
None of these should have any functional impact, they're mostly intended to minimize security vulnerabilities and promote consistency across dependencies. 

Note that mlcp-util was moved to testImplementation as `MlcpRunner` is only used for testing. 