### PR TITLE
DHFPROD-9878: Boolean Property Results Missing in Explore Table

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.tsx
+++ b/marklogic-data-hub-central/ui/src/components/results-tabular-view/results-tabular-view.tsx
@@ -520,7 +520,7 @@ const ResultsTabularView = (props) => {
       for (let subItem of item) {
         if (!Array.isArray(subItem)) {
           if (!Array.isArray(subItem.propertyValue) || subItem.propertyValue[0] === null || typeof (subItem.propertyValue[0]) !== "object") {
-            dataObj[subItem.propertyPath] = subItem.propertyValue;
+            dataObj[subItem.propertyPath] = subItem.propertyValue.toString();
           } else {
             let dataObjArr: any[] = [];
             subItem.propertyValue.forEach((el, index) => {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/entities/entity-search-lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/entities/entity-search-lib.sjs
@@ -320,7 +320,7 @@ function getPropertyValues(currentProperty, entityInstance) {
     }
   } else {
     let propertyName = currentProperty.propertyPath.split(".").pop();
-    resultObject.propertyValue = entityInstance[propertyName] ? entityInstance[propertyName] :
+    resultObject.propertyValue = (entityInstance[propertyName] !== null && entityInstance[propertyName] !== undefined) ? entityInstance[propertyName] :
         (currentProperty.multiple ? [] : "");
   }
   return resultObject;

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/addDocumentMetadataToSearchResults.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/addDocumentMetadataToSearchResults.sjs
@@ -120,7 +120,7 @@ function verifyDocumentSizes() {
     test.assertEqual("KB", response.results[0].documentSize.units),
     test.assertEqual(1, response.results[1].documentSize.value),
     test.assertEqual("MB", response.results[1].documentSize.units),
-    test.assertEqual(192, response.results[2].documentSize.value),
+    test.assertEqual(207, response.results[2].documentSize.value),
     test.assertEqual("B", response.results[2].documentSize.units)
   ]
 }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/addPropertiesToSearchResponse.sjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/addPropertiesToSearchResponse.sjs
@@ -39,7 +39,7 @@ function verifySimpleSelectedPropertiesResults() {
       }
     ]
   };
-  const selectedProperties = ["name", "nicknames"];
+  const selectedProperties = ["name", "nicknames", "active"];
   let janeExpectedResult = [
     {
       "propertyPath": "name",
@@ -51,6 +51,10 @@ function verifySimpleSelectedPropertiesResults() {
         "jane",
         "foster"
       ]
+    },
+    {
+      "propertyPath": "active",
+      "propertyValue": true
     }
   ];
 
@@ -66,6 +70,10 @@ function verifySimpleSelectedPropertiesResults() {
         "din",
         "shh"
       ]
+    },
+    {
+      "propertyPath": "active",
+      "propertyValue": false
     }
   ];
 
@@ -74,8 +82,8 @@ function verifySimpleSelectedPropertiesResults() {
     test.assertEqual(janeExpectedResult, response.results[0].entityProperties),
     test.assertEqual(sallyExpectedResult, response.results[1].entityProperties),
     test.assertEqual(sallyExpectedResult, response.results[2].entityProperties),
-    test.assertEqual(2, response.selectedPropertyDefinitions.length),
-    test.assertEqual(7, response.entityPropertyDefinitions.length)
+    test.assertEqual(3, response.selectedPropertyDefinitions.length),
+    test.assertEqual(8, response.entityPropertyDefinitions.length)
   ];
 }
 
@@ -204,7 +212,7 @@ function verifyStructuredFirstLevelSelectedPropertiesResults() {
     test.assertEqual(sallyExpectedResult, response.results[1].entityProperties),
     test.assertEqual(sallyExpectedResult, response.results[2].entityProperties),
     test.assertEqual(2, response.selectedPropertyDefinitions.length),
-    test.assertEqual(7, response.entityPropertyDefinitions.length)
+    test.assertEqual(8, response.entityPropertyDefinitions.length)
   ];
 }
 
@@ -297,7 +305,7 @@ function verifyStructuredSelectedPropertiesResults() {
     test.assertEqual(sallyExpectedResult, response.results[1].entityProperties),
     test.assertEqual(sallyExpectedResult, response.results[2].entityProperties),
     test.assertEqual(2, response.selectedPropertyDefinitions.length),
-    test.assertEqual(7, response.entityPropertyDefinitions.length)
+    test.assertEqual(8, response.entityPropertyDefinitions.length)
   ]);
 
   const selectedMetadata = response.selectedPropertyDefinitions;
@@ -539,7 +547,7 @@ function verifyResultsWithoutSelectedProperties() {
     test.assertEqual(["Sal", "din", "shh"], response.results[2].entityProperties[2].propertyValue),
     test.assertEqual(sallyShippingResults, response.results[2].entityProperties[3].propertyValue),
     test.assertEqual(5, response.selectedPropertyDefinitions.length),
-    test.assertEqual(7, response.entityPropertyDefinitions.length)
+    test.assertEqual(8, response.entityPropertyDefinitions.length)
   ];
 }
 
@@ -744,22 +752,24 @@ function verifyEntityInstanceResults() {
   };
   entitySearchLib.addPropertiesToSearchResponse(entityName, response);
   return [
-    test.assertEqual(5, Object.keys(response.results[0].entityInstance).length, "Sally has 5 props populated which are available in the xpath /*:envelope/*:instance"),
+    test.assertEqual(6, Object.keys(response.results[0].entityInstance).length, "Sally has 6 props populated which are available in the xpath /*:envelope/*:instance"),
     test.assertEqual(101, response.results[0].entityInstance.customerId),
     test.assertEqual("Sally Hardin", response.results[0].entityInstance.name),
     test.assertEqual(["Sal", "din", "shh"], response.results[0].entityInstance.nicknames),
     test.assertEqual(2, response.results[0].entityInstance.shipping.length),
     test.assertEqual(null, response.results[0].entityInstance.birthDate),
     test.assertEqual(null, response.results[0].entityInstance.status),
+    test.assertEqual(false, response.results[0].entityInstance.active),
 
     // For XML doc result
-    test.assertEqual(5, Object.keys(response.results[1].entityInstance).length, "Sally has 5 props populated which are available in the xpath /*:envelope/*:instance"),
+    test.assertEqual(6, Object.keys(response.results[1].entityInstance).length, "Sally has 6 props populated which are available in the xpath /*:envelope/*:instance"),
     test.assertEqual(101, response.results[1].entityInstance.customerId),
     test.assertEqual("Sally Hardin", response.results[1].entityInstance.name),
     test.assertEqual(["Sal", "din", "shh"], response.results[1].entityInstance.nicknames),
     test.assertEqual(2, response.results[1].entityInstance.shipping.length),
     test.assertEqual(null, response.results[1].entityInstance.birthDate),
     test.assertEqual(null, response.results[1].entityInstance.status),
+    test.assertEqual(false, response.results[1].entityInstance.active),
 
     // instanceWithAdditionalProperty
     test.assertEqual(4, Object.keys(response.results[2].entityInstance).length, "4 props are populated. which are available in the xpath /*:envelope/*:instance" +
@@ -844,7 +854,7 @@ function verifyEntityInstanceResultsForAllEntities() {
   };
   entitySearchLib.addPropertiesToSearchResponse(entityName, response);
   return [
-    test.assertEqual(5, Object.keys(response.results[0].entityInstance).length, "Sally has 5 props populated which are available in the xpath /*:envelope/*:instance"),
+    test.assertEqual(6, Object.keys(response.results[0].entityInstance).length, "Sally has 6 props populated which are available in the xpath /*:envelope/*:instance"),
     test.assertEqual(101, response.results[0].entityInstance.customerId),
     test.assertEqual("Sally Hardin", response.results[0].entityInstance.name),
     test.assertEqual(["Sal", "din", "shh"], response.results[0].entityInstance.nicknames),
@@ -852,7 +862,7 @@ function verifyEntityInstanceResultsForAllEntities() {
     test.assertEqual(null, response.results[0].entityInstance.birthDate),
     test.assertEqual(null, response.results[0].entityInstance.status),
     // For XML doc result
-    test.assertEqual(5, Object.keys(response.results[1].entityInstance).length, "Sally has 5 props populated which are available in the xpath /*:envelope/*:instance"),
+    test.assertEqual(6, Object.keys(response.results[1].entityInstance).length, "Sally has 6 props populated which are available in the xpath /*:envelope/*:instance"),
     test.assertEqual(101, response.results[1].entityInstance.customerId),
     test.assertEqual("Sally Hardin", response.results[1].entityInstance.name),
     test.assertEqual(["Sal", "din", "shh"], response.results[1].entityInstance.nicknames),

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/test-data/content/jane.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/test-data/content/jane.json
@@ -12,7 +12,8 @@
         "nicknames": [
           "jane",
           "foster"
-        ]
+        ],
+        "active": true
       }
     }
   }

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/test-data/content/jane.xml
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/test-data/content/jane.xml
@@ -10,6 +10,7 @@
             <name xsi:type="xs:string">Jane Foster</name>
             <nicknames datatype="array" xsi:type="xs:string">jane</nicknames>
             <nicknames datatype="array" xsi:type="xs:string">foster</nicknames>
+            <active xsi:type="xs:boolean">true</active>
         </Customer>
     </instance>
 </envelope>

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/test-data/content/sally.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/test-data/content/sally.json
@@ -19,6 +19,7 @@
           "din",
           "shh"
         ],
+        "active": false,
         "shipping": [
           {
             "Address": {

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/test-data/content/sally.xml
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/test-data/content/sally.xml
@@ -13,6 +13,7 @@
             <nicknames datatype="array" xsi:type="xs:string">Sal</nicknames>
             <nicknames datatype="array" xsi:type="xs:string">din</nicknames>
             <nicknames datatype="array" xsi:type="xs:string">shh</nicknames>
+            <active xsi:type="xs:boolean">false</active>
             <shipping datatype="array">
                 <Address>
                     <street xsi:type="xs:string">Whitwell Place</street>

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/test-data/entities/Customer.entity.json
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/entities/search/test-data/entities/Customer.entity.json
@@ -41,6 +41,9 @@
         },
         "customerSince": {
           "datatype": "date"
+        },
+        "active": {
+          "datatype": "boolean"
         }
       }
     },


### PR DESCRIPTION
### Description

- Duplicate PR for 5.8 that was merged in develop

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
- [x] Ran cypress tests on firefox locally
  

- ##### Reviewer:

- [x] Reviewed Tests
- [x] Added to Release Wiki

