### PR TITLE
DHFPROD-9939: Curate Card Footers Are Cut Off

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/merging/merging-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/merging/merging-card.tsx
@@ -532,13 +532,13 @@ const MergingCard: React.FC<Props> = (props) => {
                   className={styles.cardStyle}
                 >
                   <div className={styles.formatFileContainer}>
-                    <span aria-label={`${step.name}-step-label`} className={styles.mapNameStyle}>{getInitialChars(step.name, 27, "...")}</span>
+                    <span aria-label={`${step.name}-step-label`} className={styles.mapNameStyle}>{getInitialChars(step.name, 26, "...")}</span>
                   </div>
                   <br />
                   {step.selectedSource === "collection" ? (
                     <div className={styles.sourceQuery}>Collection: {extractCollectionFromSrcQuery(step.sourceQuery)}</div>
                   ) : (
-                    <div className={styles.sourceQuery}>Source Query: {getInitialChars(step.sourceQuery, 32, "...")}</div>
+                    <div className={styles.sourceQuery}>Source Query: {getInitialChars(step.sourceQuery, 30, "...")}</div>
                   )}
                   <br /><br />
                   <p className={styles.lastUpdatedStyle}>Last Updated: {convertDateFromISO(step.lastUpdated)}</p>


### PR DESCRIPTION
### Description
Curate Card Footers Are Cut Off

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
- [x] Ran cypress tests on firefox locally
  

- ##### Reviewer:

- [x] Reviewed Tests
- n/a Added to Release Wiki

