### PR TITLE
DHFPROD-9960: Structured Property Relationships cannot be edited

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/load.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/load.tsx
@@ -294,7 +294,7 @@ class LoadPage {
   }
 
   addStepToNewFlow(stepName: string) {
-    cy.get(`[aria-label="${stepName}"]`).trigger("mouseover");
+    cy.get(`[aria-label="${stepName}"]`).trigger("mouseover", {force: true});
     this.addToNewFlow(stepName).click();
   }
 
@@ -309,7 +309,7 @@ class LoadPage {
   }
 
   addStepToExistingFlow(stepName: string, flowName: string) {
-    this.stepName(stepName).trigger("mouseover");
+    this.stepName(stepName).trigger("mouseover", {force: true});
     this.existingFlowsList(stepName).click();
     cy.findByLabelText(`${flowName}-option`).click();
   }

--- a/marklogic-data-hub-central/ui/src/components/modeling/graph-view/relationship-modal/add-edit-relationship.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/graph-view/relationship-modal/add-edit-relationship.tsx
@@ -292,6 +292,14 @@ const AddEditRelationship: React.FC<Props> = ({
     const edge = edgeData.find((edge) => edge.from === definitionName && edge.label === propertyName && edge.structParent !== "");
     if (edge) {
       updatedDefinitions[edge.structParent]["properties"][propertyName] = newProperty;
+      if (propertyName !== editPropertyOptions.name) {
+        let reMapDefinition = Object.keys(updatedDefinitions[edge.structParent]["properties"]).map((key) => {
+          const newKey = key === propertyName ? editPropertyOptions.name : key;
+          const value = key === propertyName ? newProperty : updatedDefinitions[edge.structParent]["properties"][key];
+          return {[newKey]: value};
+        });
+        updatedDefinitions[edge.structParent]["properties"] = reMapDefinition.reduce((a, b) => Object.assign({}, a, b));
+      }
     } else {
       entityTypeDefinition["properties"][propertyName] = newProperty;
 

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
@@ -839,7 +839,6 @@ const PropertyTable: React.FC<Props> = (props) => {
       entityName: entityName,
       modelDefinition: updatedDefinitions
     };
-
     await saveAndUpdateModifiedEntity(entityModified, entitiesRelated, undefined);
   };
 


### PR DESCRIPTION
### Description

- This is an edge case only in the graph view where the child of a structured property is configured in a relationship.
- Test scenario added to manual wiki: https://wiki.marklogic.com/display/ENGINEERING/Manual+Testing+Scenarios

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
- [x] Ran cypress tests on firefox locally
  

- ##### Reviewer:

- N/A Reviewed Tests
- N/A Added to Release Wiki

