### PR TITLE
DHFPROD-9644: Add a second "Add Property" button in DHC/Model screen

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/e2e/modeling/graphValidations.cy.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/e2e/modeling/graphValidations.cy.tsx
@@ -102,6 +102,7 @@ describe("Graph Validations", () => {
   it("can view and works with the Optional section and select source property dropdown", {defaultCommandTimeout: 120000}, () => {
     cy.log("**Visit Customer entity**");
     entityTypeTable.viewEntityInGraphView("Customer");
+    graphViewSidePanel.getAddPropertyLinkButton("Customer").scrollIntoView().should("exist");
 
     cy.log("**Select Related Concept Classes tab**");
     graphViewSidePanel.getRelatedConceptClassesTab().click();

--- a/marklogic-data-hub-central/ui/e2e/cypress/e2e/modeling/writerScenario1.cy.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/e2e/modeling/writerScenario1.cy.tsx
@@ -259,6 +259,8 @@ describe("Entity Modeling Senario 1: Writer Role", () => {
 
   it("Adding property to Person entity", () => {
     entityTypeTable.getExpandEntityIcon("Person");
+    // as Person has less than 10 properties, the add property link button shouldn't be visible
+    propertyTable.getLinkAddButton("Person").should("not.exist");
     propertyTable.getAddPropertyButton("Person").click();
     propertyModal.clearPropertyName();
     propertyModal.newPropertyName("newID");

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/graph-view-side-panel.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/graph-view-side-panel.tsx
@@ -121,6 +121,10 @@ class GraphViewSidePanel {
   getConfirmationModal() {
     return cy.findByTestId("confirmation-modal");
   }
+
+  getAddPropertyLinkButton(entity: string) {
+    return cy.get(`[aria-label=${entity}-linkAddButton]`);
+  }
 }
 
 const graphViewSidePanel = new GraphViewSidePanel();

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/property-table.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/property-table.tsx
@@ -106,6 +106,10 @@ class PropertyTable {
     return cy.findByText(property);
   }
 
+  getLinkAddButton(entity: string) {
+    return cy.get(`[aria-label=${entity}-linkAddButton]`);
+  }
+
 }
 
 const propertyTable = new PropertyTable();

--- a/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.tsx
+++ b/marklogic-data-hub-central/ui/src/components/advanced-settings/advanced-settings.tsx
@@ -1078,7 +1078,7 @@ const AdvancedSettings: React.FC<Props> = props => {
                   {defaultCollections.map((collection, i) => {
                     return (
                       <div data-testid={`defaultCollections-${collection}`} key={i}>
-                        <AddTooltipWhenTextOverflow text={collection}  forceRender={true}/>
+                        <AddTooltipWhenTextOverflow text={collection} forceRender={true} />
                       </div>
                     );
                   })}

--- a/marklogic-data-hub-central/ui/src/components/confirmation-modal/confirmation-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/confirmation-modal/confirmation-modal.tsx
@@ -280,9 +280,7 @@ const ConfirmationModal: React.FC<Props> = props => {
           )}
           {props.type === ConfirmationType.RevertChanges && (
             <>
-              <p aria-label="save-all-text">
-                Are you sure you want to revert all of your unpublished changes?
-              </p>
+              <p aria-label="save-all-text">Are you sure you want to revert all of your unpublished changes?</p>
               <p className={styles.revertChangeText}>{ModelingMessages.revertChangesConfirm}</p>
             </>
           )}

--- a/marklogic-data-hub-central/ui/src/components/entities/entity-tiles.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/entity-tiles.tsx
@@ -185,7 +185,8 @@ const EntityTiles = props => {
                   Unable to create mapping step. A mapping step with the name
                 <b>
                   <AddTooltipWhenTextOverflow text={mapping.name} />
-                </b> already exists.
+                </b>{" "}
+                  already exists.
               </p>
             ),
           })

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.test.tsx
@@ -10,7 +10,6 @@ import mocks from "../../../api/__mocks__/mocks.data";
 import {SecurityTooltips} from "../../../config/tooltips.config";
 import dayjs from "dayjs";
 
-
 jest.mock("axios");
 
 const mockHistoryPush = jest.fn();

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
@@ -138,7 +138,8 @@ const MappingCard: React.FC<Props> = props => {
             Are you sure you want to delete the
             <strong>
               <AddTooltipWhenTextOverflow text={mappingArtifactName} />
-            </strong> step?
+            </strong>{" "}
+            step?
           </p>
         </span>
         <div className={"d-flex justify-content-center pt-4 pb-2"}>

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-step-detail/mapping-step-detail.tsx
@@ -2361,10 +2361,11 @@ const MappingStepDetail: React.FC = () => {
                 <span className={styles.entityTypeTitle}>
                   <p className={styles.entityTypeText}>
                     <span className={styles.entityIcon} />
-                    <strong className={styles.entityName} aria-label={`Entity-Type-${curationOptions.activeStep.entityName}`} >
-                      <div>
-                        Entity Type:&nbsp;
-                      </div>
+                    <strong
+                      className={styles.entityName}
+                      aria-label={`Entity-Type-${curationOptions.activeStep.entityName}`}
+                    >
+                      <div>Entity Type:&nbsp;</div>
                       <AddTooltipWhenTextOverflow text={curationOptions.activeStep.entityName} />
                     </strong>
                   </p>

--- a/marklogic-data-hub-central/ui/src/components/load/load-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/load/load-card.tsx
@@ -91,7 +91,6 @@ const LoadCard: React.FC<Props> = props => {
     return customStyles;
   };
 
-
   const handleCardDelete = name => {
     setDialogVisible(true);
     setLoadArtifactName(name);

--- a/marklogic-data-hub-central/ui/src/components/modeling/concept-class-modal/concept-class-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/concept-class-modal/concept-class-modal.tsx
@@ -264,7 +264,9 @@ const ConceptClassModal: React.FC<Props> = props => {
               <Row>
                 <Col className={errorName || isErrorOfType("name") ? "d-flex has-error" : "d-flex"}>
                   {isEditModal ? (
-                    <div className={styles.nameOverflow}><AddTooltipWhenTextOverflow text={conceptName} /></div>
+                    <div className={styles.nameOverflow}>
+                      <AddTooltipWhenTextOverflow text={conceptName} />
+                    </div>
                   ) : (
                     <HCInput
                       id="concept-class-name"

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-modal/entity-type-modal.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-modal/entity-type-modal.tsx
@@ -305,7 +305,9 @@ const EntityTypeModal: React.FC<Props> = props => {
               <Row>
                 <Col className={errorName || isErrorOfType("name") ? "d-flex has-error" : "d-flex"}>
                   {props.isEditModal ? (
-                    <div className={styles.nameOverflow}><AddTooltipWhenTextOverflow text={name} /></div>
+                    <div className={styles.nameOverflow}>
+                      <AddTooltipWhenTextOverflow text={name} />
+                    </div>
                   ) : (
                     <HCInput
                       id="entity-name"

--- a/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/entity-type-table/entity-type-table.tsx
@@ -263,7 +263,9 @@ const EntityTypeTable: React.FC<Props> = props => {
                 </span>
               </HCTooltip>
             ) : (
-              <span data-testid={entityName + "-span"}><AddTooltipWhenTextOverflow text={entityName} placement="right" /></span>
+              <span data-testid={entityName + "-span"}>
+                <AddTooltipWhenTextOverflow text={entityName} placement="right" />
+              </span>
             )}
           </>
         );

--- a/marklogic-data-hub-central/ui/src/components/modeling/graph-view/side-panel/side-panel.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/graph-view/side-panel/side-panel.tsx
@@ -637,12 +637,17 @@ const GraphViewSidePanel: React.FC<Props> = ({
       return (
         <div id="entityType-tab-content">
           <Form className={"container-fluid"}>
-            <Row className={`mb-3 ${styles.nameWrap}`} >
+            <Row className={`mb-3 ${styles.nameWrap}`}>
               <FormLabel column lg={3}>
                 {"Name:"}
               </FormLabel>
-              <Col className={`d-flex align-items-center ${styles.nameOverflow}`} data-testid={modelingOptions.selectedEntity}>
-                <AddTooltipWhenTextOverflow text={modelingOptions.selectedEntity ? modelingOptions.selectedEntity : ""} />
+              <Col
+                className={`d-flex align-items-center ${styles.nameOverflow}`}
+                data-testid={modelingOptions.selectedEntity}
+              >
+                <AddTooltipWhenTextOverflow
+                  text={modelingOptions.selectedEntity ? modelingOptions.selectedEntity : ""}
+                />
               </Col>
             </Row>
             <Row className={"mb-3"}>

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.module.scss
@@ -136,6 +136,8 @@
   &:hover{
       color: var(--hoverColor);
   }
+  display: flex;
+  align-items: center;
 }
 
 .foreignKeyRelationshipIcon {
@@ -163,4 +165,33 @@
   width: 100%;
   padding-top: 5px;
   padding-bottom: 10px;
+}
+
+.addEntityProp{
+  display: grid;
+  place-items: center;
+  padding: 16px 16px !important;
+  border: 1px solid #e8e8e8;
+  border-radius: 0px !important;
+  border-top-width: 0px !important;
+
+  &SidePanel {
+    border-left: 0;
+    border-right: 0;
+  }
+}
+
+.buttonLink{
+  padding: 0px !important;
+  border: 0 !important;
+  margin: 0 !important;
+  text-align: center;
+}
+
+.tableContainer{
+  margin-bottom: 1rem !important;
+}
+
+table {
+  margin-bottom: 0 !important;
 }

--- a/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/property-table/property-table.tsx
@@ -147,7 +147,6 @@ const PropertyTable: React.FC<Props> = props => {
     }
   }, [newRowKey]);
 
-
   const columns = [
     {
       text: "Property Name",
@@ -208,8 +207,13 @@ const PropertyTable: React.FC<Props> = props => {
         } else {
           renderText = (
             <span data-testid={text + "-span"} aria-label={"Property-name"}>
-
-              {record.joinPropertyType && record.joinPropertyType !== "" ? <i><AddTooltipWhenTextOverflow text={text} /></i> : <AddTooltipWhenTextOverflow text={text} />}
+              {record.joinPropertyType && record.joinPropertyType !== "" ? (
+                <i>
+                  <AddTooltipWhenTextOverflow text={text} />
+                </i>
+              ) : (
+                <AddTooltipWhenTextOverflow text={text} />
+              )}
               {record.multiple === record.propertyName && (
                 <HCTooltip text={"Multiple"} id={"tooltip-" + record.propertyName} placement={"bottom"}>
                   <img className={styles.arrayImage} src={arrayIcon} alt={""} data-testid={"multiple-icon-" + text} />
@@ -503,9 +507,21 @@ const PropertyTable: React.FC<Props> = props => {
           >
             <span className="p-2 inline-block cursor-pointer">
               <FontAwesomeIcon
+                tabIndex={0}
                 data-testid={"add-struct-" + propertyName}
                 className={styles.addIcon}
                 icon={faPlusSquare}
+                onKeyDown={event => {
+                  if (event.key === "Enter") {
+                    setStructuredTypeOptions({
+                      isStructured: true,
+                      name: text,
+                      propertyName: "",
+                    });
+                    setEditPropertyOptions({...editPropertyOptions, isEdit: false});
+                    toggleShowPropertyModal(true);
+                  }
+                }}
                 onClick={() => {
                   setStructuredTypeOptions({
                     isStructured: true,
@@ -531,6 +547,7 @@ const PropertyTable: React.FC<Props> = props => {
           >
             <i>
               <FontAwesomeIcon
+                tabIndex={0}
                 data-testid={"add-struct-" + propertyName}
                 className={styles.addIconReadOnly}
                 icon={faPlusSquare}
@@ -1306,42 +1323,61 @@ const PropertyTable: React.FC<Props> = props => {
         </div>
       ) : (
         <>
-          {headerColumns.length ? (
-            <HCTable
-              rowKey={sidePanelView ? "key" : "propertyName"}
-              rowClassName={record => {
-                let propertyName =
+          <div className={styles.tableContainer}>
+            {headerColumns.length ? (
+
+              <HCTable
+                rowKey={sidePanelView ? "key" : "propertyName"}
+                rowClassName={record => {
+                  let propertyName =
                   record.hasOwnProperty("add") && record.add !== ""
                     ? record.add
                       .split(",")
                       .map(item => encrypt(item))
                       .join("-")
                     : encrypt(record.propertyName);
-                return "scroll-" + encrypt(entityName) + "-" + propertyName + " hc-table_row";
-              }}
-              columns={headerColumns}
-              data={handlePropertyNames(tableData)}
-              onExpand={
-                sidePanelView ? (record, expanded) => toggleSourceRowExpanded(record, expanded, "key") : onExpand
-              }
-              expandedRowKeys={sidePanelView ? sourceExpandedKeys : expandedRows}
-              keyUtil={"key"}
-              baseIndent={20}
-              pagination={false}
-              component={"property"}
-              showExpandIndicator={{bordered: true}}
-              childrenIndent={true}
-              subTableHeader={!sidePanelView}
-              nestedParams={{
-                headerColumns,
-                iconCellList: ["identifier", "multiple", "sortable", "delete", "add"],
-                state: sidePanelView
-                  ? [sourceExpandedKeys, setSourceExpandedKeys]
-                  : [expandedNestedRows, setExpandedNestedRows],
-              }}
-              className={sidePanelView ? "side-panel" : ""}
-            />
-          ) : null}
+                  return "scroll-" + encrypt(entityName) + "-" + propertyName + " hc-table_row";
+                }}
+                columns={headerColumns}
+                data={handlePropertyNames(tableData)}
+                onExpand={
+                  sidePanelView ? (record, expanded) => toggleSourceRowExpanded(record, expanded, "key") : onExpand
+                }
+                expandedRowKeys={sidePanelView ? sourceExpandedKeys : expandedRows}
+                keyUtil={"key"}
+                baseIndent={20}
+                pagination={false}
+                component={"property"}
+                showExpandIndicator={{bordered: true}}
+                childrenIndent={true}
+                subTableHeader={!sidePanelView}
+                nestedParams={{
+                  headerColumns,
+                  iconCellList: ["identifier", "multiple", "sortable", "delete", "add"],
+                  state: sidePanelView
+                    ? [sourceExpandedKeys, setSourceExpandedKeys]
+                    : [expandedNestedRows, setExpandedNestedRows],
+                }}
+                className={sidePanelView ? "side-panel" : ""}
+              />
+            ) : null}
+            {tableData.length > 9 && (
+              <div
+                className={
+                  sidePanelView ? [styles.addEntityProp, styles.addEntityPropSidePanel].join(" ") : styles.addEntityProp
+                }
+              >
+                <button
+                  aria-label={`${entityName}-linkAddButton`}
+                  onClick={() => addPropertyButtonClicked()}
+                  className={["d-block btn-lg btn btn-link", styles.buttonLink].join(" ")}
+                >
+              + Add Entity Property
+                </button>
+              </div>
+            )}
+
+          </div>
         </>
       )}
     </div>


### PR DESCRIPTION
### Description

Adds `Add Entity Property` button under properties table.

![image](https://user-images.githubusercontent.com/108084664/226705894-4068adc8-4dc8-4fec-9643-fba6cc867154.png)


![image](https://user-images.githubusercontent.com/108084664/226705808-fafeaa96-0e44-4ba4-9083-8d529aa20abc.png)




#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- n/a Added Tests
- [x] Ran newly added/edited cypress tests on Firefox locally
  

- ##### Reviewer:

- [x] Reviewed Tests
- [x] Added to Release Wiki

