### PR TITLE
DHFPROD-9998: Validate Structured Property Relationships Can Be Edited

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/e2e/modeling/writerScenarioGraph.cy.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/e2e/modeling/writerScenarioGraph.cy.tsx
@@ -478,4 +478,46 @@ describe("Entity Modeling: Graph View", () => {
     });
     graphViewSidePanel.getPropertyName("purchased").should("not.exist");
   });
+
+  it("edit structured property relationship", () => {
+    toolbar.getModelToolbarIcon().click();
+    modelPage.selectView("table");
+
+    //Creates a structured property on Customer
+    cy.log("**Creates a structured property on Customer**");
+    entityTypeTable.viewEntityInGraphView("Customer");
+    graphViewSidePanel.getAddPropertyForStructuredProperties("shipping").click();
+    propertyModal.newPropertyName("structuredPropertyTest");
+    propertyModal.openPropertyDropdown();
+    propertyModal.getTypeFromDropdown("Related Entity");
+    propertyModal.getCascadedTypeFromDropdown("Person");
+    propertyModal.getSubmitButton().click();
+    cy.waitForAsyncRequest();
+
+    //Edits the relationship from the graph
+    cy.log("**Edits the relationship from the graph**");
+    graphVis.getPositionOfEdgeBetween("Customer,Person").then((edgePosition: any) => {
+      cy.wait(150);
+      graphVis.getGraphVisCanvas().click(edgePosition.x, edgePosition.y, {force: true});
+    });
+    relationshipModal.editRelationshipName("new-Relationship-!Name");
+    relationshipModal.confirmationOptions("Save");
+    cy.get(`[data-icon="exclamation-circle"]`).should("exist").then(() => {
+      relationshipModal.editRelationshipName("new-Relationship-1Name");
+      relationshipModal.confirmationOptions("Save");
+    });
+    cy.wait(2000);
+    cy.waitForAsyncRequest();
+
+    //Verifies the relationship name is updated
+    cy.log("**Verifies the relationship name is updated**");
+    modelPage.selectView("table");
+    entityTypeTable.getExpandEntityIcon("Customer");
+    propertyTable.getPropertyName("new-Relationship-1Name").should("exist");
+
+    // deletes the relationship
+    cy.log("**Deletes the relationship**");
+    propertyTable.getDeletePropertyIcon("Customer-Address-shipping", "new-Relationship-1Name").scrollIntoView().click();
+    confirmationModal.getYesButton(ConfirmationType.DeletePropertyWarn);
+  });
 });

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/graph-view-side-panel.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/graph-view-side-panel.tsx
@@ -125,6 +125,10 @@ class GraphViewSidePanel {
   getAddPropertyLinkButton(entity: string) {
     return cy.get(`[aria-label=${entity}-linkAddButton]`);
   }
+
+  getAddPropertyForStructuredProperties(structured: string) {
+    return cy.get(`[data-testid=add-struct-${structured}]`);
+  }
 }
 
 const graphViewSidePanel = new GraphViewSidePanel();

--- a/marklogic-data-hub-central/ui/src/components/modeling/graph-view/relationship-modal/add-edit-relationship.tsx
+++ b/marklogic-data-hub-central/ui/src/components/modeling/graph-view/relationship-modal/add-edit-relationship.tsx
@@ -303,7 +303,7 @@ const AddEditRelationship: React.FC<Props> = ({
     let newProperty = createPropertyDefinitionPayload(editPropertyOptions.propertyOptions);
 
     const edge = edgeData.find(
-      edge => edge.from === definitionName && edge.label === propertyName && edge.structParent !== "",
+      edge => edge.from === definitionName && edge.predicate === propertyName && edge.structParent !== "",
     );
     if (edge) {
       updatedDefinitions[edge.structParent]["properties"][propertyName] = newProperty;


### PR DESCRIPTION
### Description

Adds cypress test scenario to `writerScenarioGraph.cy.tsx` and fixes identing issues.

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
- [x] Ran newly added/edited cypress tests on Firefox locally
  

- ##### Reviewer:

- [x] Reviewed Tests
- n/a Added to Release Wiki

