### PR TITLE
DHFPROD-10240: check e2e win-chrome failures in the latest chrome version iteration 2

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/e2e/curation/run/runFlow.cy.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/e2e/curation/run/runFlow.cy.tsx
@@ -272,10 +272,12 @@ describe("Run Tile tests", () => {
 
     cy.log("**Deleting last step added**");
     runPage.deleteStep("map-orders", flowName).click();
+    cy.intercept("DELETE", "/api/flows/testPersonXML/steps/**").as("DeleteFlow");
     runPage.deleteStepConfirmationMessage("map-orders", flowName);
     cy.findByLabelText("Yes").click();
 
     cy.intercept("GET", "/api/jobs/**").as("runResponse");
+    cy.wait("@DeleteFlow");
     cy.get(`#runFlow-${flowName}`).should("be.visible", {timeout: 8000}).click({force: true});
     cy.uploadFile("input/person.xml");
     cy.wait("@runResponse");

--- a/marklogic-data-hub-central/ui/e2e/cypress/e2e/mastering/e2eMasteringflow.cy.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/e2e/mastering/e2eMasteringflow.cy.tsx
@@ -68,7 +68,10 @@ describe("Validate E2E Mastering Flow", () => {
     loadPage.stepSourceNameInput().clear().type("patientSourceName");
     loadPage.stepSourceNameType().clear().type("patientSourceType");
     loadPage.uriPrefixInput().clear().type("/patient/");
+    cy.intercept("/api/flows").as("loadView");
     loadPage.saveButton().click();
+    cy.wait("@loadView");
+    cy.wait("@loadView");
     cy.findByText(loadStepName).should("be.visible");
   });
 

--- a/marklogic-data-hub-central/ui/e2e/cypress/e2e/modeling/graphValidations.cy.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/e2e/modeling/graphValidations.cy.tsx
@@ -272,9 +272,10 @@ describe("Graph Validations", () => {
     propertyTable.getProperty("test2-id").should("exist");
 
     cy.log("**Opens a-Test1 details**");
+    cy.intercept("/api/models/primaryEntityTypes?includeDrafts=true").as("loadTable");
     cy.get("#switch-view-table").click({force: true});
-    cy.waitForAsyncRequest();
-    entityTypeTable.viewEntityInGraphView("a-Test1");
+    cy.wait("@loadTable");
+    entityTypeTable.viewEntityInGraphViewNotScroll("a-Test1");
     graphViewSidePanel.getPropertiesTab().click({force: true});
     graphViewSidePanel.getPropertyName("relTest1-Test2").should("be.visible");
 

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/entity-type-table.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/model/entity-type-table.tsx
@@ -48,6 +48,11 @@ class EntityTypeTable {
     cy.waitForAsyncRequest();
   }
 
+  viewEntityInGraphViewNotScroll(entityName: string) {
+    cy.get(`[data-testid="${entityName}-graphView-icon"]`).should("be.visible").click({force: true});
+    cy.waitForAsyncRequest();
+  }
+
   getRevertButtonTableView() {
     return cy.findByLabelText("revert-changes-table-view");
   }


### PR DESCRIPTION
### Description
This is the second iteration to solve failures in nightly chrome

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
- [x] Ran newly added/edited cypress tests on Firefox locally
  

- ##### Reviewer:

- [x] Reviewed Tests
- [n/a] Added to Release Wiki

