### PR TITLE
DHFPROD-10240: check e2e win-chrome failures in the latest chrome version

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/e2e/curation/run/runFlow.cy.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/e2e/curation/run/runFlow.cy.tsx
@@ -262,6 +262,7 @@ describe("Run Tile tests", () => {
 
     cy.intercept("GET", "/api/jobs/**").as("runResponse");
     cy.wait("@DeleteFlow");
+    runPage.verifyStepNotPresent(flowName, "map-orders");
     cy.get(`#runFlow-${flowName}`).should("be.visible", {timeout: 8000}).click({force: true});
     cy.uploadFile("input/person.xml");
     cy.wait("@runResponse");

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/pages/run.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/pages/run.tsx
@@ -259,6 +259,10 @@ class RunPage {
     return cy.get(`tbody`).children();
   }
 
+  verifyStepNotPresent(flowName:string, stepName:string) {
+    cy.get(`#${flowName}-${stepName}-card`).should("not.exist");
+  }
+
   verifyStepCardOrder(stepNames: string[]) {
     this.getStepsFromModal().each(($el, index) => {
       cy.wrap($el).should("contain.text", stepNames[index]);


### PR DESCRIPTION


### Description
This PR fixes 
![image](https://github.com/marklogic/marklogic-data-hub/assets/116110652/a49dee78-cb41-4e87-bdd5-02575934c38d)
on nightly 
#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
- [x] Ran newly added/edited cypress tests on Firefox locally
  

- ##### Reviewer:

- [x] Reviewed Tests
- [n/a] Added to Release Wiki

