### PR TITLE
DHFPROD-10368: Unmerge nodes that aren't part of core search results

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/explore/graph-explore-side-panel/graph-explore-side-panel.tsx
+++ b/marklogic-data-hub-central/ui/src/components/explore/graph-explore-side-panel/graph-explore-side-panel.tsx
@@ -20,7 +20,7 @@ type Props = {
   openUnmergeCompare: any;
   loadingCompare: string;
   data: any[];
-  isUnmergeAvailable: (nodeId: string) => boolean;
+  isUnmergeAvailable: (nodeId: string, expandedNodeData: {}) => boolean;
 };
 
 const DEFAULT_TAB = "instance";

--- a/marklogic-data-hub-central/ui/src/components/explore/graph-vis-explore/graph-vis-explore.tsx
+++ b/marklogic-data-hub-central/ui/src/components/explore/graph-vis-explore/graph-vis-explore.tsx
@@ -31,8 +31,8 @@ type Props = {
   setIsLoading: (loading: boolean) => void;
   entityDefArray: any[];
   data: any[];
-  openUnmergeCompare: (item: object) => void;
-  isUnmergeAvailable: (nodeId: string) => boolean;
+  openUnmergeCompare: (uri: object, item: object) => void;
+  isUnmergeAvailable: (nodeId: string, expandedNodeData: {}) => boolean;
 };
 
 const GraphVisExplore: React.FC<Props> = props => {
@@ -936,9 +936,16 @@ const GraphVisExplore: React.FC<Props> = props => {
         break;
       }
       case "Unmerge": {
-        const filteredData = props.data.filter(item => item["uri"] === clickedNode["nodeId"]);
+        const allNodes = Object.values(expandedNodeData)
+          .reduce((prev:any[], current:any) => prev.concat(current?.nodes), props.data);
+        const filteredData = allNodes.filter(item => item["uri"] === clickedNode["nodeId"] || item["id"] === clickedNode["nodeId"]);
         if (filteredData.length > 0 && canWriteMatchMerge) {
-          props.openUnmergeCompare(filteredData[0].uri);
+          const item = filteredData[0];
+          if (!item.uri) {
+            item.uri = item.docUri;
+            item.entityName = item.group.substring(item.group.lastIndexOf("/") + 1);
+          }
+          props.openUnmergeCompare(item.uri, item);
         }
         break;
       }
@@ -1062,7 +1069,7 @@ const GraphVisExplore: React.FC<Props> = props => {
             Show all records
           </div>
         )}
-        {props.isUnmergeAvailable(clickedNode["nodeId"]) && unmergeOption()}
+        {props.isUnmergeAvailable(clickedNode["nodeId"], expandedNodeData) && unmergeOption()}
         <div id="centerNode" key="10" className={styles.contextMenuItem}>
           Center this record
         </div>

--- a/marklogic-data-hub-central/ui/src/components/table-view/table-view.tsx
+++ b/marklogic-data-hub-central/ui/src/components/table-view/table-view.tsx
@@ -13,9 +13,9 @@ interface Props {
   isEntityInstance: boolean;
   isSidePanel?: boolean;
   data?: any;
-  openUnmergeCompare?: (item: object) => void;
+  openUnmergeCompare?: (uri: object, item: object) => void;
   loadingCompare?: string;
-  isUnmergeAvailable?: (nodeid: string) => boolean;
+  isUnmergeAvailable?: (nodeid: string, expandedNodeData:{}) => boolean;
 }
 
 const TableView: React.FC<Props> = props => {
@@ -109,15 +109,15 @@ const TableView: React.FC<Props> = props => {
 
     setExpandedRows(newExpandedRows);
   };
-  const handleOpenCompare = docUri => {
+  const handleOpenCompare = (docUri, item) => {
     if (props.openUnmergeCompare && typeof props.openUnmergeCompare === "function") {
-      props.openUnmergeCompare(docUri);
+      props.openUnmergeCompare(docUri, item);
     }
   };
 
   const unmergeIcon = () => {
     if (props.data) {
-      if (!props.isUnmergeAvailable?.(props.data.docUri)) return null;
+      if (!props.isUnmergeAvailable?.(props.data.docUri, {[props.data.docUri]: {nodes: [props.data]}})) return null;
       if (props.data.unmerge) {
         if (canWriteMatchMerge) {
           return (
@@ -140,7 +140,7 @@ const TableView: React.FC<Props> = props => {
                       className={styles.unMergeIcon}
                       data-testid={`unmergeIcon`}
                       aria-label={`unmerge-icon`}
-                      onClick={() => handleOpenCompare(props.data.docUri)}
+                      onClick={() => handleOpenCompare(props.data.docUri, props.data)}
                     />
                   </i>
                 </HCTooltip>

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/mastering/common.mjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/mastering/common.mjs
@@ -387,7 +387,7 @@ class GenericMatchModel {
 
   propertyValues(propertyPath, documentNode) {
     const propertyDefinition = this.propertyDefinition(propertyPath);
-    return propertyDefinition.path ? documentNode.xpath(propertyDefinition.path, this._namespaces) : documentNode.xpath(`.//${propertyDefinition.namespace ? "ns:": ""}${propertyDefinition.localname}`, {ns: propertyDefinition.namespace});
+    return propertyDefinition.path ? documentNode.xpath(propertyDefinition.path, this._namespaces) : documentNode.xpath(`.//${propertyDefinition.namespace ? "ns:": ""}${propertyDefinition.localname}[string(.) ne '' or . instance of object-node()]`, {ns: propertyDefinition.namespace});
   }
 
   propertyIndexes(propertyPath) {

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/mastering/merging/mergeable.mjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/mastering/merging/mergeable.mjs
@@ -41,10 +41,11 @@ export default class Mergeable {
 
       this.mergeStep.targetCollections.onMerge = this.mergeStep.targetCollections.onMerge || {};
       this.mergeStep.targetCollections.onMerge.add = [`sm-${targetEntityTitle}-merged`, `sm-${targetEntityTitle}-mastered`, targetEntityTitle].concat(this.mergeStep.targetCollections.onMerge.add || []).filter(c => c);
+      this.mergeStep.targetCollections.onMerge.remove = [`sm-${targetEntityTitle}-archived`].concat(this.mergeStep.targetCollections.onMerge.remove || []).filter(c => c);
 
       this.mergeStep.targetCollections.onNoMatch = this.mergeStep.targetCollections.onNoMatch || {};
       this.mergeStep.targetCollections.onNoMatch.add = [`sm-${targetEntityTitle}-mastered`, targetEntityTitle].concat(this.mergeStep.targetCollections.onNoMatch.add || []).filter(c => c);
-      this.mergeStep.targetCollections.onNoMatch.remove = [`sm-${targetEntityTitle}-archived`].concat(this.mergeStep.targetCollections.onMerge.remove || []);
+      this.mergeStep.targetCollections.onNoMatch.remove = [`sm-${targetEntityTitle}-archived`].concat(this.mergeStep.targetCollections.onNoMatch.remove || []);
 
       this.mergeStep.targetCollections.onNotification = this.mergeStep.targetCollections.onNotification || {};
       this.mergeStep.targetCollections.onNotification.add = [`sm-${targetEntityTitle}-notification`].concat(this.mergeStep.targetCollections.onNotification.add || []).filter(c => c);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/core/models/entityModel.mjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/core/models/entityModel.mjs
@@ -200,7 +200,7 @@ export class EntityModel {
       xdmp.trace(consts.TRACE_ENTITY_DEBUG, `Extracting values for property ${propertyPath} of ${this.entityModelIRI} from ${xdmp.describe(documentNode)}`);
     }
     const propertyDefinition = this.propertyDefinition(propertyPath);
-    return propertyDefinition.path ? documentNode.xpath(propertyDefinition.path, this._namespaces) : documentNode.xpath(`.//${propertyDefinition.namespace ? "ns:": ""}${propertyDefinition.localname}`, {ns: propertyDefinition.namespace});
+    return propertyDefinition.path ? documentNode.xpath(`${propertyDefinition.path}[string(.) ne '' or . instance of object-node()]`, this._namespaces) : documentNode.xpath(`.//${propertyDefinition.namespace ? "ns:": ""}${propertyDefinition.localname}[string(.) ne '' or . instance of object-node()]`, {ns: propertyDefinition.namespace});
   }
 
   /*

--- a/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/matching/nullNodeMatch.mjs
+++ b/marklogic-data-hub/src/test/ml-modules/root/test/suites/data-hub/5/smart-mastering/matching/nullNodeMatch.mjs
@@ -1,0 +1,19 @@
+import MatchableModule from "/data-hub/5/mastering/matching/matchable.mjs";
+const test = require("/test/test-helper.xqy");
+const Matchable = MatchableModule.Matchable;
+const lib = require('/test/suites/data-hub/5/smart-mastering/matching/lib/lib.xqy');
+const matcher = require('/com.marklogic.smart-mastering/matcher.xqy');
+
+const matchJson = matcher.getOptionsAsJson(lib['MATCH-OPTIONS-NAME']);
+
+function testNullNodeMatch() {
+  const matchableInstance = new Matchable(matchJson.toObject(), {});
+  const uri = lib["URI9"];
+  const contentObject = {uri, value: cts.doc(uri)};
+  matchableInstance.matchRulesetDefinitions().forEach(def => def.buildCtsQuery(contentObject));
+  return [
+    test.assertExists(matchableInstance, "Matchable class instance should exist.")
+  ];
+}
+
+testNullNodeMatch();


### PR DESCRIPTION
### Description

Also handles JSON null properties in the new JavaScript code and no longer applies the archived collection to merged documents that are merged multiple times.

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
- N/A Ran newly added/edited cypress tests on Firefox locally
  

- ##### Reviewer:

- N/A Reviewed Tests
- N/A Added to Release Wiki

