### PR TITLE
DHFPROD-10424: Matched entities table renders empty before request is…

### DIFF
--- a/marklogic-data-hub-central/ui/e2e/cypress/e2e/curation/curate/matching.cy.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/e2e/curation/curate/matching.cy.tsx
@@ -15,6 +15,7 @@ import {
 
 import "cypress-wait-until";
 
+
 const matchStep = "matchCustTest";
 const matchStepCollection = "matchCustTestCollection";
 
@@ -427,6 +428,7 @@ describe("Matching", () => {
         matchingStepDetail.getUriOnlyInputField().clear().type(uris[i]);
         matchingStepDetail.getAddUriOnlyIcon().click();
       }
+      matchingStepDetail.getEmptyMatchedEntities().should("not.exist");
       cy.log("**test two truthy URI matches**");
       matchingStepDetail.getTestMatchUriButton();
       cy.waitForAsyncRequest();
@@ -461,6 +463,7 @@ describe("Matching", () => {
       matchingStepDetail.getUriInputField().scrollIntoView().type("/json/noDataUri");
       matchingStepDetail.getAddUriIcon().click();
       matchingStepDetail.getTestMatchUriButton();
+      matchingStepDetail.getEmptyMatchedEntities().should("not.exist");
       cy.waitForAsyncRequest();
       cy.wait(1000);
       cy.findByLabelText("noMatchedDataView").should("have.length.gt", 0);
@@ -499,6 +502,7 @@ describe("Matching", () => {
       cy.log("**To test when user selects all data and click on test button**");
       matchingStepDetail.getAllDataRadio().click();
       matchingStepDetail.getTestMatchUriButton();
+      matchingStepDetail.getEmptyMatchedEntities().should("not.exist");
       cy.waitForAsyncRequest();
       cy.wait(3000);
       cy.findByLabelText("noMatchedDataView").should("not.exist");

--- a/marklogic-data-hub-central/ui/e2e/cypress/support/components/matching/matching-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/e2e/cypress/support/components/matching/matching-step-detail.tsx
@@ -123,6 +123,10 @@ class MatchingStepDetail {
   getBackButton() {
     return cy.get("[aria-label=\"Back\"]");
   }
+
+  getEmptyMatchedEntities() {
+    return cy.findByText("(Threshold: 0)", {timeout: 0});
+  }
 }
 
 const matchingStepDetail = new MatchingStepDetail();

--- a/marklogic-data-hub-central/ui/src/components/entities/matching/matching-step-detail/matching-step-detail.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/matching/matching-step-detail/matching-step-detail.tsx
@@ -1529,7 +1529,7 @@ const MatchingStepDetail: React.FC = () => {
                         />
                       </div>
                     </div>
-                    {rulesetDataList.length > 0 &&
+                    {rulesetDataList.length > 0 && rulesetDataList[0].rulesetName !== "" &&
                       rulesetDataList.map((rulesetDataList, index) => (
                         <Accordion
                           id="testMatchedPanel"
@@ -1663,7 +1663,7 @@ const MatchingStepDetail: React.FC = () => {
                         />
                       </div>
                     </div>
-                    {rulesetNonMatchedDataList?.map((rulesetDataList, index) => (
+                    {rulesetDataList[0].rulesetName !== "" && rulesetNonMatchedDataList?.map((rulesetDataList, index) => (
                       <Accordion
                         id="testNotMatchedPanel"
                         className={"w-100"}


### PR DESCRIPTION
… done

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
- [x] Ran newly added/edited cypress tests on Firefox locally
  

- ##### Reviewer:

- [x] Reviewed Tests
- [n/a] Added to Release Wiki

