### PR TITLE
DHFPROD-10434: BE:Matching synonyms not working

### DIFF
--- a/examples/real-estate/dataset/thesaurus/thesaurus2.xml
+++ b/examples/real-estate/dataset/thesaurus/thesaurus2.xml
@@ -3,237 +3,237 @@
   Each entry is lower-cased, as the thesaurus.xqy algorithm lower-cases a value before doing a thesaurus lookup.
   -->
   <entry>
-    <term>Masedon Day Care</term>
+    <term>masedon day care</term>
     <synonym>
-      <term>Covolini Day Care</term>
+      <term>covolini day care</term>
     </synonym>
   </entry>
   <entry>
-    <term>Halahan Day Care</term>
+    <term>halahan day care</term>
     <synonym>
-      <term>Brosoli Day Care</term>
+      <term>brosoli day care</term>
     </synonym>
   </entry>
   <entry>
-    <term>Bellas Day Care</term>
+    <term>bellas day care</term>
     <synonym>
-      <term>Dillway Day Care</term>
+      <term>dillway day care</term>
     </synonym>
   </entry>
   <entry>
-    <term>Antrum Day Care</term>
+    <term>antrum day care</term>
     <synonym>
-      <term>Posselow Day Care</term>
+      <term>posselow day care</term>
     </synonym>
   </entry>
   <entry>
-    <term>Bonafant Day Care</term>
+    <term>bonafant day care</term>
     <synonym>
-      <term>Vandrill Day Care</term>
+      <term>vandrill day care</term>
     </synonym>
     <synonym>
-      <term>Oneil Day Care</term>
+      <term>oneil day care</term>
     </synonym>
     <synonym>
-      <term>Meriott Day Caree</term>
+      <term>meriott day caree</term>
     </synonym>
     <synonym>
-      <term>Whife Day Care</term>
-    </synonym>
-  </entry>
-  <entry>
-    <term>Iverson Day Care</term>
-    <synonym>
-      <term>Osmar Day Care</term>
-    </synonym>
-    <synonym>
-      <term>Andrewartha Day Care</term>
+      <term>whife day care</term>
     </synonym>
   </entry>
   <entry>
-    <term>Charlin Day Care</term>
+    <term>iverson day care</term>
     <synonym>
-      <term>Drain Day Care</term>
+      <term>osmar day care</term>
     </synonym>
     <synonym>
-      <term>Herley Day Care</term>
-    </synonym>
-  </entry>
-  <entry>
-    <term>Seakin Day Care</term>
-    <synonym>
-      <term>Antcliffe Day Care</term>
+      <term>andrewartha day care</term>
     </synonym>
   </entry>
   <entry>
-    <term>Stryde Day Care</term>
+    <term>charlin cay care</term>
     <synonym>
-      <term>Bolus Day Care</term>
+      <term>drain day care</term>
+    </synonym>
+    <synonym>
+      <term>herley day care</term>
     </synonym>
   </entry>
   <entry>
-    <term>Maciejewski Day Care</term>
+    <term>seakin day care</term>
     <synonym>
-      <term>Curtin Day Care</term>
-    </synonym>
-    <synonym>
-      <term>Yeardley Day Care</term>
+      <term>antcliffe day care</term>
     </synonym>
   </entry>
   <entry>
-    <term>Poluzzi Day Care</term>
+    <term>stryde day care</term>
     <synonym>
-      <term>Fechnie Day Care</term>
+      <term>bolus day care</term>
     </synonym>
   </entry>
   <entry>
-    <term>Service Day Care</term>
+    <term>maciejewski day care</term>
     <synonym>
-      <term>Belk Day Care</term>
+      <term>curtin day care</term>
+    </synonym>
+    <synonym>
+      <term>yeardley day care</term>
     </synonym>
   </entry>
   <entry>
-    <term>Guenther Day Care</term>
+    <term>poluzzi day care</term>
     <synonym>
-      <term>McElmurray Day Care</term>
+      <term>fechnie day care</term>
     </synonym>
   </entry>
   <entry>
-    <term>Webborn Day Care</term>
+    <term>service day care</term>
     <synonym>
-      <term>Gatch Day Care</term>
+      <term>belk day care</term>
     </synonym>
   </entry>
   <entry>
-    <term>Brewin Day Care</term>
+    <term>guenther day care</term>
     <synonym>
-      <term>Port Day Care</term>
+      <term>mcelmurray day care</term>
     </synonym>
   </entry>
   <entry>
-    <term>Otter Home</term>
+    <term>webborn day care</term>
     <synonym>
-      <term>Suerz Home</term>
+      <term>gatch day care</term>
     </synonym>
   </entry>
   <entry>
-    <term>Masedon Day Care</term>
+    <term>brewin day care</term>
     <synonym>
-      <term>Covolini Day Care</term>
+      <term>port day care</term>
     </synonym>
   </entry>
   <entry>
-    <term>Ronci Home</term>
+    <term>otter home</term>
     <synonym>
-      <term>Whitwham Home</term>
+      <term>suerz home</term>
     </synonym>
   </entry>
   <entry>
-    <term>Smewin Home</term>
+    <term>masedon day care</term>
     <synonym>
-      <term>Brazer Home</term>
+      <term>covolini day care</term>
     </synonym>
   </entry>
   <entry>
-    <term>Crew Home</term>
+    <term>ronci Home</term>
     <synonym>
-      <term>Spurden Home</term>
+      <term>whitwham home</term>
     </synonym>
   </entry>
   <entry>
-    <term>Muddiman Home</term>
+    <term>smewin home</term>
     <synonym>
-      <term>Moorey Home</term>
+      <term>brazer home</term>
     </synonym>
   </entry>
   <entry>
-    <term>MacGiffin Home</term>
+    <term>crew home</term>
     <synonym>
-      <term>Surr Home</term>
+      <term>spurden home</term>
     </synonym>
   </entry>
   <entry>
-    <term>Pilch Home</term>
+    <term>muddiman home</term>
     <synonym>
-      <term>Klawi Home</term>
+      <term>moorey home</term>
     </synonym>
   </entry>
   <entry>
-    <term>Tellenbroker Home</term>
+    <term>macgiffin home</term>
     <synonym>
-      <term>Cordet Home</term>
+      <term>surr home</term>
     </synonym>
   </entry>
   <entry>
-    <term>Eilhermann Home</term>
+    <term>pilch home</term>
     <synonym>
-      <term>Downse Home</term>
+      <term>ñlawi home</term>
     </synonym>
   </entry>
   <entry>
-    <term>Keizman Home</term>
+    <term>tellenbroker home</term>
     <synonym>
-      <term>Tredwell Home</term>
-    </synonym>
-    <synonym>
-      <term>Clunan Home</term>
-    </synonym>
-    <synonym>
-      <term>Sindle Home</term>
+      <term>cordet Home</term>
     </synonym>
   </entry>
   <entry>
-    <term>Patnelli Home</term>
+    <term>eilhermann home</term>
     <synonym>
-      <term>Severns Home</term>
+      <term>downse home</term>
     </synonym>
   </entry>
   <entry>
-    <term>Beagin Home</term>
+    <term>keizman home</term>
     <synonym>
-      <term>Champley Home</term>
+      <term>tredwell home</term>
+    </synonym>
+    <synonym>
+      <term>clunan home</term>
+    </synonym>
+    <synonym>
+      <term>sindle home</term>
     </synonym>
   </entry>
   <entry>
-    <term>Le Pine Home</term>
+    <term>patnelli home</term>
     <synonym>
-      <term>Gethins Home</term>
+      <term>severns home</term>
     </synonym>
   </entry>
   <entry>
-    <term>Pickavant Home</term>
+    <term>beagin home</term>
     <synonym>
-      <term>Hagart Home</term>
+      <term>champley home</term>
     </synonym>
   </entry>
   <entry>
-    <term>Burmaster Home</term>
+    <term>le pine home</term>
     <synonym>
-      <term>Jodrelle Home</term>
-    </synonym>
-    <synonym>
-      <term>Batstone Home</term>
-    </synonym>
-    <synonym>
-      <term>Groll Home</term>
+      <term>gethins home</term>
     </synonym>
   </entry>
   <entry>
-    <term>Fried Home</term>
+    <term>pickavant home</term>
     <synonym>
-      <term>Luscott Home</term>
+      <term>hagart home</term>
     </synonym>
   </entry>
   <entry>
-    <term>Dodgshun Home</term>
+    <term>burmaster home</term>
     <synonym>
-      <term>Sandever Home</term>
+      <term>jodrelle home</term>
+    </synonym>
+    <synonym>
+      <term>batstone home</term>
+    </synonym>
+    <synonym>
+      <term>groll home</term>
     </synonym>
   </entry>
   <entry>
-    <term>Tiffany Home</term>
+    <term>fried home</term>
     <synonym>
-      <term>Sandever Home</term>
+      <term>luscott home</term>
+    </synonym>
+  </entry>
+  <entry>
+    <term>dodgshun home</term>
+    <synonym>
+      <term>sandever home</term>
+    </synonym>
+  </entry>
+  <entry>
+    <term>tiffany home</term>
+    <synonym>
+      <term>sandever home</term>
     </synonym>
   </entry>
 </thesaurus>


### PR DESCRIPTION
### Description
The underlying issue causing this error, as well as another one we have identified, is tied to the real estate project's data. Specifically, the file used to configure synonyms in this instance should contain values in lowercase.

#### Checklist: 
```diff
- Note: do not change the below
```

- ##### Owner:

- [x] JIRA_ID included in all the commit messages
- [x] PR title is in the format JIRA_ID:Title
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [n/a] Added Tests
- [n/a] Ran newly added/edited cypress tests on Firefox locally
  

- ##### Reviewer:

- [x] Reviewed Tests
- [n/a] Added to Release Wiki

